### PR TITLE
CHANGE: Send an Update at the end of InitializeInPlayer.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1048,6 +1048,10 @@ namespace UnityEngine.Experimental.Input
                 s_ConnectionToEditor.Bind(PlayerConnection.instance, PlayerConnection.instance.isConnected);
             }
             #endif
+
+            // Send an initial Update so that user methods such as Start and Awake
+            // can access the input devices prior to thier Upate methods.
+            Update();
         }
 
 #endif // UNITY_EDITOR


### PR DESCRIPTION
Send an Update at the end of InitializeInPlayer.  Tested with a sample project in standalone windows player.  Confirmed that both device count is > 0 in both Awake and Start.

Note: I couldn't figure out how to write a test for this in our existing core tests?  