### PR TITLE
Sensitivity fix: 1102635, 1102629

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/SensitivityProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/SensitivityProcessor.cs
@@ -16,15 +16,22 @@ namespace UnityEngine.Experimental.Input.Processors
         public Vector2 Process(Vector2 value, InputControl control)
         {
             // Query dimensions of device.
-            var dimensions = new Vector2(1f, 1f);
             var device = control.device;
             var command = QueryDimensionsCommand.Create();
             if (device.ExecuteCommand(ref command) >= 0)
+            {
+                var dimensions = new Vector2(1f, 1f);
                 dimensions = command.outDimensions;
 
-            // Scale X and Y.
-            var sensitivityValue = sensitivityOrDefault;
-            return new Vector2(value.x / dimensions.x * sensitivityValue, value.y / dimensions.y * sensitivityValue);
+                // Scale X and Y.
+                var sensitivityValue = sensitivityOrDefault;
+                return new Vector2(value.x / dimensions.x * sensitivityValue,
+                    value.y / dimensions.y * sensitivityValue);
+            }
+
+            // If we can't get dimensions from the device,
+            // leave the value alone.
+            return value;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -4402,6 +4402,27 @@ partial class CoreTests
             Has.All.Matches((InputManager.StateChangeMonitorsForDevice x) => x.count == 0));
     }
 
+    [Test]
+    [Category("Actions")]
+    public void Actions_SensitivityProcessorDoesNotCorruptValues() 
+    {
+        var pointer = InputSystem.AddDevice<Pointer>();
+        var action = new InputAction();
+        action.AddBinding("/<Pointer>/delta");
+
+        Vector2? look = null;
+        action.performed +=
+            ctx => { look = ctx.ReadValue<Vector2>(); };
+
+        action.Enable();
+
+        InputSystem.QueueStateEvent(pointer, new PointerState { delta = new Vector2(59.0f, 38.0f) });
+        InputSystem.Update();
+        Assert.That(look.HasValue, Is.True);
+        Assert.That(look.Value.x, Is.EqualTo(59.0).Within(0.000001));
+        Assert.That(look.Value.y, Is.EqualTo(38.0f).Within(0.000001));
+    }
+
     // This test requires that pointer deltas correctly snap back to 0 when the pointer isn't moved.
     [Test]
     [Category("Actions")]


### PR DESCRIPTION
Devices that do not have dimensions corrupt data in the sensitivity processor.  Fix is to let value pass thru if there are no dimensions available from the device.