### PR TITLE
NEW: Warn the user if the old input system is the active.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -88,6 +88,14 @@ namespace UnityEngine.Experimental.Input
             }
         }
 
+        #if UNITY_EDITOR
+        public bool oldInputWarnUserFlag
+        {
+            get { return m_OldInputWarnUserFlag; }
+            set { m_OldInputWarnUserFlag = value; }
+        }
+        #endif
+
         public event DeviceChangeListener onDeviceChange
         {
             add { m_DeviceChangeListeners.Append(value); }
@@ -1227,6 +1235,7 @@ namespace UnityEngine.Experimental.Input
         [NonSerialized] internal IInputRuntime m_Runtime;
 
         #if UNITY_EDITOR
+        [NonSerialized] private bool m_OldInputWarnUserFlag;  // Let the user know if they have the old input manager set, but the new input system installed.
         [NonSerialized] internal IInputDiagnostics m_Diagnostics;
         #endif
 
@@ -2272,6 +2281,10 @@ namespace UnityEngine.Experimental.Input
             public InputUpdate.SerializedState updateState;
             public InputUpdateType updateMask;
 
+            #if UNITY_EDITOR
+            public bool oldInputWarnUserFlag;
+            #endif
+
             // The rest is state that we want to preserve across Save() and Restore() but
             // not across domain reloads.
 
@@ -2371,6 +2384,7 @@ namespace UnityEngine.Experimental.Input
                 runtime = m_Runtime,
 
                 #if UNITY_EDITOR
+                oldInputWarnUserFlag = m_OldInputWarnUserFlag,
                 diagnostics = m_Diagnostics
                 #endif
             };
@@ -2399,8 +2413,9 @@ namespace UnityEngine.Experimental.Input
             m_LayoutChangeListeners = state.layoutChangeListeners;
             m_EventListeners = state.eventListeners;
             m_UpdateMask = state.updateMask;
-
+            
             #if UNITY_EDITOR
+            m_OldInputWarnUserFlag = state.oldInputWarnUserFlag;
             m_Diagnostics = state.diagnostics;
             #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -88,14 +88,6 @@ namespace UnityEngine.Experimental.Input
             }
         }
 
-        #if UNITY_EDITOR
-        public bool oldInputWarnUserFlag
-        {
-            get { return m_OldInputWarnUserFlag; }
-            set { m_OldInputWarnUserFlag = value; }
-        }
-        #endif
-
         public event DeviceChangeListener onDeviceChange
         {
             add { m_DeviceChangeListeners.Append(value); }
@@ -1235,7 +1227,6 @@ namespace UnityEngine.Experimental.Input
         [NonSerialized] internal IInputRuntime m_Runtime;
 
         #if UNITY_EDITOR
-        [NonSerialized] private bool m_OldInputWarnUserFlag;  // Let the user know if they have the old input manager set, but the new input system installed.
         [NonSerialized] internal IInputDiagnostics m_Diagnostics;
         #endif
 
@@ -2281,10 +2272,6 @@ namespace UnityEngine.Experimental.Input
             public InputUpdate.SerializedState updateState;
             public InputUpdateType updateMask;
 
-            #if UNITY_EDITOR
-            public bool oldInputWarnUserFlag;
-            #endif
-
             // The rest is state that we want to preserve across Save() and Restore() but
             // not across domain reloads.
 
@@ -2384,7 +2371,6 @@ namespace UnityEngine.Experimental.Input
                 runtime = m_Runtime,
 
                 #if UNITY_EDITOR
-                oldInputWarnUserFlag = m_OldInputWarnUserFlag,
                 diagnostics = m_Diagnostics
                 #endif
             };
@@ -2413,9 +2399,8 @@ namespace UnityEngine.Experimental.Input
             m_LayoutChangeListeners = state.layoutChangeListeners;
             m_EventListeners = state.eventListeners;
             m_UpdateMask = state.updateMask;
-            
+
             #if UNITY_EDITOR
-            m_OldInputWarnUserFlag = state.oldInputWarnUserFlag;
             m_Diagnostics = state.diagnostics;
             #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1096,6 +1096,23 @@ namespace UnityEngine.Experimental.Input
 #if UNITY_EDITOR
         private static InputSystemObject s_SystemObject;
 
+        private static void CheckCurrentPlayerSettingForInputSystem()
+        {
+            PlayerSettings[] array = Resources.FindObjectsOfTypeAll<PlayerSettings>();
+            var playerSettings = array.Length > 0 ? array[0] : null;
+            if (playerSettings)
+            {
+                var s_PlayerSettings = new SerializedObject(playerSettings);
+
+                // Only warn the user once.  Save the warning flag across domain reloads.
+                if (s_PlayerSettings.FindProperty("enableNativePlatformBackendsForNewInputSystem").boolValue == false && !s_Manager.oldInputWarnUserFlag)
+                {
+                     EditorUtility.DisplayDialog("Input Manager Active", "You currently have the input system package installed, however it is not active due to the Active Input Handling player setting set to Input Manager.", "OK");
+                     s_Manager.oldInputWarnUserFlag = true;
+                }
+            }
+        }
+
         private static void InitializeInEditor()
         {
             var existingSystemObjects = Resources.FindObjectsOfTypeAll<InputSystemObject>();
@@ -1116,6 +1133,8 @@ namespace UnityEngine.Experimental.Input
             }
 
             EditorApplication.playModeStateChanged += OnPlayModeChange;
+
+            CheckCurrentPlayerSettingForInputSystem();           
         }
 
         // We don't want play mode modifications to layouts and controls to seep

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1121,7 +1121,7 @@ namespace UnityEngine.Experimental.Input
             // If it is the old system, warn the user that they have the new
             // input system installed, but have not switched it to active.
             if (!s_SystemObject.IsNewInputSystemActiveInPlayerSettings())
-                s_SystemObject.DisplayOldInputSystemWarningDialog();
+                s_SystemObject.DisplayNativeBackendsDisabledWarningDialog();
         }
 
         // We don't want play mode modifications to layouts and controls to seep

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1096,23 +1096,6 @@ namespace UnityEngine.Experimental.Input
 #if UNITY_EDITOR
         private static InputSystemObject s_SystemObject;
 
-        private static void CheckCurrentPlayerSettingForInputSystem()
-        {
-            PlayerSettings[] array = Resources.FindObjectsOfTypeAll<PlayerSettings>();
-            var playerSettings = array.Length > 0 ? array[0] : null;
-            if (playerSettings)
-            {
-                var s_PlayerSettings = new SerializedObject(playerSettings);
-
-                // Only warn the user once.  Save the warning flag across domain reloads.
-                if (s_PlayerSettings.FindProperty("enableNativePlatformBackendsForNewInputSystem").boolValue == false && !s_Manager.oldInputWarnUserFlag)
-                {
-                     EditorUtility.DisplayDialog("Input Manager Active", "You currently have the input system package installed, however it is not active due to the Active Input Handling player setting set to Input Manager.", "OK");
-                     s_Manager.oldInputWarnUserFlag = true;
-                }
-            }
-        }
-
         private static void InitializeInEditor()
         {
             var existingSystemObjects = Resources.FindObjectsOfTypeAll<InputSystemObject>();
@@ -1134,7 +1117,11 @@ namespace UnityEngine.Experimental.Input
 
             EditorApplication.playModeStateChanged += OnPlayModeChange;
 
-            CheckCurrentPlayerSettingForInputSystem();           
+            // Check the editor player settings to see which input system is active.
+            // If it is the old system, warn the user that they have the new
+            // input system installed, but have not switched it to active.
+            if (!s_SystemObject.IsNewInputSystemActiveInPlayerSettings())
+                s_SystemObject.DisplayOldInputSystemWarningDialog();
         }
 
         // We don't want play mode modifications to layouts and controls to seep


### PR DESCRIPTION
If the new input system package is installed, but the old input system is the active player setting, it can cause confusion with the user. 