### PR TITLE
InputActionAssetReferences in ScriptableObjects will continue to work…

### DIFF
--- a/Assets/Demo/DemoControls.cs
+++ b/Assets/Demo/DemoControls.cs
@@ -17,7 +17,7 @@ public class DemoControls : InputActionAssetReference
     {
     }
 
-    private bool m_Initialized;
+    [NonSerialized] private bool m_Initialized;
     private void Initialize()
     {
         // gameplay

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed deleting multiple items at same time in action editor leading to wrong items being deleted.
 - Fixed copy-pasting actions not preserving action properties other than name.
 - Fixed memory corruptions coming from binding resolution of actions.
+- InputActionAssetReferences in ScriptableObjects will continue to work after domain reloads in the editor.
 
 ## [0.2.1-preview] - 2019-03-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -106,7 +106,7 @@ namespace UnityEngine.Experimental.Input.Editor
             writer.EndBlock();
 
             // Initialize method.
-            writer.WriteLine("private bool m_Initialized;");
+            writer.WriteLine("[NonSerialized] private bool m_Initialized;");
             writer.WriteLine("private void Initialize()");
             writer.BeginBlock();
             foreach (var set in maps)


### PR DESCRIPTION
… after domain reloads in the editor.

These did not work, because the m_Initialized property was serialized, so it would not reinitialize the callbacks.

Fixes https://fogbugz.unity3d.com/f/cases/1135158/