### PR TITLE
Use native InputEvent struct from unity

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -11,7 +11,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
     /// A chunk of memory signaling a data transfer in the input system.
     /// </summary>
     // NOTE: This has to be layout compatible with native events.
-    [StructLayout(LayoutKind.Explicit)]
+    [StructLayout(LayoutKind.Explicit, Size = kBaseEventSize)]
     public struct InputEvent
     {
         private const uint kHandledMask = 0x80000000;
@@ -120,6 +120,14 @@ namespace UnityEngine.Experimental.Input.LowLevel
         {
             get => m_Event.time;
             set => m_Event.time = value;
+        }
+
+        static InputEvent()
+        {
+            unsafe
+            {
+                Debug.Assert(kBaseEventSize == sizeof(NativeInputEvent), "kBaseEventSize sizemust match NativeInputEvent struct size.");
+            }
         }
 
         public InputEvent(FourCC type, int sizeInBytes, int deviceId, double time = -1)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using UnityEngine.Experimental.Input.Utilities;
+using UnityEngineInternal.Input;
 
 ////REVIEW: can we get rid of the timestamp offsetting in the player and leave that complication for the editor only?
 
@@ -10,7 +11,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
     /// A chunk of memory signaling a data transfer in the input system.
     /// </summary>
     // NOTE: This has to be layout compatible with native events.
-    [StructLayout(LayoutKind.Explicit, Size = kBaseEventSize)]
+    [StructLayout(LayoutKind.Explicit)]
     public struct InputEvent
     {
         private const uint kHandledMask = 0x80000000;
@@ -20,19 +21,16 @@ namespace UnityEngine.Experimental.Input.LowLevel
         public const int kInvalidId = 0;
         public const int kAlignment = 4;
 
-        [FieldOffset(0)] private FourCC m_Type;
-        [FieldOffset(4)] private ushort m_SizeInBytes;
-        [FieldOffset(6)] private ushort m_DeviceId;
-        [FieldOffset(8)] internal uint m_EventId;
-        [FieldOffset(12)] private double m_Time;
+        [FieldOffset(0)]
+        private NativeInputEvent m_Event;
 
         /// <summary>
         /// Type code for the event.
         /// </summary>
         public FourCC type
         {
-            get => m_Type;
-            set => m_Type = value;
+            get => new FourCC((int)m_Event.type);
+            set => m_Event.type = (NativeInputEventType)(int)value;
         }
 
         /// <summary>
@@ -60,12 +58,12 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// </example>
         public uint sizeInBytes
         {
-            get => m_SizeInBytes;
+            get => m_Event.sizeInBytes;
             set
             {
                 if (value > ushort.MaxValue)
                     throw new ArgumentException("Maximum event size is " + ushort.MaxValue, nameof(value));
-                m_SizeInBytes = (ushort)value;
+               m_Event.sizeInBytes = (ushort)value;
             }
         }
 
@@ -77,8 +75,8 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// </remarks>
         public int eventId
         {
-            get => (int)(m_EventId & kIdMask);
-            set => m_EventId = (uint)value | (m_EventId & ~kIdMask);
+            get => (int)(m_Event.eventId & kIdMask);
+            set => m_Event.eventId = (int)(value | (m_Event.eventId & ~kIdMask));
         }
 
         /// <summary>
@@ -93,8 +91,8 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// <seealso cref="InputSystem.GetDeviceById"/>
         public int deviceId
         {
-            get => m_DeviceId;
-            set => m_DeviceId = (ushort)value;
+            get => m_Event.deviceId;
+            set => m_Event.deviceId = (ushort)value;
         }
 
         /// <summary>
@@ -106,8 +104,8 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// </remarks>
         public double time
         {
-            get => m_Time - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
-            set => m_Time = value + InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
+            get => m_Event.time - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
+            set => m_Event.time = value + InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
         }
 
         /// <summary>
@@ -120,8 +118,8 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// </remarks>
         internal double internalTime
         {
-            get => m_Time;
-            set => m_Time = value;
+            get => m_Event.time;
+            set => m_Event.time = value;
         }
 
         public InputEvent(FourCC type, int sizeInBytes, int deviceId, double time = -1)
@@ -129,11 +127,11 @@ namespace UnityEngine.Experimental.Input.LowLevel
             if (time < 0)
                 time = InputRuntime.s_Instance.currentTime;
 
-            m_Type = type;
-            m_SizeInBytes = (ushort)sizeInBytes;
-            m_DeviceId = (ushort)deviceId;
-            m_Time = time;
-            m_EventId = kInvalidId;
+            m_Event.type = (NativeInputEventType)(int)type;
+            m_Event.sizeInBytes = (ushort)sizeInBytes;
+            m_Event.deviceId = (ushort)deviceId;
+            m_Event.time = time;
+            m_Event.eventId = kInvalidId;
         }
 
         // We internally use bits inside m_EventId as flags. IDs are linearly counted up by the
@@ -143,13 +141,13 @@ namespace UnityEngine.Experimental.Input.LowLevel
         //       when they go on the queue makes sense in itself, though, so this is fine.
         public bool handled
         {
-            get => (m_EventId & kHandledMask) == kHandledMask;
+            get => (m_Event.eventId & kHandledMask) == kHandledMask;
             set
             {
                 if (value)
-                    m_EventId |= kHandledMask;
+                    m_Event.eventId = (int)(m_Event.eventId | kHandledMask);
                 else
-                    m_EventId &= ~kHandledMask;
+                    m_Event.eventId = (int)(m_Event.eventId & ~kHandledMask);
             }
         }
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -94,7 +94,7 @@ namespace UnityEngine.Experimental.Input
 
             lock (m_Lock)
             {
-                eventPtr->m_EventId = m_NextEventId;
+                eventPtr->eventId = m_NextEventId;
                 ++m_NextEventId;
 
                 // Enlarge buffer, if we have to.
@@ -357,7 +357,7 @@ namespace UnityEngine.Experimental.Input
         }
 
         private int m_NextDeviceId = 1;
-        private uint m_NextEventId = 1;
+        private int m_NextEventId = 1;
         private int m_EventCount;
         private int m_EventWritePosition;
         private NativeArray<byte> m_EventBuffer = new NativeArray<byte>(1024 * 1024, Allocator.Persistent);


### PR DESCRIPTION
As discussed, we'd like to be able to change the struct layout of the Input Events to avoid the misaligned double. To do so, I am changing the InputEvent struct to encapsulate UnityEngineInternal.Input.NativeInputEvent instead of duplicating it's content. That way, we hand control over the struct layout back to Unity, where we can then change it without breaking the package.

Since this change is internal to the InputEvent class, no API or functionality should be changed by this.

Caveat: We can now change the native layout of NativeInputEvent, but we cannot change it's size, as that is hardcoded in InputEvent.kBaseEventSize. This is because other structs containing InputEvents need this constant for their explicit layouts, and C# does not allow compile-time sizeof of structs (as the size could change at runtime if the struct contained pointers or references, which is not the case here, but still a language restriction).