### PR TITLE
Fix beep when binding keys interactively

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionAsset/AssetInspectorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionAsset/AssetInspectorWindow.cs
@@ -558,6 +558,11 @@ namespace UnityEngine.Experimental.Input.Editor
                 m_BindingPropertyView.CancelInteractivePicking();
                 Repaint();
             }
+
+            // Eat key events to supress the editor from passing them to the OS 
+            // (causing beeps or menu commands being triggered).
+            if (Event.current.isKey)
+                Event.current.Use();            
         }
 
         public static void RefreshAllOnAssetReimport()


### PR DESCRIPTION
Fix https://fogbugz.unity3d.com/f/cases/1105301

Longer term, this raises some questions. The IMGUI Event system is currently deeply interleaved with OS event handling, and it handles things like marking events as "used", so they won't get passed on to the OS (which is the case here). If we want to drive this system by the new Input system (which I think we should), then we'd also need to handle this logic in the new input system. But given that the new input system buffers events and processes them later, I guess we could not actually do that (?). So this might be a blocking problem in the idea of driving IMGUI events from the new input system.