### PR TITLE
Fix build errors with UWP/IL2CPP

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputTemplate.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputTemplate.cs
@@ -7,7 +7,7 @@ using ISX.LowLevel;
 using ISX.Utilities;
 using UnityEngine;
 
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -6,7 +6,7 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using ISX.LowLevel;
 using ISX.Utilities;
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/RemoteInputPlayerConnection.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/RemoteInputPlayerConnection.cs
@@ -3,7 +3,7 @@ using ISX.Utilities;
 using UnityEngine;
 using UnityEngine.Networking.PlayerConnection;
 
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -10,7 +10,7 @@ using ISX.LowLevel;
 using ISX.Modifiers;
 using ISX.Processors;
 using ISX.Utilities;
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -16,7 +16,7 @@ using ISX.Editor;
 using UnityEngine.Networking.PlayerConnection;
 #endif
 
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/Net35Compatibility.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/Net35Compatibility.cs
@@ -1,4 +1,4 @@
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -61,4 +61,4 @@ namespace ISX.Net35Compatibility
         }
     }
 }
-#endif // !NET_4_0
+#endif // !(NET_4_0 || NET_4_6)

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadWriteArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadWriteArray.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !NET_4_0
+#if !(NET_4_0 || NET_4_6)
 using ISX.Net35Compatibility;
 #endif
 


### PR DESCRIPTION
Looks like UWP/IL2CPP uses the NET_4_6 instead of NET_4_0 for 4.6 .net compat level.  This change fixes the build errors on UWP with IL2CPP as the scripting backend.