### PR TITLE
Bug 295: Fixed device count not ready in Start/Awake for editor.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1640,6 +1640,10 @@ namespace UnityEngine.Experimental.Input
                     EditorPlayerSettings.newSystemBackendsEnabled = true;
             }
             s_SystemObject.newInputBackendsCheckedAsEnabled = true;
+
+            // Send an initial Update so that user methods such as Start and Awake
+            // can access the input devices.
+            Update();
         }
 
         internal static void OnPlayModeChange(PlayModeStateChange change)


### PR DESCRIPTION
Was already fixed in player.  Was previously working in editor for other reasons, but code changes in Editor most likely took away that functionality.  Fixed now in editor with same fix that was in player.  