### PR TITLE
CHANGE: Add UWP to the list of conditions to not use net35 compat

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Utilities;
 
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -6,7 +6,7 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Utilities;
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/RemoteInputPlayerConnection.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/RemoteInputPlayerConnection.cs
@@ -2,7 +2,7 @@ using System;
 using UnityEngine.Experimental.Input.Utilities;
 using UnityEngine.Networking.PlayerConnection;
 
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -12,7 +12,7 @@ using UnityEngine.Experimental.Input.Interactions;
 using UnityEngine.Experimental.Input.Utilities;
 using Unity.Collections;
 using UnityEngine.Experimental.Input.Layouts;
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -20,7 +20,7 @@ using UnityEditor.Networking.PlayerConnection;
 using UnityEngine.Networking.PlayerConnection;
 #endif
 
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
@@ -3,7 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Unity.Collections;
 
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/Net35Compatibility.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/Net35Compatibility.cs
@@ -1,4 +1,4 @@
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadWriteArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadWriteArray.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Remoting.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Remoting.cs
@@ -8,7 +8,7 @@ using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Utilities;
 using UnityEngine.Networking.PlayerConnection;
 
-#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0)
+#if !(NET_4_0 || NET_4_6 || NET_STANDARD_2_0 || UNITY_WSA)
 using UnityEngine.Experimental.Input.Net35Compatibility;
 #endif
 


### PR DESCRIPTION
UWP does not get NET_4_6 or NETSTNDARD_2_0 defines.  As well as UWP used CoreFX that had newer C# features in older libs.   Just take Net35, compatibility out of UWP and users must use new 4.x scripting engine.