### PR TITLE
FIX: When we went from field to property, we lost bit reset.

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -94,7 +94,8 @@ namespace UnityEngine.Experimental.Input
 
             lock (m_Lock)
             {
-                eventPtr->eventId = m_NextEventId;
+                eventPtr->eventId = m_NextEventId; 
+                eventPtr->handled = false;
                 ++m_NextEventId;
 
                 // Enlarge buffer, if we have to.


### PR DESCRIPTION
In the process of changing to use the native InputEvent struct, the act of resetting the ID in the test runners InputTestRuntime lost its ability to completely reset the value , the handled bit.  It went from a field to a property meaning only the setter for event ID was getting processed.

on another note, we do "overflow" while doing this "handled" bit, but the way C# handles the overflow, it still works.  Wouldn't it be cleaner and less error prone, if we just had handled as a bool on the struct instead of the "bit" on the id field?