### PR TITLE
Fixed InputSettings.UpdateMode.ProcessEventsManually

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make parsing of float parameters support floats represented in "e"-notation and "Infinity".
 - Input device icons in input debugger window now render in appropriate resolution on retina displays.
 - Fixed Xbox Controller on macOS reporting negative values for the sticks when represented as dpad buttons.
+- `InputSettings.UpdateMode.ProcessEventsManually` now correctly triggers updates when calling `InputSystem.Update(InputUpdateType.Manual)`.
 	
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3233,7 +3233,7 @@ namespace UnityEngine.Experimental.Input
             m_StateBuffers = state.buffers;
             m_LayoutRegistrationVersion = state.layoutRegistrationVersion + 1;
             m_DeviceSetupVersion = state.deviceSetupVersion + 1;
-            m_UpdateMask = state.updateMask;
+            updateMask = state.updateMask;
             m_Metrics = state.metrics;
             m_PollingFrequency = state.pollingFrequency;
 

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -36,6 +36,10 @@ namespace UnityEngine.Experimental.Input.LowLevel
             {
                 NativeInputSystem.Update(NativeInputUpdateType.BeforeRender);
             }
+            if ((updateType & InputUpdateType.Manual) == InputUpdateType.Manual)
+            {
+                NativeInputSystem.Update((NativeInputUpdateType)InputUpdateType.Manual);
+            }
 
             #if UNITY_EDITOR
             if ((updateType & InputUpdateType.Editor) == InputUpdateType.Editor)


### PR DESCRIPTION
Addresses https://fogbugz.unity3d.com/f/cases/1138654/

Two reasons this did not work:

-The native runtime would not call NativeInputSystem.Update for manual updates
-We would set m_UpdateMask from the state loaded from the configuration asset, but not the backend mask - which we would then never set, because we only change it when `m_UpdateMask` is changed. (probably irrelevant after https://github.com/Unity-Technologies/InputSystem/pull/456 lands)