### PR TITLE
Fix apply binding override

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -393,7 +393,7 @@ namespace UnityEngine.Experimental.Input
                 throw new InvalidOperationException(
                     string.Format("Cannot change overrides on action '{0}' while the action is enabled", this));
 
-            if (bindingIndex < 0 || bindingIndex > m_BindingsCount)
+            if (bindingIndex < 0 || bindingIndex >= m_BindingsCount)
                 throw new IndexOutOfRangeException(
                     string.Format("Binding index {0} is out of range for action '{1}' which has {2} bindings",
                         bindingIndex, this, m_BindingsCount));

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSet.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSet.cs
@@ -124,14 +124,8 @@ namespace UnityEngine.Experimental.Input
 
         public void ApplyOverrides(IEnumerable<InputBindingOverride> overrides)
         {
-			foreach (var binding in overrides)
-			{
-				var action = TryGetAction(binding.action);
-				if (action == null)
-					continue;
-				action.ApplyBindingOverride(binding);
-			}
-		}
+            throw new NotImplementedException();
+        }
 
         public void RemoveOverrides(IEnumerable<InputBindingOverride> overrides)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSet.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSet.cs
@@ -124,8 +124,14 @@ namespace UnityEngine.Experimental.Input
 
         public void ApplyOverrides(IEnumerable<InputBindingOverride> overrides)
         {
-            throw new NotImplementedException();
-        }
+			foreach (var binding in overrides)
+			{
+				var action = TryGetAction(binding.action);
+				if (action == null)
+					continue;
+				action.ApplyBindingOverride(binding);
+			}
+		}
 
         public void RemoveOverrides(IEnumerable<InputBindingOverride> overrides)
         {

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
@@ -6269,6 +6269,24 @@ class CoreTests : InputTestFixture
 
     [Test]
     [Category("Actions")]
+    public void Actions_CanOverrideBindings()
+    {
+        var gamepad = (Gamepad)InputSystem.AddDevice("Gamepad");
+        var action = new InputAction(binding: "/gamepad/leftTrigger");
+        action.ApplyBindingOverride(new InputBindingOverride {binding = "/gamepad/rightTrigger"});
+        action.Enable();
+
+        var wasPerformed = false;
+        action.performed += ctx => wasPerformed = true;
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState {rightTrigger = 1});
+        InputSystem.Update();
+
+        Assert.That(wasPerformed);
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_CanCreateButtonAxisComposite()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
@@ -6447,7 +6447,34 @@ class CoreTests : InputTestFixture
         Assert.That(deserialized[0].actions[0].bindings[4].isPartOfComposite, Is.True);
     }
 
-    [Test]
+	[Test]
+	[Category("Sets")]
+	public void Sets_OnSetWithMultipleBindings_ApplyOverrides()
+	{
+		var set = new InputActionSet();
+		var action1 = set.AddAction("action1", "/<keyboard>/enter");
+		var action2 = set.AddAction("action2", "/<gamepad>/buttonSouth");
+
+		var listOverrides = new List<InputBindingOverride>(3);
+		listOverrides.Add(new InputBindingOverride {action = "action3", binding = "/gamepad/buttonSouth"});
+		listOverrides.Add(new InputBindingOverride {action = "action2", binding = "/gamepad/rightTrigger"});
+		listOverrides.Add(new InputBindingOverride {action = "action1", binding = "/gamepad/leftTrigger"});
+
+		Assert.DoesNotThrow(() => set.ApplyOverrides(listOverrides));
+
+		action1.Enable();
+		action2.Enable();
+
+		Assert.That(action1.bindings[0].overridePath, Is.Not.Null);
+		Assert.That(action2.bindings[0].overridePath, Is.Not.Null);
+		Assert.That(action1.bindings[0].overridePath, Is.EqualTo("/gamepad/leftTrigger"));
+		Assert.That(action2.bindings[0].overridePath, Is.EqualTo("/gamepad/rightTrigger"));
+
+		var action = new InputAction(binding: "/gamepad/leftTrigger");
+		action.Enable();
+	}
+
+	[Test]
     [Category("Actions")]
     public void Actions_WhileActionIsEnabled_CannotApplyOverrides()
     {

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
@@ -6269,24 +6269,6 @@ class CoreTests : InputTestFixture
 
     [Test]
     [Category("Actions")]
-    public void Actions_CanOverrideBindings()
-    {
-        var gamepad = (Gamepad)InputSystem.AddDevice("Gamepad");
-        var action = new InputAction(binding: "/gamepad/leftTrigger");
-        action.ApplyBindingOverride(new InputBindingOverride {binding = "/gamepad/rightTrigger"});
-        action.Enable();
-
-        var wasPerformed = false;
-        action.performed += ctx => wasPerformed = true;
-
-        InputSystem.QueueStateEvent(gamepad, new GamepadState {rightTrigger = 1});
-        InputSystem.Update();
-
-        Assert.That(wasPerformed);
-    }
-
-    [Test]
-    [Category("Actions")]
     public void Actions_CanCreateButtonAxisComposite()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();


### PR DESCRIPTION
Fixed checking the index on the range of the array of bindings.
If the index is 1, and the number of bindings is 1, then the check was successful, but when the value was filled from the array, an exception was thrown.