### PR TITLE
Sort events by id instead of by time

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Remote connections in input debugger now remain connected across domain reloads.
 - Don't incorrectly create non-functioning devices if a physical device implements multiple incompatible logical HID devices (such as the MacBook keyboard/touch pad and touch bar).
+- Sort events in input debugger window by id rather then by timestamp.
 
 Actions:
 - Editor beeping or triggering menu commands when binding keys interactively.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputEventTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputEventTreeView.cs
@@ -188,11 +188,11 @@ namespace UnityEngine.Experimental.Input.Editor
             Array.Sort(m_Events,
                 (a, b) =>
                 {
-                    var aTime = a.time;
-                    var bTime = b.time;
-                    if (aTime > bTime)
+                    var aId = a.id;
+                    var bId = b.id;
+                    if (aId > bId)
                         return -1;
-                    if (bTime > aTime)
+                    if (aId < bId)
                         return 1;
                     return 0;
                 });


### PR DESCRIPTION
In response to https://fogbugz.unity3d.com/f/cases/1132707/, I opened this native PR to fix time stamps on windows: https://ono.unity3d.com/unity/unity/pull-request/83921/_/platform/foundation/fix-windows-input-timestamps

As a result of that, multiple events which have identical time stamps from the OS (which is not uncommon when eg. moving the mouse, as the resolution of the OS timer is low on windows) would now also get identical time stamps in Unity (which makes sense).

But this would result in events being shown in ambiguous order when sorted by time stamp in the UI. So instead we sort by Event ID (which should still grow with time), which defines a well-defined order.