### PR TITLE
CHANGE: Update script compiler test with latest trunk code.

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Compilation/ScriptCompilersTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Compilation/ScriptCompilersTests.cs
@@ -71,13 +71,18 @@ public class ScriptCompilersTests
 
         var apiCompatibilityLevel = PlayerSettings.GetApiCompatibilityLevel(EditorUserBuildSettings.activeBuildTargetGroup);
 
+        // Hopefully the churn on these mono library helpers is over, this is going to be a bit a pain to 
+        // always chase.
+#if UNITY_2018_3_OR_NEWER && !(UNITY_2019_1_OR_NEWER)
         var scriptAssembly = new ScriptAssembly
         {
             Filename = AssetPath.GetFileName(outputAssemblyPath),
             Flags = AssemblyFlags.None
         };
-
         references.AddRange(MonoLibraryHelpers.GetSystemLibraryReferences(apiCompatibilityLevel, buildTarget, language, true, scriptAssembly));
+#elif UNITY_2019_1_OR_NEWER
+        references.AddRange(MonoLibraryHelpers.GetSystemLibraryReferences(apiCompatibilityLevel, buildTarget, language));
+#endif
 
         var sources = new List<string>();
         sources.AddRange(Directory.GetFiles(inputFilePath, "*.cs", SearchOption.AllDirectories));


### PR DESCRIPTION
compiler classes changed in 2019.1 trunk.  Added ifdef, really hope they don't change this code too much more, starting to be come a maintenance issue.