### PR TITLE
FIX: Pass package manager validation suite.

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Compilation/Assembly-CSharp-Editor-testable.asmdef
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Compilation/Assembly-CSharp-Editor-testable.asmdef
@@ -2,7 +2,7 @@
     "name": "Assembly-CSharp-Editor-testable",
     "references": [],
     "optionalUnityReferences": [ "TestAssemblies" ],
-    "includePlatforms": [],
+    "includePlatforms": ["Editor"],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,9 +1,9 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "0.0.12-preview",
+	"version": "0.0.14-preview",
 	"unity": "2018.2",
-	"description": "A new input system.",
+	"description": "A new input system composed of Controls, Layouts, States and Actions.",
 	"keywords": [
 		"input",
 		"events",


### PR DESCRIPTION
First step before I can submit a request of production consideration is the package manager validation suite.   Had to tweak a few trivial fields to get it to pass.  I guess our description was not long enough, so I threw in some more words?  Feel free to suggest a better description.    Here are results of a clean pass on latest develop.  Will have to wait for these changes to get into 0.0.15-preview in staging to actually formally submit to release management.

Validation Suite Results for package "com.unity.inputsystem"
 - Path: C:\Users\UnityAdmin\Desktop\TEST777\Packages\com.unity.inputsystem
 - Version: 0.0.14-preview
 - Test Time: 12/12/2018 11:47:35 AM

VALIDATION RESULTS:
-------------------

Succeeded - "Assembly Definition Validation"
Checking: {Package-Root}\InputSystem\Unity.InputSystem.asmdef

Checking: {Package-Root}\Tests\InputSystem\Unity.InputSystem.Tests.asmdef

Checking: {Package-Root}\Tests\InputSystem\Compilation\Assembly-CSharp-Editor-testable.asmdef

Checking: {Package-Root}\Tests\InputSystem\Editor\EditorTests.asmdef

Succeeded - "ChangeLog Validation"

Succeeded - "Dependency Validation"

Succeeded - "Documentation Validation"

Succeeded - "Manifest Validation"
Skipping Git tags check as this is a package in development.

Succeeded - "Meta Files Validation"

Succeeded - "Required File Type Validation"

Succeeded - "Restricted File Type Validation"

Succeeded - "Tests Validation"

Succeeded - "Unity Version Validation"

Succeeded - "Package Update Validation"

NotRun - "API Validation"
No previous package version. Skipping Semantic Versioning checks.

NotRun - "Package Diff Evaluation"
No previous package version. Skipping diff evaluation.

NotRun - "Project Template Validation"
com.unity.inputsystem is not a project template.

NotRun - "Samples Validation"
No samples found. Skipping Samples Validation.

NotImplementedYet - "Folder Structure Validation"

NotImplementedYet - "License Validation"

NotImplementedYet - "Signature Validation"
