### PR TITLE
FIX: Updated ifdefs for 4.x to include NET_STANDARD_2_0)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Utilities;
 
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Utilities;
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/RemoteInputPlayerConnection.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/RemoteInputPlayerConnection.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine.Experimental.Input.Utilities;
 using UnityEngine.Networking.PlayerConnection;
 
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -11,7 +11,7 @@ using UnityEngine.Experimental.Input.Modifiers;
 using UnityEngine.Experimental.Input.Processors;
 using UnityEngine.Experimental.Input.Utilities;
 using Unity.Collections;
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -18,7 +18,7 @@ using UnityEngine.Experimental.Input.Editor;
 using UnityEngine.Networking.PlayerConnection;
 #endif
 
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/Net35Compatibility.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/Net35Compatibility.cs
@@ -1,4 +1,4 @@
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -61,4 +61,4 @@ namespace UnityEngine.Experimental.Input.Net35Compatibility
         }
     }
 }
-#endif // !(NET_4_0 || NET_4_6)
+#endif // !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadWriteArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadWriteArray.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests.cs
@@ -21,7 +21,7 @@ using UnityEngine.Experimental.Input.Editor;
 using UnityEditor;
 #endif
 
-#if !(NET_4_0 || NET_4_6)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 


### PR DESCRIPTION
Tom had found input system would not compile on UWP.  I switched profiled to .NET Standard 2.0 under 4.x and found same issue.  Then found we have to include NET_STANDARD_2_0 anywhere that we are doing 4.X specific things.  Hopefully in the future the old run time will just go away and make these things less clunky.

Testing:
Ran playmode tests under 4.x runtime with net standard as compatibility setting.