### PR TITLE
Action importer fixes

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the input system package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.x.x-preview] - XXXX-XX-XX
+
+### Fixes
+- InputActions editor: Fixed warnings in Console when using InputActions editor
+- InputActions editor: Fixed Assert when generating C# class and make sure it gets imported correctly
+- InputActions editor: Generate directories as needed when generating C# class, and allow path names without "Assets/" path prefix.
+
 ## [0.2.0-preview] - 2019-02-12
 
 This release contains a number of fairly significant changes. The focus has been on further improving the action system to make it easier to use as well as to make it work more reliably and predictably.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionCodeGenerator.cs
@@ -472,13 +472,6 @@ namespace UnityEngine.Experimental.Input.Editor
                     return false;
             }
 
-            if (!filePath.ToLower().StartsWith("assets/"))
-                filePath = Path.Combine("Assets", filePath);
-
-            var dir = Path.GetDirectoryName(filePath);
-            if (!Directory.Exists(dir))
-                Directory.CreateDirectory(dir);
-
             // Write.
             File.WriteAllText(filePath, code);
             return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionCodeGenerator.cs
@@ -472,6 +472,13 @@ namespace UnityEngine.Experimental.Input.Editor
                     return false;
             }
 
+            if (!filePath.ToLower().StartsWith("assets/"))
+                filePath = Path.Combine("Assets", filePath);
+
+            var dir = Path.GetDirectoryName(filePath);
+            if (!Directory.Exists(dir))
+                Directory.CreateDirectory(dir);
+
             // Write.
             File.WriteAllText(filePath, code);
             return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionImporter.cs
@@ -53,16 +53,6 @@ namespace UnityEngine.Experimental.Input.Editor
             remove => s_OnImportCallbacks.Remove(value);
         }
 
-        // When we generate the wrapper code cs file during asset import, we cannot call ImportAsset on that directly because
-        // script assets have to be imported before all other assets, and are not allowed to be added to the import queue during
-        // asset import. So instead we register a callback to trigger a delayed asset refresh which should then pick up the
-        // changed/added script, and trigger a new import.
-        static void DelayedRefresh()
-        {
-            AssetDatabase.Refresh();
-            EditorApplication.update -= DelayedRefresh;
-        }
-
         public override void OnImportAsset(AssetImportContext ctx)
         {
             foreach (var callback in s_OnImportCallbacks)
@@ -212,8 +202,21 @@ namespace UnityEngine.Experimental.Input.Editor
                     generateInterfaces = m_GenerateInterfaces,
                 };
 
+                if (!wrapperFilePath.ToLower().StartsWith("assets/"))
+                    wrapperFilePath = Path.Combine("Assets", wrapperFilePath);
+
+                var dir = Path.GetDirectoryName(wrapperFilePath);
+                if (!Directory.Exists(dir))
+                    Directory.CreateDirectory(dir);
+
                 if (InputActionCodeGenerator.GenerateWrapperCode(wrapperFilePath, maps, asset.controlSchemes, options))
-                    EditorApplication.update += DelayedRefresh;
+                {
+                    // When we generate the wrapper code cs file during asset import, we cannot call ImportAsset on that directly because
+                    // script assets have to be imported before all other assets, and are not allowed to be added to the import queue during
+                    // asset import. So instead we register a callback to trigger a delayed asset refresh which should then pick up the
+                    // changed/added script, and trigger a new import.
+                    EditorApplication.delayCall += AssetDatabase.Refresh;
+                }
             }
 
             // Refresh editors.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionImporterEditor.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.Experimental.Input.Editor
         public override void OnInspectorGUI()
         {
             serializedObject.Update();
+
             // Button to pop up window to edit the asset.
             if (GUILayout.Button("Edit asset"))
                 AssetInspectorWindow.OnOpenAsset(GetAsset().GetInstanceID(), 0);
@@ -65,7 +66,11 @@ namespace UnityEngine.Experimental.Input.Editor
                 EditorGUILayout.PropertyField(generateActionEventsProperty, m_GenerateActionEventsLabel);
                 EditorGUILayout.PropertyField(generateInterfacesProperty);
             }
+
+            // Using ApplyRevertGUI requires calling Update and ApplyModifiedProperties around the serializedObject,
+            // and will print warning messages otherwise (see warning message in ApplyRevertGUI implementation).
             serializedObject.ApplyModifiedProperties();
+
             ApplyRevertGUI();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputActionImporterEditor.cs
@@ -17,6 +17,7 @@ namespace UnityEngine.Experimental.Input.Editor
     {
         public override void OnInspectorGUI()
         {
+            serializedObject.Update();
             // Button to pop up window to edit the asset.
             if (GUILayout.Button("Edit asset"))
                 AssetInspectorWindow.OnOpenAsset(GetAsset().GetInstanceID(), 0);
@@ -64,7 +65,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 EditorGUILayout.PropertyField(generateActionEventsProperty, m_GenerateActionEventsLabel);
                 EditorGUILayout.PropertyField(generateInterfacesProperty);
             }
-
+            serializedObject.ApplyModifiedProperties();
             ApplyRevertGUI();
         }
 


### PR DESCRIPTION
I was looking at https://fogbugz.unity3d.com/f/cases/1091478, and an across some more issues while fixing that:

- InputActions editor: Fixed warnings in Console when using InputActions editor
- InputActions editor: Fixed Assert when generating C# class and make sure it gets imported correctly
- InputActions editor: Generate directories as needed when generating C# class, and allow path names without "Assets/" path prefix.