### PR TITLE
[PS4] Added additional id's to the PS4 gamepad

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryUserIdCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryUserIdCommand.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
         public static FourCC Type { get { return new FourCC('U', 'S', 'E', 'R'); } }
 
         public const int kMaxIdLength = 256;
-        public const int kSize = InputDeviceCommand.kBaseCommandSize + kMaxIdLength + 4;
+        public const int kSize = InputDeviceCommand.kBaseCommandSize + kMaxIdLength + 2;
 
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
@@ -20,7 +20,7 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock
         public ButtonControl crossButton { get; private set; }
 
         public Vector3Control acceleration { get; private set; }
-        public Vector3Control orientation { get; private set; }
+        public QuaternionControl orientation { get; private set; }
         public Vector3Control angularVelocity { get; private set; }
 
         public new static DualShockGamepad current { get; private set; }
@@ -40,7 +40,7 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock
             optionsButton = startButton;
 
             acceleration = builder.GetControl<Vector3Control>(this, "acceleration");
-            orientation = builder.GetControl<Vector3Control>(this, "orientation");
+            orientation = builder.GetControl<QuaternionControl>(this, "orientation");
             angularVelocity = builder.GetControl<Vector3Control>(this, "angularVelocity");
 
             squareButton = buttonWest;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadPS4.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadPS4.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock.LowLevel
 
         [InputControl(name = "leftStickPress", bit = (uint)Button.L3, displayName = "L3")]
         [InputControl(name = "rightStickPress", bit = (uint)Button.R3, displayName = "R3")]
-        [InputControl(name = "options", layout = "Button", bit = (uint)Button.Options)]
+        [InputControl(name = "start", layout = "Button", bit = (uint)Button.Options)]
         [InputControl(name = "dpad", layout = "Dpad", sizeInBits = 4)]
         [InputControl(name = "dpad/up", bit = (uint)Button.DpadUp)]
         [InputControl(name = "dpad/right", bit = (uint)Button.DpadRight)]
@@ -94,18 +94,18 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock.LowLevel
 
         [InputControl(name = "orientation")]
         [FieldOffset(40)]
-        public Vector3 orientation;
+        public Quaternion orientation;
 
         [InputControl(name = "angularVelocity")]
-        [FieldOffset(52)]
+        [FieldOffset(56)]
         public Vector3 angularVelocity;
 
         [InputControl]
-        [FieldOffset(64)]
+        [FieldOffset(68)]
         public PS4Touch touch0;
 
         [InputControl]
-        [FieldOffset(76)]
+        [FieldOffset(80)]
         public PS4Touch touch1;
 
         public FourCC GetFormat()
@@ -130,7 +130,8 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock.LowLevel
         {
             Rumble = 0x1,
             Color = 0x2,
-            ResetColor = 0x4
+            ResetColor = 0x4,
+            ResetOrientation = 0x8
         }
 
         [FieldOffset(0)] public InputDeviceCommand baseCommand;
@@ -167,11 +168,52 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock.LowLevel
             flags |= (byte)Flags.ResetColor;
         }
 
+        public void ResetOrientation()
+        {
+            flags |= (byte)Flags.ResetOrientation;
+        }
+
         public static DualShockPS4OuputCommand Create()
         {
             return new DualShockPS4OuputCommand
             {
                 baseCommand = new InputDeviceCommand(Type, kSize)
+            };
+        }
+    }
+
+    /// <summary>
+    /// Retrieve the slotId, colorId and userId of the controller
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = kSize)]
+    public struct QuerySlotIdCommand : IInputDeviceCommandInfo
+    {
+        public static FourCC Type { get { return new FourCC('S', 'L', 'I', 'D'); } }
+
+        public const int kSize = InputDeviceCommand.kBaseCommandSize + 12;
+
+        [FieldOffset(0)]
+        public InputDeviceCommand baseCommand;
+
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
+        public int slotId;
+
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + 4)]
+        public int defaultColorId;
+
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + 8)]
+        public int userId;
+
+        public FourCC GetTypeStatic()
+        {
+            return Type;
+        }
+
+        public static QuerySlotIdCommand Create()
+        {
+            return new QuerySlotIdCommand()
+            {
+                baseCommand = new InputDeviceCommand(Type, kSize),
             };
         }
     }
@@ -230,6 +272,115 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock
     {
         ////TODO: move up into base
         public ReadOnlyArray<PS4TouchControl> touches { get; private set; }
+
+        static DualShockGamepadPS4[] devices = new DualShockGamepadPS4[4];
+
+        // Slot id for the gamepad. Once set will never change.
+        private int m_slotId = -1;
+        private int m_defaultColorId = -1;
+        private int m_userId = -1;
+        private void UpdatePadSettingsIfNeeded()
+        {
+            if (m_slotId == -1)
+            {
+                var command = QuerySlotIdCommand.Create();
+
+                if (ExecuteCommand(ref command) > 0)
+                {
+                    m_slotId = command.slotId;
+                    m_defaultColorId = command.defaultColorId;
+                    m_userId = command.userId;
+
+                    if (m_LightBarColor.HasValue == false)
+                    {
+                        m_LightBarColor = GetPlayStationColor(m_defaultColorId);
+                    }
+                }
+            }
+        }
+
+        public Color LightBarColor
+        {
+            get
+            {
+                if (m_LightBarColor.HasValue == false)
+                {
+                    return GetPlayStationColor(m_defaultColorId);
+                }
+
+                return m_LightBarColor.Value;
+            }
+        }
+        private static Color GetPlayStationColor(int colorId)
+        {
+            switch (colorId)
+            {
+                case 0:
+                    return Color.blue;
+                case 1:
+                    return Color.red;
+                case 2:
+                    return Color.green;
+                case 3:
+                    return Color.magenta;
+                default:
+                    return Color.black;
+            }
+        }
+        public int slotId
+        {
+            get
+            {
+                UpdatePadSettingsIfNeeded();
+                return m_slotId;
+            }
+        }
+        public int sceUserId
+        {
+            get
+            {
+                UpdatePadSettingsIfNeeded();
+                return m_userId;
+            }
+        }
+
+        public static void OnDeviceChange(InputDevice device, InputDeviceChange change)
+        {
+            DualShockGamepadPS4 ps4Gamepad = device as DualShockGamepadPS4;
+
+            if (ps4Gamepad == null || ps4Gamepad.slotId == -1) return;
+
+            if (change == InputDeviceChange.Added)
+            {
+                // Check there is no other device already in that slot
+                if (devices[ps4Gamepad.slotId] == null)
+                {
+                    devices[ps4Gamepad.slotId] = ps4Gamepad;
+                }
+            }
+            else if (change == InputDeviceChange.Removed)
+            {
+                // check to make sure the device in the expected array index matches the actual device in that slot.
+                if (devices[ps4Gamepad.slotId] == device)
+                {
+                    devices[ps4Gamepad.slotId] = null;
+                }
+            }
+        }
+
+        public static DualShockGamepadPS4 FindBySlotId(int slotId)
+        {
+            if (devices[slotId] != null && devices[slotId].slotId == slotId)
+            {
+                return devices[slotId];
+            }
+
+            return null;
+        }
+        public static new ReadOnlyArray<DualShockGamepadPS4> all
+        {
+            get { return new ReadOnlyArray<DualShockGamepadPS4>(devices); }
+        }
 
         protected override void FinishSetup(InputDeviceBuilder builder)
         {
@@ -318,6 +469,13 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock
 
             m_LargeMotor = largeMotor;
             m_SmallMotor = smallMotor;
+        }
+        public void ResetOrientation()
+        {
+            var command = DualShockPS4OuputCommand.Create();
+            command.ResetOrientation();
+
+            ExecuteCommand(ref command);
         }
 
         private float? m_LargeMotor;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -23,6 +23,7 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock
             #endif
 
             #if UNITY_EDITOR || UNITY_PS4
+
             InputSystem.RegisterControlLayout<PS4TouchControl>("PS4Touch");
             InputSystem.RegisterControlLayout<DualShockGamepadPS4>("PS4DualShockGamepad",
                 deviceDescription: new InputDeviceDescription
@@ -30,6 +31,9 @@ namespace UnityEngine.Experimental.Input.Plugins.DualShock
                 deviceClass = "PS4DualShockGamepad",
                 interfaceName = "PS4"
             });
+
+            InputSystem.onDeviceChange += DualShockGamepadPS4.OnDeviceChange;
+
             #endif
         }
     }

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -136,7 +136,7 @@ class DualShockTests : InputTestFixture
             leftTrigger = 0.567f,
             rightTrigger = 0.891f,
             acceleration = new Vector3(0.987f, 0.654f, 0.321f),
-            orientation = new Vector3(0.111f, 0.222f, 0.333f),
+            orientation = new Quaternion(0.111f, 0.222f, 0.333f, 0.444f),
             angularVelocity = new Vector3(0.444f, 0.555f, 0.666f),
             touch0 = new PS4Touch
             {
@@ -175,9 +175,16 @@ class DualShockTests : InputTestFixture
         Assert.That(gamepad.acceleration.y.ReadValue(), Is.EqualTo(0.654).Within(0.00001));
         Assert.That(gamepad.acceleration.z.ReadValue(), Is.EqualTo(0.321).Within(0.00001));
 
-        Assert.That(gamepad.orientation.x.ReadValue(), Is.EqualTo(0.111).Within(0.00001));
-        Assert.That(gamepad.orientation.y.ReadValue(), Is.EqualTo(0.222).Within(0.00001));
-        Assert.That(gamepad.orientation.z.ReadValue(), Is.EqualTo(0.333).Within(0.00001));
+        Quaternion orientation = gamepad.orientation.ReadValue();
+
+        Assert.That(orientation.x, Is.EqualTo(0.111).Within(0.00001));
+        Assert.That(orientation.y, Is.EqualTo(0.222).Within(0.00001));
+        Assert.That(orientation.z, Is.EqualTo(0.333).Within(0.00001));
+        Assert.That(orientation.w, Is.EqualTo(0.444).Within(0.00001));
+
+        //Assert.That(gamepad.orientation.x.ReadValue(), Is.EqualTo(0.111).Within(0.00001));
+        //Assert.That(gamepad.orientation.y.ReadValue(), Is.EqualTo(0.222).Within(0.00001));
+        //Assert.That(gamepad.orientation.z.ReadValue(), Is.EqualTo(0.333).Within(0.00001));
 
         Assert.That(gamepad.angularVelocity.x.ReadValue(), Is.EqualTo(0.444).Within(0.00001));
         Assert.That(gamepad.angularVelocity.y.ReadValue(), Is.EqualTo(0.555).Within(0.00001));

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -182,10 +182,6 @@ class DualShockTests : InputTestFixture
         Assert.That(orientation.z, Is.EqualTo(0.333).Within(0.00001));
         Assert.That(orientation.w, Is.EqualTo(0.444).Within(0.00001));
 
-        //Assert.That(gamepad.orientation.x.ReadValue(), Is.EqualTo(0.111).Within(0.00001));
-        //Assert.That(gamepad.orientation.y.ReadValue(), Is.EqualTo(0.222).Within(0.00001));
-        //Assert.That(gamepad.orientation.z.ReadValue(), Is.EqualTo(0.333).Within(0.00001));
-
         Assert.That(gamepad.angularVelocity.x.ReadValue(), Is.EqualTo(0.444).Within(0.00001));
         Assert.That(gamepad.angularVelocity.y.ReadValue(), Is.EqualTo(0.555).Within(0.00001));
         Assert.That(gamepad.angularVelocity.z.ReadValue(), Is.EqualTo(0.666).Within(0.00001));


### PR DESCRIPTION
Match connected gamepads to a logged-in user on the console.

Had to change the size of QueryUserIdCommand, because the length of a string is only 2 bytes in the native runtime. 

Changed 'orientation' to use a QuaternionControl instead as the PS4 native gamepad code passes a quaternion rather than Euler angles. I'm not sure how this affects the PC. Also I'm not sure if the HID API on the PC is  Euler or Quaternion. Either gamepad is providing Euler and the library is converting it to Quaternion or the PC code is incorrect. This will need to be investigated. It would be nice to provide a Quaternion on the PS4 as this is what a developer would normally expect but it might mean moving the 'orientation' property outside of the DualShockGamepad class and into the DualShockGamepadPS4 and DualShockGamepadHID separately. 

I have implemented the 'all' property on the DualShockGamepadPS4 to keep a list of gamepads. I did this by implementing the OnDeviceChange method. I can then read the gamepads 'slotid' and use that to add the gamepad to the matching index. That way the indexes of the gamepads in the array is the same as their slotids. This kind of feels correct from an API point of view as this is how developers would access a gamepad by using it's index from 0-3.  