### PR TITLE
Disable InputActionAsset when destroyed

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Input Settings configured in the editor are now transferred to the built player correctly.
 - Time slicing for fixed updates now works correctly, even when pausing or dropping frames.
+- Make sure we Disable any InputActionAsset when it is being destroyed. Otherwise, callbacks which were not cleaned up would could cause exceptions.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
@@ -520,6 +520,7 @@ namespace UnityEngine.Experimental.Input
 
         private void OnDestroy()
         {
+            Disable();
             if (m_SharedStateForAllMaps != null)
             {
                 m_SharedStateForAllMaps.Dispose(); // Will clean up InputActionMap state.

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -3535,6 +3535,37 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_DestroyingAssetClearsCallbacks()
+    {
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = new InputActionMap("map");
+
+        asset.AddActionMap(map);
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var action = map.AddAction("action", "/gamepad/leftTrigger");
+        asset.Enable();
+
+        var wasPerformed = false;
+        action.performed += ctx => wasPerformed = true;
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 1 });
+        InputSystem.Update();
+
+        Assert.That(wasPerformed);
+        wasPerformed = false;
+
+        UnityEngine.Object.DestroyImmediate(asset);
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0 });
+        // There must be no exceptions here from trying to call any callbacks on the destroyed asset.
+        InputSystem.Update();
+
+        Assert.That(wasPerformed, Is.False);
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_MapsInAssetMustHaveName()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();


### PR DESCRIPTION
Fixes https://fogbugz.unity3d.com/f/cases/1140845/