### PR TITLE
Handle ShouldRunUpdate in managed code

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -150,7 +150,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// <remarks>
         /// This can be used to turn on or off event processing for background windows.
         /// </remarks>
-        bool runInBackground { set; }
+        bool shouldRunInBackground { set; }
 
         ScreenOrientation screenOrientation { get; }
         Vector2 screenSize { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -145,13 +145,12 @@ namespace UnityEngine.Experimental.Input.LowLevel
         double fixedUpdateIntervalInSeconds { get; }
 
         /// <summary>
-        /// Mask that determines which input updates are executed by the runtime.
+        /// Flag which tells runtime whether to process input events when in the background.
         /// </summary>
         /// <remarks>
-        /// This can be used to turn off unneeded updates (like fixed updates) or turn on updates
-        /// that are disabled by default (like before-render updates).
+        /// This can be used to turn on or off event processing for background windows.
         /// </remarks>
-        InputUpdateType updateMask { set; }
+        bool runInBackground { set; }
 
         ScreenOrientation screenOrientation { get; }
         Vector2 screenSize { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -83,6 +83,8 @@ namespace UnityEngine.Experimental.Input.LowLevel
         /// </remarks>
         Action<InputUpdateType> onBeforeUpdate { set; }
 
+        Func<InputUpdateType, bool> onShouldRunUpdate { set; }
+
         /// <summary>
         /// Set delegate to be called when a new device is discovered.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -111,19 +111,15 @@ namespace UnityEngine.Experimental.Input
             get => m_UpdateMask;
             set
             {
-                if (m_UpdateMask == value)
-                    return;
-
                 // In editor, we don't allow disabling editor updates.
                 #if UNITY_EDITOR
                 value |= InputUpdateType.Editor;
                 #endif
 
+                if (m_UpdateMask == value)
+                    return;
+                    
                 m_UpdateMask = value;
-
-                // Tell runtime.
-                if (m_Runtime != null)
-                    m_Runtime.updateMask = m_UpdateMask;
 
                 // Recreate state buffers.
                 if (m_DevicesCount > 0)
@@ -1495,9 +1491,9 @@ namespace UnityEngine.Experimental.Input
             m_Runtime.onUpdate = OnUpdate;
             m_Runtime.onDeviceDiscovered = OnNativeDeviceDiscovered;
             m_Runtime.onFocusChanged = OnFocusChanged;
-            m_Runtime.updateMask = updateMask;
             m_Runtime.onShouldRunUpdate = ShouldRunUpdate;
             m_Runtime.pollingFrequency = pollingFrequency;
+            m_Runtime.runInBackground = m_Settings.runInBackground;
 
             // We only hook NativeInputSystem.onBeforeUpdate if necessary.
             if (m_BeforeUpdateListeners.length > 0 || m_HaveDevicesWithStateCallbackReceivers)
@@ -2109,8 +2105,7 @@ namespace UnityEngine.Experimental.Input
                 default:
                     throw new NotImplementedException("Input update mode: " + m_Settings.updateMode);
             }
-            if (m_Settings.runInBackground)
-                newUpdateMask |= (InputUpdateType)(1 << 31);
+
             #if UNITY_EDITOR
             // In the editor, we force editor updates to be on even if InputEditorUserSettings.lockInputToGameView is
             // on as otherwise we'll end up accumulating events in edit mode without anyone flushing the
@@ -2118,6 +2113,8 @@ namespace UnityEngine.Experimental.Input
             newUpdateMask |= InputUpdateType.Editor;
             #endif
             updateMask = newUpdateMask;
+
+            m_Runtime.runInBackground = m_Settings.runInBackground;
 
             ////TODO: optimize this so that we don't repeatedly recreate state if we add/remove multiple devices
             ////      (same goes for not resolving actions repeatedly)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1402,6 +1402,7 @@ namespace UnityEngine.Experimental.Input
             // we don't know which one the user is going to use. The user
             // can manually turn off one of them to optimize operation.
             m_UpdateMask = InputUpdateType.Dynamic | InputUpdateType.Fixed;
+            m_HasFocus = Application.isFocused;
 #if UNITY_EDITOR
             m_UpdateMask |= InputUpdateType.Editor;
 #endif
@@ -1577,6 +1578,7 @@ namespace UnityEngine.Experimental.Input
         private InlinedArray<Action> m_SettingsChangedListeners;
         private bool m_NativeBeforeUpdateHooked;
         private bool m_HaveDevicesWithStateCallbackReceivers;
+        private bool m_HasFocus;
 
         #if UNITY_ANALYTICS || UNITY_EDITOR
         private bool m_HaveSentStartupAnalytics;
@@ -2176,6 +2178,7 @@ namespace UnityEngine.Experimental.Input
 
         private void OnFocusChanged(bool focus)
         {
+            m_HasFocus = focus;
             var deviceCount = m_DevicesCount;
             for (var i = 0; i < deviceCount; ++i)
             {
@@ -2196,13 +2199,13 @@ namespace UnityEngine.Experimental.Input
                     //       Force input updating while keyboard is show
                     //       In the future, hopefully we'll have TouchscreenKeyboard integrated in thew new input system directly
                     //       Thus with removal of KeyboardOnScreen, KeyboardOnScreen::IsVisible() check should go away
-                    if (!(m_Settings.runInBackground || TouchScreenKeyboard.visible) && !Application.isFocused)
+                    if (!(m_Settings.runInBackground || TouchScreenKeyboard.visible) && !m_HasFocus)
                         return false;
                     break;
 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
                     // If we're in play mode and the player has focus (or ignores focus), don't run editor updates.
-                    if (Application.isPlaying && !EditorApplication.isPaused && (Application.isFocused || m_Settings.runInBackground))
+                    if (Application.isPlaying && !EditorApplication.isPaused && (m_HasFocus || m_Settings.runInBackground))
                         return false;
                     break;
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1493,7 +1493,7 @@ namespace UnityEngine.Experimental.Input
             m_Runtime.onFocusChanged = OnFocusChanged;
             m_Runtime.onShouldRunUpdate = ShouldRunUpdate;
             m_Runtime.pollingFrequency = pollingFrequency;
-            m_Runtime.runInBackground = m_Settings.runInBackground;
+            m_Runtime.shouldRunInBackground = m_Settings.runInBackground;
 
             // We only hook NativeInputSystem.onBeforeUpdate if necessary.
             if (m_BeforeUpdateListeners.length > 0 || m_HaveDevicesWithStateCallbackReceivers)
@@ -2114,7 +2114,7 @@ namespace UnityEngine.Experimental.Input
             #endif
             updateMask = newUpdateMask;
 
-            m_Runtime.runInBackground = m_Settings.runInBackground;
+            m_Runtime.shouldRunInBackground = m_Settings.runInBackground;
 
             ////TODO: optimize this so that we don't repeatedly recreate state if we add/remove multiple devices
             ////      (same goes for not resolving actions repeatedly)

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -219,9 +219,9 @@ namespace UnityEngine.Experimental.Input.LowLevel
 
         public double fixedUpdateIntervalInSeconds => Time.fixedDeltaTime;
 
-        public InputUpdateType updateMask
+        public bool shouldRunInBackground
         {
-            set => NativeInputSystem.SetUpdateMask((NativeInputUpdateType)value);
+            set => NativeInputSystem.SetUpdateMask((NativeInputUpdateType)(value ? 1 << 31 : 0));
         }
 
         private Action m_ShutdownMethod;

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -151,6 +151,19 @@ namespace UnityEngine.Experimental.Input.LowLevel
             }
         }
 
+        public Func<InputUpdateType, bool> onShouldRunUpdate
+        {
+            set
+            {
+                // This is stupid but the enum prevents us from jacking the delegate in directly.
+                // This means we get a double dispatch here :(
+                if (value != null)
+                    NativeInputSystem.onShouldRunUpdate = updateType => value((InputUpdateType)updateType);
+                else
+                    NativeInputSystem.onShouldRunUpdate = null;
+            }
+        }
+
         public Action<int, string> onDeviceDiscovered
         {
             set => NativeInputSystem.onDeviceDiscovered = value;

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
@@ -530,11 +530,11 @@ partial class CoreTests
 
         InputSystem.RegisterLayout(deviceJson);
 
-        Assert.That(runtime.updateMask & InputUpdateType.BeforeRender, Is.EqualTo((InputUpdateType)0));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.BeforeRender, Is.EqualTo((InputUpdateType)0));
 
         InputSystem.AddDevice("CustomGamepad");
 
-        Assert.That(runtime.updateMask & InputUpdateType.BeforeRender, Is.EqualTo(InputUpdateType.BeforeRender));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.BeforeRender, Is.EqualTo(InputUpdateType.BeforeRender));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
@@ -554,15 +554,15 @@ partial class CoreTests
         var device1 = InputSystem.AddDevice("CustomGamepad");
         var device2 = InputSystem.AddDevice("CustomGamepad");
 
-        Assert.That(runtime.updateMask & InputUpdateType.BeforeRender, Is.EqualTo(InputUpdateType.BeforeRender));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.BeforeRender, Is.EqualTo(InputUpdateType.BeforeRender));
 
         InputSystem.RemoveDevice(device1);
 
-        Assert.That(runtime.updateMask & InputUpdateType.BeforeRender, Is.EqualTo(InputUpdateType.BeforeRender));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.BeforeRender, Is.EqualTo(InputUpdateType.BeforeRender));
 
         InputSystem.RemoveDevice(device2);
 
-        Assert.That(runtime.updateMask & InputUpdateType.BeforeRender, Is.EqualTo((InputUpdateType)0));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.BeforeRender, Is.EqualTo((InputUpdateType)0));
     }
 
     private class TestDeviceReceivingAddAndRemoveNotification : Mouse

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
@@ -674,7 +674,7 @@ partial class CoreTests
     [Category("Editor")]
     public void Editor_AlwaysKeepsEditorUpdatesEnabled()
     {
-        Assert.That(runtime.updateMask & InputUpdateType.Editor, Is.EqualTo(InputUpdateType.Editor));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Editor, Is.EqualTo(InputUpdateType.Editor));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
@@ -192,15 +192,15 @@ partial class CoreTests
         Assert.That(receivedOnChange, Is.True);
         Assert.That(InputSystem.GetMetrics().currentStateSizeInBytes,
             Is.LessThanOrEqualTo(InputSystem.GetMetrics().maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
-        Assert.That(runtime.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
-        Assert.That(runtime.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.False);
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.False);
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.True);
 
         #if UNITY_EDITOR
         // Edit mode updates shouldn't have been disabled in editor.
-        Assert.That(runtime.updateMask & InputUpdateType.Editor, Is.Not.Zero);
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Editor, Is.Not.Zero);
         #endif
 
         InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Left));
@@ -225,8 +225,8 @@ partial class CoreTests
         Assert.That(receivedOnChange, Is.True);
         Assert.That(InputSystem.GetMetrics().currentStateSizeInBytes,
             Is.LessThanOrEqualTo(InputSystem.GetMetrics().maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
-        Assert.That(runtime.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.Fixed));
-        Assert.That(runtime.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.Fixed));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.True);
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.False);
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.False);
@@ -254,6 +254,7 @@ partial class CoreTests
         bool runInBackground = runInBackgroundMode == Events_ShouldRunUpdate_TracksFocus_Mode.RunInBackground;
         InputSystem.settings.runInBackground = runInBackground;
         Assert.That(InputSystem.settings.runInBackground, Is.EqualTo(runInBackground));
+        Assert.That(runtime.shouldRunInBackground, Is.EqualTo(runInBackground));
         InputSystem.s_Manager.updateMask = InputUpdateType.Default;
 
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Dynamic));
@@ -312,8 +313,8 @@ partial class CoreTests
         Assert.That(receivedOnChange, Is.True);
         Assert.That(InputSystem.GetMetrics().currentStateSizeInBytes,
             Is.LessThanOrEqualTo(InputSystem.GetMetrics().maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
-        Assert.That(runtime.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
-        Assert.That(runtime.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.Dynamic));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
+        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.Dynamic));
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.False);
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.True);
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.False);

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
@@ -237,10 +237,6 @@ partial class CoreTests
         Assert.That(mouse.leftButton.isPressed, Is.True);
     }
 
-#if UNITY_EDITOR
-    // Test that changing focus enables or disables input processing, depending on the value of the
-    // runInBackground setting. Can only be effectively tested in the editor, because we don't have
-    // a generic means of setting player focuse (in the editor we can focus or unfocus the game window).
     public enum Events_ShouldRunUpdate_TracksFocus_Mode
     {
         RunInBackground, DontRunInBackground
@@ -261,19 +257,18 @@ partial class CoreTests
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Fixed));
         Assert.That(!runtime.onShouldRunUpdate.Invoke(InputUpdateType.Editor));
 
-        UnityEditor.EditorApplication.ExecuteMenuItem("Window/General/Scene");
+        runtime.onFocusChanged.Invoke(false);
 
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Dynamic), Is.EqualTo(runInBackground));
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Fixed), Is.EqualTo(runInBackground));
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Editor), Is.EqualTo(!runInBackground));
 
-        UnityEditor.EditorApplication.ExecuteMenuItem("Window/General/Game");
+        runtime.onFocusChanged.Invoke(true);
 
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Dynamic));
         Assert.That(runtime.onShouldRunUpdate.Invoke(InputUpdateType.Fixed));
         Assert.That(!runtime.onShouldRunUpdate.Invoke(InputUpdateType.Editor));
     }
-#endif
 
     [Test]
     [Category("Events")]

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -314,6 +314,7 @@ namespace UnityEngine.Experimental.Input
 
         public InputUpdateDelegate onUpdate { get; set; }
         public Action<InputUpdateType> onBeforeUpdate { get; set; }
+        public Func<InputUpdateType, bool> onShouldRunUpdate { get; set; }
         public Action<int, string> onDeviceDiscovered { get; set; }
         public Action onShutdown { get; set; }
         public Action<bool> onFocusChanged { get; set; }

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -320,7 +320,7 @@ namespace UnityEngine.Experimental.Input
         public Action<bool> onFocusChanged { get; set; }
         public float pollingFrequency { get; set; }
         public double currentTime { get; set; }
-        public InputUpdateType updateMask { get; set; }
+        public bool shouldRunInBackground { get; set; }
         public int frameCount { get; set; }
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;


### PR DESCRIPTION
Following https://ono.unity3d.com/unity/unity/pull-request/83610/_/platform/foundation/input-should-update, we can now move the logic to decide if we want to run updates to managed code. This PR does that.