### PR TITLE
CHANGE: With recent commit to HID, we now have usage in the name.

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/HIDTests.cs
@@ -562,7 +562,7 @@ internal class HIDTests : InputTestFixture
     // direct control over the naming.
     [Test]
     [Category("Devices")]
-    public void Devices_HIDsWithoutProductName_AreNamedByTheirVendorAndProductID()
+    public void Devices_HIDsWithoutProductName_AreNamedByTheirVendorAndProductIDAndUsageName()
     {
         var hidDescriptor = new HID.HIDDeviceDescriptor
         {
@@ -586,7 +586,7 @@ internal class HIDTests : InputTestFixture
         InputSystem.Update();
 
         var device = (HID)InputSystem.devices.First(x => x is HID);
-        Assert.That(device.name, Is.EqualTo("1234-5678"));
+        Assert.That(device.name, Is.EqualTo("1234-5678 MultiAxisController"));
     }
 
     [Test]


### PR DESCRIPTION
Looks like there was a recent change to how handle HID.   I modified the test, to reflect changes.  

Did the change actually break the test? If so, I will revert this PR.   The HIDS now report usage in the
device name.