### PR TITLE
 Don't incorrectly create non-functioning devices

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Remote connections in input debugger now remain connected across domain reloads.
+- Don't incorrectly create non-functioning devices if a physical device implements multiple incompatible logical HID devices (such as the MacBook keyboard/touch pad and touch bar).
 
 Actions:
 - Editor beeping or triggering menu commands when binding keys interactively.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -139,17 +139,18 @@ namespace UnityEngine.Experimental.Input.Plugins.HID
             // We go with the string versions if we have them and with the numeric versions if we don't.
             string layoutName;
             var deviceMatcher = InputDeviceMatcher.FromDeviceDescription(description);
+            var usageName = hidDeviceDescriptor.usagePage == UsagePage.GenericDesktop ? ((GenericDesktop)hidDeviceDescriptor.usage).ToString() : hidDeviceDescriptor.usagePage.ToString();
             if (!string.IsNullOrEmpty(description.product) && !string.IsNullOrEmpty(description.manufacturer))
             {
-                layoutName = string.Format("{0}::{1} {2}", kHIDNamespace, description.manufacturer, description.product);
+                layoutName = string.Format("{0}::{1} {2} {3}", kHIDNamespace, description.manufacturer, description.product, usageName);
             }
             else
             {
                 // Sanity check to make sure we really have the data we expect.
                 if (hidDeviceDescriptor.vendorId == 0)
                     return null;
-                layoutName = string.Format("{0}::{1:X}-{2:X}", kHIDNamespace, hidDeviceDescriptor.vendorId,
-                    hidDeviceDescriptor.productId);
+                layoutName = string.Format("{0}::{1:X}-{2:X} {3}", kHIDNamespace, hidDeviceDescriptor.vendorId,
+                    hidDeviceDescriptor.productId, usageName);
 
                 deviceMatcher = deviceMatcher
                     .WithCapability("productId", hidDeviceDescriptor.productId)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -155,6 +155,11 @@ namespace UnityEngine.Experimental.Input.Plugins.HID
                     .WithCapability("productId", hidDeviceDescriptor.productId)
                     .WithCapability("vendorId", hidDeviceDescriptor.vendorId);
             }
+
+            // We also need to match the devices usage. This is because some physical devices may report multiple
+            // logical devices with different, incompatible properties (this is the case for the MacBook keyboard/mouse 
+            // and touch bar devices). These devices will then match by vendor/product ids, but get different usages.
+            // Incorrectly matching them would generate garbage devices and errors on domain reload.
             deviceMatcher = deviceMatcher
                 .WithCapability("usage", hidDeviceDescriptor.usage)
                 .WithCapability("usagePage", hidDeviceDescriptor.usagePage);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -151,9 +151,13 @@ namespace UnityEngine.Experimental.Input.Plugins.HID
                 layoutName = string.Format("{0}::{1:X}-{2:X}", kHIDNamespace, hidDeviceDescriptor.vendorId,
                     hidDeviceDescriptor.productId);
 
-                deviceMatcher.WithCapability("productId", hidDeviceDescriptor.productId);
-                deviceMatcher.WithCapability("vendorId", hidDeviceDescriptor.vendorId);
+                deviceMatcher = deviceMatcher
+                    .WithCapability("productId", hidDeviceDescriptor.productId)
+                    .WithCapability("vendorId", hidDeviceDescriptor.vendorId);
             }
+            deviceMatcher = deviceMatcher
+                .WithCapability("usage", hidDeviceDescriptor.usage)
+                .WithCapability("usagePage", hidDeviceDescriptor.usagePage);
 
             // Register layout builder that will turn the HID descriptor into an
             // InputControlLayout instance.


### PR DESCRIPTION
Don't incorrectly create non-functioning devices if a physical device implements multiple incompatible logical HID devices.

This is the proper fix for the issue where we get errors recreating devices on domain reload. It also gets rid of the unusable garbage duplicate devices.

What was happening is that some devices on the mac report as multiple incompatible HID devices, most of which we have no use for. Then, if we'd detect one instance which we could use, we'd create a device, and a device matcher, which would then go back and create devices for all the HID devices we had no use for, as they have the same product and vendor ids. Then when domain reloading, depending on the order of devices, we may have not recreated that matcher yet, so we get an exception when trying to create them again.