### PR TITLE
Removed non-functioning sort triangles in event list in Input Debugger device windows.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remote connections in input debugger now remain connected across domain reloads.
 - Don't incorrectly create non-functioning devices if a physical device implements multiple incompatible logical HID devices (such as the MacBook keyboard/touch pad and touch bar).
+- Removed non-functioning sort triangles in event list in Input Debugger device windows.
 
 Actions:
 - Editor beeping or triggering menu commands when binding keys interactively.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputEventTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputEventTreeView.cs
@@ -64,35 +64,40 @@ namespace UnityEngine.Experimental.Input.Editor
             {
                 width = 80,
                 minWidth = 60,
-                headerContent = new GUIContent("Id")
+                headerContent = new GUIContent("Id"),
+                canSort = false
             };
             columns[(int)ColumnId.Type] =
                 new MultiColumnHeaderState.Column
             {
                 width = 60,
                 minWidth = 60,
-                headerContent = new GUIContent("Type")
+                headerContent = new GUIContent("Type"),
+                canSort = false
             };
             columns[(int)ColumnId.Device] =
                 new MultiColumnHeaderState.Column
             {
                 width = 80,
                 minWidth = 60,
-                headerContent = new GUIContent("Device")
+                headerContent = new GUIContent("Device"),
+                canSort = false
             };
             columns[(int)ColumnId.Size] =
                 new MultiColumnHeaderState.Column
             {
                 width = 50,
                 minWidth = 50,
-                headerContent = new GUIContent("Size")
+                headerContent = new GUIContent("Size"),
+                canSort = false
             };
             columns[(int)ColumnId.Time] =
                 new MultiColumnHeaderState.Column
             {
                 width = 100,
                 minWidth = 80,
-                headerContent = new GUIContent("Time")
+                headerContent = new GUIContent("Time"),
+                canSort = false
             };
 
             columns[(int)ColumnId.Details] =
@@ -100,7 +105,8 @@ namespace UnityEngine.Experimental.Input.Editor
             {
                 width = 250,
                 minWidth = 100,
-                headerContent = new GUIContent("Details")
+                headerContent = new GUIContent("Details"),
+                canSort = false
             };
 
             return new MultiColumnHeaderState(columns);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputEventTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputEventTreeView.cs
@@ -15,6 +15,8 @@ using UnityEngine.Profiling;
 
 ////TODO: add diagnostics to immediately highlight problems with events (e.g. events getting ignored because of incorrect type codes)
 
+////TODO: implement support for sorting data by different property collumns (we currently always sort events by ID)
+
 namespace UnityEngine.Experimental.Input.Editor
 {
     // Multi-column TreeView that shows the events in a trace.


### PR DESCRIPTION
Currently, in the event lists in the Input Debugger device windows, we show clickable sort triangles for each column. But these don't work, as we have not implemented the logic to sort by the different data types. I don't think that in our case there is any actual user need for sorting this data by different types, so I removed the disfunctional search triangle widgets.