### PR TITLE
Fixed Xbox Controller on macOS reporting negative values for the stic…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -53,7 +53,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Sort events in input debugger window by id rather then by timestamp.
 - Make parsing of float parameters support floats represented in "e"-notation and "Infinity".
 - Input device icons in input debugger window now render in appropriate resolution on retina displays.
-
+- Fixed Xbox Controller on macOS reporting negative values for the sticks when represented as dpad buttons.
+	
 #### Actions
 
 - Pasting or duplicating an action in an action map asset will now assign a new and unique ID to the action.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
@@ -77,8 +77,8 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
         [InputControl(name = "leftStick/left", offset = 0, format = "SHRT", parameters = "")]
         [InputControl(name = "leftStick/right", offset = 0, format = "SHRT", parameters = "")]
         [InputControl(name = "leftStick/y", offset = 2, format = "SHRT", parameters = "invert")]
-        [InputControl(name = "leftStick/up", offset = 2, format = "SHRT", parameters = "clamp,clampMin=-1,clampMax=1,invert=true")]
-        [InputControl(name = "leftStick/down", offset = 2, format = "SHRT", parameters = "clamp,clampMin=-1,clampMax=1,invert=false")]
+        [InputControl(name = "leftStick/up", offset = 2, format = "SHRT", parameters = "clamp,clampMin=-1,clampMax=0,invert=true")]
+        [InputControl(name = "leftStick/down", offset = 2, format = "SHRT", parameters = "clamp,clampMin=0,clampMax=1,invert=false")]
         [FieldOffset(6)] public short leftStickX;
         [FieldOffset(8)] public short leftStickY;
 
@@ -87,8 +87,8 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
         [InputControl(name = "rightStick/left", offset = 0, format = "SHRT", parameters = "")]
         [InputControl(name = "rightStick/right", offset = 0, format = "SHRT", parameters = "")]
         [InputControl(name = "rightStick/y", offset = 2, format = "SHRT", parameters = "invert")]
-        [InputControl(name = "rightStick/up", offset = 2, format = "SHRT", parameters = "clamp,clampMin=-1,clampMax=1,invert=true")]
-        [InputControl(name = "rightStick/down", offset = 2, format = "SHRT", parameters = "clamp,clampMin=-1,clampMax=1,invert=false")]
+        [InputControl(name = "rightStick/up", offset = 2, format = "SHRT", parameters = "clamp,clampMin=-1,clampMax=0,invert=true")]
+        [InputControl(name = "rightStick/down", offset = 2, format = "SHRT", parameters = "clamp,clampMin=0,clampMax=1,invert=false")]
         [FieldOffset(10)] public short rightStickX;
         [FieldOffset(12)] public short rightStickY;
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/XInputTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/XInputTests.cs
@@ -163,8 +163,18 @@ internal class XInputTests : InputTestFixture
 
         Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
         Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
+        Assert.That(gamepad.leftStick.up.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
+        Assert.That(gamepad.leftStick.down.ReadValue(), Is.EqualTo(0.0).Within(0.001));
+        Assert.That(gamepad.leftStick.right.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
+        Assert.That(gamepad.leftStick.left.ReadValue(), Is.EqualTo(0.0).Within(0.001));
+
         Assert.That(gamepad.rightStick.x.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
         Assert.That(gamepad.rightStick.y.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
+        Assert.That(gamepad.rightStick.up.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
+        Assert.That(gamepad.rightStick.down.ReadValue(), Is.EqualTo(0.0).Within(0.001));
+        Assert.That(gamepad.rightStick.right.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
+        Assert.That(gamepad.rightStick.left.ReadValue(), Is.EqualTo(0.0).Within(0.001));
+
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(1));
         Assert.That(gamepad.rightTrigger.ReadValue(), Is.EqualTo(1));
 


### PR DESCRIPTION
…ks when represented as dpad buttons.

Same as https://github.com/Unity-Technologies/InputSystem/pull/443, but changed to work with @douglas-piconi 's latest changes, and added testing.