### PR TITLE
FIX: Check index of range array.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -393,7 +393,7 @@ namespace UnityEngine.Experimental.Input
                 throw new InvalidOperationException(
                     string.Format("Cannot change overrides on action '{0}' while the action is enabled", this));
 
-            if (bindingIndex < 0 || bindingIndex > m_BindingsCount)
+            if (bindingIndex < 0 || bindingIndex >= m_BindingsCount)
                 throw new IndexOutOfRangeException(
                     string.Format("Binding index {0} is out of range for action '{1}' which has {2} bindings",
                         bindingIndex, this, m_BindingsCount));


### PR DESCRIPTION
Fixed checking the index on the range of the array of bindings.
If the index is 1, and the number of bindings is 1, then the check was successful, but when the value was filled from the array, an exception was thrown.