### PR TITLE
Make remote test deterministic

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Remoting.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Remoting.cs
@@ -108,7 +108,11 @@ partial class CoreTests
     {
 #if UNITY_EDITOR
         // In the editor, RemoteInputPlayerConnection is a scriptable singleton. Creating multiple instances of it
-        // will cause an error message - but will work nevertheless, so we expect that error to let us run the test.
+        // will cause an error messages - but will work nevertheless, so we expect those errors to let us run the test.
+        // We call RemoteInputPlayerConnection.instance once to make sure that we an instance is created, and we get
+        // a deterministic number of two errors.
+        var instance = RemoteInputPlayerConnection.instance;
+        UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "ScriptableSingleton already exists. Did you query the singleton in a constructor?");   
         UnityEngine.TestTools.LogAssert.Expect(LogType.Error, "ScriptableSingleton already exists. Did you query the singleton in a constructor?");
 #endif
         var connectionToEditor = ScriptableObject.CreateInstance<RemoteInputPlayerConnection>();


### PR DESCRIPTION
This test was unstable because it would print an error message once or twice depending on whether the singleton was created before. This makes it stable.