### PR TITLE
FIX: Fixed OnScreenStick improperly calculating positions in its own local space rather than its parent's

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -18,13 +18,13 @@ namespace UnityEngine.Experimental.Input.Plugins.OnScreen
 
         public void OnPointerDown(PointerEventData data)
         {
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(GetComponentInParent<RectTransform>(), data.position, data.pressEventCamera, out m_PointerDownPos);
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(transform.parent.GetComponentInParent<RectTransform>(), data.position, data.pressEventCamera, out m_PointerDownPos);
         }
 
         public void OnDrag(PointerEventData data)
         {
             Vector2 position;
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(GetComponentInParent<RectTransform>(), data.position, data.pressEventCamera, out position);
+            RectTransformUtility.ScreenPointToLocalPointInRectangle(transform.parent.GetComponentInParent<RectTransform>(), data.position, data.pressEventCamera, out position);
             Vector2 delta = position - m_PointerDownPos;
 
             delta = Vector2.ClampMagnitude(delta, movementRange);


### PR DESCRIPTION
Local positions for the input passed through by the OnScreenStick component was incorrectly using positions in its own local space (which was moving) rather than its parent's. This was causing jitter in its behaviour, and in the input submitted by it.