### PR TITLE
Fixed `startTime` and `duration` properties of action callbacks.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed copy-pasting actions not preserving action properties other than name.
 - Fixed memory corruptions coming from binding resolution of actions.
 - InputActionAssetReferences in ScriptableObjects will continue to work after domain reloads in the editor.
+- Fixed `startTime` and `duration` properties of action callbacks.
 
 ## [0.2.1-preview] - 2019-03-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -694,7 +694,7 @@ namespace UnityEngine.Experimental.Input
                 {
                     if (m_State == null)
                         return 0;
-                    return m_State.interactionStates[actionIndex].startTime;
+                    return m_State.actionStates[actionIndex].startTime;
                 }
             }
 


### PR DESCRIPTION
`startTime` was read from `interactionStates`, unlike `time` which was read from `actionStates`, which seemed wrong and did not work correctly.

Fixes https://fogbugz.unity3d.com/f/cases/1138249/

