### PR TITLE
"Press and Release" interactions will now invoke the `performed` callback twice

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - The input debugger will no longer automatically show remote devices when the profiler is connected. Instead, use the new menu in debugger toolbar to connect to players or to enable/disable remote input debugging.
+- "Press and Release" interactions will now invoke the `performed` callback on both press and release (instead of invoking `performed` and `cancel`, which was inconsistent with other behaviors).
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -93,12 +93,13 @@ namespace UnityEngine.Experimental.Input.Interactions
                             if (isActuated)
                                 context.PerformedAndStayPerformed();
                             else
-                                context.Cancelled();
+                            {
+                                context.PerformedAndGoBackToWaiting();
+                                context.Waiting();
+                            }
                         }
                         else if (!isActuated)
-                        {
-                            context.Cancelled();
-                        }
+                            context.PerformedAndGoBackToWaiting();
 
                         m_WaitingForRelease = isActuated;
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -93,10 +93,7 @@ namespace UnityEngine.Experimental.Input.Interactions
                             if (isActuated)
                                 context.PerformedAndStayPerformed();
                             else
-                            {
                                 context.PerformedAndGoBackToWaiting();
-                                context.Waiting();
-                            }
                         }
                         else if (!isActuated)
                             context.PerformedAndGoBackToWaiting();

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -1557,7 +1557,7 @@ partial class CoreTests
                     .EqualTo(InputActionPhase.Performed));
             Assert.That(actions,
                 Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Cancelled));
+                    .EqualTo(InputActionPhase.Performed));
 
             trace.Clear();
 
@@ -1631,7 +1631,7 @@ partial class CoreTests
                     .EqualTo(InputActionPhase.Performed));
             Assert.That(actions,
                 Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Cancelled));
+                    .EqualTo(InputActionPhase.Performed));
 
             trace.Clear();
 


### PR DESCRIPTION
"Press and Release" interactions will now invoke the `performed` callback on both press and release (instead of invoking `performed` and `cancel`, which was inconsistent with other behaviors).

This is based on https://fogbugz.unity3d.com/f/cases/1134081/, and the related discussion on Slack were we decided that this would be more intuitive.