### PR TITLE
Fix incompatible postprocessors

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     [InputControl(layout = "Button")]
     private string buttonControlPath;
     ```
+- Processors of incompatible types will now be ignored instead of throwing an exception.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -2021,7 +2021,11 @@ namespace UnityEngine.Experimental.Input
             {
                 var processorStartIndex = bindingStates[bindingIndex].processorStartIndex;
                 for (var i = 0; i < processorCount; ++i)
-                    value = ((InputProcessor<TValue>)processors[processorStartIndex + i]).Process(value, controlOfType);
+                {
+                    var processor = processors[processorStartIndex + i] as InputProcessor<TValue>;
+                    if (processor != null)
+                        value = processor.Process(value, controlOfType);
+                }
             }
 
             return value;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -505,6 +505,10 @@ namespace UnityEngine.Experimental.Input.Editor
         {
             m_ActionAssetManager.ApplyChanges();
 
+            // Update dirty count, otherwise ReloadIfSerializedObjectHasBeenChanged will trigger a full ApplyAndReloadTrees
+            m_ActionMapsTree.UpdateSerializedObjectDirtyCount();
+            m_ActionsTree.UpdateSerializedObjectDirtyCount();
+
             // If auto-save is active, immediately flush out the changes to disk. Otherwise just
             // put us into dirty state.
             if (InputEditorUserSettings.autoSaveInputActionAssets)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
@@ -17,7 +17,7 @@ namespace UnityEngine.Experimental.Input.Editor
         public static FourCC k_PropertiesChanged = new FourCC("PROP");
 
         public InputActionPropertiesView(SerializedProperty actionProperty, Action<FourCC> onChange = null)
-            : base("Action", actionProperty, onChange)
+            : base("Action", actionProperty, onChange, actionProperty.FindPropertyRelative("m_ExpectedControlLayout").stringValue)
         {
             m_ExpectedControlLayoutProperty = actionProperty.FindPropertyRelative("m_ExpectedControlLayout");
             m_FlagsProperty = actionProperty.FindPropertyRelative("m_Flags");

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -1192,7 +1192,7 @@ namespace UnityEngine.Experimental.Input.Editor
             onSerializedObjectModified?.Invoke();
         }
 
-        private void UpdateSerializedObjectDirtyCount()
+        public void UpdateSerializedObjectDirtyCount()
         {
             m_SerializedObjectDirtyCount = EditorUtility.GetDirtyCount(serializedObject.targetObject);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
@@ -146,7 +146,14 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
             var listRect = GUILayoutUtility.GetRect(200, m_ListView.GetHeight());
             listRect = EditorGUI.IndentedRect(listRect);
             m_ListView.DoList(listRect);
-            m_EditableParametersForSelectedItem.OnGUI();
+            if (m_EditableParametersForSelectedItem.hasUIToShow)
+            {
+                var label = $"Parameters for {ObjectNames.NicifyVariableName(m_ParametersForEachListItem[m_ListView.index].name)}";
+                EditorGUILayout.LabelField(label, EditorStyles.boldLabel);
+                EditorGUI.indentLevel++;
+                m_EditableParametersForSelectedItem.OnGUI();
+                EditorGUI.indentLevel--;
+            }
         }
 
         public string ToSerializableString()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -29,6 +29,8 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         /// </summary>
         public Action onChange { get; set; }
 
+        public bool hasUIToShow => (m_Parameters != null && m_Parameters.Length > 0)|| m_ParameterEditor != null;
+
         /// <summary>
         /// Get the current parameter values according to the editor state.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
@@ -19,7 +19,7 @@ namespace UnityEngine.Experimental.Input.Editor
             m_InteractionsProperty = bindingOrAction.FindPropertyRelative("m_Interactions");
             m_ProcessorsProperty = bindingOrAction.FindPropertyRelative("m_Processors");
 
-            m_InteractionsList = new InteractionsListView(m_InteractionsProperty, OnInteractionsModified, expectedControlLayout);
+            m_InteractionsList = new InteractionsListView(m_InteractionsProperty, OnInteractionsModified, null);
             m_ProcessorsList = new ProcessorsListView(m_ProcessorsProperty, OnProcessorsModified, expectedControlLayout);
 
             m_OnChange = onChange;

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -2584,6 +2584,33 @@ partial class CoreTests
         Assert.That(receivedVector.Value.y, Is.EqualTo(0.5678).Within(0.00001));
     }
 
+    [Test]
+    [Category("Actions")]
+    public void Actions_IncompatibleProcessorIsIgnored()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        InputSystem.RegisterControlProcessor<ConstantVector2TestProcessor>();
+        var action = new InputAction(processors: "ConstantVector2Test");
+        action.AddBinding("<Gamepad>/leftStick/x");
+        action.Enable();
+
+        float? receivedFloat = null;
+        action.performed +=
+            ctx =>
+            {
+                Assert.That(receivedFloat, Is.Null);
+                // ConstantVector2TestProcessor processes Vector2s. It would throw an exception when 
+                // trying to use it reading a float if not ignored.
+                receivedFloat = ctx.ReadValue<float>();
+            };
+
+        Set(gamepad.leftStick, Vector2.one);
+
+        Assert.That(receivedFloat, Is.Not.Null);
+        Assert.That(receivedFloat.Value, Is.EqualTo(1).Within(0.00001));
+    }
+
     // ReSharper disable once ClassNeverInstantiated.Local
     private class ConstantVector2TestProcessor : InputProcessor<Vector2>
     {


### PR DESCRIPTION
This is to fix https://fogbugz.unity3d.com/f/cases/1135152/

Currently, it is possible to assign incompatible processors to bindings/actions, which will then throw an exception when trying to read the value. In the example given in that fogbugz case, a processor is assigned to a composite axis making up a dpad. It is then correctly applied on the axis, but the input system will try to apply it again on the composite dpad, failing, because it does not match the type. In this case, it should be applied the first time, but not the second type.

So, I decided that we should always ignore incompatible processors. Also, I changed the Action editor UI to
1. Make it impossible to assign incompatible processors to actions (before it would only filter on bindings)
2. If there are incompatible processors (which can happen when changing action type after adding a processor), label those as "(Ignored)".
3. Also, I added a header to the parameters UI for processors and interactions to make the association of the parameters with the list view item more clear.
4. Fixed reloading the Action Asset editing UI when editing parameters, thus clearing your selection and no longer showing the parameters (https://fogbugz.unity3d.com/f/cases/1138244/)