### PR TITLE
FIX: Updated PS4 tests for 2019.1 version as they no longer user IOCT…

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/PS4Tests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/PS4Tests.cs
@@ -134,6 +134,36 @@ public class PS4Tests : InputTestFixture
     [Category("Devices")]
     public void Devices_CanReadSlotIndexAndGetDualShockPS4BySlotIndex()
     {
+#if UNITY_2019_1_OR_NEWER
+
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            deviceClass = "PS4DualShockGamepad",
+            interfaceName = "PS4",
+            capabilities = new PS4InputDeviceDescriptor { slotId = 0, isAimController = false,  defaultColorId = 0, userId = 1234  }.ToJson()
+        }.ToJson(), 1);
+
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            deviceClass = "PS4DualShockGamepad",
+            interfaceName = "PS4",
+            capabilities = new PS4InputDeviceDescriptor { slotId = 1, isAimController = false, defaultColorId = 0, userId = 1234 }.ToJson()
+        }.ToJson(), 2);
+
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            deviceClass = "PS4DualShockGamepad",
+            interfaceName = "PS4",
+            capabilities = new PS4InputDeviceDescriptor { slotId = 2, isAimController = false, defaultColorId = 0, userId = 1234 }.ToJson()
+        }.ToJson(), 3);
+
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            deviceClass = "PS4DualShockGamepad",
+            interfaceName = "PS4",
+            capabilities = new PS4InputDeviceDescriptor { slotId = 3, isAimController = false, defaultColorId = 0, userId = 1234 }.ToJson()
+        }.ToJson(), 4);
+#else
         runtime.ReportNewInputDevice(new InputDeviceDescription
         {
             deviceClass = "PS4DualShockGamepad",
@@ -159,6 +189,7 @@ public class PS4Tests : InputTestFixture
         runtime.SetDeviceCommandCallback(2, QueryPS4ControllerInfo.Create().WithSlotIndex(1));
         runtime.SetDeviceCommandCallback(3, QueryPS4ControllerInfo.Create().WithSlotIndex(2));
         runtime.SetDeviceCommandCallback(4, QueryPS4ControllerInfo.Create().WithSlotIndex(3));
+#endif
 
         InputSystem.Update();
 
@@ -182,6 +213,31 @@ public class PS4Tests : InputTestFixture
     [Category("Devices")]
     public unsafe void Devices_CanQueryPS4UserIdFromDualShockPS4()
     {
+#if UNITY_2019_1_OR_NEWER
+
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            deviceClass = "PS4DualShockGamepad",
+            interfaceName = "PS4",
+            capabilities = new PS4InputDeviceDescriptor
+            {
+                slotId = 0,
+                isAimController = false,
+                defaultColorId = 0,
+                userId = 1234
+            }.ToJson()
+        }.ToJson(), 1);
+        InputSystem.Update();
+
+        InputDevice device = InputSystem.devices[0];
+
+        Assert.That(device, Is.AssignableTo<DualShockGamepadPS4>());
+
+        var gamepad = (DualShockGamepadPS4)device;
+
+        Assert.That(gamepad.ps4UserId, Is.EqualTo(1234));
+        Assert.That(gamepad.slotIndex, Is.EqualTo(0));
+#else
         runtime.ReportNewInputDevice(new InputDeviceDescription
         {
             deviceClass = "PS4DualShockGamepad",
@@ -204,11 +260,12 @@ public class PS4Tests : InputTestFixture
                 Assert.Fail("Received wrong type of command");
                 return InputDeviceCommand.kGenericFailure;
             });
-        
+
         InputSystem.Update();
         var gamepad = (DualShockGamepadPS4)InputSystem.devices[0];
 
         Assert.That(gamepad.ps4UserId, Is.EqualTo(1234));
+#endif
     }
 
     [Test]


### PR DESCRIPTION
…L but use 'capabilities' instead for some fields.