### PR TITLE
Fix exceptions on domain reload

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3269,7 +3269,7 @@ namespace UnityEngine.Experimental.Input
                         // to create a device with the same layout.
                         if (!deviceState.description.empty)
                         {
-                            device = AddDevice(deviceState.description, throwIfNoLayoutFound: true,
+                            device = AddDevice(deviceState.description, throwIfNoLayoutFound: false,
                                 deviceId: deviceState.deviceId, deviceFlags: deviceState.flags);
                         }
                         else


### PR DESCRIPTION
Currently, we add newly discovered devices with `throwIfNoLayoutFound: false`, but then, on domain reload, we re-add the same devices with `throwIfNoLayoutFound: true`, which causes exceptions in the console on domain reload (for instance when entering play mode on the mac, which reports some devices we don't not know how to deal with: https://github.com/Unity-Technologies/InputSystem/issues/252). We should handle both cases equally.