### PR TITLE
Register analytics events on first use instead of in initialization

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputAnalytics.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputAnalytics.cs
@@ -11,19 +11,11 @@ namespace UnityEngine.Experimental.Input
     internal static class InputAnalytics
     {
         public const string kEventStartup = "input_startup";
-        public const string kEventFirstUserInteraction = "input_first_user_interaction";
         public const string kEventShutdown = "input_shutdown";
 
         public static void Initialize(InputManager manager)
         {
-            var runtime = manager.m_Runtime;
-            Debug.Assert(runtime != null);
-
-            // Register our analytics events. We want all of them to be pretty low volume.
-            // All of them are per session. kEventStartup can even be per installation.
-            runtime.RegisterAnalyticsEvent(kEventStartup, 10, 100);
-            runtime.RegisterAnalyticsEvent(kEventFirstUserInteraction, 10, 100);
-            runtime.RegisterAnalyticsEvent(kEventShutdown, 10, 100);
+            Debug.Assert(manager.m_Runtime != null);
         }
 
         public static void OnStartup(InputManager manager)
@@ -68,6 +60,7 @@ namespace UnityEngine.Experimental.Input
             data.old_enabled = EditorPlayerSettings.oldSystemBackendsEnabled;
             #endif
 
+            manager.m_Runtime.RegisterAnalyticsEvent(kEventStartup, 10, 100);
             manager.m_Runtime.SendAnalyticsEvent(kEventStartup, data);
         }
 
@@ -88,6 +81,7 @@ namespace UnityEngine.Experimental.Input
                 total_event_processing_time = (float)metrics.totalEventProcessingTime,
             };
 
+            manager.m_Runtime.RegisterAnalyticsEvent(kEventShutdown, 10, 100);
             manager.m_Runtime.SendAnalyticsEvent(kEventShutdown, data);
         }
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Analytics.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Analytics.cs
@@ -18,45 +18,21 @@ partial class CoreTests
 {
     [Test]
     [Category("Analytics")]
-    public void Analytics_RegistersEventsWhenInitialized()
-    {
-        var receivedNames = new List<string>();
-        var receivedMaxPerHours = new List<int>();
-        var receivedMaxPropertiesPerEvents = new List<int>();
-
-        runtime.onRegisterAnalyticsEvent =
-            (name, maxPerHour, maxPropertiesPerEvent) =>
-        {
-            receivedNames.Add(name);
-            receivedMaxPerHours.Add(maxPerHour);
-            receivedMaxPropertiesPerEvents.Add(maxPropertiesPerEvent);
-        };
-
-        // The test fixture has already initialized the input system.
-        // Create a new manager to test registration.
-        var manager = new InputManager();
-        var settings = ScriptableObject.CreateInstance<InputSettings>();
-        manager.Initialize(runtime, settings);
-
-        Assert.That(receivedNames,
-            Is.EquivalentTo(new[]
-            {
-                InputAnalytics.kEventStartup, InputAnalytics.kEventFirstUserInteraction, InputAnalytics.kEventShutdown
-            }));
-        Assert.That(receivedMaxPerHours.Count, Is.EqualTo(3));
-        Assert.That(receivedMaxPropertiesPerEvents.Count, Is.EqualTo(3));
-    }
-
-    [Test]
-    [Category("Analytics")]
     public void Analytics_ReceivesStartupEventOnFirstUpdate()
     {
+        var registeredNames = new List<string>();
         string receivedName = null;
         object receivedData = null;
+
+        runtime.onRegisterAnalyticsEvent = (name, maxPerHour, maxPropertiesPerEvent) =>
+        {
+            registeredNames.Add(name);
+        };
 
         runtime.onSendAnalyticsEvent =
             (name, data) =>
         {
+            Assert.That(registeredNames.Contains(name));
             Assert.That(receivedName, Is.Null);
             receivedName = name;
             receivedData = data;
@@ -185,11 +161,19 @@ partial class CoreTests
         InputSystem.QueueStateEvent(gamepad, new GamepadState());
         InputSystem.Update(InputUpdateType.Fixed);
 
+        var registeredNames = new List<string>();
         string receivedName = null;
         object receivedData = null;
+
+        runtime.onRegisterAnalyticsEvent = (name, maxPerHour, maxPropertiesPerEvent) =>
+        {
+            registeredNames.Add(name);
+        };
+
         runtime.onSendAnalyticsEvent =
             (name, data) =>
         {
+            Assert.That(registeredNames.Contains(name));
             Assert.That(receivedData, Is.Null);
             receivedName = name;
             receivedData = data;


### PR DESCRIPTION
As part of the discussion on what to do to make domain reloads faster, I suggested not registering the analytics events on every domain reload (as that seems to take ~15ms of time for some reason I don't understand).

This PR registers analytics events only when they are first sent, saving those 15ms on every reload.

This is solving the same problem as #446 , but on a higher level and less generic, as suggested by @Rene-Damm. Unlike that suggestion, I did not add a global for each event (`s_StartupEventRegistered`) to check if it had been registered before, however, as I did not think that this was necessary, as the respective functions invoking the events are already only called once anyways - and if they are not, there is more broken then this, so I don't think we need safeguards around event registration in particular (as doing that multiple times probably hurts much less then calling the function multiple times). If we think we need to track event registration, I think it makes more sense to do that generically (as my last suggested solution did).