### PR TITLE
FIX: Linux joystick tests.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Support gamepad vibration on Switch.
+- Added support for Joysticks on Linux.
 
 #### Actions
 
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - The input debugger will no longer automatically show remote devices when the profiler is connected. Instead, use the new menu in debugger toolbar to connect to players or to enable/disable remote input debugging.
 - "Press and Release" interactions will now invoke the `performed` callback on both press and release (instead of invoking `performed` and `cancel`, which was inconsistent with other behaviors).
+- `Joystick.axes` and `Joystick.buttons` have been removed.
 
 #### Actions
 
@@ -56,7 +58,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make parsing of float parameters support floats represented in "e"-notation and "Infinity".
 - Input device icons in input debugger window now render in appropriate resolution on retina displays.
 - Fixed Xbox Controller on macOS reporting negative values for the sticks when represented as dpad buttons.
-	
+
 #### Actions
 
 - Pasting or duplicating an action in an action map asset will now assign a new and unique ID to the action.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -11,6 +11,8 @@ using UnityEngine.Experimental.Input.Utilities;
 // - By group (e.g. "search for binding on action 'fire' with group 'keyboard&mouse' and override it with '<Keyboard>/space'")
 // - By action (e.g. "bind action 'fire' from whatever it is right now to '<Gamepad>/leftStick'")
 
+////TODO: allow rebinding by GUIDs now that we have IDs on bindings
+
 ////FIXME: properly work with composites
 
 namespace UnityEngine.Experimental.Input

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -23,11 +23,13 @@ namespace UnityEngine.Experimental.Input.Controls
         public float clampMin;
         public float clampMax;
         public float clampConstant;
+        ////REVIEW: why not just roll this into scaleFactor?
         public bool invert; // If true, multiply by -1.
         public bool normalize;
         public float normalizeMin;
         public float normalizeMax;
         public float normalizeZero;
+        ////REVIEW: why not just have a default scaleFactor of 1?
         public bool scale;
         public float scaleFactor;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -20,10 +20,7 @@ namespace UnityEngine.Experimental.Input.Controls
     public class ButtonControl : AxisControl
     {
         public float pressPoint;
-        public float pressPointOrDefault
-        {
-            get { return pressPoint > 0.0f ? pressPoint : InputSystem.settings.defaultButtonPressPoint; }
-        }
+        public float pressPointOrDefault => pressPoint > 0.0f ? pressPoint : InputSystem.settings.defaultButtonPressPoint;
 
         public ButtonControl()
         {
@@ -37,19 +34,10 @@ namespace UnityEngine.Experimental.Input.Controls
             return value >= pressPointOrDefault;
         }
 
-        public bool isPressed
-        {
-            get { return IsValueConsideredPressed(ReadValue()); }
-        }
+        public bool isPressed => IsValueConsideredPressed(ReadValue());
 
-        public bool wasPressedThisFrame
-        {
-            get { return device.wasUpdatedThisFrame && IsValueConsideredPressed(ReadValue()) && !IsValueConsideredPressed(ReadValueFromPreviousFrame()); }
-        }
+        public bool wasPressedThisFrame => device.wasUpdatedThisFrame && IsValueConsideredPressed(ReadValue()) && !IsValueConsideredPressed(ReadValueFromPreviousFrame());
 
-        public bool wasReleasedThisFrame
-        {
-            get { return device.wasUpdatedThisFrame && !IsValueConsideredPressed(ReadValue()) && IsValueConsideredPressed(ReadValueFromPreviousFrame()); }
-        }
+        public bool wasReleasedThisFrame => device.wasUpdatedThisFrame && !IsValueConsideredPressed(ReadValue()) && IsValueConsideredPressed(ReadValueFromPreviousFrame());
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -42,8 +42,8 @@ namespace UnityEngine.Experimental.Input.Controls
         // The DpadAxisControl has it's own logic to read state from the parent dpad.
         // The useStateFrom argument here is not actually used by that. The only reason
         // it is set up here is to avoid any state bytes being reserved for the DpadAxisControl.
-        [InputControl(name = "x", layout = "DpadAxis", useStateFrom = "right")]
-        [InputControl(name = "y", layout = "DpadAxis", useStateFrom = "up")]
+        [InputControl(name = "x", layout = "DpadAxis", useStateFrom = "right", synthetic = true)]
+        [InputControl(name = "y", layout = "DpadAxis", useStateFrom = "up", synthetic = true)]
 
         /// <summary>
         /// The button representing the vertical upwards state of the D-Pad.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine.Experimental.Input.Controls;
 using UnityEngine.Experimental.Input.LowLevel;
@@ -273,7 +274,7 @@ namespace UnityEngine.Experimental.Input
         /// gamepad["{PrimaryAction}"] // Returns the control with PrimaryAction usage, i.e. Gamepad.aButton
         /// </code>
         /// </example>
-        /// <exception cref="IndexOutOfRangeException"><paramref name="path"/> cannot be found.</exception>
+        /// <exception cref="KeyNotFoundException"><paramref name="path"/> cannot be found.</exception>
         /// <seealso cref="InputControlPath"/>
         /// <seealso cref="path"/>
         /// <seealso cref="TryGetChildControl"/>
@@ -283,7 +284,7 @@ namespace UnityEngine.Experimental.Input
             {
                 var control = InputControlPath.TryFindChild(this, path);
                 if (control == null)
-                    throw new IndexOutOfRangeException(
+                    throw new KeyNotFoundException(
                         $"Cannot find control '{path}' as child of '{this}'");
                 return control;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.Experimental.Input.LowLevel;
@@ -132,7 +133,7 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             var statePtr = control.GetStatePtrFromStateEvent(inputEvent);
             if (statePtr == null)
@@ -149,7 +150,7 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             var result = default(TValue);
             control.ReadUnprocessedValueFromEvent(eventPtr, out result);
@@ -160,7 +161,7 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             var statePtr = control.GetStatePtrFromStateEvent(inputEvent);
             if (statePtr == null)
@@ -176,7 +177,7 @@ namespace UnityEngine.Experimental.Input
         public static unsafe void WriteValueFromObjectIntoEvent(this InputControl control, InputEventPtr eventPtr, object value)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             var statePtr = control.GetStatePtrFromStateEvent(eventPtr);
             if (statePtr == null)
@@ -201,9 +202,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe void WriteValueIntoState(this InputControl control, void* statePtr)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             var valueSize = control.valueSizeInBytes;
             var valuePtr = UnsafeUtility.Malloc(valueSize, 8, Allocator.Temp);
@@ -222,12 +223,11 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
-            var controlOfType = control as InputControl<TValue>;
-            if (controlOfType == null)
-                throw new ArgumentException(string.Format("Expecting control of type '{0}' but got '{1}'",
-                    typeof(TValue).Name, control.GetType().Name));
+            if (!(control is InputControl<TValue> controlOfType))
+                throw new ArgumentException(
+                    $"Expecting control of type '{typeof(TValue).Name}' but got '{control.GetType().Name}'");
 
             controlOfType.WriteValueIntoState(value, statePtr);
         }
@@ -236,9 +236,9 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             var valuePtr = UnsafeUtility.AddressOf(ref value);
             var valueSize = UnsafeUtility.SizeOf<TValue>();
@@ -250,7 +250,7 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             control.WriteValueIntoState(control.ReadValue(), statePtr);
         }
@@ -269,16 +269,14 @@ namespace UnityEngine.Experimental.Input
             where TState : struct, IInputStateTypeInfo
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             // Make sure the control's state actually fits within the given state.
             var sizeOfState = UnsafeUtility.SizeOf<TState>();
             if (control.stateOffsetRelativeToDeviceRoot + control.m_StateBlock.alignedSizeInBytes >= sizeOfState)
                 throw new ArgumentException(
-                    string.Format(
-                        "Control {0} with offset {1} and size of {2} bits is out of bounds for state of type {3} with size {4}",
-                        control.path, control.stateOffsetRelativeToDeviceRoot, control.m_StateBlock.sizeInBits,
-                        typeof(TState).Name, sizeOfState), "state");
+                    $"Control {control.path} with offset {control.stateOffsetRelativeToDeviceRoot} and size of {control.m_StateBlock.sizeInBits} bits is out of bounds for state of type {typeof(TState).Name} with size {sizeOfState}",
+                    nameof(state));
 
             // Write value.
             var statePtr = (byte*)UnsafeUtility.AddressOf(ref state);
@@ -289,14 +287,13 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (!eventPtr.valid)
-                throw new ArgumentNullException("eventPtr");
+                throw new ArgumentNullException(nameof(eventPtr));
 
-            var controlOfType = control as InputControl<TValue>;
-            if (controlOfType == null)
-                throw new ArgumentException(string.Format("Expecting control of type '{0}' but got '{1}'",
-                    typeof(TValue).Name, control.GetType().Name));
+            if (!(control is InputControl<TValue> controlOfType))
+                throw new ArgumentException(
+                    $"Expecting control of type '{typeof(TValue).Name}' but got '{control.GetType().Name}'");
 
             controlOfType.WriteValueIntoEvent(value, eventPtr);
         }
@@ -305,9 +302,9 @@ namespace UnityEngine.Experimental.Input
             where TValue : struct
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (!eventPtr.valid)
-                throw new ArgumentNullException("eventPtr");
+                throw new ArgumentNullException(nameof(eventPtr));
 
             var statePtr = control.GetStatePtrFromStateEvent(eventPtr);
             if (statePtr == null)
@@ -319,7 +316,7 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool CheckStateIsAtDefault(this InputControl control)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             return CheckStateIsAtDefault(control, control.currentStatePtr);
         }
@@ -340,9 +337,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool CheckStateIsAtDefault(this InputControl control, void* statePtr, void* maskPtr = null)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             return control.CompareState(statePtr, control.defaultStatePtr, maskPtr);
         }
@@ -350,7 +347,7 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool CheckStateIsAtDefaultIgnoringNoise(this InputControl control)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
 
             return control.CheckStateIsAtDefaultIgnoringNoise(control.currentStatePtr);
         }
@@ -358,9 +355,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool CheckStateIsAtDefaultIgnoringNoise(this InputControl control, void* statePtr)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             return control.CheckStateIsAtDefault(statePtr, InputStateBuffers.s_NoiseMaskBuffer);
         }
@@ -381,9 +378,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool CompareStateIgnoringNoise(this InputControl control, void* statePtr)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             return control.CompareState(control.currentStatePtr, statePtr, control.noiseMaskPtr);
         }
@@ -391,9 +388,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool CompareState(this InputControl control, void* statePtr, void* maskPtr = null)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             return control.CompareState(control.currentStatePtr, statePtr, maskPtr);
         }
@@ -406,9 +403,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool HasValueChangeInState(this InputControl control, void* statePtr)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
 
             return control.CompareValue(control.currentStatePtr, statePtr);
         }
@@ -416,9 +413,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe bool HasValueChangeInEvent(this InputControl control, InputEventPtr eventPtr)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (!eventPtr.valid)
-                throw new ArgumentNullException("eventPtr");
+                throw new ArgumentNullException(nameof(eventPtr));
 
             return control.CompareValue(control.currentStatePtr, control.GetStatePtrFromStateEvent(eventPtr));
         }
@@ -426,9 +423,9 @@ namespace UnityEngine.Experimental.Input
         public static unsafe void* GetStatePtrFromStateEvent(this InputControl control, InputEventPtr eventPtr)
         {
             if (control == null)
-                throw new ArgumentNullException("control");
+                throw new ArgumentNullException(nameof(control));
             if (!eventPtr.valid)
-                throw new ArgumentNullException("eventPtr");
+                throw new ArgumentNullException(nameof(eventPtr));
 
             uint stateOffset;
             FourCC stateFormat;
@@ -465,9 +462,7 @@ namespace UnityEngine.Experimental.Input
             var device = control.device;
             if (stateFormat != device.m_StateBlock.format)
                 throw new InvalidOperationException(
-                    string.Format(
-                        "Cannot read control '{0}' from {1} with format {2}; device '{3}' expects format {4}",
-                        control.path, eventPtr.type, stateFormat, device, device.m_StateBlock.format));
+                    $"Cannot read control '{control.path}' from {eventPtr.type} with format {stateFormat}; device '{device}' expects format {device.m_StateBlock.format}");
 
             // Once a device has been added, global state buffer offsets are baked into control hierarchies.
             // We need to unsubtract those offsets here.
@@ -477,6 +472,21 @@ namespace UnityEngine.Experimental.Input
                 return null;
 
             return (byte*)statePtr - (int)stateOffset;
+        }
+
+        public static void FindControlsRecursive<TControl>(this InputControl parent, IList<TControl> controls, Func<TControl, bool> predicate)
+            where TControl : InputControl
+        {
+            if (parent is TControl parentAsTControl && predicate(parentAsTControl))
+                controls.Add(parentAsTControl);
+
+            var children = parent.children;
+            var childCount = children.Count;
+            for (var i = 0; i < childCount; ++i)
+            {
+                var child = parent.children[i];
+                FindControlsRecursive(child, controls, predicate);
+            }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
@@ -9,10 +9,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
 {
     public struct JoystickState : IInputStateTypeInfo
     {
-        public static FourCC kFormat
-        {
-            get { return new FourCC('J', 'O', 'Y'); }
-        }
+        public static FourCC kFormat => new FourCC('J', 'O', 'Y');
 
         [InputControl(name = "hat", layout = "Dpad", usage = "Hatswitch")]
         [InputControl(name = "trigger", layout = "Button", usages = new[] { "PrimaryTrigger", "PrimaryAction" }, bit = (int)Button.Trigger)]
@@ -41,9 +38,13 @@ namespace UnityEngine.Experimental.Input.LowLevel
 
 namespace UnityEngine.Experimental.Input
 {
-    // A joystick with an arbitrary number of buttons and axes.
-    // By default comes with just a trigger, a potentially twistable
-    // stick and an optional single hatswitch.
+    /// <summary>
+    /// A joystick with an arbitrary number of buttons and axes.
+    /// </summary>
+    /// <remarks>
+    /// By default comes with just a trigger, a potentially twistable
+    /// stick and an optional single hatswitch.
+    /// </remarks>
     [InputControlLayout(stateType = typeof(JoystickState))]
     public class Joystick : InputDevice
     {
@@ -54,33 +55,10 @@ namespace UnityEngine.Experimental.Input
         public AxisControl twist { get; private set; }
         public DpadControl hat { get; private set; }
 
-        ////REVIEW: are these really useful?
-        // List of all buttons and axes on the joystick.
-        public ReadOnlyArray<ButtonControl> buttons
-        {
-            get { return new ReadOnlyArray<ButtonControl>(m_Buttons); }
-        }
-
-        public ReadOnlyArray<AxisControl> axes
-        {
-            get { return new ReadOnlyArray<AxisControl>(m_Axes); }
-        }
-
-        public static Joystick current { get; internal set; }
+        public static Joystick current { get; private set; }
 
         protected override void FinishSetup(InputDeviceBuilder builder)
         {
-            var buttons = new List<ButtonControl>();
-            var axes = new List<AxisControl>();
-
-            FindControlsRecursive(this, buttons, x => !(x.parent is StickControl) && !(x.parent is DpadControl));
-            FindControlsRecursive(this, axes, x => !(x is ButtonControl));
-
-            if (buttons.Count > 0)
-                m_Buttons = buttons.ToArray();
-            if (axes.Count > 0)
-                m_Axes = axes.ToArray();
-
             // Mandatory controls.
             trigger = builder.GetControl<ButtonControl>("{PrimaryTrigger}");
             stick = builder.GetControl<StickControl>("{Primary2DMotion}");
@@ -103,25 +81,6 @@ namespace UnityEngine.Experimental.Input
             base.OnRemoved();
             if (current == this)
                 current = null;
-        }
-
-        ////TODO: move this into InputControl
-        private void FindControlsRecursive<TControl>(InputControl parent, List<TControl> controls, Func<TControl, bool> filter)
-            where TControl : InputControl
-        {
-            var parentAsTControl = parent as TControl;
-            if (parentAsTControl != null && filter(parentAsTControl))
-            {
-                controls.Add(parentAsTControl);
-            }
-
-            var children = parent.children;
-            var childCount = children.Count;
-            for (var i = 0; i < childCount; ++i)
-            {
-                var child = parent.children[i];
-                FindControlsRecursive<TControl>(child, controls, filter);
-            }
         }
 
         private ButtonControl[] m_Buttons;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -146,7 +146,6 @@ namespace UnityEngine.Experimental.Input
         public AxisControl twist { get; private set; }
 
         public IntegerControl pointerId { get; private set; }
-        ////TODO: find a way which gives values as PointerPhase instead of as int
         public PointerPhaseControl phase { get; private set; }
         public IntegerControl displayIndex { get; private set; }////TODO: kill this
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
@@ -238,6 +238,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 MakeUniqueControlSchemeName);
         }
 
+        ////REVIEW: renaming a control scheme should probably update the binding group (also on all bindings)
         private void OnEditSelectedControlScheme(object position)
         {
             Debug.Assert(m_SelectedControlSchemeIndex >= 0, "Control scheme must be selected");

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -29,7 +29,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         /// </summary>
         public Action onChange { get; set; }
 
-        public bool hasUIToShow => (m_Parameters != null && m_Parameters.Length > 0)|| m_ParameterEditor != null;
+        public bool hasUIToShow => (m_Parameters != null && m_Parameters.Length > 0) || m_ParameterEditor != null;
 
         /// <summary>
         /// Get the current parameter values according to the editor state.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
@@ -4,6 +4,8 @@ using UnityEditor;
 using UnityEngine.Experimental.Input.Editor.Lists;
 using UnityEngine.Experimental.Input.Utilities;
 
+////TODO: show parameters for selected interaction or processor inline in list rather than separately underneath list
+
 namespace UnityEngine.Experimental.Input.Editor
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -22,6 +22,8 @@ using UnityEditor;
 
 ////TODO: make capitalization consistent in the generated code
 
+////REVIEW: allow putting *all* of the data from the inputactions asset into the generated class?
+
 namespace UnityEngine.Experimental.Input.Editor
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -63,7 +63,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
             {
                 if (value > ushort.MaxValue)
                     throw new ArgumentException("Maximum event size is " + ushort.MaxValue, nameof(value));
-               m_Event.sizeInBytes = (ushort)value;
+                m_Event.sizeInBytes = (ushort)value;
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -362,6 +362,7 @@ namespace UnityEngine.Experimental.Input
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentNullException(nameof(name));
 
+            ////FIXME: this is no longer necessary; kill it
             // If we have an instance, make sure it is [Serializable].
             if (instance != null)
             {
@@ -1885,6 +1886,10 @@ namespace UnityEngine.Experimental.Input
 
         private void OnNativeDeviceDiscovered(int deviceId, string deviceDescriptor)
         {
+            // Make sure we're not adding to m_AvailableDevices before we restored what we
+            // had before a domain reload.
+            RestoreDevicesAfterDomainReloadIfNecessary();
+
             // Parse description.
             var description = InputDeviceDescription.FromJson(deviceDescriptor);
 
@@ -1972,16 +1977,21 @@ namespace UnityEngine.Experimental.Input
             m_NativeBeforeUpdateHooked = true;
         }
 
+        private void RestoreDevicesAfterDomainReloadIfNecessary()
+        {
+            #if UNITY_EDITOR
+            if (m_SavedDeviceStates != null)
+                RestoreDevicesAfterDomainReload();
+            #endif
+        }
+
         private unsafe void OnBeforeUpdate(InputUpdateType updateType)
         {
             ////FIXME: this shouldn't happen; looks like are sometimes getting before-update calls from native when we shouldn't
             if ((updateType & m_UpdateMask) == 0)
                 return;
 
-            #if UNITY_EDITOR
-            if (m_SavedDeviceStates != null)
-                RestoreDevicesAfterDomainReload();
-            #endif
+            RestoreDevicesAfterDomainReloadIfNecessary();
 
             // For devices that have state callbacks, tell them we're carrying state over
             // into the next frame.
@@ -2211,10 +2221,7 @@ namespace UnityEngine.Experimental.Input
             //       execution (and we're not sure where it's coming from).
             Profiler.BeginSample("InputUpdate");
 
-            #if UNITY_EDITOR
-            if (m_SavedDeviceStates != null)
-                RestoreDevicesAfterDomainReload();
-            #endif
+            RestoreDevicesAfterDomainReloadIfNecessary();
 
             // First update sends out startup analytics.
             #if UNITY_ANALYTICS || UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -395,6 +395,8 @@ namespace UnityEngine.Experimental.Input
 
         #region Processors
 
+        ////TODO: rename to RegisterProcessor
+
         /// <summary>
         /// Register an <see cref="InputProcessor{TValue}"/> with the system.
         /// </summary>
@@ -960,7 +962,7 @@ namespace UnityEngine.Experimental.Input
             if (monitor == null)
                 throw new ArgumentNullException(nameof(monitor));
             if (control.device.m_DeviceIndex == InputDevice.kInvalidDeviceIndex)
-                throw new ArgumentException(message: string.Format("Device for control '{0}' has not been added to system"), nameof(control));
+                throw new ArgumentException(string.Format("Device for control '{0}' has not been added to system"), nameof(control));
 
             s_Manager.AddStateChangeMonitor(control, monitor, monitorIndex);
         }
@@ -1218,6 +1220,8 @@ namespace UnityEngine.Experimental.Input
             var inputEvent = TextEvent.Create(device.id, character, time);
             s_Manager.QueueEvent(ref inputEvent);
         }
+
+        ////REVIEW: this should run the "natural" update according to what's configured in the input systems (e.g. manual if manual is chosen there)
 
         public static void Update()
         {
@@ -1769,7 +1773,7 @@ namespace UnityEngine.Experimental.Input
             #endif
 
             #if UNITY_EDITOR || UNITY_STANDALONE_LINUX
-            Plugins.Linux.SDLSupport.Initialize();
+            Plugins.Linux.LinuxSupport.Initialize();
             #endif
 
             #if UNITY_EDITOR || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_WSA

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/LinuxSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/LinuxSupport.cs
@@ -1,6 +1,5 @@
+#if UNITY_EDITOR || UNITY_STANDALONE_LINUX
 using System;
-using System.Collections.Generic;
-using UnityEngine.Experimental.Input.Layouts;
 
 namespace UnityEngine.Experimental.Input.Plugins.Linux
 {
@@ -80,22 +79,22 @@ namespace UnityEngine.Experimental.Input.Plugins.Linux
     }
 
     [Serializable]
-    struct SDLFeatureDescriptor
+    internal struct SDLFeatureDescriptor
     {
         public JoystickFeatureType featureType;
         public int usageHint;
         public int size;
         public int offset;
         public int bit;
-        public Int32 min;
-        public Int32 max;
+        public int min;
+        public int max;
     }
 
     //Sync to XRInputDeviceDefinition in XRInputDeviceDefinition.h
     [Serializable]
-    class SDLDeviceDescriptor
+    internal class SDLDeviceDescriptor
     {
-        public List<SDLFeatureDescriptor> controls;
+        public SDLFeatureDescriptor[] controls;
 
         internal string ToJson()
         {
@@ -107,17 +106,18 @@ namespace UnityEngine.Experimental.Input.Plugins.Linux
             return JsonUtility.FromJson<SDLDeviceDescriptor>(json);
         }
     }
+
 #pragma warning restore 0649
 
     /// <summary>
     /// A small helper class to aid in initializing and registering SDL devices and layout builders.
     /// </summary>
-    public static class SDLSupport
+    public static class LinuxSupport
     {
         /// <summary>
         /// The current interface code sent with devices to identify as Linux SDL devices.
         /// </summary>
-        public const string kXRInterfaceCurrent = "Linux";
+        public const string kInterfaceName = "Linux";
 
         public static string GetAxisNameFromUsage(SDLAxisUsage usage)
         {
@@ -138,3 +138,4 @@ namespace UnityEngine.Experimental.Input.Plugins.Linux
         }
     }
 }
+#endif // UNITY_EDITOR || UNITY_STANDALONE_LINUX

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/LinuxSupport.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/LinuxSupport.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f153bab7b2bb63d409bbb73d4bcacb95
+guid: 3da49be2d645b418c8ee308bb1a011c7
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -2598,12 +2598,12 @@ partial class CoreTests
         float? receivedFloat = null;
         action.performed +=
             ctx =>
-            {
-                Assert.That(receivedFloat, Is.Null);
-                // ConstantVector2TestProcessor processes Vector2s. It would throw an exception when 
-                // trying to use it reading a float if not ignored.
-                receivedFloat = ctx.ReadValue<float>();
-            };
+        {
+            Assert.That(receivedFloat, Is.Null);
+            // ConstantVector2TestProcessor processes Vector2s. It would throw an exception when
+            // trying to use it reading a float if not ignored.
+            receivedFloat = ctx.ReadValue<float>();
+        };
 
         Set(gamepad.leftStick, Vector2.one);
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
@@ -1842,11 +1842,8 @@ partial class CoreTests
         Assert.That(Joystick.current, Is.SameAs(device));
 
         var joystick = (Joystick)device;
-
-        Assert.That(joystick.axes, Has.Count.EqualTo(4)); // Includes stick.
-        Assert.That(joystick.buttons, Has.Count.EqualTo(3)); // Includes trigger.
-        Assert.That(joystick.trigger.name, Is.EqualTo("trigger"));
-        Assert.That(joystick.stick.name, Is.EqualTo("stick"));
+        Assert.That(joystick.stick, Is.Not.Null);
+        Assert.That(joystick.trigger, Is.Not.Null);
     }
 
     // The whole dynamic vs fixed vs before-render vs editor update mechanic is a can of worms. In the

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -1,125 +1,251 @@
-#if UNITY_EDITOR || UNITY_STANDALONE // UNITY_STANDALONE_LINUX
+#if UNITY_EDITOR || UNITY_STANDALONE_LINUX
 using NUnit.Framework;
 using System.Runtime.InteropServices;
 using UnityEngine.Experimental.Input;
 using UnityEngine.Experimental.Input.Utilities;
 using UnityEngine.Experimental.Input.Plugins.Linux;
 using UnityEngine.Experimental.Input.Controls;
+using UnityEngine.Experimental.Input.LowLevel;
 
 internal class LinuxTests : InputTestFixture
 {
-    [StructLayout(LayoutKind.Explicit)]
-    unsafe struct TestSDLJoystick : IInputStateTypeInfo
+    [Test]
+    [Category("Devices")]
+    public void Devices_SupportsLinuxSDLJoysticks()
     {
-        [FieldOffset(0)] public byte buttonMask1;
-        [FieldOffset(1)] public uint buttonMask2;
+        runtime.ReportNewInputDevice(TestSDLJoystick.descriptorString);
+
+        InputSystem.Update();
+
+        var device = InputSystem.devices[0];
+
+        Assert.That(device, Is.Not.Null);
+        Assert.That(device, Is.TypeOf<Joystick>());
+
+        var joystick = (Joystick)device;
+
+        // Buttons.
+        Assert.That(joystick["Trigger"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Thumb"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Thumb2"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Top"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Top2"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Pinkie"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Base"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Base2"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Base3"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Base4"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Base5"], Is.TypeOf<ButtonControl>());
+        Assert.That(joystick["Base6"], Is.TypeOf<ButtonControl>());
+
+        Assert.That(joystick["Trigger"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Thumb"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Thumb2"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Top"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Top2"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Pinkie"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Base"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Base2"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Base3"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Base4"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Base5"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Base6"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+
+        Assert.That(joystick["Trigger"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Thumb"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Thumb2"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Top"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Top2"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Pinkie"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Base"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Base2"].stateBlock.byteOffset, Is.EqualTo(0));
+        Assert.That(joystick["Base3"].stateBlock.byteOffset, Is.EqualTo(1));
+        Assert.That(joystick["Base4"].stateBlock.byteOffset, Is.EqualTo(1));
+        Assert.That(joystick["Base5"].stateBlock.byteOffset, Is.EqualTo(1));
+        Assert.That(joystick["Base6"].stateBlock.byteOffset, Is.EqualTo(1));
+
+        Assert.That(joystick["Trigger"].stateBlock.bitOffset, Is.EqualTo(0));
+        Assert.That(joystick["Thumb"].stateBlock.bitOffset, Is.EqualTo(1));
+        Assert.That(joystick["Thumb2"].stateBlock.bitOffset, Is.EqualTo(2));
+        Assert.That(joystick["Top"].stateBlock.bitOffset, Is.EqualTo(3));
+        Assert.That(joystick["Top2"].stateBlock.bitOffset, Is.EqualTo(4));
+        Assert.That(joystick["Pinkie"].stateBlock.bitOffset, Is.EqualTo(5));
+        Assert.That(joystick["Base"].stateBlock.bitOffset, Is.EqualTo(6));
+        Assert.That(joystick["Base2"].stateBlock.bitOffset, Is.EqualTo(7));
+        Assert.That(joystick["Base3"].stateBlock.bitOffset, Is.EqualTo(0));
+        Assert.That(joystick["Base4"].stateBlock.bitOffset, Is.EqualTo(1));
+        Assert.That(joystick["Base5"].stateBlock.bitOffset, Is.EqualTo(2));
+        Assert.That(joystick["Base6"].stateBlock.bitOffset, Is.EqualTo(3));
+
+        Assert.That(joystick["Trigger"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Thumb"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Thumb2"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Top"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Top2"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Pinkie"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Base"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Base2"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Base3"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Base4"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Base5"].stateBlock.sizeInBits, Is.EqualTo(1));
+        Assert.That(joystick["Base6"].stateBlock.sizeInBits, Is.EqualTo(1));
+
+        // Stick.
+        Assert.That(joystick["Stick"], Is.TypeOf<StickControl>());
+        Assert.That(joystick["Stick"].stateBlock.byteOffset, Is.EqualTo(4));
+        Assert.That(joystick["Stick"].stateBlock.sizeInBits, Is.EqualTo(64));
+        Assert.That(joystick["Stick/x"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Stick/y"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Stick/x"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Stick/y"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Stick/x"].stateBlock.byteOffset, Is.EqualTo(4)); // Parent offset baked in.
+        Assert.That(joystick["Stick/y"].stateBlock.byteOffset, Is.EqualTo(8));
+
+        // Axes.
+        Assert.That(joystick["RotateZ"], Is.TypeOf<AxisControl>());
+        Assert.That(joystick["RotateZ"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["RotateZ"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["RotateZ"].stateBlock.byteOffset, Is.EqualTo(12));
+        Assert.That(joystick["Throttle"], Is.TypeOf<AxisControl>());
+        Assert.That(joystick["Throttle"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Throttle"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Throttle"].stateBlock.byteOffset, Is.EqualTo(16));
+
+        // Hat.
+        Assert.That(joystick["Hat"], Is.TypeOf<DpadControl>());
+        Assert.That(joystick["Hat"].stateBlock.byteOffset, Is.EqualTo(20));
+        Assert.That(joystick["Hat"].stateBlock.sizeInBits, Is.EqualTo(64));
+        Assert.That(joystick["Hat/up"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Hat/down"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Hat/left"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Hat/right"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Hat/up"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Hat/down"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Hat/left"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Hat/right"].stateBlock.sizeInBits, Is.EqualTo(32));
+        Assert.That(joystick["Hat/up"].stateBlock.byteOffset, Is.EqualTo(24)); // Parent offset baked in.
+        Assert.That(joystick["Hat/down"].stateBlock.byteOffset, Is.EqualTo(24));
+        Assert.That(joystick["Hat/left"].stateBlock.byteOffset, Is.EqualTo(20));
+        Assert.That(joystick["Hat/right"].stateBlock.byteOffset, Is.EqualTo(20));
+
+        // Control properties.
+        Assert.That(joystick.trigger, Is.SameAs(joystick["Trigger"]));
+        Assert.That(joystick.hat, Is.SameAs(joystick["Hat"]));
+        Assert.That(joystick.stick, Is.SameAs(joystick["Stick"]));
+        Assert.That(joystick.twist, Is.SameAs(joystick["RotateZ"]));
+
+        Assert.That(joystick["Thumb"].stateBlock.bitOffset, Is.EqualTo(1));
+        Assert.That(joystick["Thumb2"].stateBlock.bitOffset, Is.EqualTo(2));
+        Assert.That(joystick["Top"].stateBlock.bitOffset, Is.EqualTo(3));
+        Assert.That(joystick["Top2"].stateBlock.bitOffset, Is.EqualTo(4));
+        Assert.That(joystick["Pinkie"].stateBlock.bitOffset, Is.EqualTo(5));
+        Assert.That(joystick["Base"].stateBlock.bitOffset, Is.EqualTo(6));
+        Assert.That(joystick["Base2"].stateBlock.bitOffset, Is.EqualTo(7));
+        Assert.That(joystick["Base3"].stateBlock.bitOffset, Is.EqualTo(0));
+        Assert.That(joystick["Base4"].stateBlock.bitOffset, Is.EqualTo(1));
+        Assert.That(joystick["Base5"].stateBlock.bitOffset, Is.EqualTo(2));
+        Assert.That(joystick["Base6"].stateBlock.bitOffset, Is.EqualTo(3));
+
+        // Check button presses.
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Trigger), (ButtonControl)joystick["Trigger"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Thumb), (ButtonControl)joystick["Thumb"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Thumb2), (ButtonControl)joystick["Thumb2"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Top), (ButtonControl)joystick["Top"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Top2), (ButtonControl)joystick["Top2"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Pinkie), (ButtonControl)joystick["Pinkie"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Base), (ButtonControl)joystick["Base"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Base2), (ButtonControl)joystick["Base2"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Base3), (ButtonControl)joystick["Base3"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Base4), (ButtonControl)joystick["Base4"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Base5), (ButtonControl)joystick["Base5"]);
+        AssertButtonPress(joystick, new TestSDLJoystick().WithButton(SDLButtonUsage.Base6), (ButtonControl)joystick["Base6"]);
+
+        // Check axis motion.
+        InputSystem.QueueStateEvent(joystick, new TestSDLJoystick
+        {
+            hatX = int.MaxValue,
+            hatY = int.MinValue,
+            rotateZAxis = int.MaxValue,
+            xAxis = short.MinValue,
+            yAxis = short.MaxValue,
+            throttleAxis = int.MinValue,
+        });
+        InputSystem.Update();
+
+        Assert.That(joystick.stick.x.ReadUnprocessedValue(), Is.EqualTo(-1).Within(0.00001));
+        Assert.That(joystick.stick.y.ReadUnprocessedValue(), Is.EqualTo(-1).Within(0.00001));
+        Assert.That(joystick.stick.up.isPressed, Is.False);
+        Assert.That(joystick.stick.down.isPressed, Is.True);
+        Assert.That(joystick.stick.left.isPressed, Is.True);
+        Assert.That(joystick.stick.right.isPressed, Is.False);
+        Assert.That(joystick.hat.up.isPressed, Is.True);
+        Assert.That(joystick.hat.down.isPressed, Is.False);
+        Assert.That(joystick.hat.left.isPressed, Is.False);
+        Assert.That(joystick.hat.right.isPressed, Is.True);
+        Assert.That(joystick.twist.ReadUnprocessedValue(), Is.EqualTo(1).Within(0.00001));
+        Assert.That(joystick["Throttle"].ReadValueAsObject(), Is.EqualTo(-1).Within(0.00001));
+
+        InputSystem.QueueStateEvent(joystick, new TestSDLJoystick
+        {
+            hatX = int.MinValue,
+            hatY = int.MaxValue,
+            rotateZAxis = int.MinValue,
+            xAxis = short.MaxValue,
+            yAxis = short.MinValue,
+            throttleAxis = int.MaxValue,
+        });
+        InputSystem.Update();
+
+        Assert.That(joystick.stick.x.ReadUnprocessedValue(), Is.EqualTo(1).Within(0.00001));
+        Assert.That(joystick.stick.y.ReadUnprocessedValue(), Is.EqualTo(1).Within(0.00001));
+        Assert.That(joystick.stick.up.isPressed, Is.True);
+        Assert.That(joystick.stick.down.isPressed, Is.False);
+        Assert.That(joystick.stick.left.isPressed, Is.False);
+        Assert.That(joystick.stick.right.isPressed, Is.True);
+        Assert.That(joystick.hat.up.isPressed, Is.False);
+        Assert.That(joystick.hat.down.isPressed, Is.True);
+        Assert.That(joystick.hat.left.isPressed, Is.True);
+        Assert.That(joystick.hat.right.isPressed, Is.False);
+        Assert.That(joystick.twist.ReadUnprocessedValue(), Is.EqualTo(-1).Within(0.00001));
+        Assert.That(joystick["Throttle"].ReadValueAsObject(), Is.EqualTo(1).Within(0.00001));
+
+        InputSystem.QueueStateEvent(joystick, new TestSDLJoystick());
+        InputSystem.Update();
+
+        Assert.That(joystick.stick.x.ReadUnprocessedValue(), Is.EqualTo(0).Within(0.00001));
+        Assert.That(joystick.stick.y.ReadUnprocessedValue(), Is.EqualTo(0).Within(0.00001));
+        Assert.That(joystick.stick.up.isPressed, Is.False);
+        Assert.That(joystick.stick.down.isPressed, Is.False);
+        Assert.That(joystick.stick.left.isPressed, Is.False);
+        Assert.That(joystick.stick.right.isPressed, Is.False);
+        Assert.That(joystick.hat.up.isPressed, Is.False);
+        Assert.That(joystick.hat.down.isPressed, Is.False);
+        Assert.That(joystick.hat.left.isPressed, Is.False);
+        Assert.That(joystick.hat.right.isPressed, Is.False);
+        Assert.That(joystick.twist.ReadUnprocessedValue(), Is.EqualTo(0).Within(0.00001));
+        Assert.That(joystick["Throttle"].ReadValueAsObject(), Is.EqualTo(0).Within(0.00001));
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct TestSDLJoystick : IInputStateTypeInfo
+    {
+        [FieldOffset(0)] public int buttons;
         [FieldOffset(4)] public int xAxis;
         [FieldOffset(8)] public int yAxis;
         [FieldOffset(12)] public int rotateZAxis;
-        [FieldOffset(16)] public int ThrottleAxis;
-        [FieldOffset(20)] public int hat1;
-        [FieldOffset(24)] public int hat2;
+        [FieldOffset(16)] public int throttleAxis;
+        [FieldOffset(20)] public int hatX;
+        [FieldOffset(24)] public int hatY;
 
-        public void SetButtonValue(SDLButtonUsage usage, bool value)
+        public TestSDLJoystick WithButton(SDLButtonUsage usage, bool value = true)
         {
-            bool useButtonMask2 = false;
-            byte bitflag = 0;
-            switch (usage)
-            {
-                case SDLButtonUsage.Trigger:
-                {
-                    bitflag = 1 >> 0;
-                }
-                break;
-                case SDLButtonUsage.Thumb:
-                {
-                    bitflag = 1 >> 1;
-                }
-                break;
-                case SDLButtonUsage.Thumb2:
-                {
-                    bitflag = 1 >> 2;
-                }
-                break;
-                case SDLButtonUsage.Top:
-                {
-                    bitflag = 1 >> 3;
-                }
-                break;
-                case SDLButtonUsage.Top2:
-                {
-                    bitflag = 1 >> 4;
-                }
-                break;
-                case SDLButtonUsage.Pinkie:
-                {
-                    bitflag = 1 >> 5;
-                }
-                break;
-                case SDLButtonUsage.Base:
-                {
-                    bitflag = 1 >> 6;
-                }
-                break;
-                case SDLButtonUsage.Base2:
-                {
-                    bitflag = 1 >> 7;
-                }
-                break;
-                case SDLButtonUsage.Base3:
-                {
-                    useButtonMask2 = true;
-                    bitflag = 1 >> 0;
-                }
-                break;
-                case SDLButtonUsage.Base4:
-                {
-                    useButtonMask2 = true;
-                    bitflag = 1 >> 1;
-                }
-                break;
-                case SDLButtonUsage.Base5:
-                {
-                    useButtonMask2 = true;
-                    bitflag = 1 >> 2;
-                }
-                break;
-                case SDLButtonUsage.Base6:
-                {
-                    useButtonMask2 = true;
-                    bitflag = 1 >> 3;
-                }
-                break;
-                default:
-                    //Do Nothing
-                    break;
-            }
+            var bitMask = 1 << ((int)usage - 1);
 
-            if (bitflag != 0)
-            {
-                if (value)
-                {
-                    if (useButtonMask2)
-                    {
-                        buttonMask2 |= bitflag;
-                    }
-                    else
-                    {
-                        buttonMask1 |= bitflag;
-                    }
-                }
-                else
-                {
-                    if (useButtonMask2)
-                    {
-                        buttonMask2 &= (byte)~bitflag;
-                    }
-                    else
-                    {
-                        buttonMask1 &= (byte)~bitflag;
-                    }
-                }
-            }
+            if (value)
+                buttons |= bitMask;
+            else
+                buttons &= ~bitMask;
+            return this;
         }
 
         public FourCC GetFormat()
@@ -127,176 +253,33 @@ internal class LinuxTests : InputTestFixture
             return new FourCC('L', 'J', 'O', 'Y');
         }
 
-        public static readonly string descriptorString = "{\"interface\":\"Linux\",\"type\":\"Joystick\",\"product\":\"TestProduct\",\"manufacturer\":\"TestManufacturer\",\"serial\":\"030000006d04000015c2000010010000\",\"version\":\"272\",\"capabilities\":\"{\\\"controls\\\":[{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":1,\\\"bit\\\":0},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":2,\\\"bit\\\":1},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":3,\\\"bit\\\":2},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":4,\\\"bit\\\":3},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":5,\\\"bit\\\":4},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":6,\\\"bit\\\":5},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":7,\\\"bit\\\":6},{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":8,\\\"bit\\\":7},{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":9,\\\"bit\\\":0},{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":10,\\\"bit\\\":1},{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":11,\\\"bit\\\":2},{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":12,\\\"bit\\\":3},{\\\"offset\\\":4,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":1,\\\"min\\\":-32768,\\\"max\\\":32767},{\\\"offset\\\":8,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":2,\\\"min\\\":-32768,\\\"max\\\":32767},{\\\"offset\\\":12,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":6,\\\"min\\\":-32768,\\\"max\\\":32767},{\\\"offset\\\":16,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":7,\\\"min\\\":-32768,\\\"max\\\":32767},{\\\"offset\\\":20,\\\"featureSize\\\":4,\\\"featureType\\\":4,\\\"usageHint\\\":12,\\\"min\\\":-1,\\\"max\\\":1},{\\\"offset\\\":24,\\\"featureSize\\\":4,\\\"featureType\\\":4,\\\"usageHint\\\":13,\\\"min\\\":-1,\\\"max\\\":1}]}\"}";
-    }
-
-    [Test]
-    public void Layout_LinuxLayoutTest()
-    {
-        runtime.ReportNewInputDevice(TestSDLJoystick.descriptorString);
-
-        InputSystem.Update();
-
-        var generatedLayout = InputSystem.TryLoadLayout("Linux::TestManufacturer::TestProduct");
-
-        Assert.That(generatedLayout, Is.Not.Null);
-        Assert.That(generatedLayout.controls, Has.Count.EqualTo(16));
-
-        var triggerControl = generatedLayout.controls[0];
-        Assert.That(triggerControl.name, Is.EqualTo(SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Trigger)));
-        Assert.That(triggerControl.offset, Is.EqualTo(0));
-        Assert.That(triggerControl.layout, Is.EqualTo(new InternedString("Button")));
-    }
-
-    [Test]
-    public void State_LinuxDeviceTest()
-    {
-        runtime.ReportNewInputDevice(TestSDLJoystick.descriptorString);
-
-        InputSystem.Update();
-
-        Assert.That(InputSystem.devices, Has.Count.EqualTo(1));
-        var createdDevice = InputSystem.devices[0];
-
-        Assert.That(createdDevice.allControls, Has.Count.EqualTo(16));
-
-        InputControl triggerControl = createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Trigger)];
-        Assert.That(triggerControl, Is.TypeOf(typeof(ButtonControl)));
-
-        InputControl thumbControl = createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Thumb)];
-        Assert.That(thumbControl, Is.TypeOf(typeof(ButtonControl)));
-
-        InputControl thumb2Control = createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Thumb2)];
-        Assert.That(thumb2Control, Is.TypeOf(typeof(ButtonControl)));
-
-        InputControl topControl = createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Top)];;
-        Assert.That(topControl, Is.TypeOf(typeof(ButtonControl)));
-
-        InputControl top2Control = createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Top2)];
-        Assert.That(top2Control, Is.TypeOf(typeof(ButtonControl)));
-
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Top)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Top2)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Pinkie)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Base)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Base2)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Base3)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Base4)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Base5)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Base6)], Is.Not.Null);
-
-        Assert.That(createdDevice[SDLSupport.GetAxisNameFromUsage(SDLAxisUsage.X)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetAxisNameFromUsage(SDLAxisUsage.Y)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetAxisNameFromUsage(SDLAxisUsage.RotateZ)], Is.Not.Null);
-        Assert.That(createdDevice[SDLSupport.GetAxisNameFromUsage(SDLAxisUsage.Throttle)], Is.Not.Null);
-    }
-
-    [Test]
-    public void State_LinuxStateTest()
-    {
-        runtime.ReportNewInputDevice(TestSDLJoystick.descriptorString);
-
-        InputSystem.Update();
-
-        Assert.That(InputSystem.devices, Has.Count.EqualTo(1));
-        var device = InputSystem.devices[0];
-
-        TestSDLJoystick joystickState = new TestSDLJoystick();
-
-        ButtonControl triggerControl = device[SDLSupport.GetButtonNameFromUsage(SDLButtonUsage.Trigger)] as ButtonControl;
-        Assert.That(triggerControl.isPressed, Is.False);
-
-        joystickState.SetButtonValue(SDLButtonUsage.Trigger, true);
-        InputSystem.QueueStateEvent(device, joystickState);
-        InputSystem.Update();
-
-        Assert.That(triggerControl.isPressed, Is.True);
-
-        joystickState.SetButtonValue(SDLButtonUsage.Trigger, false);
-        InputSystem.QueueStateEvent(device, joystickState);
-        InputSystem.Update();
-
-        Assert.That(triggerControl.isPressed, Is.False);
-    }
-
-    [Test]
-    public void State_LinuxJoystickStickAxesReportProperValues()
-    {
-        runtime.ReportNewInputDevice(TestSDLJoystick.descriptorString);
-
-        InputSystem.Update();
-
-        Assert.That(InputSystem.devices, Has.Count.EqualTo(1));
-        var device = InputSystem.devices[0];
-
-        ButtonControl leftButton = device["stick/left"] as ButtonControl;
-        ButtonControl rightButton = device["stick/right"] as ButtonControl;
-        AxisControl xAxis = device["stick/x"] as AxisControl;
-        ButtonControl downButton = device["stick/down"] as ButtonControl;
-        ButtonControl upButton = device["stick/up"] as ButtonControl;
-        AxisControl yAxis = device["stick/y"] as AxisControl;
-
-        TestSDLJoystick joystickState = new TestSDLJoystick();
-
-        InputSystem.QueueStateEvent(device, joystickState);
-        InputSystem.Update();
-
-        joystickState.yAxis = short.MaxValue;
-        joystickState.xAxis = short.MaxValue;
-
-        InputSystem.QueueStateEvent(device, joystickState);
-        InputSystem.Update();
-
-        float leftValue = leftButton.ReadValue();
-        float rightValue = rightButton.ReadValue();
-        float xValue = xAxis.ReadValue();
-        float downValue = downButton.ReadValue();
-        float upValue = upButton.ReadValue();
-        float yValue = yAxis.ReadValue();
-        Assert.That(downValue, Is.EqualTo(1.0f));
-        Assert.That(upValue, Is.EqualTo(0.0f));
-        Assert.That(yValue, Is.EqualTo(-1.0f));
-        Assert.That(leftValue, Is.EqualTo(0.0f));
-        Assert.That(rightValue, Is.EqualTo(1.0f));
-        Assert.That(xValue, Is.EqualTo(1.0f));
-
-        joystickState.yAxis = short.MinValue;
-        joystickState.xAxis = short.MinValue;
-
-        InputSystem.QueueStateEvent(device, joystickState);
-        InputSystem.Update();
-
-        leftValue = leftButton.ReadValue();
-        rightValue = rightButton.ReadValue();
-        xValue = xAxis.ReadValue();
-        downValue = downButton.ReadValue();
-        upValue = upButton.ReadValue();
-        yValue = yAxis.ReadValue();
-        Assert.That(downValue, Is.EqualTo(0.0f));
-        Assert.That(upValue, Is.EqualTo(1.0f));
-        Assert.That(yValue, Is.EqualTo(1.0f));
-        Assert.That(leftValue, Is.EqualTo(1.0f));
-        Assert.That(rightValue, Is.EqualTo(0.0f));
-        Assert.That(xValue, Is.EqualTo(-1.0f));
-
-        joystickState.yAxis = 0;
-        joystickState.xAxis = 0;
-
-        InputSystem.QueueStateEvent(device, joystickState);
-        InputSystem.Update();
-
-        leftValue = leftButton.ReadValue();
-        rightValue = rightButton.ReadValue();
-        xValue = xAxis.ReadValue();
-        downValue = downButton.ReadValue();
-        upValue = upButton.ReadValue();
-        yValue = yAxis.ReadValue();
-        Assert.That(downValue, Is.EqualTo(0.0f));
-        Assert.That(upValue, Is.EqualTo(0.0f));
-        Assert.That(yValue, Is.EqualTo(0.0f));
-        Assert.That(leftValue, Is.EqualTo(0.0f));
-        Assert.That(rightValue, Is.EqualTo(0.0f));
-        Assert.That(xValue, Is.EqualTo(0.0f));
+        public static readonly string descriptorString =
+            "{\"interface\":\"Linux\"," +
+            "\"type\":\"Joystick\"," +
+            "\"product\":\"TestProduct\"," +
+            "\"manufacturer\":\"TestManufacturer\"," +
+            "\"serial\":\"030000006d04000015c2000010010000\"," +
+            "\"version\":\"272\"," +
+            "\"capabilities\":\"{" +
+            "\\\"controls\\\":[" +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":1,\\\"bit\\\":0}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":2,\\\"bit\\\":1}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":3,\\\"bit\\\":2}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":4,\\\"bit\\\":3}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":5,\\\"bit\\\":4}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":6,\\\"bit\\\":5}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":7,\\\"bit\\\":6}," +
+            "{\\\"offset\\\":0,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":8,\\\"bit\\\":7}," +
+            "{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":9,\\\"bit\\\":0}," +
+            "{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":10,\\\"bit\\\":1}," +
+            "{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":11,\\\"bit\\\":2}," +
+            "{\\\"offset\\\":1,\\\"featureSize\\\":1,\\\"featureType\\\":3,\\\"usageHint\\\":12,\\\"bit\\\":3}," +
+            "{\\\"offset\\\":4,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":1,\\\"min\\\":-32768,\\\"max\\\":32767}," +
+            "{\\\"offset\\\":8,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":2,\\\"min\\\":-32768,\\\"max\\\":32767}," +
+            "{\\\"offset\\\":12,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":6,\\\"min\\\":-32768,\\\"max\\\":32767}," +
+            "{\\\"offset\\\":16,\\\"featureSize\\\":4,\\\"featureType\\\":1,\\\"usageHint\\\":7,\\\"min\\\":-32768,\\\"max\\\":32767}," +
+            "{\\\"offset\\\":20,\\\"featureSize\\\":4,\\\"featureType\\\":4,\\\"usageHint\\\":12,\\\"min\\\":-1,\\\"max\\\":1}," +
+            "{\\\"offset\\\":24,\\\"featureSize\\\":4,\\\"featureType\\\":4,\\\"usageHint\\\":13,\\\"min\\\":-1,\\\"max\\\":1}]}\"}";
     }
 }
-#endif //UNITY_EDITOR || UNITY_STANDALONE // UNITY_STANDALONE_LINUX
+#endif // UNITY_EDITOR || UNITY_STANDALONE_LINUX


### PR DESCRIPTION
Ended up just collapsing the Linux joystick test into one single thing.

Some misc changes
- Nuked `Joystick.axes` and `Joystick.buttons`. Don't see much usefulness in those.
- Made `DpadControl.x` and `DpadControl.y` synthetic.
- `InputControl.this[path]` now throws `KeyNotFoundException` instead of `IndexOutOfRangeException`; as requested by scripting API review.