### PR TITLE
FIX: When cloning an InputActionSet, ensure the cloned actions refer to the newly created set

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSet.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSet.cs
@@ -185,6 +185,17 @@ namespace UnityEngine.Experimental.Input
                 m_Actions = ArrayHelpers.Clone(m_Actions)
             };
 
+            if(clone.m_Actions != null)
+            {
+                // ensure cloned actions refer to the new set and are not singletons
+                var cloneActions = clone.m_Actions;
+                var length = cloneActions.Length;
+                for(int i = 0; i < length; ++i)
+                {
+                    cloneActions[i].m_ActionSet = clone;
+                }
+            }
+            
             return clone;
         }
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
@@ -6690,6 +6690,8 @@ class CoreTests : InputTestFixture
         Assert.That(clone.actions, Has.None.SameAs(action2));
         Assert.That(clone.actions[0].name, Is.EqualTo(set.actions[0].name));
         Assert.That(clone.actions[1].name, Is.EqualTo(set.actions[1].name));
+        Assert.That(clone.actions[0].set, Is.EqualTo(clone));
+        Assert.That(clone.actions[1].set, Is.EqualTo(clone));
     }
 
     [Test]


### PR DESCRIPTION
…, as they'll default to the SingletonActionSet (null) when initially cloned

CHANGED: Updated tests to verify changes