### PR TITLE
Fix timeslicing

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Input Settings configured in the editor are now transferred to the built player correctly.
+- Time slicing for fixed updates now works correctly, even when pausing or dropping frames.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -135,6 +135,15 @@ namespace UnityEngine.Experimental.Input.LowLevel
         double currentTime { get; }
 
         /// <summary>
+        /// The current time on the same timeline that input events are delivered on, for the current FixedUpdate.
+        /// </summary>
+        /// <remarks>
+        /// This should be used inside FixedUpdate calls instead of currentTime, as FixedUpdates are simulated at times
+        /// not matching the real time the simulation corresponds to.
+        /// </remarks>
+        double currentTimeForFixedUpdate { get; }
+
+        /// <summary>
         /// The time offset that <see cref="currentTime"/> currently has to <see cref="Time.realtimeSinceStartup"/>.
         /// </summary>
         double currentTimeOffsetToRealtimeSinceStartup { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -149,11 +149,6 @@ namespace UnityEngine.Experimental.Input.LowLevel
         double currentTimeOffsetToRealtimeSinceStartup { get; }
 
         /// <summary>
-        /// Frequency at which fixed updates are being run.
-        /// </summary>
-        double fixedUpdateIntervalInSeconds { get; }
-
-        /// <summary>
         /// Flag which tells runtime whether to process input events when in the background.
         /// </summary>
         /// <remarks>

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -68,7 +68,6 @@ namespace UnityEngine.Experimental.Input
         public static InputUpdateType s_LastUpdateType;
         public static uint s_DynamicUpdateCount;
         public static uint s_FixedUpdateCount;
-        public static double s_LastFixedUpdateTime;
         public static uint s_LastUpdateRetainedEventBytes;
         public static uint s_LastUpdateRetainedEventCount;
 
@@ -78,7 +77,6 @@ namespace UnityEngine.Experimental.Input
             public InputUpdateType lastUpdateType;
             public uint dynamicUpdateCount;
             public uint fixedUpdateCount;
-            public double lastFixedUpdateTime;
             public uint lastUpdateRetainedEventBytes;
             public uint lastUpdateRetainedEventCount;
         }
@@ -90,7 +88,6 @@ namespace UnityEngine.Experimental.Input
                 lastUpdateType = s_LastUpdateType,
                 dynamicUpdateCount = s_DynamicUpdateCount,
                 fixedUpdateCount = s_FixedUpdateCount,
-                lastFixedUpdateTime = s_LastFixedUpdateTime,
                 lastUpdateRetainedEventBytes = s_LastUpdateRetainedEventBytes,
                 lastUpdateRetainedEventCount = s_LastUpdateRetainedEventCount,
             };
@@ -101,7 +98,6 @@ namespace UnityEngine.Experimental.Input
             s_LastUpdateType = state.lastUpdateType;
             s_DynamicUpdateCount = state.dynamicUpdateCount;
             s_FixedUpdateCount = state.fixedUpdateCount;
-            s_LastFixedUpdateTime = state.lastFixedUpdateTime;
             s_LastUpdateRetainedEventBytes = state.lastUpdateRetainedEventBytes;
             s_LastUpdateRetainedEventCount = state.lastUpdateRetainedEventCount;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -212,6 +212,8 @@ namespace UnityEngine.Experimental.Input.LowLevel
 
         public double currentTime => NativeInputSystem.currentTime;
 
+        public double currentTimeForFixedUpdate => Time.fixedUnscaledTime + currentTimeOffsetToRealtimeSinceStartup;
+
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
 
         public double fixedUpdateIntervalInSeconds => Time.fixedDeltaTime;

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -215,9 +215,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
         public double currentTimeForFixedUpdate => Time.fixedUnscaledTime + currentTimeOffsetToRealtimeSinceStartup;
 
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
-
-        public double fixedUpdateIntervalInSeconds => Time.fixedDeltaTime;
-
+        
         public bool shouldRunInBackground
         {
             set => NativeInputSystem.SetUpdateMask((NativeInputUpdateType)(value ? 1 << 31 : 0));

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Events.cs
@@ -407,8 +407,6 @@ partial class CoreTests
     [Category("Events")]
     public unsafe void Events_TimeslicingCanBeTurnedOff()
     {
-        runtime.fixedUpdateIntervalInSeconds = 1.0 / 60; // 60 FPS.
-
         // Get first update out of the way with timeslicing on. First fixed update will consume all
         // input so we can't really tell the difference.
         InputSystem.Update(InputUpdateType.Fixed);

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -321,6 +321,7 @@ namespace UnityEngine.Experimental.Input
         public Action<bool> onFocusChanged { get; set; }
         public float pollingFrequency { get; set; }
         public double currentTime { get; set; }
+        public double currentTimeForFixedUpdate { get; set; }
         public bool shouldRunInBackground { get; set; }
         public int frameCount { get; set; }
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -326,9 +326,7 @@ namespace UnityEngine.Experimental.Input
         public int frameCount { get; set; }
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;
-
-        public double fixedUpdateIntervalInSeconds { get; set; } = 1.0 / 30;
-
+        
         public ScreenOrientation screenOrientation { set; get; } = ScreenOrientation.Portrait;
 
         public Vector2 screenSize { set; get; } = new Vector2(Screen.width, Screen.height);


### PR DESCRIPTION
Use Time.fixedUnscaledTime as a time base for time slicing, which correctly compensates for dropped frames, pausing of time scale changes.