### PR TITLE
FIX: PlayerInput not finding actions when using Unity Events (#500).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - `PlayerInput` no longer fails to find actions when using UnityEvents (#500).
 - The `"{...}"` format for referencing action maps and actions using GUIDs as strings has been obsoleted. It will still work but adding the extra braces is no longer necessary.
+- Drag&dropping bindings between other bindings that came before them in the list no longer drops the items at a location one higher up in the list than intended.
+
 ## [0.2.6-preview] - 2019-03-20
 
 >NOTE: The UI code for editing actions has largely been rewritten. There may be regressions.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Time slicing for fixed updates now works correctly, even when pausing or dropping frames.
 - Make sure we Disable any InputActionAsset when it is being destroyed. Otherwise, callbacks which were not cleaned up would could cause exceptions.
 
+#### Actions
+
+- `PlayerInput` no longer fails to find actions when using UnityEvents (#500).
+- The `"{...}"` format for referencing action maps and actions using GUIDs as strings has been obsoleted. It will still work but adding the extra braces is no longer necessary.
 ## [0.2.6-preview] - 2019-03-20
 
 >NOTE: The UI code for editing actions has largely been rewritten. There may be regressions.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -742,6 +742,11 @@ namespace UnityEngine.Experimental.Input
                 throw new NotImplementedException();
             }
             */
+
+            public override string ToString()
+            {
+                return $"{{ action={action} phase={phase} time={time} control={control} value={ReadValueAsObject()} interaction={interaction} }}";
+            }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
@@ -203,10 +203,10 @@ namespace UnityEngine.Experimental.Input
         /// asset.FindAction("map2/action2") // Returns action2.
         /// asset.FindAction("map3/action3") // Returns action3.
         ///
-        /// Search by unique action ID. The GUID needs to be surrounded by "{...}".
-        /// asset.FindAction($"{{{action1.id.ToString()}}}") // Returns action1.
-        /// asset.FindAction($"{{{action2.id.ToString()}}}") // Returns action2.
-        /// asset.FindAction($"{{{action3.id.ToString()}}}") // Returns action3.
+        /// Search by unique action ID.
+        /// asset.FindAction(action1.id.ToString()) // Returns action1.
+        /// asset.FindAction(action2.id.ToString()) // Returns action2.
+        /// asset.FindAction(action3.id.ToString()) // Returns action3.
         /// </code>
         /// </example>
         public InputAction FindAction(string name)
@@ -236,7 +236,7 @@ namespace UnityEngine.Experimental.Input
                 var actionName = new Substring(name, indexOfSlash + 1);
 
                 if (mapName.isEmpty || actionName.isEmpty)
-                    throw new ArgumentException("Malformed action path: " + name, "name");
+                    throw new ArgumentException("Malformed action path: " + name, nameof(name));
 
                 for (var i = 0; i < m_ActionMaps.Length; ++i)
                 {
@@ -297,42 +297,41 @@ namespace UnityEngine.Experimental.Input
             map.m_Asset = null;
         }
 
-        public void RemoveActionMap(string name)
+        public void RemoveActionMap(string nameOrId)
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException(nameof(name));
+            if (string.IsNullOrEmpty(nameOrId))
+                throw new ArgumentNullException(nameof(nameOrId));
 
-            var map = TryGetActionMap(name);
+            var map = TryGetActionMap(nameOrId);
             if (map != null)
                 RemoveActionMap(map);
         }
 
-        public InputActionMap TryGetActionMap(string name)
+        public InputActionMap TryGetActionMap(string nameOrId)
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentException("Name cannot be null or empty", nameof(name));
+            if (string.IsNullOrEmpty(nameOrId))
+                throw new ArgumentException("Name cannot be null or empty", nameof(nameOrId));
 
             if (m_ActionMaps == null)
                 return null;
 
-            if (name.Length > 1 && name[0] == '{' && name[name.Length - 1] == '}')
+            // If the name contains a hyphen, it may be a GUID.
+            if (nameOrId.Contains('-') && Guid.TryParse(nameOrId, out var id))
             {
-                var idLength = name.Length - 2;
                 for (var i = 0; i < m_ActionMaps.Length; ++i)
                 {
                     var map = m_ActionMaps[i];
-                    if (string.Compare(name, 1, map.m_Id, 0, idLength, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    if (map.idDontGenerate == id)
                         return map;
                 }
             }
-            else
+
+            // Default lookup is by name (case-insensitive).
+            for (var i = 0; i < m_ActionMaps.Length; ++i)
             {
-                for (var i = 0; i < m_ActionMaps.Length; ++i)
-                {
-                    var map = m_ActionMaps[i];
-                    if (string.Compare(name, map.name, StringComparison.InvariantCultureIgnoreCase) == 0)
-                        return map;
-                }
+                var map = m_ActionMaps[i];
+                if (string.Compare(nameOrId, map.name, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    return map;
             }
 
             return null;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -210,20 +210,18 @@ namespace UnityEngine.Experimental.Input
                 return InputActionState.kInvalidIndex;
             var actionCount = m_Actions.Length;
 
-            var isReferenceById = nameOrId[0] == '{';
-            if (isReferenceById)
+            // If it contains hyphens, it may be a GUID so try looking up that way.
+            if (nameOrId.Contains('-') && Guid.TryParse(nameOrId, out var id))
             {
-                var id = new Guid(nameOrId);
                 for (var i = 0; i < actionCount; ++i)
                     if (m_Actions[i].idDontGenerate == id)
                         return i;
             }
-            else
-            {
-                for (var i = 0; i < actionCount; ++i)
-                    if (string.Compare(m_Actions[i].m_Name, nameOrId, StringComparison.InvariantCultureIgnoreCase) == 0)
-                        return i;
-            }
+
+            // Default search goes by name (case insensitive).
+            for (var i = 0; i < actionCount; ++i)
+                if (string.Compare(m_Actions[i].m_Name, nameOrId, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    return i;
 
             return InputActionState.kInvalidIndex;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -173,7 +173,7 @@ namespace UnityEngine.Experimental.Input
             if (action == Guid.Empty)
                 return AddBinding(actionMap, path: path, interactions: interactions, groups: groups);
             return AddBinding(actionMap, path: path, interactions: interactions, groups: groups,
-                action: $"{{{action}}}");
+                action: action.ToString());
         }
 
         public static BindingSyntax AddBinding(this InputActionMap actionMap, InputBinding binding)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
@@ -155,7 +155,7 @@ namespace UnityEngine.Experimental.Input
         }
 
         /// <summary>
-        /// Name of the action triggered by the binding.
+        /// Name or ID of the action triggered by the binding.
         /// </summary>
         /// <remarks>
         /// This is null if the binding does not trigger an action.
@@ -163,6 +163,8 @@ namespace UnityEngine.Experimental.Input
         /// For InputBindings that are used as filters, this can be a "mapName/actionName" combination
         /// or "mapName/*" to match all actions in the given map.
         /// </remarks>
+        /// <seealso cref="InputAction.name"/>
+        /// <seealso cref="InputAction.id"/>
         public string action
         {
             get => m_Action;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -134,7 +134,7 @@ namespace UnityEngine.Experimental.Input.Editor
         {
             // Make sure we have an action selected.
             var actionItems = m_ActionsTree.GetSelectedItems().OfType<ActionTreeItem>();
-            if (actionItems.Count() == 0)
+            if (!actionItems.Any())
             {
                 EditorApplication.Beep();
                 return;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -510,7 +510,7 @@ namespace UnityEngine.Experimental.Input.Editor
                         break;
 
                     case k_PasteCommand:
-                        var systemCopyBuffer = EditorGUIUtility.systemCopyBuffer;
+                        var systemCopyBuffer = EditorHelpers.GetSystemCopyBufferContents();
                         if (systemCopyBuffer != null && systemCopyBuffer.StartsWith(k_CopyPasteMarker))
                             uiEvent.Use();
                         break;
@@ -532,8 +532,8 @@ namespace UnityEngine.Experimental.Input.Editor
                         break;
                     case k_DuplicateCommand:
                         var buffer = new StringBuilder();
-                        CopySelectedItems(buffer);
-                        PasteData(buffer.ToString());
+                        CopySelectedItemsTo(buffer);
+                        PasteDataFrom(buffer.ToString());
                         break;
                     case k_DeleteCommand:
                         DeleteDataOfSelectedItems();
@@ -558,11 +558,11 @@ namespace UnityEngine.Experimental.Input.Editor
         public void CopySelectedItemsToClipboard()
         {
             var copyBuffer = new StringBuilder();
-            CopySelectedItems(copyBuffer);
-            EditorGUIUtility.systemCopyBuffer = copyBuffer.ToString();
+            CopySelectedItemsTo(copyBuffer);
+            EditorHelpers.SetSystemCopyBufferContents(copyBuffer.ToString());
         }
 
-        private void CopySelectedItems(StringBuilder buffer)
+        public void CopySelectedItemsTo(StringBuilder buffer)
         {
             CopyItems(GetSelectedItemsWithChildrenFilteredOut(), buffer);
         }
@@ -630,10 +630,10 @@ namespace UnityEngine.Experimental.Input.Editor
 
         public void PasteDataFromClipboard()
         {
-            PasteData(EditorGUIUtility.systemCopyBuffer);
+            PasteDataFrom(EditorHelpers.GetSystemCopyBufferContents());
         }
 
-        private void PasteData(string copyBufferString)
+        public void PasteDataFrom(string copyBufferString)
         {
             if (!copyBufferString.StartsWith(k_CopyPasteMarker))
                 return;
@@ -670,7 +670,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 // We may have pasted into a different tree view. Only select the items if we can find them in
                 // our current tree view.
                 var newItems = newItemPropertyPaths.Select(FindItemByPropertyPath).Where(x => x != null);
-                if (newItems.Count() > 0)
+                if (newItems.Any())
                     SelectItems(newItems);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
@@ -448,7 +448,7 @@ namespace UnityEngine.Experimental.Input.Editor
 
                 // Adjust child index by index of composite item itself.
                 arrayIndex = childIndex != null
-                    ? this.arrayIndex + childIndex.Value
+                    ? this.arrayIndex + 1 + childIndex.Value // Dropping at #0 should put as our index plus one.
                     : this.arrayIndex + 1 + InputActionSerializationHelpers.GetCompositePartCount(array, this.arrayIndex);
 
                 return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
@@ -1,0 +1,37 @@
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+
+namespace UnityEngine.Experimental.Input.Editor
+{
+    internal static class EditorHelpers
+    {
+        public static Action<string> SetSystemCopyBufferContents = s => EditorGUIUtility.systemCopyBuffer = s;
+        public static Func<string> GetSystemCopyBufferContents = () => EditorGUIUtility.systemCopyBuffer;
+
+        // It seems we're getting instabilities on the farm from using EditorGUIUtility.systemCopyBuffer directly in tests.
+        // Ideally, we'd have a mocking library to just work around that but well, we don't. So this provides a solution
+        // locally to tests.
+        public class FakeSystemCopyBuffer : IDisposable
+        {
+            private string m_Contents;
+            private readonly Action<string> m_OldSet;
+            private readonly Func<string> m_OldGet;
+
+            public FakeSystemCopyBuffer()
+            {
+                m_OldGet = GetSystemCopyBufferContents;
+                m_OldSet = SetSystemCopyBufferContents;
+                SetSystemCopyBufferContents = s => m_Contents = s;
+                GetSystemCopyBufferContents = () => m_Contents;
+            }
+
+            public void Dispose()
+            {
+                SetSystemCopyBufferContents = m_OldSet;
+                GetSystemCopyBufferContents = m_OldGet;
+            }
+        }
+    }
+}
+#endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d671947d51444fb9b8a4bf96c16bfed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -190,7 +190,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 using (var actionsProperty = actionsArrayProperty.GetArrayElementAtIndex(actionIndex))
                 {
                     var actionName = GetName(actionsProperty);
-                    var actionIdString = $"{{{actionId}}}";
+                    var actionIdString = actionId.ToString();
 
                     // Delete all bindings that refer to the action by ID or name.
                     for (var i = 0; i < bindingsArrayProperty.arraySize; ++i)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/ActionEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/ActionEvent.cs
@@ -34,14 +34,14 @@ namespace UnityEngine.Experimental.Input.LowLevel
 
         public double startTime
         {
-            get { return m_StartTime; }
-            set { m_StartTime = value; }
+            get => m_StartTime;
+            set => m_StartTime = value;
         }
 
         public InputActionPhase phase
         {
-            get { return (InputActionPhase)m_Phase; }
-            set { m_Phase = (byte)value; }
+            get => (InputActionPhase)m_Phase;
+            set => m_Phase = (byte)value;
         }
 
         public byte* valueData
@@ -55,14 +55,11 @@ namespace UnityEngine.Experimental.Input.LowLevel
             }
         }
 
-        public int valueSizeInBytes
-        {
-            get { return (int)baseEvent.sizeInBytes - InputEvent.kBaseEventSize - 16; }
-        }
+        public int valueSizeInBytes => (int)baseEvent.sizeInBytes - InputEvent.kBaseEventSize - 16;
 
         public int stateIndex
         {
-            get { return m_StateIndex; }
+            get => m_StateIndex;
             set
             {
                 Debug.Assert(value >= 0 && value <= byte.MaxValue);
@@ -74,7 +71,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
 
         public int controlIndex
         {
-            get { return m_ControlIndex; }
+            get => m_ControlIndex;
             set
             {
                 Debug.Assert(value >= 0 && value <= ushort.MaxValue);
@@ -86,7 +83,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
 
         public int bindingIndex
         {
-            get { return m_BindingIndex; }
+            get => m_BindingIndex;
             set
             {
                 Debug.Assert(value >= 0 && value <= ushort.MaxValue);
@@ -139,10 +136,9 @@ namespace UnityEngine.Experimental.Input.LowLevel
         public static ActionEvent* From(InputEventPtr ptr)
         {
             if (!ptr.valid)
-                throw new ArgumentNullException("ptr");
+                throw new ArgumentNullException(nameof(ptr));
             if (!ptr.IsA<ActionEvent>())
-                throw new InvalidCastException(string.Format("Cannot cast event with type '{0}' into ActionEvent",
-                    ptr.type));
+                throw new InvalidCastException($"Cannot cast event with type '{ptr.type}' into ActionEvent");
 
             return (ActionEvent*)ptr.data;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -215,7 +215,7 @@ namespace UnityEngine.Experimental.Input.LowLevel
         public double currentTimeForFixedUpdate => Time.fixedUnscaledTime + currentTimeOffsetToRealtimeSinceStartup;
 
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
-        
+
         public bool shouldRunInBackground
         {
             set => NativeInputSystem.SetUpdateMask((NativeInputUpdateType)(value ? 1 << 31 : 0));

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1092,6 +1092,14 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput
             m_PlayerIndex = -1;
         }
 
+        /// <summary>
+        /// Debug helper method that can be hooked up to actions when using <see cref="PlayerNotifications.InvokeUnityEvents"/>.
+        /// </summary>
+        public void DebugLogAction(InputAction.CallbackContext context)
+        {
+            Debug.Log(context.ToString());
+        }
+
         private void HandleDeviceLost()
         {
             switch (m_NotificationBehavior)
@@ -1203,7 +1211,7 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput
                 if (action.actionMap.asset == null)
                     throw new ArgumentException($"Action must be part of an asset (given action '{action}' is not)");
 
-                m_ActionId = $"{{{action.id.ToString()}}}";
+                m_ActionId = action.id.ToString();
                 m_ActionName = $"{action.actionMap.name}/{action.name}";
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -100,7 +100,7 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput.Editor
                         var asset = (InputActionAsset)serializedObject.FindProperty("m_Actions").objectReferenceValue;
                         var actionMap = asset.TryGetActionMap(m_ActionMapOptions[selected].text);
                         if (actionMap != null)
-                            defaultActionMapProperty.stringValue = $"{{{actionMap.id}}}";
+                            defaultActionMapProperty.stringValue = actionMap.id.ToString();
                     }
                     m_SelectedDefaultActionMap = selected;
                 }
@@ -404,7 +404,7 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput.Editor
                 // Add any new actions.
                 foreach (var action in asset)
                 {
-                    newActionEvents.Add(new PlayerInput.ActionEvent(action.id));
+                    newActionEvents.Add(new PlayerInput.ActionEvent(action.id, action.ToString()));
                     newActionNames.Add(new GUIContent(action + " Action"));
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/StringHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/StringHelpers.cs
@@ -31,6 +31,13 @@ namespace UnityEngine.Experimental.Input.Utilities
             return builder.ToString();
         }
 
+        public static bool Contains(this string str, char ch)
+        {
+            if (str == null)
+                return false;
+            return str.IndexOf(ch) != -1;
+        }
+
         public static bool Contains(this string str, string text, StringComparison comparison)
         {
             if (str == null)

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -2007,10 +2007,55 @@ partial class CoreTests
 
         Assert.That(map.TryGetAction("action1"), Is.SameAs(action1));
         Assert.That(map.TryGetAction("action2"), Is.SameAs(action2));
+        Assert.That(map.TryGetAction("action3"), Is.Null);
 
         // Lookup is case-insensitive.
         Assert.That(map.TryGetAction("Action1"), Is.SameAs(action1));
         Assert.That(map.TryGetAction("Action2"), Is.SameAs(action2));
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanLookUpActionsInMapById()
+    {
+        var map = new InputActionMap();
+
+        var action1 = map.AddAction("action1");
+        var action2 = map.AddAction("action2");
+
+        Assert.That(map.TryGetAction(action1.id), Is.SameAs(action1));
+        Assert.That(map.TryGetAction(action2.id), Is.SameAs(action2));
+        Assert.That(map.TryGetAction(Guid.NewGuid()), Is.Null);
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanLookUpActionsInMapByStringId()
+    {
+        var map = new InputActionMap();
+
+        var action1 = map.AddAction("action1");
+        var action2 = map.AddAction("action2");
+
+        Assert.That(map.TryGetAction(action1.id.ToString()), Is.SameAs(action1));
+        Assert.That(map.TryGetAction(action2.id.ToString()), Is.SameAs(action2));
+        Assert.That(map.TryGetAction(Guid.NewGuid().ToString()), Is.Null);
+    }
+
+    // We used to require string GUIDs to be using a "{...}" format when looking up actions. We no
+    // longer do this but there's still data that may be using this format so make sure it works for now.
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanLookUpActionsInMapByStringId_UsingOldBracedFormat()
+    {
+        var map = new InputActionMap();
+
+        var action1 = map.AddAction("action1");
+        var action2 = map.AddAction("action2");
+
+        Assert.That(map.TryGetAction($"{{{action1.id.ToString()}}}"), Is.SameAs(action1));
+        Assert.That(map.TryGetAction($"{{{action2.id.ToString()}}}"), Is.SameAs(action2));
+        Assert.That(map.TryGetAction($"{{{Guid.NewGuid().ToString()}}}"), Is.Null);
     }
 
     [Test]
@@ -3596,6 +3641,7 @@ partial class CoreTests
         asset.AddActionMap(map);
 
         Assert.That(asset.TryGetActionMap("test"), Is.SameAs(map));
+        Assert.That(asset.TryGetActionMap("other"), Is.Null);
     }
 
     [Test]
@@ -3606,7 +3652,22 @@ partial class CoreTests
         var map = new InputActionMap("test");
         asset.AddActionMap(map);
 
+        Assert.That(asset.TryGetActionMap(map.id.ToString()), Is.SameAs(map));
+        Assert.That(asset.TryGetActionMap(Guid.NewGuid().ToString()), Is.Null);
+    }
+
+    // Legacy format where we use "{...}" notation to indicate we have a GUID string. No longer necessary but
+    // we may have some old data that uses it.
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanLookUpMapInAssetById_UsingOldBracedFormat()
+    {
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = new InputActionMap("test");
+        asset.AddActionMap(map);
+
         Assert.That(asset.TryGetActionMap($"{{{map.id}}}"), Is.SameAs(map));
+        Assert.That(asset.TryGetActionMap($"{{{Guid.NewGuid().ToString()}}}"), Is.Null);
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
@@ -731,7 +732,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPasteActionMap()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -756,38 +756,40 @@ partial class CoreTests
         tree.Reload();
         tree.SelectItem("map1");
 
-        tree.CopySelectedItemsToClipboard();
-        Assert.That(EditorGUIUtility.systemCopyBuffer, Does.StartWith(InputActionTreeView.k_CopyPasteMarker));
-        tree.PasteDataFromClipboard();
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
+            tree.CopySelectedItemsToClipboard();
+            Assert.That(EditorHelpers.GetSystemCopyBufferContents(), Does.StartWith(InputActionTreeView.k_CopyPasteMarker));
+            tree.PasteDataFromClipboard();
 
-        Assert.That(tree.rootItem.children, Has.Count.EqualTo(3));
-        Assert.That(tree.rootItem.children[1], Is.TypeOf<ActionMapTreeItem>());
-        Assert.That(tree.rootItem.children[1].displayName, Is.EqualTo("map3"));
-        Assert.That(tree.rootItem.children[1].As<ActionMapTreeItem>().guid, Is.Not.EqualTo(map1.id));
-        Assert.That(tree.rootItem.children[1].children, Is.Not.Null);
-        Assert.That(tree.rootItem.children[1].children, Has.Count.EqualTo(2));
-        Assert.That(tree.rootItem.children[1].children[0], Is.TypeOf<ActionTreeItem>());
-        Assert.That(tree.rootItem.children[1].children[1], Is.TypeOf<ActionTreeItem>());
-        Assert.That(tree.rootItem.children[1].children[0].displayName, Is.EqualTo("action1"));
-        Assert.That(tree.rootItem.children[1].children[1].displayName, Is.EqualTo("action2"));
-        Assert.That(tree.rootItem.children[1].children[0].children, Is.Not.Null);
-        Assert.That(tree.rootItem.children[1].children[1].children, Is.Not.Null);
-        Assert.That(tree.rootItem.children[1].children[0].children, Has.Count.EqualTo(2));
-        Assert.That(tree.rootItem.children[1].children[1].children, Has.Count.EqualTo(1));
-        Assert.That(tree.rootItem.children[1].children[0].children[0], Is.TypeOf<BindingTreeItem>());
-        Assert.That(tree.rootItem.children[1].children[0].children[1], Is.TypeOf<BindingTreeItem>());
-        Assert.That(tree.rootItem.children[1].children[1].children[0], Is.TypeOf<BindingTreeItem>());
-        Assert.That(tree.rootItem.children[1].children[0].children[0].As<BindingTreeItem>().path,
-            Is.EqualTo("<Gamepad>/leftStick"));
-        Assert.That(tree.rootItem.children[1].children[0].children[1].As<BindingTreeItem>().path,
-            Is.EqualTo("<Keyboard>/a"));
-        Assert.That(tree.rootItem.children[1].children[1].children[0].As<BindingTreeItem>().path,
-            Is.EqualTo("<Gamepad>/rightStick"));
+            Assert.That(tree.rootItem.children, Has.Count.EqualTo(3));
+            Assert.That(tree.rootItem.children[1], Is.TypeOf<ActionMapTreeItem>());
+            Assert.That(tree.rootItem.children[1].displayName, Is.EqualTo("map3"));
+            Assert.That(tree.rootItem.children[1].As<ActionMapTreeItem>().guid, Is.Not.EqualTo(map1.id));
+            Assert.That(tree.rootItem.children[1].children, Is.Not.Null);
+            Assert.That(tree.rootItem.children[1].children, Has.Count.EqualTo(2));
+            Assert.That(tree.rootItem.children[1].children[0], Is.TypeOf<ActionTreeItem>());
+            Assert.That(tree.rootItem.children[1].children[1], Is.TypeOf<ActionTreeItem>());
+            Assert.That(tree.rootItem.children[1].children[0].displayName, Is.EqualTo("action1"));
+            Assert.That(tree.rootItem.children[1].children[1].displayName, Is.EqualTo("action2"));
+            Assert.That(tree.rootItem.children[1].children[0].children, Is.Not.Null);
+            Assert.That(tree.rootItem.children[1].children[1].children, Is.Not.Null);
+            Assert.That(tree.rootItem.children[1].children[0].children, Has.Count.EqualTo(2));
+            Assert.That(tree.rootItem.children[1].children[1].children, Has.Count.EqualTo(1));
+            Assert.That(tree.rootItem.children[1].children[0].children[0], Is.TypeOf<BindingTreeItem>());
+            Assert.That(tree.rootItem.children[1].children[0].children[1], Is.TypeOf<BindingTreeItem>());
+            Assert.That(tree.rootItem.children[1].children[1].children[0], Is.TypeOf<BindingTreeItem>());
+            Assert.That(tree.rootItem.children[1].children[0].children[0].As<BindingTreeItem>().path,
+                Is.EqualTo("<Gamepad>/leftStick"));
+            Assert.That(tree.rootItem.children[1].children[0].children[1].As<BindingTreeItem>().path,
+                Is.EqualTo("<Keyboard>/a"));
+            Assert.That(tree.rootItem.children[1].children[1].children[0].As<BindingTreeItem>().path,
+                Is.EqualTo("<Gamepad>/rightStick"));
+        }
     }
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPasteAction_IntoSameActionMap()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -807,23 +809,25 @@ partial class CoreTests
         tree.Reload();
         tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Actions.Array.data[1]"));
 
-        tree.CopySelectedItemsToClipboard();
-        Assert.That(EditorGUIUtility.systemCopyBuffer, Does.StartWith(InputActionTreeView.k_CopyPasteMarker));
-        tree.PasteDataFromClipboard();
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
+            tree.CopySelectedItemsToClipboard();
+            Assert.That(EditorHelpers.GetSystemCopyBufferContents(), Does.StartWith(InputActionTreeView.k_CopyPasteMarker));
+            tree.PasteDataFromClipboard();
 
-        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(3));
-        Assert.That(tree.rootItem.children[0].children[2], Is.TypeOf<ActionTreeItem>());
-        Assert.That(tree.rootItem.children[0].children[2].displayName, Is.EqualTo("action3"));
-        Assert.That(tree.rootItem.children[0].children[2].children, Is.Not.Null);
-        Assert.That(tree.rootItem.children[0].children[2].children, Has.Count.EqualTo(1));
-        Assert.That(tree.rootItem.children[0].children[2].children[0], Is.TypeOf<BindingTreeItem>());
-        Assert.That(tree.rootItem.children[0].children[2].children[0].As<BindingTreeItem>().path,
-            Is.EqualTo("<Gamepad>/rightStick"));
+            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(3));
+            Assert.That(tree.rootItem.children[0].children[2], Is.TypeOf<ActionTreeItem>());
+            Assert.That(tree.rootItem.children[0].children[2].displayName, Is.EqualTo("action3"));
+            Assert.That(tree.rootItem.children[0].children[2].children, Is.Not.Null);
+            Assert.That(tree.rootItem.children[0].children[2].children, Has.Count.EqualTo(1));
+            Assert.That(tree.rootItem.children[0].children[2].children[0], Is.TypeOf<BindingTreeItem>());
+            Assert.That(tree.rootItem.children[0].children[2].children[0].As<BindingTreeItem>().path,
+                Is.EqualTo("<Gamepad>/rightStick"));
+        }
     }
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPasteAction_IntoDifferentActionMap()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -835,14 +839,15 @@ partial class CoreTests
         action1.AddBinding("<Keyboard>/a");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var serializedObject = new SerializedObject(asset))
+        var serializedObject = new SerializedObject(asset);
+        var tree = new InputActionTreeView(serializedObject)
         {
-            var tree = new InputActionTreeView(serializedObject)
-            {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(serializedObject),
-            };
+            onBuildTree = () => InputActionTreeView.BuildFullTree(serializedObject),
+        };
+        tree.Reload();
 
-            tree.Reload();
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Actions.Array.data[0]"));
             tree.CopySelectedItemsToClipboard();
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[1].m_Actions.Array.data[0]"));
@@ -864,7 +869,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPasteBinding_IntoSameAction()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -875,14 +879,15 @@ partial class CoreTests
         action1.AddBinding("<Keyboard>/a");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var serializedObject = new SerializedObject(asset))
+        var serializedObject = new SerializedObject(asset);
+        var tree = new InputActionTreeView(serializedObject)
         {
-            var tree = new InputActionTreeView(serializedObject)
-            {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(serializedObject),
-            };
+            onBuildTree = () => InputActionTreeView.BuildFullTree(serializedObject),
+        };
+        tree.Reload();
 
-            tree.Reload();
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[0]"));
             tree.CopySelectedItemsToClipboard();
             tree.PasteDataFromClipboard();
@@ -898,7 +903,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPasteBinding_IntoDifferentAction()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -909,14 +913,15 @@ partial class CoreTests
         action1.AddBinding("<Keyboard>/a");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var serializedObject = new SerializedObject(asset))
+        var serializedObject = new SerializedObject(asset);
+        var tree = new InputActionTreeView(serializedObject)
         {
-            var tree = new InputActionTreeView(serializedObject)
-            {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(serializedObject),
-            };
+            onBuildTree = () => InputActionTreeView.BuildFullTree(serializedObject),
+        };
+        tree.Reload();
 
-            tree.Reload();
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[0]"));
             tree.CopySelectedItemsToClipboard();
             tree.SelectItem("map1/action2");
@@ -939,19 +944,21 @@ partial class CoreTests
         var map = asset.AddActionMap("map");
         map.AddAction("action", binding: "<Gamepad>leftStick");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var selectionChanged = false;
+        var tree = new InputActionTreeView(so)
         {
-            var selectionChanged = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSelectionChanged = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                }
-            };
-            tree.Reload();
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            }
+        };
+        tree.Reload();
+
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[0]"));
             selectionChanged = false;
             tree.CopySelectedItemsToClipboard();
@@ -966,7 +973,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPasteCompositeBinding()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -978,25 +984,27 @@ partial class CoreTests
             .With("Negative", "<Keyboard>/b");
         action.AddBinding("<Gamepad>/leftStick/y");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var selectionChanged = false;
+        var serializedObjectModified = false;
+        var tree = new InputActionTreeView(so)
         {
-            var selectionChanged = false;
-            var serializedObjectModified = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSelectionChanged = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                },
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(serializedObjectModified, Is.False);
-                    serializedObjectModified = true;
-                }
-            };
-            tree.Reload();
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            },
+            onSerializedObjectModified = () =>
+            {
+                Assert.That(serializedObjectModified, Is.False);
+                serializedObjectModified = true;
+            }
+        };
+        tree.Reload();
+
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[1]"));
             selectionChanged = false;
             tree.CopySelectedItemsToClipboard();
@@ -1023,7 +1031,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPastePartOfCompositeBinding_IntoSameComposite()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -1034,25 +1041,27 @@ partial class CoreTests
             .With("Negative", "<Keyboard>/b");
         action.AddBinding("<Gamepad>/rightTrigger");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var selectionChanged = false;
+        var serializedObjectModified = false;
+        var tree = new InputActionTreeView(so)
         {
-            var selectionChanged = false;
-            var serializedObjectModified = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSelectionChanged = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                },
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(serializedObjectModified, Is.False);
-                    serializedObjectModified = true;
-                }
-            };
-            tree.Reload();
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            },
+            onSerializedObjectModified = () =>
+            {
+                Assert.That(serializedObjectModified, Is.False);
+                serializedObjectModified = true;
+            }
+        };
+        tree.Reload();
+
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[1]"));
             tree.CopySelectedItemsToClipboard();
             selectionChanged = false;
@@ -1081,7 +1090,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCopyPastePartOfCompositeBinding_IntoDifferentComposite()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -1094,25 +1102,27 @@ partial class CoreTests
             .With("Positive", "<Gamepad>/buttonEast")
             .With("Negative", "<Gamepad>/buttonWest");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var selectionChanged = false;
+        var serializedObjectModified = false;
+        var tree = new InputActionTreeView(so)
         {
-            var selectionChanged = false;
-            var serializedObjectModified = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSelectionChanged = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                },
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(serializedObjectModified, Is.False);
-                    serializedObjectModified = true;
-                }
-            };
-            tree.Reload();
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            },
+            onSerializedObjectModified = () =>
+            {
+                Assert.That(serializedObjectModified, Is.False);
+                serializedObjectModified = true;
+            }
+        };
+        tree.Reload();
+
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[2]"));
             tree.CopySelectedItemsToClipboard();
             selectionChanged = false;
@@ -1150,7 +1160,6 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    [Ignore("Disable broken test Fogbugz ticket entered.")]
     public void Editor_ActionTree_CanCutAndPasteAction()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -1163,25 +1172,27 @@ partial class CoreTests
             .With("Negative", "<Keyboard>/b");
         map2.AddAction("action2", "<Keyboard>/space");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var selectionChanged = false;
+        var serializedObjectModified = false;
+        var tree = new InputActionTreeView(so)
         {
-            var selectionChanged = false;
-            var serializedObjectModified = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSelectionChanged = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                },
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(serializedObjectModified, Is.False);
-                    serializedObjectModified = true;
-                }
-            };
-            tree.Reload();
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            },
+            onSerializedObjectModified = () =>
+            {
+                Assert.That(serializedObjectModified, Is.False);
+                serializedObjectModified = true;
+            }
+        };
+        tree.Reload();
+
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
             tree.SelectItem("map1/action1");
             selectionChanged = false;
             tree.HandleCopyPasteCommandEvent(EditorGUIUtility.CommandEvent(InputActionTreeView.k_CutCommand));
@@ -1191,7 +1202,7 @@ partial class CoreTests
             Assert.That(tree.GetSelectedItems(), Is.Empty);
             Assert.That(tree.FindItemByPath("map1/action1"), Is.Null);
             Assert.That(tree["map1"].children, Is.Null.Or.Empty);
-            Assert.That(EditorGUIUtility.systemCopyBuffer, Does.StartWith(InputActionTreeView.k_CopyPasteMarker));
+            Assert.That(EditorHelpers.GetSystemCopyBufferContents(), Does.StartWith(InputActionTreeView.k_CopyPasteMarker));
 
             selectionChanged = false;
             serializedObjectModified = false;
@@ -1238,91 +1249,89 @@ partial class CoreTests
             .With("Positive", "<Gamepad>/buttonSouth", groups: "BB")
             .With("Negative", "<Gamepad>/buttonNorth", groups: "BB");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var tree = new InputActionTreeView(so)
         {
-            var tree = new InputActionTreeView(so)
-            {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so)
-            };
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so)
+        };
 
-            // Filter by just name.
-            tree.SetItemSearchFilterAndReload("cc");
+        // Filter by just name.
+        tree.SetItemSearchFilterAndReload("cc");
 
-            Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map2"));
-            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("CCAA"));
-            Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[0].children[0].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[0].children[1], Is.TypeOf<CompositeBindingTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[0].children[1].children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map2"));
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("CCAA"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[0].children[0].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[0].children[1], Is.TypeOf<CompositeBindingTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[0].children[1].children, Has.Count.EqualTo(2));
 
-            // Filter by binding group.
-            // NOTE: This should match by the *complete* group name, not just by substring.
-            tree.SetItemSearchFilterAndReload("g:B");
+        // Filter by binding group.
+        // NOTE: This should match by the *complete* group name, not just by substring.
+        tree.SetItemSearchFilterAndReload("g:B");
 
-            Assert.That(tree.rootItem.children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[1], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
-            Assert.That(tree.rootItem.children[1].displayName, Is.EqualTo("map2"));
-            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[0].children[0], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[1], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("AAAA"));
-            Assert.That(tree.rootItem.children[0].children[1].displayName, Is.EqualTo("AABB"));
-            Assert.That(tree.rootItem.children[0].children[0].children, Is.Empty);
-            Assert.That(tree.rootItem.children[0].children[1].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[1].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[1].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/rightStick"));
-            Assert.That(tree.rootItem.children[1].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[1].children[0], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[1].children[0].displayName, Is.EqualTo("CCAA"));
-            Assert.That(tree.rootItem.children[1].children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[1].children[0].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree.rootItem.children[1].children[0].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Keyboard>/a"));
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[1], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
+        Assert.That(tree.rootItem.children[1].displayName, Is.EqualTo("map2"));
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[0].children[0], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[1], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("AAAA"));
+        Assert.That(tree.rootItem.children[0].children[1].displayName, Is.EqualTo("AABB"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Is.Empty);
+        Assert.That(tree.rootItem.children[0].children[1].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[1].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[1].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/rightStick"));
+        Assert.That(tree.rootItem.children[1].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[1].children[0], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[1].children[0].displayName, Is.EqualTo("CCAA"));
+        Assert.That(tree.rootItem.children[1].children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[1].children[0].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree.rootItem.children[1].children[0].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Keyboard>/a"));
 
-            // Filter by device layout.
-            tree.SetItemSearchFilterAndReload("d:Gamepad");
+        // Filter by device layout.
+        tree.SetItemSearchFilterAndReload("d:Gamepad");
 
-            Assert.That(tree.rootItem.children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[1], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
-            Assert.That(tree.rootItem.children[1].displayName, Is.EqualTo("map2"));
-            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[0].children[0], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[1], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("AAAA"));
-            Assert.That(tree.rootItem.children[0].children[1].displayName, Is.EqualTo("AABB"));
-            Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/leftStick"));
-            Assert.That(tree.rootItem.children[0].children[1].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[1].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree.rootItem.children[0].children[1].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/rightStick"));
-            Assert.That(tree.rootItem.children[1].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[1].children[0], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree.rootItem.children[1].children[0].displayName, Is.EqualTo("CCAA"));
-            Assert.That(tree.rootItem.children[1].children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[1].children[0].children[0], Is.TypeOf<CompositeBindingTreeItem>());
-            Assert.That(tree.rootItem.children[1].children[0].children[0].children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[1].children[0].children[0].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/buttonSouth"));
-            Assert.That(tree.rootItem.children[1].children[0].children[0].children[1].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/buttonNorth"));
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[1], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
+        Assert.That(tree.rootItem.children[1].displayName, Is.EqualTo("map2"));
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[0].children[0], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[1], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("AAAA"));
+        Assert.That(tree.rootItem.children[0].children[1].displayName, Is.EqualTo("AABB"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/leftStick"));
+        Assert.That(tree.rootItem.children[0].children[1].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[1].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree.rootItem.children[0].children[1].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/rightStick"));
+        Assert.That(tree.rootItem.children[1].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[1].children[0], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree.rootItem.children[1].children[0].displayName, Is.EqualTo("CCAA"));
+        Assert.That(tree.rootItem.children[1].children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[1].children[0].children[0], Is.TypeOf<CompositeBindingTreeItem>());
+        Assert.That(tree.rootItem.children[1].children[0].children[0].children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[1].children[0].children[0].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/buttonSouth"));
+        Assert.That(tree.rootItem.children[1].children[0].children[0].children[1].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/buttonNorth"));
 
-            // Filter that matches nothing.
-            tree.SetItemSearchFilterAndReload("matchesNothing");
+        // Filter that matches nothing.
+        tree.SetItemSearchFilterAndReload("matchesNothing");
 
-            Assert.That(tree.rootItem.children, Is.Empty);
-        }
+        Assert.That(tree.rootItem.children, Is.Empty);
     }
 
     // Bindings that have no associated binding group (i.e. aren't part of any control scheme), will not be constrained
@@ -1338,22 +1347,20 @@ partial class CoreTests
         action.AddBinding("<Gamepad>/leftStick", groups: "A"); // In group.
         action.AddBinding("<Gamepad>/rightStick"); // Not in group.
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var tree = new InputActionTreeView(so)
         {
-            var tree = new InputActionTreeView(so)
-            {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so)
-            };
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so)
+        };
 
-            tree.SetItemSearchFilterAndReload("g:A");
+        tree.SetItemSearchFilterAndReload("g:A");
 
-            var actionItem = tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Actions.Array.data[0]");
-            Assert.That(actionItem, Is.Not.Null);
+        var actionItem = tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Actions.Array.data[0]");
+        Assert.That(actionItem, Is.Not.Null);
 
-            Assert.That(actionItem.children, Has.Count.EqualTo(2));
-            Assert.That(actionItem.children[0].displayName, Does.Not.Contain("{GLOBAL}"));
-            Assert.That(actionItem.children[1].displayName, Does.Contain("{GLOBAL}"));
-        }
+        Assert.That(actionItem.children, Has.Count.EqualTo(2));
+        Assert.That(actionItem.children[0].displayName, Does.Not.Contain("{GLOBAL}"));
+        Assert.That(actionItem.children[1].displayName, Does.Contain("{GLOBAL}"));
     }
 
     [Test]
@@ -1369,45 +1376,43 @@ partial class CoreTests
         action1.AddBinding("<Gamepad>/leftStick");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var modified = false;
+        var selectionChanged = false;
+        var tree = new InputActionTreeView(so)
         {
-            var modified = false;
-            var selectionChanged = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSerializedObjectModified = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(modified, Is.False);
-                    modified = true;
-                },
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                }
-            };
-            tree.Reload();
-            tree.SelectItem("map1");
-            selectionChanged = false;
-            tree.SelectItem("map3", additive: true);
-            selectionChanged = false;
-            tree.DeleteDataOfSelectedItems();
+                Assert.That(modified, Is.False);
+                modified = true;
+            },
+            onSelectionChanged = () =>
+            {
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            }
+        };
+        tree.Reload();
+        tree.SelectItem("map1");
+        selectionChanged = false;
+        tree.SelectItem("map3", additive: true);
+        selectionChanged = false;
+        tree.DeleteDataOfSelectedItems();
 
-            Assert.That(selectionChanged, Is.True);
-            Assert.That(modified, Is.True);
-            Assert.That(tree.HasSelection, Is.False);
-            Assert.That(tree.rootItem.children, Is.Not.Null);
-            Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map2"));
-            Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
-            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action2"));
-            Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/rightStick"));
-        }
+        Assert.That(selectionChanged, Is.True);
+        Assert.That(modified, Is.True);
+        Assert.That(tree.HasSelection, Is.False);
+        Assert.That(tree.rootItem.children, Is.Not.Null);
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map2"));
+        Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action2"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/rightStick"));
     }
 
     [Test]
@@ -1422,45 +1427,43 @@ partial class CoreTests
         action1.AddBinding("<Gamepad>/leftStick");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var modified = false;
+        var selectionChanged = false;
+        var tree = new InputActionTreeView(so)
         {
-            var modified = false;
-            var selectionChanged = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSerializedObjectModified = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(modified, Is.False);
-                    modified = true;
-                },
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                }
-            };
-            tree.Reload();
-            tree.SelectItem("map1/action1");
-            selectionChanged = false;
-            tree.SelectItem("map1/action3", additive: true);
-            selectionChanged = false;
-            tree.DeleteDataOfSelectedItems();
+                Assert.That(modified, Is.False);
+                modified = true;
+            },
+            onSelectionChanged = () =>
+            {
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            }
+        };
+        tree.Reload();
+        tree.SelectItem("map1/action1");
+        selectionChanged = false;
+        tree.SelectItem("map1/action3", additive: true);
+        selectionChanged = false;
+        tree.DeleteDataOfSelectedItems();
 
-            Assert.That(selectionChanged, Is.True);
-            Assert.That(modified, Is.True);
-            Assert.That(tree.HasSelection, Is.False);
-            Assert.That(tree.rootItem.children, Is.Not.Null);
-            Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
-            Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
-            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action2"));
-            Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/rightStick"));
-        }
+        Assert.That(selectionChanged, Is.True);
+        Assert.That(modified, Is.True);
+        Assert.That(tree.HasSelection, Is.False);
+        Assert.That(tree.rootItem.children, Is.Not.Null);
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
+        Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action2"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/rightStick"));
     }
 
     [Test]
@@ -1476,50 +1479,48 @@ partial class CoreTests
         action1.AddBinding("<Gamepad>/dpad");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var modified = false;
+        var selectionChanged = false;
+        var tree = new InputActionTreeView(so)
         {
-            var modified = false;
-            var selectionChanged = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSerializedObjectModified = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(modified, Is.False);
-                    modified = true;
-                },
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                }
-            };
-            tree.Reload();
-            tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[1]"));
-            selectionChanged = false;
-            tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[2]"),
-                additive: true);
-            selectionChanged = false;
-            tree.DeleteDataOfSelectedItems();
+                Assert.That(modified, Is.False);
+                modified = true;
+            },
+            onSelectionChanged = () =>
+            {
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            }
+        };
+        tree.Reload();
+        tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[1]"));
+        selectionChanged = false;
+        tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[2]"),
+            additive: true);
+        selectionChanged = false;
+        tree.DeleteDataOfSelectedItems();
 
-            Assert.That(selectionChanged, Is.True);
-            Assert.That(modified, Is.True);
-            Assert.That(tree.HasSelection, Is.False);
-            Assert.That(tree.rootItem.children, Is.Not.Null);
-            Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
-            Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
-            Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(2));
-            Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action1"));
-            Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/leftStick"));
-            Assert.That(tree.rootItem.children[0].children[1].displayName, Is.EqualTo("action2"));
-            Assert.That(tree.rootItem.children[0].children[1].children, Has.Count.EqualTo(1));
-            Assert.That(tree.rootItem.children[0].children[1].children[0].As<BindingTreeItem>().path,
-                Is.EqualTo("<Gamepad>/rightStick"));
-        }
+        Assert.That(selectionChanged, Is.True);
+        Assert.That(modified, Is.True);
+        Assert.That(tree.HasSelection, Is.False);
+        Assert.That(tree.rootItem.children, Is.Not.Null);
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
+        Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(2));
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action1"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/leftStick"));
+        Assert.That(tree.rootItem.children[0].children[1].displayName, Is.EqualTo("action2"));
+        Assert.That(tree.rootItem.children[0].children[1].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[1].children[0].As<BindingTreeItem>().path,
+            Is.EqualTo("<Gamepad>/rightStick"));
     }
 
     [Test]
@@ -1536,45 +1537,43 @@ partial class CoreTests
         action1.AddBinding("<Gamepad>/dpad");
         action2.AddBinding("<Gamepad>/rightStick");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var modified = false;
+        var selectionChanged = false;
+        var tree = new InputActionTreeView(so)
         {
-            var modified = false;
-            var selectionChanged = false;
-            var tree = new InputActionTreeView(so)
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSerializedObjectModified = () =>
             {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so),
-                onSerializedObjectModified = () =>
-                {
-                    Assert.That(modified, Is.False);
-                    modified = true;
-                },
-                onSelectionChanged = () =>
-                {
-                    Assert.That(selectionChanged, Is.False);
-                    selectionChanged = true;
-                }
-            };
-            tree.Reload();
-            tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[0]"));
-            selectionChanged = false;
-            tree.DeleteDataOfSelectedItems();
+                Assert.That(modified, Is.False);
+                modified = true;
+            },
+            onSelectionChanged = () =>
+            {
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            }
+        };
+        tree.Reload();
+        tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[0]"));
+        selectionChanged = false;
+        tree.DeleteDataOfSelectedItems();
 
-            Assert.That(selectionChanged, Is.True);
-            Assert.That(modified, Is.True);
-            Assert.That(tree.HasSelection, Is.False);
-            Assert.That(tree["map1"], Is.TypeOf<ActionMapTreeItem>());
-            Assert.That(tree["map1"].children, Has.Count.EqualTo(2));
-            Assert.That(tree["map1/action1"], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree["map1/action2"], Is.TypeOf<ActionTreeItem>());
-            Assert.That(tree["map1/action1"].children, Has.Count.EqualTo(1));
-            Assert.That(tree["map1/action2"].children, Has.Count.EqualTo(1));
-            Assert.That(tree["map1/action1"].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree["map1/action2"].children[0], Is.TypeOf<BindingTreeItem>());
-            Assert.That(tree["map1/action1"].children[0].children, Is.Null);
-            Assert.That(tree["map1/action2"].children[0].children, Is.Null);
-            Assert.That(tree["map1/action1"].children[0].As<BindingTreeItem>().path, Is.EqualTo("<Gamepad>/dpad"));
-            Assert.That(tree["map1/action2"].children[0].As<BindingTreeItem>().path, Is.EqualTo("<Gamepad>/rightStick"));
-        }
+        Assert.That(selectionChanged, Is.True);
+        Assert.That(modified, Is.True);
+        Assert.That(tree.HasSelection, Is.False);
+        Assert.That(tree["map1"], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree["map1"].children, Has.Count.EqualTo(2));
+        Assert.That(tree["map1/action1"], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree["map1/action2"], Is.TypeOf<ActionTreeItem>());
+        Assert.That(tree["map1/action1"].children, Has.Count.EqualTo(1));
+        Assert.That(tree["map1/action2"].children, Has.Count.EqualTo(1));
+        Assert.That(tree["map1/action1"].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree["map1/action2"].children[0], Is.TypeOf<BindingTreeItem>());
+        Assert.That(tree["map1/action1"].children[0].children, Is.Null);
+        Assert.That(tree["map1/action2"].children[0].children, Is.Null);
+        Assert.That(tree["map1/action1"].children[0].As<BindingTreeItem>().path, Is.EqualTo("<Gamepad>/dpad"));
+        Assert.That(tree["map1/action2"].children[0].As<BindingTreeItem>().path, Is.EqualTo("<Gamepad>/rightStick"));
     }
 
     [Test]
@@ -1588,16 +1587,14 @@ partial class CoreTests
             .With("Negative", "<Keyboard>/a")
             .With("Positive", "<Keyboard>/b");
 
-        using (var so = new SerializedObject(asset))
+        var so = new SerializedObject(asset);
+        var tree = new InputActionTreeView(so)
         {
-            var tree = new InputActionTreeView(so)
-            {
-                onBuildTree = () => InputActionTreeView.BuildFullTree(so)
-            };
-            tree.Reload();
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so)
+        };
+        tree.Reload();
 
-            Assert.That(tree["map/action"].children[0].displayName, Is.EqualTo("1D Axis"));
-        }
+        Assert.That(tree["map/action"].children[0].displayName, Is.EqualTo("1D Axis"));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -326,7 +326,7 @@ namespace UnityEngine.Experimental.Input
         public int frameCount { get; set; }
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;
-        
+
         public ScreenOrientation screenOrientation { set; get; } = ScreenOrientation.Portrait;
 
         public Vector2 screenSize { set; get; } = new Vector2(Screen.width, Screen.height);


### PR DESCRIPTION
Also fixes drag&dropping between items sometimes being off-by-one.

Finally, also attempts a fix at the recent test instabilities with the ActionTree tests.