### PR TITLE
FIX: Native Event Buffer changes have landed in 2019_1.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -64,7 +64,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
                 ////      to mutate the buffer and keep events around from update to update.
 
                 if (value != null)
-                    #if UNITY_2019_2_OR_NEWER
+                    #if UNITY_2019_1_OR_NEWER
                     NativeInputSystem.onUpdate =
                         (updateType, eventBufferPtr) =>
                     {


### PR DESCRIPTION
Fix 2019.1.0 beta1  compile issue now that native event has landed.