### PR TITLE
FIX: Clean compiler warnings generated from Unity 2018.2 Editor.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionProperty.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionProperty.cs
@@ -53,6 +53,22 @@ namespace UnityEngine.Experimental.Input
             return m_Reference == other;
         }
 
+        public override bool Equals(object o)  
+        {  
+            if (m_UseReference)
+                return this.Equals(o as InputActionReference);
+            else
+                return this.Equals(o as InputAction);
+        }  
+
+        public override int GetHashCode()  
+        {  
+            if (m_UseReference)
+                return m_Reference.GetHashCode();
+            else
+                return m_Action.GetHashCode();
+        }
+
         public static bool operator==(InputActionProperty left, InputActionProperty right)
         {
             return left.Equals(right);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionAsset/PropertyLists.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionAsset/PropertyLists.cs
@@ -27,7 +27,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
         protected override void AddElement(object data)
         {
-            if (m_ListView.list.Count == 1 && m_ListView.list[0] == "")
+            if (m_ListView.list.Count == 1 && (string)m_ListView.list[0] == "")
             {
                 m_ListView.list.Clear();
             }
@@ -54,7 +54,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
         protected override void AddElement(object data)
         {
-            if (m_ListView.list.Count == 1 && m_ListView.list[0] == "")
+            if (m_ListView.list.Count == 1 && (string)m_ListView.list[0] == "")
             {
                 m_ListView.list.Clear();
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionDebuggerWindow.cs
@@ -9,6 +9,8 @@ namespace UnityEngine.Experimental.Input.Editor
 {
     public class InputActionDebuggerWindow : EditorWindow
     {
+        [NonSerialized] private InputAction m_Action = null;
+
         public static void CreateOrShowExisting(InputAction action)
         {
             // See if we have an existing window for the action and if so pop it in front.
@@ -37,7 +39,7 @@ namespace UnityEngine.Experimental.Input.Editor
         {
         }
 
-        [NonSerialized] private InputAction m_Action;
+ 
 
         private static List<InputActionDebuggerWindow> s_OpenDebuggerWindows;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputBindingDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputBindingDrawer.cs
@@ -153,7 +153,7 @@ namespace UnityEngine.Experimental.Input.Editor
             private int m_SelectedInteraction;
             private ReorderableList m_InteractionListView;
 
-            public Action<SerializedProperty> onApplyCallback;
+            public Action<SerializedProperty> onApplyCallback = null;
 
             public ModifyPopupWindow(SerializedProperty bindingProperty)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputControlPicker/InputControlPickerPopup.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputControlPicker/InputControlPickerPopup.cs
@@ -23,7 +23,6 @@ namespace UnityEngine.Experimental.Input.Editor
         private SerializedProperty m_PathProperty;
         private InputControlTree m_PathTree;
         private TreeViewState m_PathTreeState;
-        private bool m_FirstRenderCompleted;
         string[] m_DeviceFilter;
 
         public InputControlPickerPopup(SerializedProperty pathProperty, TreeViewState treeViewState = null)
@@ -64,7 +63,6 @@ namespace UnityEngine.Experimental.Input.Editor
             var listRect = new Rect(rect.x, rect.y + toolbarRect.height, rect.width, rect.height - toolbarRect.height);
 
             m_PathTree.OnGUI(listRect);
-            m_FirstRenderCompleted = true;
         }
 
         private void OnSelected(string path)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2828,7 +2828,7 @@ namespace UnityEngine.Experimental.Input
                                 deviceDescription: m_AvailableDevices[i].description,
                                 deviceFlags: m_AvailableDevices[i].isNative ? InputDevice.DeviceFlags.Native : 0);
                         }
-                        catch (Exception exception)
+                        catch (Exception)
                         {
                             // Just ignore. Simply means we still can't really turn the device into something useful.
                         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -932,7 +932,7 @@ namespace UnityEngine.Experimental.Input.Plugins.HID
                     usage = usage,
                     usagePage = usagePage,
                     elements = m_Elements != null ? m_Elements.ToArray() : null,
-                    collections = m_Collections != null ? m_Collections.ToArray() : null,
+                    collections =  null,
                 };
 
                 return descriptor;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
@@ -361,12 +361,7 @@ namespace UnityEngine.Experimental.Input.Plugins.HID
             public int? usage;
             public int? usageMinimum;
             public int? usageMaximum;
-            public int? designatorIndex;
-            public int? designatorMinimum;
-            public int? designatorMaximum;
-            public int? stringIndex;
-            public int? stringMinimum;
-            public int? stringMaximum;
+
 
             public List<int> usageList;
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
@@ -42,8 +42,6 @@ namespace UnityEngine.Experimental.Input
                 m_StateBuffer.Dispose();
 
             m_StateBuffer = new NativeArray<byte>();
-            m_Head = 0;
-            m_Tail = 0;
         }
 
         ////REVIEW: make control settable?
@@ -54,8 +52,6 @@ namespace UnityEngine.Experimental.Input
         public int Count { get; private set; }
 
         private NativeArray<byte> m_StateBuffer;
-        private int m_Head;
-        private int m_Tail;
     }
 
     /// <summary>

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -71,6 +71,7 @@ partial class CoreTests
     public void TODO_Actions_CanLayerMapsOnTopOfEachOther()
     {
         // Make up a layered control scheme three levels deep.
+        /*
         var fpsControls = new InputActionMap("fpsControls");
         var moveAction = fpsControls.AddAction("move");
         var shootAction = fpsControls.AddAction("shoot");
@@ -78,7 +79,7 @@ partial class CoreTests
         var sniperControls = new InputActionMap("sniper", extend: fpsControls);
         var scopeAction = sniperControls.AddAction("scope");
         var swapScopeControls = new InputActionMap("swapScope", extend: sniperControls);
-        /*
+   
         swapScopeControls.AddBinding();
 
         // Information from 'baseMap' coming through on 'derivedMap'.

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
@@ -20,6 +20,9 @@ partial class CoreTests
     [Serializable]
     struct PackageJson
     {
+        // Need to pragma out this warning, its a known limitation 
+        // of the compiler to warn when the field is assigned thru serialization
+        #pragma warning disable CS0649
         public string version;
     }
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
@@ -637,10 +637,9 @@ partial class CoreTests
 
     private struct CustomNestedDeviceState : IInputStateTypeInfo
     {
-        [InputControl(name = "button1", layout = "Button")]
-        public int buttons;
 
-        [InputControl(layout = "Axis")] public float axis2;
+
+
 
         public FourCC GetFormat()
         {
@@ -652,7 +651,7 @@ partial class CoreTests
     {
         [InputControl(layout = "Axis")] public float axis;
 
-        public CustomNestedDeviceState nested;
+
 
         public FourCC GetFormat()
         {
@@ -714,7 +713,7 @@ partial class CoreTests
     private struct ExtendedCustomDeviceState : IInputStateTypeInfo
     {
         public CustomDeviceState baseState;
-        public int extra;
+
 
         public FourCC GetFormat()
         {

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Layouts.cs
@@ -1101,13 +1101,11 @@ partial class CoreTests
     // comes out with an "INT" format and not a "FLT" format.
     private struct StateStructWithPrimitiveFields : IInputStateTypeInfo
     {
-        [InputControl(layout = "Axis")] public byte byteAxis;
-        [InputControl(layout = "Axis")] public short shortAxis;
 
-        [InputControl(layout = "Axis")] public int intAxis;
 
-        // No float as that is the default format for Axis anyway.
-        [InputControl(layout = "Axis")] public double doubleAxis;
+
+
+
 
         public FourCC GetFormat()
         {
@@ -1628,11 +1626,9 @@ partial class CoreTests
 
     private struct StateWithTwoLayoutVariants : IInputStateTypeInfo
     {
-        [InputControl(name = "button", layout = "Button", variants = "A")]
-        public int buttons;
 
-        [InputControl(name = "axis", layout = "Axis", variants = "B")]
-        public float axis;
+
+
 
         public FourCC GetFormat()
         {
@@ -1882,8 +1878,8 @@ partial class CoreTests
     //[InputControl(name = "axis", offset = InputStateBlock.kInvalidOffset)]
     private struct BaseInputState : IInputStateTypeInfo
     {
-        [InputControl(layout = "Axis")] public float axis;
-        public int padding;
+
+
         public FourCC GetFormat()
         {
             return new FourCC("BASE");


### PR DESCRIPTION
Was going to bundle this up with other warnings work, but let just get this in develop for now.
This commit cleans out non-rosyln compiler (ie pre 2018.3)