### PR TITLE
NEW: Add the ability for automated test runner to choose runtime.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,9 @@
 stages:
-  - test
+  - test-net4x
+  - test-net20
 
 test:windows:2018-2-net4x:
-  stage: test
+  stage: test-net4x
   image: 'build-pipeline/addressables_win:stable'
   artifacts:
     paths:
@@ -18,7 +19,7 @@ test:windows:2018-2-net4x:
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
 test:windows:2018-3-net4x:
-  stage: test
+  stage: test-net4x
   image: 'build-pipeline/addressables_win:stable'
   artifacts:
     paths:
@@ -34,7 +35,7 @@ test:windows:2018-3-net4x:
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
 test:windows:2019-1-net4x:
-  stage: test
+  stage: test-net4x
   image: 'build-pipeline/addressables_win:stable'
   artifacts:
     paths:
@@ -51,7 +52,7 @@ test:windows:2019-1-net4x:
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
 test:osx:2018-2-net4x:
-  stage: test
+  stage: test-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -68,7 +69,7 @@ test:osx:2018-2-net4x:
     - /opt/post_build_script.sh
 
 test:osx:2018-3-net4x:
-  stage: test
+  stage: test-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -85,7 +86,7 @@ test:osx:2018-3-net4x:
     - /opt/post_build_script.sh
     
 test:osx:2019-1-net4x:
-  stage: test
+  stage: test-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -102,8 +103,10 @@ test:osx:2019-1-net4x:
     - /opt/post_build_script.sh
 
 test:windows:2018-2-net20:
-  stage: test
+  stage: test-net20
   image: 'build-pipeline/addressables_win:stable'
+  dependencies:
+    - test-net40
   artifacts:
     paths:
       - "TestArtifacts"
@@ -118,8 +121,10 @@ test:windows:2018-2-net20:
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
 test:windows:2018-3-net20:
-  stage: test
+  stage: test-net20
   image: 'build-pipeline/addressables_win:stable'
+  dependencies:
+    - test-net40
   artifacts:
     paths:
       - "TestArtifacts"
@@ -134,8 +139,10 @@ test:windows:2018-3-net20:
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
 test:windows:2019-1-net20:
-  stage: test
+  stage: test-net20
   image: 'build-pipeline/addressables_win:stable'
+  dependencies:
+    - test-net40
   artifacts:
     paths:
       - "TestArtifacts"
@@ -151,7 +158,9 @@ test:windows:2019-1-net20:
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
 test:osx:2018-2-net20:
-  stage: test
+  stage: test-net20
+  dependencies:
+    - test-net40
   artifacts:
     paths:
       - "TestArtifacts"
@@ -168,7 +177,9 @@ test:osx:2018-2-net20:
     - /opt/post_build_script.sh
 
 test:osx:2018-3-net20:
-  stage: test
+  stage: test-net20
+  dependencies:
+    - test-net40
   artifacts:
     paths:
       - "TestArtifacts"
@@ -185,7 +196,9 @@ test:osx:2018-3-net20:
     - /opt/post_build_script.sh
     
 test:osx:2019-1-net20:
-  stage: test
+  stage: test-net20
+  dependencies:
+    - test-net40
   artifacts:
     paths:
       - "TestArtifacts"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ test:windows:2018-2:
   tags:
    - bokken-runner
   script:
-    - python.exe -u testrunner.py Editor --version=2018.2
+    - python.exe -u testrunner.py Editor --version=2018.2 --runtime=latest
   before_script:
     - mkdir C:\ProgramData\Unity
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
@@ -28,7 +28,7 @@ test:windows:2018-3:
   tags:
    - bokken-runner
   script:
-    - python.exe -u testrunner.py Editor --version=2018.3
+    - python.exe -u testrunner.py Editor --version=2018.3 --runtime=latest
   before_script:
     - mkdir C:\ProgramData\Unity
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
@@ -45,7 +45,7 @@ test:windows:2019-1:
    - bokken-runner
   script:
     - echo "Running Playmode Tests"
-    - python.exe -u testrunner.py Editor --version=2019.1
+    - python.exe -u testrunner.py Editor --version=2019.1 --runtime=latest
   before_script:
     - mkdir C:\ProgramData\Unity
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
@@ -63,7 +63,7 @@ test:osx:2018-2:
   before_script:
     - curl -o /Library/Application\ Support/Unity/Unity_lic.ulf http://172.28.214.140/upload/licence/Unity_lic.ulf
   script:
-    - python testrunner.py Editor --version=2018.2
+    - python testrunner.py Editor --version=2018.2 --runtime=latest
   after_script:
     - /opt/post_build_script.sh
 
@@ -80,7 +80,7 @@ test:osx:2018-3:
   before_script:
     - curl -o /Library/Application\ Support/Unity/Unity_lic.ulf http://172.28.214.140/upload/licence/Unity_lic.ulf
   script:
-    - python testrunner.py Editor --version=2018.3
+    - python testrunner.py Editor --version=2018.3 --runtime=latest
   after_script:
     - /opt/post_build_script.sh
     
@@ -97,7 +97,7 @@ test:osx:2019-1:
   before_script:
     - curl -o /Library/Application\ Support/Unity/Unity_lic.ulf http://172.28.214.140/upload/licence/Unity_lic.ulf
   script:
-    - python testrunner.py Editor --version=2019.1
+    - python testrunner.py Editor --version=2019.1 --runtime=latest
   after_script:
     - /opt/post_build_script.sh
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 stages:
   - test
 
-test:windows:2018-2:
+test:windows:2018-2-net4x:
   stage: test
   image: 'build-pipeline/addressables_win:stable'
   artifacts:
@@ -17,7 +17,7 @@ test:windows:2018-2:
     - mkdir C:\ProgramData\Unity
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
-test:windows:2018-3:
+test:windows:2018-3-net4x:
   stage: test
   image: 'build-pipeline/addressables_win:stable'
   artifacts:
@@ -33,7 +33,7 @@ test:windows:2018-3:
     - mkdir C:\ProgramData\Unity
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
-test:windows:2019-1:
+test:windows:2019-1-net4x:
   stage: test
   image: 'build-pipeline/addressables_win:stable'
   artifacts:
@@ -50,7 +50,7 @@ test:windows:2019-1:
     - mkdir C:\ProgramData\Unity
     - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
 
-test:osx:2018-2:
+test:osx:2018-2-net4x:
   stage: test
   artifacts:
     paths:
@@ -67,7 +67,7 @@ test:osx:2018-2:
   after_script:
     - /opt/post_build_script.sh
 
-test:osx:2018-3:
+test:osx:2018-3-net4x:
   stage: test
   artifacts:
     paths:
@@ -84,7 +84,7 @@ test:osx:2018-3:
   after_script:
     - /opt/post_build_script.sh
     
-test:osx:2019-1:
+test:osx:2019-1-net4x:
   stage: test
   artifacts:
     paths:
@@ -101,3 +101,103 @@ test:osx:2019-1:
   after_script:
     - /opt/post_build_script.sh
 
+test:windows:2018-2-net20:
+  stage: test
+  image: 'build-pipeline/addressables_win:stable'
+  artifacts:
+    paths:
+      - "TestArtifacts"
+    expire_in: 1 week
+    when: always
+  tags:
+   - bokken-runner
+  script:
+    - python.exe -u testrunner.py Editor --version=2018.2 --runtime=legacy
+  before_script:
+    - mkdir C:\ProgramData\Unity
+    - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
+
+test:windows:2018-3-net20:
+  stage: test
+  image: 'build-pipeline/addressables_win:stable'
+  artifacts:
+    paths:
+      - "TestArtifacts"
+    expire_in: 1 week
+    when: always
+  tags:
+   - bokken-runner
+  script:
+    - python.exe -u testrunner.py Editor --version=2018.3 --runtime=legacy
+  before_script:
+    - mkdir C:\ProgramData\Unity
+    - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
+
+test:windows:2019-1-net20:
+  stage: test
+  image: 'build-pipeline/addressables_win:stable'
+  artifacts:
+    paths:
+      - "TestArtifacts"
+    expire_in: 1 week
+    when: always
+  tags:
+   - bokken-runner
+  script:
+    - echo "Running Playmode Tests"
+    - python.exe -u testrunner.py Editor --version=2019.1 --runtime=legacy
+  before_script:
+    - mkdir C:\ProgramData\Unity
+    - wget -P C:\ProgramData\Unity\ http://172.28.214.140/upload/licence/Unity_lic.ulf
+
+test:osx:2018-2-net20:
+  stage: test
+  artifacts:
+    paths:
+      - "TestArtifacts"
+    expire_in: 1 week
+    when: always
+  tags:
+    - buildfarm
+    - darwin
+  before_script:
+    - curl -o /Library/Application\ Support/Unity/Unity_lic.ulf http://172.28.214.140/upload/licence/Unity_lic.ulf
+  script:
+    - python testrunner.py Editor --version=2018.2 --runtime=legacy
+  after_script:
+    - /opt/post_build_script.sh
+
+test:osx:2018-3-net20:
+  stage: test
+  artifacts:
+    paths:
+      - "TestArtifacts"
+    expire_in: 1 week
+    when: always
+  tags:
+    - buildfarm
+    - darwin
+  before_script:
+    - curl -o /Library/Application\ Support/Unity/Unity_lic.ulf http://172.28.214.140/upload/licence/Unity_lic.ulf
+  script:
+    - python testrunner.py Editor --version=2018.3 --runtime=legacy
+  after_script:
+    - /opt/post_build_script.sh
+    
+test:osx:2019-1-net20:
+  stage: test
+  artifacts:
+    paths:
+      - "TestArtifacts"
+    expire_in: 1 week
+    when: always
+  tags:
+    - buildfarm
+    - darwin
+  before_script:
+    - curl -o /Library/Application\ Support/Unity/Unity_lic.ulf http://172.28.214.140/upload/licence/Unity_lic.ulf
+  script:
+    - python testrunner.py Editor --version=2019.1 --runtime=legacy
+  after_script:
+    - /opt/post_build_script.sh
+    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -106,7 +106,7 @@ test:windows:2018-2-net20:
   stage: test-net20
   image: 'build-pipeline/addressables_win:stable'
   dependencies:
-    - test-net40
+    - test:windows:2018-2-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -124,7 +124,7 @@ test:windows:2018-3-net20:
   stage: test-net20
   image: 'build-pipeline/addressables_win:stable'
   dependencies:
-    - test-net40
+    - test:windows:2018-3-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -142,7 +142,7 @@ test:windows:2019-1-net20:
   stage: test-net20
   image: 'build-pipeline/addressables_win:stable'
   dependencies:
-    - test-net40
+    - test:windows:2019-1-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -160,7 +160,7 @@ test:windows:2019-1-net20:
 test:osx:2018-2-net20:
   stage: test-net20
   dependencies:
-    - test-net40
+    - test:osx:2018-2-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -179,7 +179,7 @@ test:osx:2018-2-net20:
 test:osx:2018-3-net20:
   stage: test-net20
   dependencies:
-    - test-net40
+    - test:osx:2018-3-net4x
   artifacts:
     paths:
       - "TestArtifacts"
@@ -198,7 +198,7 @@ test:osx:2018-3-net20:
 test:osx:2019-1-net20:
   stage: test-net20
   dependencies:
-    - test-net40
+    - test:osx:2019-1-net4x
   artifacts:
     paths:
       - "TestArtifacts"

--- a/testrunner.py
+++ b/testrunner.py
@@ -9,6 +9,7 @@ print(sys.version)
 kPIPDownloadName = "http://172.28.214.140/tools/unity-downloader/unity-downloader-cli-0.1.tar.gz"
 
 allPlatforms = ["Editor", "StandaloneLinux", "StandaloneLinux64", "StandaloneOSX", "StandaloneWindows", "StandaloneWindows64", "Android", "iOS"]
+allRuntimes = ["latest", "legacy"]
 
 editorRevisions = {
     "2018.2": "5c716fc4faab59de610b4b74b9dad7c9f7ae60b0",
@@ -51,10 +52,12 @@ def RunProcess(args):
 parser = argparse.ArgumentParser(description="Run the trace event profiler tests")
 parser.add_argument('runtimePlatform', nargs='*', choices=allPlatforms)
 parser.add_argument('--version', choices=editorRevisions.keys())
+parser.add_argument('--runtime', choices=allRuntimes)
 args = parser.parse_args(sys.argv[1:])
 
 runtimePlatforms = args.runtimePlatform
 unityVersion = args.version
+runtimeVersion = args.runtime
 
 kRootRepoDirectory = os.path.dirname(os.path.realpath(__file__))
 kProjectPath = os.path.dirname(os.path.realpath(__file__))
@@ -88,6 +91,7 @@ for platform in runtimePlatforms:
     runOptions["projectPath"] = kProjectPath
     runOptions["testResults"] = os.path.join(kTestArtifactPath, "%s_TestResults.txt" % platform)
     runOptions["logFile"] = os.path.join(kTestArtifactPath, "%s_EditorLog.txt" % platform)
+    runOptions["scripting-runtime-version"] = runtimeVersion
 
     if(platform != "Editor"):
         runOptions["testPlatform"] = platform


### PR DESCRIPTION
defaulting all tests to latest.  legacy is deprecated as of 2018.3.