### PR TITLE
FIX: Floating-point parameters being sensitive to current culture.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PlayerInput` no longer fails to find actions when using UnityEvents (#500).
 - The `"{...}"` format for referencing action maps and actions using GUIDs as strings has been obsoleted. It will still work but adding the extra braces is no longer necessary.
 - Drag&dropping bindings between other bindings that came before them in the list no longer drops the items at a location one higher up in the list than intended.
+- In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -55,7 +55,7 @@ namespace UnityEngine.Experimental.Input
         /// </remarks>
         public InputBinding? bindingMask;
 
-        private List<InputControlLayout.NameAndParameters> m_Parameters;
+        private List<NameAndParameters> m_Parameters;
 
         /// <summary>
         /// Release native memory held by the resolver.
@@ -564,7 +564,7 @@ namespace UnityEngine.Experimental.Input
             ////        moving the logic to a shared place.
             ////        Alternatively, may split the paths. May help in getting rid of unnecessary allocations.
 
-            if (!InputControlLayout.ParseNameAndParameterList(interactionString, ref m_Parameters))
+            if (!NameAndParameters.ParseMultiple(interactionString, ref m_Parameters))
                 return InputActionState.kInvalidIndex;
 
             var firstInteractionIndex = totalInteractionCount;
@@ -581,7 +581,7 @@ namespace UnityEngine.Experimental.Input
                     throw new Exception($"Interaction '{m_Parameters[i].name}' is not an IInputInteraction");
 
                 // Pass parameters to it.
-                InputDeviceBuilder.SetParameters(interaction, m_Parameters[i].parameters);
+                NamedValue.ApplyAllToObject(interaction, m_Parameters[i].parameters);
 
                 // Add to list.
                 ArrayHelpers.AppendWithCapacity(ref interactions, ref totalInteractionCount, interaction);
@@ -592,7 +592,7 @@ namespace UnityEngine.Experimental.Input
 
         private int ResolveProcessors(string processorString)
         {
-            if (!InputControlLayout.ParseNameAndParameterList(processorString, ref m_Parameters))
+            if (!NameAndParameters.ParseMultiple(processorString, ref m_Parameters))
                 return InputActionState.kInvalidIndex;
 
             var firstProcessorIndex = totalProcessorCount;
@@ -610,7 +610,7 @@ namespace UnityEngine.Experimental.Input
                         $"Type '{type.Name}' registered as processor called '{m_Parameters[i].name}' is not an InputProcessor");
 
                 // Pass parameters to it.
-                InputDeviceBuilder.SetParameters(processor, m_Parameters[i].parameters);
+                NamedValue.ApplyAllToObject(processor, m_Parameters[i].parameters);
 
                 // Add to list.
                 ArrayHelpers.AppendWithCapacity(ref processors, ref totalProcessorCount, processor);
@@ -621,7 +621,7 @@ namespace UnityEngine.Experimental.Input
 
         private static InputBindingComposite InstantiateBindingComposite(string nameAndParameters)
         {
-            var nameAndParametersParsed = InputControlLayout.ParseNameAndParameters(nameAndParameters);
+            var nameAndParametersParsed = NameAndParameters.Parse(nameAndParameters);
 
             // Look up.
             var type = InputBindingComposite.s_Composites.LookupTypeRegistration(nameAndParametersParsed.name);
@@ -635,7 +635,7 @@ namespace UnityEngine.Experimental.Input
                     $"Registered type '{type.Name}' used for '{nameAndParametersParsed.name}' is not an InputBindingComposite");
 
             // Set parameters.
-            InputDeviceBuilder.SetParameters(instance, nameAndParametersParsed.parameters);
+            NamedValue.ApplyAllToObject(instance, nameAndParametersParsed.parameters);
 
             return instance;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -85,8 +85,8 @@ namespace UnityEngine.Experimental.Input.Controls
                 return -1;
 
             var value = ReadValueFromState(statePtr);
-            var min = m_MinValue.ToFloat();
-            var max = m_MaxValue.ToFloat();
+            var min = m_MinValue.ToSingle();
+            var max = m_MaxValue.ToSingle();
 
             value = Mathf.Clamp(value, min, max);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -19,25 +18,13 @@ using UnityEngine.Experimental.Input.Utilities;
 
 ////TODO: allow things like "-something" and "+something" for usages, processors, etc
 
-////TODO: change interactions and processors to use kSeparator
-
 ////TODO: allow setting whether the device should automatically become current and whether it wants noise filtering
-
-////TODO: turn 'overrides' into feature where layouts can be registered as overrides and they get merged *into* the layout
-////      they are overriding
 
 ////TODO: ensure that if a layout sets a device description, it is indeed a device layout
 
 ////TODO: make offset on InputControlAttribute relative to field instead of relative to entire state struct
 
 ////REVIEW: common usages are on all layouts but only make sense for devices
-
-////REVIEW: kill layout namespacing for remotes and have remote players instantiate layouts from editor instead?
-////        loses the ability for layouts to be different in the player than in the editor but if we take it as granted that
-////           a) a given layout X always is the same regardless to which player it is deployed, and that
-////           b) the editor always has all layouts
-////        then we can just kill off the entire namespacing. This also makes it much easier to tweak layouts in the
-////        editor.
 
 namespace UnityEngine.Experimental.Input.Layouts
 {
@@ -70,279 +57,10 @@ namespace UnityEngine.Experimental.Input.Layouts
     /// </remarks>
     public class InputControlLayout
     {
-        // String that is used to separate names from namespaces in layout names.
-        public const string kNamespaceQualifier = "::";
-
-        /// <summary>
-        /// The "None" layout is a reserved layout name which signals to the system
-        /// that no layout should be used (and thus no device should be created).
-        /// </summary>
-        public const string kNone = "None";
-
-        public const char kSeparator = ',';
-        public const string kSeparatorString = ",";
-
         private static InternedString s_DefaultVariant = new InternedString("Default");
         public static InternedString DefaultVariant => s_DefaultVariant;
 
-        ////TODO: replace ParameterValue with PrimitiveValueOrArray
-
-        public enum ParameterType
-        {
-            Boolean,
-            Integer,
-            Float,
-        }
-
-        // Both controls and processors can have public fields that can be set
-        // directly from layouts. The values are usually specified in strings
-        // (like "clampMin=-1") but we parse them ahead of time into instances
-        // of this structure that tell us where to store the value in the control.
-        public unsafe struct ParameterValue : IEquatable<ParameterValue>
-        {
-            public const int kMaxValueSize = 4;
-
-            public string name;
-            public ParameterType type;
-            public fixed byte value[kMaxValueSize];
-
-            public int sizeInBytes
-            {
-                get
-                {
-                    switch (type)
-                    {
-                        case ParameterType.Boolean: return sizeof(bool);
-                        case ParameterType.Float: return sizeof(float);
-                        case ParameterType.Integer: return sizeof(int);
-                    }
-                    return 0;
-                }
-            }
-
-            public ParameterValue(string name, bool value)
-                : this()
-            {
-                this.name = name;
-                SetValue(value);
-            }
-
-            public ParameterValue(string name, int value)
-                : this()
-            {
-                this.name = name;
-                SetValue(value);
-            }
-
-            public ParameterValue(string name, float value)
-                : this()
-            {
-                this.name = name;
-                SetValue(value);
-            }
-
-            public bool GetBoolValue()
-            {
-                if (type != ParameterType.Boolean)
-                    throw new InvalidOperationException("Not a bool value");
-                fixed(byte* ptr = value)
-                return *(bool*)ptr;
-            }
-
-            public int GetIntValue()
-            {
-                if (type != ParameterType.Integer)
-                    throw new InvalidOperationException("Not an integer value");
-                fixed(byte* ptr = value)
-                return *(int*)ptr;
-            }
-
-            public float GetFloatValue()
-            {
-                if (type != ParameterType.Float)
-                    throw new InvalidOperationException("Not a float value");
-                fixed(byte* ptr = value)
-                return *(float*)ptr;
-            }
-
-            public void SetValue(bool value)
-            {
-                type = ParameterType.Boolean;
-                fixed(byte* ptr = this.value)
-                * (bool*)ptr = value;
-            }
-
-            public void SetValue(int value)
-            {
-                type = ParameterType.Integer;
-                fixed(byte* ptr = this.value)
-                * (int*)ptr = value;
-            }
-
-            public void SetValue(float value)
-            {
-                type = ParameterType.Float;
-                fixed(byte* ptr = this.value)
-                * (float*)ptr = value;
-            }
-
-            public void SetValue(string value)
-            {
-                fixed(byte* ptr = this.value)
-                {
-                    switch (type)
-                    {
-                        case ParameterType.Boolean:
-                            if (bool.TryParse(value, out var result))
-                            {
-                                *(bool*)ptr = result;
-                            }
-                            break;
-                        case ParameterType.Integer:
-                            if (int.TryParse(value, out var intResult))
-                            {
-                                *(int*)ptr = intResult;
-                            }
-                            break;
-                        case ParameterType.Float:
-                            if (float.TryParse(value, out var floatResult))
-                            {
-                                *(float*)ptr = floatResult;
-                            }
-                            break;
-                    }
-                }
-            }
-
-            public ParameterValue ConvertTo(ParameterType type)
-            {
-                switch (type)
-                {
-                    case ParameterType.Boolean:
-                        if (this.type == ParameterType.Float)
-                            return new ParameterValue(name, GetFloatValue() > 0 || GetFloatValue() < 0);
-                        if (this.type == ParameterType.Integer)
-                            return new ParameterValue(name, GetIntValue() != 0);
-                        return this;
-
-                    case ParameterType.Integer:
-                        if (this.type == ParameterType.Boolean)
-                            return new ParameterValue(name, GetBoolValue() ? 1 : 0);
-                        if (this.type == ParameterType.Float)
-                            return new ParameterValue(name, (int)GetFloatValue());
-                        return this;
-
-                    case ParameterType.Float:
-                        if (this.type == ParameterType.Boolean)
-                            return new ParameterValue(name, GetBoolValue() ? 1f : 0f);
-                        if (this.type == ParameterType.Integer)
-                            return new ParameterValue(name, (float)GetIntValue());
-                        return this;
-                }
-
-                throw new InvalidOperationException("Should not reach here");
-            }
-
-            public string GetValueAsString()
-            {
-                fixed(byte* ptr = value)
-                {
-                    switch (type)
-                    {
-                        case ParameterType.Boolean:
-                            if (*(bool*)ptr)
-                                return "true";
-                            return "false";
-                        case ParameterType.Integer:
-                            var intValue = *(int*)ptr;
-                            return intValue.ToString();
-                        case ParameterType.Float:
-                            var floatValue = *(float*)ptr;
-                            return floatValue.ToString();
-                    }
-                }
-
-                return string.Empty;
-            }
-
-            public override string ToString()
-            {
-                fixed(byte* ptr = value)
-                {
-                    switch (type)
-                    {
-                        case ParameterType.Boolean:
-                            if (*(bool*)ptr)
-                                return name;
-                            return $"{name}=false";
-                        case ParameterType.Integer:
-                            var intValue = *(int*)ptr;
-                            return $"{name}={intValue}";
-                        case ParameterType.Float:
-                            ////FIXME: this needs to be invariant culture
-                            var floatValue = *(float*)ptr;
-                            return $"{name}={floatValue}";
-                    }
-                }
-
-                return string.Empty;
-            }
-
-            public bool Equals(ParameterValue other)
-            {
-                fixed(byte* valuePtr = value)
-                {
-                    return string.Equals(name, other.name, StringComparison.InvariantCultureIgnoreCase)
-                        && type == other.type
-                        && *(int*)valuePtr == *(int*)other.value;
-                }
-            }
-
-            public override bool Equals(object obj)
-            {
-                if (ReferenceEquals(null, obj))
-                    return false;
-                return obj is ParameterValue parameterValue && Equals(parameterValue);
-            }
-
-            public override int GetHashCode()
-            {
-                unchecked
-                {
-                    fixed(byte* valuePtr = value)
-                    {
-                        var hashCode = (name != null ? name.GetHashCode() : 0);
-                        hashCode = (hashCode * 397) ^ (int)type;
-                        hashCode = (hashCode * 397) ^ *(int*)valuePtr;
-                        return hashCode;
-                    }
-                }
-            }
-
-            public static bool operator==(ParameterValue left, ParameterValue right)
-            {
-                return left.Equals(right);
-            }
-
-            public static bool operator!=(ParameterValue left, ParameterValue right)
-            {
-                return !left.Equals(right);
-            }
-        }
-
-        public struct NameAndParameters
-        {
-            public string name;
-            public ReadOnlyArray<ParameterValue> parameters;
-
-            public override string ToString()
-            {
-                if (parameters.Count == 0)
-                    return name;
-                var parameterString = string.Join(kSeparatorString, parameters.Select(x => x.ToString()).ToArray());
-                return $"{name}({parameterString})";
-            }
-        }
+        public const string VariantSeparator = ";";
 
         /// <summary>
         /// Specification for the composition of a direct or indirect child control.
@@ -392,7 +110,7 @@ namespace UnityEngine.Experimental.Input.Layouts
 
             public ReadOnlyArray<InternedString> usages;
             public ReadOnlyArray<InternedString> aliases;
-            public ReadOnlyArray<ParameterValue> parameters;
+            public ReadOnlyArray<NamedValue> parameters;
             public ReadOnlyArray<NameAndParameters> processors;
             public uint offset;
             public uint bit;
@@ -648,7 +366,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 public ControlBuilder WithLayout(string layout)
                 {
                     if (string.IsNullOrEmpty(layout))
-                        throw new ArgumentException("Layout name cannot be null or empty", "layout");
+                        throw new ArgumentException("Layout name cannot be null or empty", nameof(layout));
 
                     controls[index].layout = new InternedString(layout);
                     return this;
@@ -711,8 +429,8 @@ namespace UnityEngine.Experimental.Input.Layouts
 
                 public ControlBuilder WithParameters(string parameters)
                 {
-                    var parsed = ParseParameters(parameters);
-                    controls[index].parameters = new ReadOnlyArray<ParameterValue>(parsed);
+                    var parsed = NamedValue.ParseMultiple(parameters);
+                    controls[index].parameters = new ReadOnlyArray<NamedValue>(parsed);
                     return this;
                 }
 
@@ -1092,14 +810,14 @@ namespace UnityEngine.Experimental.Input.Layouts
             }
 
             // Determine parameters.
-            ParameterValue[] parameters = null;
+            NamedValue[] parameters = null;
             if (attribute != null && !string.IsNullOrEmpty(attribute.parameters))
-                parameters = ParseParameters(attribute.parameters);
+                parameters = NamedValue.ParseMultiple(attribute.parameters);
 
             // Determine processors.
             NameAndParameters[] processors = null;
             if (attribute != null && !string.IsNullOrEmpty(attribute.processors))
-                processors = ParseNameAndParameterList(attribute.processors);
+                processors = NameAndParameters.ParseMultiple(attribute.processors).ToArray();
 
             // Determine whether to use state from another control.
             string useStateFrom = null;
@@ -1147,7 +865,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 offset = offset,
                 bit = bit,
                 sizeInBits = sizeInBits,
-                parameters = new ReadOnlyArray<ParameterValue>(parameters),
+                parameters = new ReadOnlyArray<NamedValue>(parameters),
                 processors = new ReadOnlyArray<NameAndParameters>(processors),
                 usages = new ReadOnlyArray<InternedString>(usages),
                 aliases = new ReadOnlyArray<InternedString>(aliases),
@@ -1160,181 +878,6 @@ namespace UnityEngine.Experimental.Input.Layouts
                 minValue = minValue,
                 maxValue = maxValue,
             };
-        }
-
-        internal static NameAndParameters[] ParseNameAndParameterList(string text)
-        {
-            List<NameAndParameters> list = null;
-            if (!ParseNameAndParameterList(text, ref list))
-                return null;
-            return list.ToArray();
-        }
-
-        internal static bool ParseNameAndParameterList(string text, ref List<NameAndParameters> list)
-        {
-            text = text.Trim();
-            if (string.IsNullOrEmpty(text))
-                return false;
-
-            if (list == null)
-                list = new List<NameAndParameters>();
-            else
-                list.Clear();
-
-            var index = 0;
-            var textLength = text.Length;
-
-            while (index < textLength)
-                list.Add(ParseNameAndParameters(text, ref index));
-
-            return true;
-        }
-
-        ////TODO: switch these methods all to Substring
-
-        internal static NameAndParameters ParseNameAndParameters(string text)
-        {
-            var index = 0;
-            return ParseNameAndParameters(text, ref index);
-        }
-
-        private static NameAndParameters ParseNameAndParameters(string text, ref int index)
-        {
-            var textLength = text.Length;
-
-            // Skip whitespace.
-            while (index < textLength && char.IsWhiteSpace(text[index]))
-                ++index;
-
-            // Parse name.
-            var nameStart = index;
-            while (index < textLength)
-            {
-                var nextChar = text[index];
-                if (nextChar == '(' || nextChar == kSeparator || char.IsWhiteSpace(nextChar))
-                    break;
-                ++index;
-            }
-            if (index - nameStart == 0)
-                throw new Exception($"Expecting name at position {nameStart} in '{text}'");
-            var name = text.Substring(nameStart, index - nameStart);
-
-            // Skip whitespace.
-            while (index < textLength && char.IsWhiteSpace(text[index]))
-                ++index;
-
-            // Parse parameters.
-            ParameterValue[] parameters = null;
-            if (index < textLength && text[index] == '(')
-            {
-                ++index;
-                var closeParenIndex = text.IndexOf(')', index);
-                if (closeParenIndex == -1)
-                    throw new Exception($"Expecting ')' after '(' at position {index} in '{text}'");
-
-                var parameterString = text.Substring(index, closeParenIndex - index);
-                parameters = ParseParameters(parameterString);
-                index = closeParenIndex + 1;
-            }
-
-            if (index < textLength && (text[index] == ',' || text[index] == InputBinding.kSeparator))
-                ++index;
-
-            return new NameAndParameters {name = name, parameters = new ReadOnlyArray<ParameterValue>(parameters)};
-        }
-
-        private static ParameterValue[] ParseParameters(string parameterString)
-        {
-            parameterString = parameterString.Trim();
-            if (string.IsNullOrEmpty(parameterString))
-                return null;
-
-            var parameterCount = parameterString.CountOccurrences(kSeparator) + 1;
-            var parameters = new ParameterValue[parameterCount];
-
-            var index = 0;
-            for (var i = 0; i < parameterCount; ++i)
-            {
-                var parameter = ParseParameter(parameterString, ref index);
-                parameters[i] = parameter;
-            }
-
-            return parameters;
-        }
-
-        private static unsafe ParameterValue ParseParameter(string parameterString, ref int index)
-        {
-            var parameter = new ParameterValue();
-            var parameterStringLength = parameterString.Length;
-
-            // Skip whitespace.
-            while (index < parameterStringLength && char.IsWhiteSpace(parameterString[index]))
-                ++index;
-
-            // Parse name.
-            var nameStart = index;
-            while (index < parameterStringLength)
-            {
-                var nextChar = parameterString[index];
-                if (nextChar == '=' || nextChar == kSeparator || char.IsWhiteSpace(nextChar))
-                    break;
-                ++index;
-            }
-            parameter.name = parameterString.Substring(nameStart, index - nameStart);
-
-            // Skip whitespace.
-            while (index < parameterStringLength && char.IsWhiteSpace(parameterString[index]))
-                ++index;
-
-            if (index == parameterStringLength || parameterString[index] != '=')
-            {
-                // No value given so take "=true" as implied.
-                parameter.type = ParameterType.Boolean;
-                *(bool*)parameter.value = true;
-            }
-            else
-            {
-                ++index; // Skip over '='.
-
-                // Skip whitespace.
-                while (index < parameterStringLength && char.IsWhiteSpace(parameterString[index]))
-                    ++index;
-
-                // Parse value.
-                var valueStart = index;
-                while (index < parameterStringLength &&
-                       !(parameterString[index] == kSeparator || char.IsWhiteSpace(parameterString[index])))
-                    ++index;
-
-                ////TODO: use Substring struct here so that we don't allocate lots of useless strings
-
-                var value = parameterString.Substring(valueStart, index - valueStart);
-                if (string.Compare(value, "true", StringComparison.InvariantCultureIgnoreCase) == 0)
-                {
-                    parameter.type = ParameterType.Boolean;
-                    *(bool*)parameter.value = true;
-                }
-                else if (string.Compare(value, "false", StringComparison.InvariantCultureIgnoreCase) == 0)
-                {
-                    parameter.type = ParameterType.Boolean;
-                    *(bool*)parameter.value = false;
-                }
-                else if (value.IndexOf('.') != -1 || value.IndexOf("e", StringComparison.InvariantCultureIgnoreCase) != -1 || value.IndexOf("Infinity") != -1)
-                {
-                    parameter.type = ParameterType.Float;
-                    float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture.NumberFormat, out *(float*)parameter.value);
-                }
-                else
-                {
-                    parameter.type = ParameterType.Integer;
-                    int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture.NumberFormat, out *(int*)parameter.value);
-                }
-            }
-
-            if (index < parameterStringLength && parameterString[index] == kSeparator)
-                ++index;
-
-            return parameter;
         }
 
         ////REVIEW: this tends to cause surprises; is it worth its cost?
@@ -1540,9 +1083,9 @@ namespace UnityEngine.Experimental.Input.Layouts
                 if (!itemVariants.IsEmpty() && itemVariants != DefaultVariant)
                 {
                     // If there's multiple variants on the control, we add it to the table multiple times.
-                    if (itemVariants.ToString().IndexOf(kSeparator) != -1)
+                    if (itemVariants.ToString().IndexOf(VariantSeparator[0]) != -1)
                     {
-                        var itemVariantArray = itemVariants.ToLower().Split(kSeparator);
+                        var itemVariantArray = itemVariants.ToLower().Split(VariantSeparator[0]);
                         foreach (var name in itemVariantArray)
                         {
                             variants?.Add(name);
@@ -1571,7 +1114,7 @@ namespace UnityEngine.Experimental.Input.Layouts
             ////REVIEW: does this make sense?
             // Default variant works with any other expected variant.
             if (actual != null &&
-                StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(DefaultVariant, actual, kSeparator))
+                StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(DefaultVariant, actual, VariantSeparator[0]))
                 return true;
 
             // If we don't expect a specific variant, we accept any variant.
@@ -1584,7 +1127,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 return true;
 
             // Match if the two variant sets intersect on at least one element.
-            return StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(expected, actual, kSeparator);
+            return StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(expected, actual, VariantSeparator[0]);
         }
 
         private static void ThrowIfControlItemIsDuplicate(ref ControlItem controlItem,
@@ -1828,10 +1371,10 @@ namespace UnityEngine.Experimental.Input.Layouts
                 }
 
                 if (!string.IsNullOrEmpty(parameters))
-                    layout.parameters = new ReadOnlyArray<ParameterValue>(ParseParameters(parameters));
+                    layout.parameters = new ReadOnlyArray<NamedValue>(NamedValue.ParseMultiple(parameters));
 
                 if (!string.IsNullOrEmpty(processors))
-                    layout.processors = new ReadOnlyArray<NameAndParameters>(ParseNameAndParameterList(processors));
+                    layout.processors = new ReadOnlyArray<NameAndParameters>(NameAndParameters.ParseMultiple(processors).ToArray());
 
                 if (defaultState != null)
                     layout.defaultState = PrimitiveValueOrArray.FromObject(defaultState);

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
@@ -61,8 +61,7 @@ namespace UnityEngine.Experimental.Input.Layouts
         {
             if (existingDevice != null && existingDevice.m_DeviceIndex != InputDevice.kInvalidDeviceIndex)
                 throw new InvalidOperationException(
-                    string.Format("Cannot modify control setup of existing device {0} while added to system.",
-                        existingDevice));
+                    $"Cannot modify control setup of existing device {existingDevice} while added to system.");
 
             InstantiateLayout(layout, variants, new InternedString(), null, existingDevice);
             FinalizeControlHierarchy();
@@ -140,9 +139,8 @@ namespace UnityEngine.Experimental.Input.Layouts
 
             var controlOfType = control as TControl;
             if (controlOfType == null)
-                throw new Exception(string.Format(
-                    "Expected control '{0}' to be of type '{1}' but is of type '{2}' instead!", path,
-                    typeof(TControl).Name, control.GetType().Name));
+                throw new Exception(
+                    $"Expected control '{path}' to be of type '{typeof(TControl).Name}' but is of type '{control.GetType().Name}' instead!");
 
             return controlOfType;
         }
@@ -151,7 +149,7 @@ namespace UnityEngine.Experimental.Input.Layouts
         {
             var control = TryGetControl(path);
             if (control == null)
-                throw new Exception(string.Format("Cannot find input control '{0}'", path));
+                throw new Exception($"Cannot find input control '{path}'");
             return control;
         }
 
@@ -165,7 +163,7 @@ namespace UnityEngine.Experimental.Input.Layouts
         {
             var control = TryGetControl<TControl>(path);
             if (control == null)
-                throw new Exception(string.Format("Cannot find input control '{0}'", path));
+                throw new Exception($"Cannot find input control '{path}'");
             return control;
         }
 
@@ -178,9 +176,8 @@ namespace UnityEngine.Experimental.Input.Layouts
 
             var controlOfType = control as TControl;
             if (controlOfType == null)
-                throw new Exception(string.Format(
-                    "Expected control '{0}' to be of type '{1}' but is of type '{2}' instead!", path,
-                    typeof(TControl).Name, control.GetType().Name));
+                throw new Exception(
+                    $"Expected control '{path}' to be of type '{typeof(TControl).Name}' but is of type '{control.GetType().Name}' instead!");
 
             return controlOfType;
         }
@@ -240,20 +237,18 @@ namespace UnityEngine.Experimental.Input.Layouts
                 control = controlObject as InputControl;
                 if (control == null)
                 {
-                    throw new Exception(string.Format("Type '{0}' referenced by layout '{1}' is not an InputControl",
-                        layout.type.Name, layout.name));
+                    throw new Exception(
+                        $"Type '{layout.type.Name}' referenced by layout '{layout.name}' is not an InputControl");
                 }
             }
 
             // If it's a device, perform some extra work specific to the control
             // hierarchy root.
-            var controlAsDevice = control as InputDevice;
-            if (controlAsDevice != null)
+            if (control is InputDevice controlAsDevice)
             {
                 if (parent != null)
-                    throw new Exception(string.Format(
-                        "Cannot instantiate device layout '{0}' as child of '{1}'; devices must be added at root",
-                        layout.name, parent.path));
+                    throw new Exception(
+                        $"Cannot instantiate device layout '{layout.name}' as child of '{parent.path}'; devices must be added at root");
 
                 m_Device = controlAsDevice;
                 m_Device.m_StateBlock.byteOffset = 0;
@@ -285,9 +280,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 // Someone did "new InputDeviceBuilder(...)" with a control layout.
                 // We don't support creating control hierarchies without a device at the root.
                 throw new InvalidOperationException(
-                    string.Format(
-                        "Toplevel layout used with InputDeviceBuilder must be a device layout; '{0}' is a control layout",
-                        layout.name));
+                    $"Toplevel layout used with InputDeviceBuilder must be a device layout; '{layout.name}' is a control layout");
             }
 
             // Name defaults to name of layout.
@@ -327,7 +320,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 // now be blank) but still want crawling down the hierarchy to preserve existing
                 // controls where possible.
                 AddChildControls(layout, variants, control,
-                    existingControl != null ? existingControl.m_ChildrenReadOnly : (ReadOnlyArray<InputControl>?)null,
+                    existingControl?.m_ChildrenReadOnly,
                     ref haveChildrenUsingStateFromOtherControl);
             }
             catch
@@ -355,9 +348,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                     var referencedControl = TryGetControl(control, controlLayout.useStateFrom);
                     if (referencedControl == null)
                         throw new Exception(
-                            string.Format(
-                                "Cannot find control '{0}' referenced in 'useStateFrom' of control '{1}' in layout '{2}'",
-                                controlLayout.useStateFrom, controlLayout.name, layout.name));
+                            $"Cannot find control '{controlLayout.useStateFrom}' referenced in 'useStateFrom' of control '{controlLayout.name}' in layout '{layout.name}'");
 
                     // Copy its state settings.
                     child.m_StateBlock = referencedControl.m_StateBlock;
@@ -396,9 +387,8 @@ namespace UnityEngine.Experimental.Input.Layouts
                 if (controlLayouts[i].isModifyingChildControlByPath)
                 {
                     if (controlLayouts[i].isArray)
-                        throw new NotSupportedException(string.Format(
-                            "Control '{0}' in layout '{1}' is modifying the child of another control but is marked as an array",
-                            controlLayouts[i].name, layout.name));
+                        throw new NotSupportedException(
+                            $"Control '{controlLayouts[i].name}' in layout '{layout.name}' is modifying the child of another control but is marked as an array");
 
                     haveControlLayoutWithPath = true;
                     InsertChildControlOverrides(parent, ref controlLayouts[i]);
@@ -408,7 +398,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 // Skip if variants don't match.
                 if (!controlLayouts[i].variants.IsEmpty() &&
                     !StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(controlLayouts[i].variants,
-                        variants, InputControlLayout.kSeparator))
+                        variants, ','))
                     continue;
 
                 if (controlLayouts[i].isArray)
@@ -436,8 +426,8 @@ namespace UnityEngine.Experimental.Input.Layouts
                 // If the control is part of a variant, skip it if it isn't in the variants we're
                 // looking for.
                 if (!controlLayout.variants.IsEmpty() &&
-                    !StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(controlLayout.variants, variants,
-                        InputControlLayout.kSeparator))
+                    !StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(controlLayout.variants,
+                        variants, ','))
                     continue;
 
                 // If it's an array, add a control for each array element.
@@ -504,18 +494,16 @@ namespace UnityEngine.Experimental.Input.Layouts
 
             ////REVIEW: can we check this in InputControlLayout instead?
             if (string.IsNullOrEmpty(controlItem.layout))
-                throw new Exception(string.Format("Layout has not been set on control '{0}' in '{1}'",
-                    controlItem.name, layout.name));
+                throw new Exception($"Layout has not been set on control '{controlItem.name}' in '{layout.name}'");
 
             // See if there is an override for the control.
             InputControlLayout.ControlItem? controlOverride = null;
             if (m_ChildControlOverrides != null)
             {
-                var path = string.Format("{0}/{1}", parent.path, name);
+                var path = $"{parent.path}/{name}";
                 var pathLowerCase = path.ToLower();
 
-                InputControlLayout.ControlItem match;
-                if (m_ChildControlOverrides.TryGetValue(pathLowerCase, out match))
+                if (m_ChildControlOverrides.TryGetValue(pathLowerCase, out var match))
                     controlOverride = match;
             }
 
@@ -551,8 +539,7 @@ namespace UnityEngine.Experimental.Input.Layouts
             {
                 // Throw better exception that gives more info.
                 throw new Exception(
-                    string.Format("Cannot find layout '{0}' used in control '{1}' of layout '{2}'",
-                        exception.layout, name, layout.name),
+                    $"Cannot find layout '{exception.layout}' used in control '{name}' of layout '{layout.name}'",
                     exception);
             }
 
@@ -608,7 +595,7 @@ namespace UnityEngine.Experimental.Input.Layouts
             ////        of successive re-allocations
 
             // Add usages.
-            var usages = controlOverride != null ? controlOverride.Value.usages : controlItem.usages;
+            var usages = controlOverride?.usages ?? controlItem.usages;
             if (usages.Count > 0)
             {
                 var usageCount = usages.Count;
@@ -634,7 +621,7 @@ namespace UnityEngine.Experimental.Input.Layouts
 
             // Set parameters.
             if (controlItem.parameters.Count > 0)
-                SetParameters(control, controlItem.parameters);
+                NamedValue.ApplyAllToObject(control, controlItem.parameters);
 
             // Add processors.
             if (controlItem.processors.Count > 0)
@@ -652,8 +639,7 @@ namespace UnityEngine.Experimental.Input.Layouts
             var pathLowerCase = path.ToLower();
 
             // See if there are existing overrides for the control.
-            InputControlLayout.ControlItem existingOverrides;
-            if (!m_ChildControlOverrides.TryGetValue(pathLowerCase, out existingOverrides))
+            if (!m_ChildControlOverrides.TryGetValue(pathLowerCase, out var existingOverrides))
             {
                 // So, so just insert our overrides and we're done.
                 m_ChildControlOverrides[pathLowerCase] = controlItem;
@@ -720,7 +706,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                     AddProcessors(child, ref controlItem, layout.name);
                 ////REVIEW: ATM parameters applied using this path add on top instead of just overriding existing parameters
                 if (controlItem.parameters.Count > 0)
-                    SetParameters(child, controlItem.parameters);
+                    NamedValue.ApplyAllToObject(child, controlItem.parameters);
                 if (!string.IsNullOrEmpty(controlItem.displayName))
                     child.m_DisplayNameFromLayout = controlItem.displayName;
                 if (!controlItem.defaultState.isEmpty)
@@ -760,14 +746,12 @@ namespace UnityEngine.Experimental.Input.Layouts
             var immediateParent = InputControlPath.TryFindChild(parent, immediateParentPath);
             if (immediateParent == null)
                 throw new Exception(
-                    string.Format("Cannot find parent '{0}' of control '{1}' in layout '{2}'", immediateParentPath,
-                        controlItem.name, layout.name));
+                    $"Cannot find parent '{immediateParentPath}' of control '{controlItem.name}' in layout '{layout.name}'");
 
             var controlName = path.Substring(indexOfSlash + 1);
             if (controlName.Length == 0)
                 throw new Exception(
-                    string.Format("Path cannot end in '/' (control '{0}' in layout '{1}')", controlItem.name,
-                        layout.name));
+                    $"Path cannot end in '/' (control '{controlItem.name}' in layout '{layout.name}')");
 
             // Make room in the device's child array.
             var childStartIndex = immediateParent.m_ChildrenReadOnly.m_StartIndex;
@@ -862,54 +846,15 @@ namespace UnityEngine.Experimental.Input.Layouts
                 var type = InputProcessor.s_Processors.LookupTypeRegistration(name);
                 if (type == null)
                     throw new Exception(
-                        string.Format("Cannot find processor '{0}' referenced by control '{1}' in layout '{2}'", name,
-                            controlItem.name, layoutName));
+                        $"Cannot find processor '{name}' referenced by control '{controlItem.name}' in layout '{layoutName}'");
 
                 var processor = Activator.CreateInstance(type);
 
                 var parameters = controlItem.processors[n].parameters;
                 if (parameters.Count > 0)
-                    SetParameters(processor, parameters);
+                    NamedValue.ApplyAllToObject(processor, parameters);
 
                 control.AddProcessor(processor);
-            }
-        }
-
-        internal static void SetParameters(object onObject, ReadOnlyArray<InputControlLayout.ParameterValue> parameters)
-        {
-            var objectType = onObject.GetType();
-            for (var i = 0; i < parameters.Count; ++i)
-            {
-                var parameter = parameters[i];
-
-                ////REVIEW: what about properties?
-
-                var field = objectType.GetField(parameter.name,
-                    BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (field == null)
-                    throw new Exception(string.Format("Cannot find public field {0} in {1} (referenced by parameter)",
-                        parameter.name, objectType.Name));
-
-                ////REVIEW: can we do this without boxing?
-
-                object value = null;
-                unsafe
-                {
-                    switch (parameter.type)
-                    {
-                        case InputControlLayout.ParameterType.Boolean:
-                            value = *(bool*)parameter.value;
-                            break;
-                        case InputControlLayout.ParameterType.Integer:
-                            value = *(int*)parameter.value;
-                            break;
-                        case InputControlLayout.ParameterType.Float:
-                            value = *(float*)parameter.value;
-                            break;
-                    }
-                }
-
-                field.SetValue(onObject, value);
             }
         }
 
@@ -947,9 +892,7 @@ namespace UnityEngine.Experimental.Input.Layouts
             if (control.m_StateBlock.sizeInBits == 0 && children.Count == 0)
             {
                 throw new Exception(
-                    string.Format(
-                        "Control '{0}' with layout '{1}' has no size set and has no children to compute size from",
-                        control.path, control.layout));
+                    $"Control '{control.path}' with layout '{control.layout}' has no size set and has no children to compute size from");
             }
 
             // If there's no children, our job is done.
@@ -971,7 +914,7 @@ namespace UnityEngine.Experimental.Input.Layouts
                 var childSizeInBits = child.m_StateBlock.sizeInBits;
                 if (childSizeInBits == 0 || childSizeInBits == InputStateBlock.kInvalidOffset)
                     throw new Exception(
-                        string.Format("Child '{0}' of '{1}' has no size set!", child.name, control.name));
+                        $"Child '{child.name}' of '{control.name}' has no size set!");
 
                 // Skip children that don't have fixed offsets.
                 if (child.m_StateBlock.byteOffset == InputStateBlock.kInvalidOffset ||
@@ -1067,7 +1010,7 @@ namespace UnityEngine.Experimental.Input.Layouts
             control.m_StateBlock.sizeInBits = totalSizeInBytes * 8;
         }
 
-        // Finalize array references in the control hierarchy and make all state offets relative to the
+        // Finalize array references in the control hierarchy and make all state offsets relative to the
         // device root.
         private void FinalizeControlHierarchy()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -137,7 +137,7 @@ namespace UnityEngine.Experimental.Input.Editor
         {
             // Find name of current composite.
             var path = m_PathProperty.stringValue;
-            var compositeNameAndParameters = InputControlLayout.ParseNameAndParameters(path);
+            var compositeNameAndParameters = NameAndParameters.Parse(path);
             var compositeName = compositeNameAndParameters.name;
             var compositeType = InputBindingComposite.s_Composites.LookupTypeRegistration(compositeName);
 
@@ -193,7 +193,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 return;
             var compositeBindingProperty = bindingArrayProperty.GetArrayElementAtIndex(compositeBindingIndex);
             var compositePath = compositeBindingProperty.FindPropertyRelative("m_Path").stringValue;
-            var compositeNameAndParameters = InputControlLayout.ParseNameAndParameters(compositePath);
+            var compositeNameAndParameters = NameAndParameters.Parse(compositePath);
 
             // Initialize option list from all parts available for the composite.
             var optionList = new List<GUIContent>();
@@ -228,7 +228,7 @@ namespace UnityEngine.Experimental.Input.Editor
             Debug.Assert(m_CompositeParameters != null);
 
             var path = m_PathProperty.stringValue;
-            var nameAndParameters = InputControlLayout.ParseNameAndParameters(path);
+            var nameAndParameters = NameAndParameters.Parse(path);
             nameAndParameters.parameters = m_CompositeParameters.GetParameters();
 
             m_PathProperty.stringValue = nameAndParameters.ToString();
@@ -253,7 +253,7 @@ namespace UnityEngine.Experimental.Input.Editor
 
         private void OnCompositeTypeChanged()
         {
-            var nameAndParameters = new InputControlLayout.NameAndParameters
+            var nameAndParameters = new NameAndParameters
             {
                 name = m_CompositeTypes[m_SelectedCompositeType],
                 parameters = m_CompositeParameters.GetParameters()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEditorInternal;
-using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.Utilities;
 
 namespace UnityEngine.Experimental.Input.Editor.Lists
@@ -14,7 +13,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
     /// to edit the parameters of the currently selected pair.
     /// </summary>
     /// <remarks>
-    /// Produces output that can be consumed by <see cref="InputControlLayout.ParseNameAndParameterList(string)"/>.
+    /// Produces output that can be consumed by <see cref="NameAndParameters.ParseMultiple"/>.
     /// </remarks>
     internal abstract class NameAndParameterListView
     {
@@ -25,8 +24,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
             m_ListItems = new List<string>();
             m_ListOptions = GetOptions();
             m_EditableParametersForSelectedItem = new ParameterListView {onChange = OnParametersChanged};
-            m_ParametersForEachListItem = InputControlLayout.ParseNameAndParameterList(m_Property.stringValue)
-                ?? new InputControlLayout.NameAndParameters[0];
+            m_ParametersForEachListItem = NameAndParameters.ParseMultiple(m_Property.stringValue).ToArray();
             m_ExpectedControlLayout = expectedControlLayout;
             Type expectedValueType = null;
             if (!string.IsNullOrEmpty(m_ExpectedControlLayout))
@@ -104,7 +102,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
             m_ListItems.Add(ObjectNames.NicifyVariableName(name));
             ArrayHelpers.Append(ref m_ParametersForEachListItem,
-                new InputControlLayout.NameAndParameters {name = name});
+                new NameAndParameters {name = name});
             m_Apply();
         }
 
@@ -114,7 +112,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
             if (selected < 0)
                 return;
 
-            m_ParametersForEachListItem[selected] = new InputControlLayout.NameAndParameters
+            m_ParametersForEachListItem[selected] = new NameAndParameters
             {
                 name = m_ParametersForEachListItem[selected].name,
                 parameters = m_EditableParametersForSelectedItem.GetParameters(),
@@ -161,7 +159,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
             if (m_ParametersForEachListItem == null)
                 return string.Empty;
 
-            return string.Join(InputControlLayout.kSeparatorString,
+            return string.Join(NamedValue.Separator,
                 m_ParametersForEachListItem.Select(x => x.ToString()).ToArray());
         }
 
@@ -171,7 +169,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         private TypeTable m_ListOptions;
         private string m_ExpectedControlLayout;
 
-        private InputControlLayout.NameAndParameters[] m_ParametersForEachListItem;
+        private NameAndParameters[] m_ParametersForEachListItem;
         private readonly ParameterListView m_EditableParametersForSelectedItem;
         private readonly Action m_Apply;
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -7,10 +7,6 @@ using UnityEditor;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.Utilities;
 
-////REVIEW: For some of the parameters (like SlowTap.duration) it is confusing to see any value at all while not yet having
-////        entered a value and seeing a value that doesn't seem to make sense (0 in this case means "no value, use default").
-////        Can we do this better? Maybe display "<default>" as text while the control is at default value?
-
 namespace UnityEngine.Experimental.Input.Editor.Lists
 {
     /// <summary>
@@ -21,6 +17,10 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
     ///
     /// Call <see cref="Initialize"/> to set up (can be done repeatedly on the same instance). Call
     /// <see cref="OnGUI"/> to render.
+    ///
+    /// Custom parameter GUIs can be defined by deriving from <see cref="InputParameterEditor{TObject}"/>.
+    /// This class will automatically incorporate custom GUIs and fall back to default GUIs where no custom
+    /// ones are defined.
     /// </remarks>
     internal class ParameterListView
     {
@@ -35,7 +35,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         /// Get the current parameter values according to the editor state.
         /// </summary>
         /// <returns>An array of parameter values.</returns>
-        public InputControlLayout.ParameterValue[] GetParameters()
+        public NamedValue[] GetParameters()
         {
             if (m_Parameters == null)
                 return null;
@@ -53,7 +53,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
                 return null;
 
             // Collect non-default parameter values.
-            var result = new InputControlLayout.ParameterValue[countOfParametersNotAtDefaultValue];
+            var result = new NamedValue[countOfParametersNotAtDefaultValue];
             var index = 0;
             for (var i = 0; i < m_Parameters.Length; ++i)
             {
@@ -75,7 +75,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         /// We need this to be able to determine the possible set of parameters and their possible values. This
         /// can be a class implementing <see cref="IInputInteraction"/>, for example.</param>
         /// <param name="existingParameters">List of existing parameters. Can be empty.</param>
-        public void Initialize(Type registeredType, ReadOnlyArray<InputControlLayout.ParameterValue> existingParameters)
+        public void Initialize(Type registeredType, ReadOnlyArray<NamedValue> existingParameters)
         {
             if (registeredType == null)
             {
@@ -118,47 +118,44 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
                 // Determine parameter type from field.
                 var fieldType = field.FieldType;
-                if (fieldType == typeof(bool))
+                if (fieldType.IsEnum)
                 {
-                    parameter.value.type = InputControlLayout.ParameterType.Boolean;
+                    // For enums, we want the underlying integer type.
+                    var underlyingType = fieldType.GetEnumUnderlyingType();
+                    var underlyingTypeCode = Type.GetTypeCode(underlyingType);
 
-                    // Determine default.
-                    if (instance != null)
-                        parameter.defaultValue = new InputControlLayout.ParameterValue(name, (bool)field.GetValue(instance));
-                }
-                else if (fieldType == typeof(int))
-                {
-                    parameter.value.type = InputControlLayout.ParameterType.Integer;
+                    parameter.value = parameter.value.ConvertTo(underlyingTypeCode);
 
-                    // Determine default.
-                    if (instance != null)
-                        parameter.defaultValue = new InputControlLayout.ParameterValue(name, (int)field.GetValue(instance));
-                }
-                else if (fieldType == typeof(float))
-                {
-                    parameter.value.type = InputControlLayout.ParameterType.Float;
-
-                    // Determine default.
-                    if (instance != null)
-                        parameter.defaultValue = new InputControlLayout.ParameterValue(name, (float)field.GetValue(instance));
-                }
-                else if (fieldType.IsEnum)
-                {
-                    parameter.value.type = InputControlLayout.ParameterType.Integer;
+                    // Read enum names and values.
                     parameter.enumNames = Enum.GetNames(fieldType).Select(x => new GUIContent(x)).ToArray();
-
                     ////REVIEW: this probably falls apart if multiple members have the same value
                     var list = new List<int>();
                     foreach (var value in Enum.GetValues(fieldType))
                         list.Add((int)value);
                     parameter.enumValues = list.ToArray();
+                }
+                else
+                {
+                    var typeCode = Type.GetTypeCode(fieldType);
+                    parameter.value = parameter.value.ConvertTo(typeCode);
+                }
 
-                    // Determine default.
-                    if (instance != null)
+                // Determine default value.
+                if (instance != null)
+                {
+                    try
                     {
-                        var defaultValue = field.GetValue(instance);
-                        var defaultValueInt = Convert.ToInt32(defaultValue);
-                        parameter.defaultValue = new InputControlLayout.ParameterValue(name, defaultValueInt);
+                        var value = field.GetValue(instance);
+                        parameter.defaultValue = new NamedValue
+                        {
+                            name = name,
+                            value = PrimitiveValue.FromObject(value)
+                        };
+                    }
+                    catch
+                    {
+                        // If the getter throws, ignore. All we lose is the actual default value from
+                        // the field.
                     }
                 }
 
@@ -191,31 +188,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
                 // the parameter values. So on this path, we actually need to update the object to reflect
                 // the current parameter values.
 
-                foreach (var parameter in m_Parameters)
-                {
-                    if (parameter.isEnum)
-                    {
-                        var enumValue = Enum.ToObject(parameter.field.FieldType, parameter.value.GetIntValue());
-                        parameter.field.SetValue(instance, enumValue);
-                    }
-                    else
-                    {
-                        switch (parameter.value.type)
-                        {
-                            case InputControlLayout.ParameterType.Float:
-                                parameter.field.SetValue(instance, parameter.value.GetFloatValue());
-                                break;
-
-                            case InputControlLayout.ParameterType.Boolean:
-                                parameter.field.SetValue(instance, parameter.value.GetBoolValue());
-                                break;
-
-                            case InputControlLayout.ParameterType.Integer:
-                                parameter.field.SetValue(instance, parameter.value.GetIntValue());
-                                break;
-                        }
-                    }
-                }
+                NamedValue.ApplyAllToObject(instance, m_Parameters.Select(x => x.value));
 
                 m_ParameterEditor = (InputParameterEditor)Activator.CreateInstance(parameterEditorType);
                 m_ParameterEditor.SetTarget(instance);
@@ -273,31 +246,41 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
                 EditorGUI.BeginChangeCheck();
 
-                string result = null;
+                object result = null;
                 if (parameter.isEnum)
                 {
-                    var intValue = parameter.value.GetIntValue();
-                    result = EditorGUILayout.IntPopup(label, intValue, parameter.enumNames, parameter.enumValues).ToString();
+                    var intValue = parameter.value.value.ToInt32();
+                    result = EditorGUILayout.IntPopup(label, intValue, parameter.enumNames, parameter.enumValues);
                 }
-                else if (parameter.value.type == InputControlLayout.ParameterType.Integer)
+                else if (parameter.value.type == TypeCode.Int64 || parameter.value.type == TypeCode.UInt64)
                 {
-                    var intValue = parameter.value.GetIntValue();
-                    result = EditorGUILayout.IntField(label, intValue).ToString();
+                    var longValue = parameter.value.value.ToInt64();
+                    result = EditorGUILayout.LongField(label, longValue);
                 }
-                else if (parameter.value.type == InputControlLayout.ParameterType.Float)
+                else if (parameter.value.type.IsInt())
                 {
-                    var floatValue = parameter.value.GetFloatValue();
-                    result = EditorGUILayout.FloatField(label, floatValue).ToString();
+                    var intValue = parameter.value.value.ToInt32();
+                    result = EditorGUILayout.IntField(label, intValue);
                 }
-                else if (parameter.value.type == InputControlLayout.ParameterType.Boolean)
+                else if (parameter.value.type == TypeCode.Single)
                 {
-                    var boolValue = parameter.value.GetBoolValue();
-                    result = EditorGUILayout.Toggle(label, boolValue).ToString();
+                    var floatValue = parameter.value.value.ToSingle();
+                    result = EditorGUILayout.FloatField(label, floatValue);
+                }
+                else if (parameter.value.type == TypeCode.Double)
+                {
+                    var floatValue = parameter.value.value.ToDouble();
+                    result = EditorGUILayout.DoubleField(label, floatValue);
+                }
+                else if (parameter.value.type == TypeCode.Boolean)
+                {
+                    var boolValue = parameter.value.value.ToBoolean();
+                    result = EditorGUILayout.Toggle(label, boolValue);
                 }
 
                 if (EditorGUI.EndChangeCheck())
                 {
-                    parameter.value.SetValue(result);
+                    parameter.value.value = PrimitiveValue.FromObject(result).ConvertTo(parameter.value.type);
                     m_Parameters[i] = parameter;
                     onChange?.Invoke();
                 }
@@ -318,43 +301,17 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
             {
                 var parameter = m_Parameters[i];
 
-                var newValue = new InputControlLayout.ParameterValue();
-                newValue.name = parameter.value.name;
-
-                var value = parameter.field.GetValue(target);
-                if (parameter.isEnum)
+                object value = null;
+                try
                 {
-                    var intValue = Convert.ToInt32(value);
-                    newValue.SetValue(intValue);
+                    value = parameter.field.GetValue(target);
                 }
-                else
+                catch
                 {
-                    switch (parameter.value.type)
-                    {
-                        case InputControlLayout.ParameterType.Float:
-                        {
-                            var floatValue = Convert.ToSingle(value);
-                            newValue.SetValue(floatValue);
-                            break;
-                        }
-
-                        case InputControlLayout.ParameterType.Boolean:
-                        {
-                            var intValue = Convert.ToInt32(value);
-                            newValue.SetValue(intValue);
-                            break;
-                        }
-
-                        case InputControlLayout.ParameterType.Integer:
-                        {
-                            var boolValue = Convert.ToBoolean(value);
-                            newValue.SetValue(boolValue);
-                            break;
-                        }
-                    }
+                    // Ignore exceptions from getters.
                 }
 
-                m_Parameters[i].value = newValue;
+                m_Parameters[i].value.value = PrimitiveValue.FromObject(value).ConvertTo(parameter.value.type);
             }
         }
 
@@ -364,8 +321,8 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
         private struct EditableParameterValue
         {
-            public InputControlLayout.ParameterValue value;
-            public InputControlLayout.ParameterValue? defaultValue;
+            public NamedValue value;
+            public NamedValue? defaultValue;
             public int[] enumValues;
             public GUIContent[] enumNames;
             public FieldInfo field;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -39,7 +39,7 @@ namespace UnityEngine.Experimental.Input.Editor
         private static int s_Disabled;
         private static InputDebuggerWindow s_Instance;
 
-        [MenuItem("Window/Input Debugger", false, 2100)]
+        [MenuItem("Window/Analysis/Input Debugger", false, 2100)]
         public static void CreateOrShow()
         {
             if (s_Instance == null)
@@ -788,11 +788,6 @@ namespace UnityEngine.Experimental.Input.Editor
             {
                 public string name;
             }
-
-            //class ActionItem : TreeViewItem
-            //{
-            //public InputAction action;
-            //}
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -483,7 +483,7 @@ namespace UnityEngine.Experimental.Input.Editor
         }
 
         public static SerializedProperty ChangeCompositeBindingType(SerializedProperty bindingProperty,
-            InputControlLayout.NameAndParameters nameAndParameters)
+            NameAndParameters nameAndParameters)
         {
             var bindingsArrayProperty = bindingProperty.GetArrayPropertyFromElement();
             Debug.Assert(bindingsArrayProperty != null, "SerializedProperty is not an array of bindings");
@@ -497,7 +497,7 @@ namespace UnityEngine.Experimental.Input.Editor
             var pathProperty = bindingProperty.FindPropertyRelative("m_Path");
             var nameProperty = bindingProperty.FindPropertyRelative("m_Name");
             if (nameProperty.stringValue ==
-                ObjectNames.NicifyVariableName(InputControlLayout.ParseNameAndParameters(pathProperty.stringValue).name))
+                ObjectNames.NicifyVariableName(NameAndParameters.Parse(pathProperty.stringValue).name))
                 nameProperty.stringValue = ObjectNames.NicifyVariableName(nameAndParameters.name);
 
             pathProperty.stringValue = nameAndParameters.ToString();

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -385,20 +385,20 @@ namespace UnityEngine.Experimental.Input.LowLevel
                         "Cannot yet write primitive values into bitfields wider than 32 bits");
 
                 if (sizeInBits == 1)
-                    MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value.ToBool());
+                    MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value.ToBoolean());
                 else
-                    MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value.ToInt());
+                    MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value.ToInt32());
             }
             else if (format == kTypeFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");
-                *(float*)valuePtr = value.ToFloat();
+                *(float*)valuePtr = value.ToSingle();
             }
             else
             {
                 throw new NotImplementedException(
-                    $"Writing primitive value of type '{value.valueType}' into state block with format '{format}'");
+                    $"Writing primitive value of type '{value.type}' into state block with format '{format}'");
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NameAndParameters.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NameAndParameters.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+////TODO: add array support
+
+////TODO: switch parsing to use to Substring
+
+namespace UnityEngine.Experimental.Input.Utilities
+{
+    /// <summary>
+    /// A combination of a name and an optional list of named parameter values. For example, "Clamp(min=1,max=2)".
+    /// </summary>
+    public struct NameAndParameters
+    {
+        public string name { get; set; }
+        public ReadOnlyArray<NamedValue> parameters { get; set; }
+
+        public override string ToString()
+        {
+            if (parameters.Count == 0)
+                return name;
+            var parameterString = string.Join(NamedValue.Separator, parameters.Select(x => x.ToString()).ToArray());
+            return $"{name}({parameterString})";
+        }
+
+        public static IEnumerable<NameAndParameters> ParseMultiple(string text)
+        {
+            List<NameAndParameters> list = null;
+            if (!ParseMultiple(text, ref list))
+                return Enumerable.Empty<NameAndParameters>();
+            return list;
+        }
+
+        internal static bool ParseMultiple(string text, ref List<NameAndParameters> list)
+        {
+            text = text.Trim();
+            if (string.IsNullOrEmpty(text))
+                return false;
+
+            if (list == null)
+                list = new List<NameAndParameters>();
+            else
+                list.Clear();
+
+            var index = 0;
+            var textLength = text.Length;
+
+            while (index < textLength)
+                list.Add(ParseNameAndParameters(text, ref index));
+
+            return true;
+        }
+
+        public static NameAndParameters Parse(string text)
+        {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+            var index = 0;
+            return ParseNameAndParameters(text, ref index);
+        }
+
+        private static NameAndParameters ParseNameAndParameters(string text, ref int index)
+        {
+            var textLength = text.Length;
+
+            // Skip whitespace.
+            while (index < textLength && char.IsWhiteSpace(text[index]))
+                ++index;
+
+            // Parse name.
+            var nameStart = index;
+            while (index < textLength)
+            {
+                var nextChar = text[index];
+                if (nextChar == '(' || nextChar == NamedValue.Separator[0] || char.IsWhiteSpace(nextChar))
+                    break;
+                ++index;
+            }
+            if (index - nameStart == 0)
+                throw new Exception($"Expecting name at position {nameStart} in '{text}'");
+            var name = text.Substring(nameStart, index - nameStart);
+
+            // Skip whitespace.
+            while (index < textLength && char.IsWhiteSpace(text[index]))
+                ++index;
+
+            // Parse parameters.
+            NamedValue[] parameters = null;
+            if (index < textLength && text[index] == '(')
+            {
+                ++index;
+                var closeParenIndex = text.IndexOf(')', index);
+                if (closeParenIndex == -1)
+                    throw new Exception($"Expecting ')' after '(' at position {index} in '{text}'");
+
+                var parameterString = text.Substring(index, closeParenIndex - index);
+                parameters = NamedValue.ParseMultiple(parameterString);
+                index = closeParenIndex + 1;
+            }
+
+            if (index < textLength && (text[index] == ',' || text[index] == InputBinding.kSeparator))
+                ++index;
+
+            return new NameAndParameters {name = name, parameters = new ReadOnlyArray<NamedValue>(parameters)};
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NameAndParameters.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NameAndParameters.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ffbcc8a975d04f12967a085a10aeb7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NamedValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NamedValue.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace UnityEngine.Experimental.Input.Utilities
+{
+    /// <summary>
+    /// A combination of a name and a value assignment for it.
+    /// </summary>
+    public struct NamedValue : IEquatable<NamedValue>
+    {
+        public const string Separator = ",";
+
+        /// <summary>
+        /// Name of the parameter.
+        /// </summary>
+        public string name { get; set; }
+
+        /// <summary>
+        /// Value of the parameter.
+        /// </summary>
+        public PrimitiveValue value { get; set; }
+
+        public TypeCode type => value.type;
+
+        public NamedValue ConvertTo(TypeCode type)
+        {
+            return new NamedValue
+            {
+                name = name,
+                value = value.ConvertTo(type)
+            };
+        }
+
+        public static NamedValue From<TValue>(string name, TValue value)
+            where TValue : struct
+        {
+            return new NamedValue
+            {
+                name = name,
+                value = PrimitiveValue.From(value)
+            };
+        }
+
+        public override string ToString()
+        {
+            return $"{name}={value}";
+        }
+
+        public bool Equals(NamedValue other)
+        {
+            return string.Equals(name, other.name, StringComparison.InvariantCultureIgnoreCase)
+                && value == other.value;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            return obj is NamedValue parameterValue && Equals(parameterValue);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (name != null ? name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ value.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public static bool operator==(NamedValue left, NamedValue right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator!=(NamedValue left, NamedValue right)
+        {
+            return !left.Equals(right);
+        }
+
+        public static NamedValue[] ParseMultiple(string parameterString)
+        {
+            parameterString = parameterString.Trim();
+            if (string.IsNullOrEmpty(parameterString))
+                return null;
+
+            var parameterCount = parameterString.CountOccurrences(Separator[0]) + 1;
+            var parameters = new NamedValue[parameterCount];
+
+            var index = 0;
+            for (var i = 0; i < parameterCount; ++i)
+            {
+                var parameter = ParseParameter(parameterString, ref index);
+                parameters[i] = parameter;
+            }
+
+            return parameters;
+        }
+
+        public static NamedValue Parse(string str)
+        {
+            var index = 0;
+            return ParseParameter(str, ref index);
+        }
+
+        private static NamedValue ParseParameter(string parameterString, ref int index)
+        {
+            var parameter = new NamedValue();
+            var parameterStringLength = parameterString.Length;
+
+            // Skip whitespace.
+            while (index < parameterStringLength && char.IsWhiteSpace(parameterString[index]))
+                ++index;
+
+            // Parse name.
+            var nameStart = index;
+            while (index < parameterStringLength)
+            {
+                var nextChar = parameterString[index];
+                if (nextChar == '=' || nextChar == Separator[0] || char.IsWhiteSpace(nextChar))
+                    break;
+                ++index;
+            }
+            parameter.name = parameterString.Substring(nameStart, index - nameStart);
+
+            // Skip whitespace.
+            while (index < parameterStringLength && char.IsWhiteSpace(parameterString[index]))
+                ++index;
+
+            if (index == parameterStringLength || parameterString[index] != '=')
+            {
+                // No value given so take "=true" as implied.
+                parameter.value = true;
+            }
+            else
+            {
+                ++index; // Skip over '='.
+
+                // Skip whitespace.
+                while (index < parameterStringLength && char.IsWhiteSpace(parameterString[index]))
+                    ++index;
+
+                // Parse value.
+                var valueStart = index;
+                while (index < parameterStringLength &&
+                       !(parameterString[index] == Separator[0] || char.IsWhiteSpace(parameterString[index])))
+                    ++index;
+
+                ////TODO: use Substring struct here so that we don't allocate lots of useless strings
+
+                var value = parameterString.Substring(valueStart, index - valueStart);
+                parameter.value = PrimitiveValue.FromString(value);
+            }
+
+            if (index < parameterStringLength && parameterString[index] == Separator[0])
+                ++index;
+
+            return parameter;
+        }
+
+        public void ApplyToObject(object instance)
+        {
+            var instanceType = instance.GetType();
+
+            ////REVIEW: what about properties?
+            var field = instanceType.GetField(name,
+                BindingFlags.IgnoreCase | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (field == null)
+                throw new Exception(
+                    $"Cannot find public field '{name}' in '{instanceType.Name}' (while trying to apply parameter)");
+
+            ////REVIEW: would be awesome to be able to do this without boxing
+            var fieldTypeCode = Type.GetTypeCode(field.FieldType);
+            field.SetValue(instance, value.ConvertTo(fieldTypeCode).ToObject());
+        }
+
+        public static void ApplyAllToObject<TParameterList>(object instance, TParameterList parameters)
+            where TParameterList : IEnumerable<NamedValue>
+        {
+            foreach (var parameter in parameters)
+                parameter.ApplyToObject(instance);
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NamedValue.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NamedValue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0e0c005ff24ec4cfb951eefa16239b9b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
@@ -1,166 +1,219 @@
 using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
+using Unity.Collections.LowLevel.Unsafe;
 
 namespace UnityEngine.Experimental.Input.Utilities
 {
-    public enum PrimitiveValueType
-    {
-        None,
-        Bool,
-        Char,
-        Byte,
-        SByte,
-        Short,
-        UShort,
-        Int,
-        UInt,
-        Long,
-        ULong,
-        Float,
-        Double,
-    }
-
     /// <summary>
     /// A union holding a primitive value.
     /// </summary>
     [StructLayout(LayoutKind.Explicit)]
-    public struct PrimitiveValue
+    public struct PrimitiveValue : IEquatable<PrimitiveValue>, IConvertible
     {
-        [FieldOffset(0)] public PrimitiveValueType valueType;
-        [FieldOffset(4)] public bool boolValue;
-        [FieldOffset(4)] public char charValue;
-        [FieldOffset(4)] public byte byteValue;
-        [FieldOffset(4)] public sbyte sbyteValue;
-        [FieldOffset(4)] public short shortValue;
-        [FieldOffset(4)] public ushort ushortValue;
-        [FieldOffset(4)] public int intValue;
-        [FieldOffset(4)] public uint uintValue;
-        [FieldOffset(4)] public long longValue;
-        [FieldOffset(4)] public ulong ulongValue;
-        [FieldOffset(4)] public float floatValue;
-        [FieldOffset(4)] public double doubleValue;
+        [FieldOffset(0)] private TypeCode m_Type;
+        [FieldOffset(4)] private bool m_BoolValue;
+        [FieldOffset(4)] private char m_CharValue;
+        [FieldOffset(4)] private byte m_ByteValue;
+        [FieldOffset(4)] private sbyte m_SByteValue;
+        [FieldOffset(4)] private short m_ShortValue;
+        [FieldOffset(4)] private ushort m_UShortValue;
+        [FieldOffset(4)] private int m_IntValue;
+        [FieldOffset(4)] private uint m_UIntValue;
+        [FieldOffset(4)] private long m_LongValue;
+        [FieldOffset(4)] private ulong m_ULongValue;
+        [FieldOffset(4)] private float m_FloatValue;
+        [FieldOffset(4)] private double m_DoubleValue;
+
+        public TypeCode type => m_Type;
 
         /// <summary>
-        /// If true, the struct contains a primitive value.
+        /// If true, the struct does not contain a primitive value.
         /// </summary>
-        public bool isEmpty
-        {
-            get { return valueType == PrimitiveValueType.None; }
-        }
+        public bool isEmpty => type == TypeCode.Empty;
 
         public PrimitiveValue(bool value)
             : this()
         {
-            valueType = PrimitiveValueType.Bool;
-            boolValue = value;
+            m_Type = TypeCode.Boolean;
+            m_BoolValue = value;
         }
 
         public PrimitiveValue(char value)
             : this()
         {
-            valueType = PrimitiveValueType.Char;
-            charValue = value;
+            m_Type = TypeCode.Char;
+            m_CharValue = value;
         }
 
         public PrimitiveValue(byte value)
             : this()
         {
-            valueType = PrimitiveValueType.Byte;
-            byteValue = value;
+            m_Type = TypeCode.Byte;
+            m_ByteValue = value;
         }
 
         public PrimitiveValue(sbyte value)
             : this()
         {
-            valueType = PrimitiveValueType.SByte;
-            sbyteValue = value;
+            m_Type = TypeCode.SByte;
+            m_SByteValue = value;
         }
 
         public PrimitiveValue(short value)
             : this()
         {
-            valueType = PrimitiveValueType.Short;
-            shortValue = value;
+            m_Type = TypeCode.Int16;
+            m_ShortValue = value;
         }
 
         public PrimitiveValue(ushort value)
             : this()
         {
-            valueType = PrimitiveValueType.UShort;
-            ushortValue = value;
+            m_Type = TypeCode.UInt16;
+            m_UShortValue = value;
         }
 
         public PrimitiveValue(int value)
             : this()
         {
-            valueType = PrimitiveValueType.Int;
-            intValue = value;
+            m_Type = TypeCode.Int32;
+            m_IntValue = value;
         }
 
         public PrimitiveValue(uint value)
             : this()
         {
-            valueType = PrimitiveValueType.UInt;
-            uintValue = value;
+            m_Type = TypeCode.UInt32;
+            m_UIntValue = value;
         }
 
         public PrimitiveValue(long value)
             : this()
         {
-            valueType = PrimitiveValueType.Long;
-            longValue = value;
+            m_Type = TypeCode.Int64;
+            m_LongValue = value;
         }
 
         public PrimitiveValue(ulong value)
             : this()
         {
-            valueType = PrimitiveValueType.ULong;
-            ulongValue = value;
+            m_Type = TypeCode.UInt64;
+            m_ULongValue = value;
         }
 
         public PrimitiveValue(float value)
             : this()
         {
-            valueType = PrimitiveValueType.Float;
-            floatValue = value;
+            m_Type = TypeCode.Single;
+            m_FloatValue = value;
         }
 
         public PrimitiveValue(double value)
             : this()
         {
-            valueType = PrimitiveValueType.Double;
-            doubleValue = value;
+            m_Type = TypeCode.Double;
+            m_DoubleValue = value;
+        }
+
+        public PrimitiveValue ConvertTo(TypeCode type)
+        {
+            switch (type)
+            {
+                case TypeCode.Boolean: return ToBoolean();
+                case TypeCode.Char: return ToChar();
+                case TypeCode.Byte: return ToByte();
+                case TypeCode.SByte: return ToSByte();
+                case TypeCode.Int16: return ToInt16();
+                case TypeCode.Int32: return ToInt32();
+                case TypeCode.Int64: return ToInt64();
+                case TypeCode.UInt16: return ToInt16();
+                case TypeCode.UInt32: return ToInt32();
+                case TypeCode.UInt64: return ToInt64();
+                case TypeCode.Single: return ToSingle();
+                case TypeCode.Double: return ToDouble();
+                case TypeCode.Empty: return new PrimitiveValue();
+            }
+
+            throw new ArgumentException($"Don't know how to convert PrimitiveValue to '{type}'", nameof(type));
+        }
+
+        public unsafe bool Equals(PrimitiveValue other)
+        {
+            if (m_Type != other.m_Type)
+                return false;
+
+            var thisValuePtr = UnsafeUtility.AddressOf(ref m_DoubleValue);
+            var otherValuePtr = UnsafeUtility.AddressOf(ref other.m_DoubleValue);
+
+            return UnsafeUtility.MemCmp(thisValuePtr, otherValuePtr, sizeof(double)) == 0;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (obj is PrimitiveValue value)
+                return Equals(value);
+            if (obj is bool || obj is char || obj is byte || obj is sbyte || obj is short
+                || obj is ushort || obj is int || obj is uint || obj is long || obj is ulong
+                || obj is float || obj is double)
+                return Equals(FromObject(obj));
+            return false;
+        }
+
+        public static bool operator==(PrimitiveValue left, PrimitiveValue right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator!=(PrimitiveValue left, PrimitiveValue right)
+        {
+            return !left.Equals(right);
+        }
+
+        public override unsafe int GetHashCode()
+        {
+            unchecked
+            {
+                fixed(double* valuePtr = &m_DoubleValue)
+                {
+                    var hashCode = m_Type.GetHashCode();
+                    hashCode = (hashCode * 397) ^ valuePtr->GetHashCode();
+                    return hashCode;
+                }
+            }
         }
 
         public override string ToString()
         {
-            switch (valueType)
+            switch (type)
             {
-                case PrimitiveValueType.Bool:
-                    return boolValue.ToString();
-                case PrimitiveValueType.Char:
-                    return charValue.ToString();
-                case PrimitiveValueType.Byte:
-                    return byteValue.ToString();
-                case PrimitiveValueType.SByte:
-                    return sbyteValue.ToString();
-                case PrimitiveValueType.Short:
-                    return shortValue.ToString();
-                case PrimitiveValueType.UShort:
-                    return ushortValue.ToString();
-                case PrimitiveValueType.Int:
-                    return intValue.ToString();
-                case PrimitiveValueType.UInt:
-                    return uintValue.ToString();
-                case PrimitiveValueType.Long:
-                    return longValue.ToString();
-                case PrimitiveValueType.ULong:
-                    return ulongValue.ToString();
-                case PrimitiveValueType.Float:
-                    return floatValue.ToString();
-                case PrimitiveValueType.Double:
-                    return doubleValue.ToString();
+                case TypeCode.Boolean:
+                    // Default ToString() uses "False" and "True". We want lowercase to match C# literals.
+                    return m_BoolValue ? "true" : "false";
+                case TypeCode.Char:
+                    return $"'{m_CharValue.ToString()}'";
+                case TypeCode.Byte:
+                    return m_ByteValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.SByte:
+                    return m_SByteValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.Int16:
+                    return m_ShortValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.UInt16:
+                    return m_UShortValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.Int32:
+                    return m_IntValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.UInt32:
+                    return m_UIntValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.Int64:
+                    return m_LongValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.UInt64:
+                    return m_ULongValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.Single:
+                    return m_FloatValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+                case TypeCode.Double:
+                    return m_DoubleValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
                 default:
                     return string.Empty;
             }
@@ -178,18 +231,17 @@ namespace UnityEngine.Experimental.Input.Utilities
                 return new PrimitiveValue(false);
 
             // Double.
-            if (value.IndexOf('.') != -1 || value.Contains("e") || value.Contains("E"))
+            if (value.Contains('.') || value.Contains("e") || value.Contains("E") ||
+                value.Contains("infinity", StringComparison.InvariantCultureIgnoreCase))
             {
-                double doubleResult;
-                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out doubleResult))
+                if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var doubleResult))
                     return new PrimitiveValue(doubleResult);
             }
 
-            // Long.
-            long longResult;
-            if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out longResult))
+            // Int.
+            if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var intResult))
             {
-                return new PrimitiveValue(longResult);
+                return new PrimitiveValue(intResult);
             }
             // Try hex format. For whatever reason, HexNumber does not allow a 0x prefix so we manually
             // get rid of it.
@@ -198,187 +250,275 @@ namespace UnityEngine.Experimental.Input.Utilities
                 var hexDigits = value.TrimStart();
                 if (hexDigits.StartsWith("0x"))
                     hexDigits = hexDigits.Substring(2);
-                if (long.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out longResult))
-                {
-                    return new PrimitiveValue(longResult);
-                }
+
+                if (int.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var hexResult))
+                    return new PrimitiveValue(hexResult);
             }
 
             ////TODO: allow trailing width specifier
             throw new NotImplementedException();
         }
 
-        public bool ToBool()
+        public TypeCode GetTypeCode()
         {
-            switch (valueType)
+            return type;
+        }
+
+        public bool ToBoolean(IFormatProvider provider = null)
+        {
+            switch (type)
             {
-                case PrimitiveValueType.Bool:
-                    return boolValue;
-                case PrimitiveValueType.Char:
-                    return charValue != '\0';
-                case PrimitiveValueType.Byte:
-                    return byteValue != 0;
-                case PrimitiveValueType.SByte:
-                    return sbyteValue != 0;
-                case PrimitiveValueType.Short:
-                    return shortValue != 0;
-                case PrimitiveValueType.UShort:
-                    return ushortValue != 0;
-                case PrimitiveValueType.Int:
-                    return intValue != 0;
-                case PrimitiveValueType.UInt:
-                    return uintValue != 0;
-                case PrimitiveValueType.Long:
-                    return longValue != 0;
-                case PrimitiveValueType.ULong:
-                    return ulongValue != 0;
-                case PrimitiveValueType.Float:
-                    return !Mathf.Approximately(floatValue, 0);
-                case PrimitiveValueType.Double:
-                    return NumberHelpers.Approximately(doubleValue, 0);
+                case TypeCode.Boolean:
+                    return m_BoolValue;
+                case TypeCode.Char:
+                    return m_CharValue != '\0';
+                case TypeCode.Byte:
+                    return m_ByteValue != 0;
+                case TypeCode.SByte:
+                    return m_SByteValue != 0;
+                case TypeCode.Int16:
+                    return m_ShortValue != 0;
+                case TypeCode.UInt16:
+                    return m_UShortValue != 0;
+                case TypeCode.Int32:
+                    return m_IntValue != 0;
+                case TypeCode.UInt32:
+                    return m_UIntValue != 0;
+                case TypeCode.Int64:
+                    return m_LongValue != 0;
+                case TypeCode.UInt64:
+                    return m_ULongValue != 0;
+                case TypeCode.Single:
+                    return !Mathf.Approximately(m_FloatValue, 0);
+                case TypeCode.Double:
+                    return NumberHelpers.Approximately(m_DoubleValue, 0);
                 default:
                     return default(bool);
             }
         }
 
-        public int ToInt()
+        public byte ToByte(IFormatProvider provider = null)
         {
-            switch (valueType)
+            return (byte)ToInt64(provider);
+        }
+
+        public char ToChar(IFormatProvider provider = null)
+        {
+            switch (type)
             {
-                case PrimitiveValueType.Bool:
-                    if (boolValue)
-                        return 1;
-                    return 0;
-                case PrimitiveValueType.Char:
-                    return charValue;
-                case PrimitiveValueType.Byte:
-                    return byteValue;
-                case PrimitiveValueType.SByte:
-                    return sbyteValue;
-                case PrimitiveValueType.Short:
-                    return shortValue;
-                case PrimitiveValueType.UShort:
-                    return ushortValue;
-                case PrimitiveValueType.Int:
-                    return intValue;
-                case PrimitiveValueType.UInt:
-                    return (int)uintValue;
-                case PrimitiveValueType.Long:
-                    return (int)longValue;
-                case PrimitiveValueType.ULong:
-                    return (int)ulongValue;
-                case PrimitiveValueType.Float:
-                    return (int)floatValue;
-                case PrimitiveValueType.Double:
-                    return (int)doubleValue;
+                case TypeCode.Char:
+                    return m_CharValue;
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                    return (char)ToInt64(provider);
                 default:
-                    return default(int);
+                    return default(char);
             }
         }
 
-        public long ToLong()
+        public DateTime ToDateTime(IFormatProvider provider = null)
         {
-            switch (valueType)
+            throw new NotSupportedException("Converting PrimitiveValue to DateTime");
+        }
+
+        public decimal ToDecimal(IFormatProvider provider = null)
+        {
+            return new decimal(ToDouble(provider));
+        }
+
+        public double ToDouble(IFormatProvider provider = null)
+        {
+            switch (type)
             {
-                case PrimitiveValueType.Bool:
-                    if (boolValue)
+                case TypeCode.Boolean:
+                    if (m_BoolValue)
                         return 1;
                     return 0;
-                case PrimitiveValueType.Char:
-                    return charValue;
-                case PrimitiveValueType.Byte:
-                    return byteValue;
-                case PrimitiveValueType.SByte:
-                    return sbyteValue;
-                case PrimitiveValueType.Short:
-                    return shortValue;
-                case PrimitiveValueType.UShort:
-                    return ushortValue;
-                case PrimitiveValueType.Int:
-                    return intValue;
-                case PrimitiveValueType.UInt:
-                    return uintValue;
-                case PrimitiveValueType.Long:
-                    return longValue;
-                case PrimitiveValueType.ULong:
-                    return (long)ulongValue;
-                case PrimitiveValueType.Float:
-                    return (long)floatValue;
-                case PrimitiveValueType.Double:
-                    return (long)doubleValue;
+                case TypeCode.Char:
+                    return m_CharValue;
+                case TypeCode.Byte:
+                    return m_ByteValue;
+                case TypeCode.SByte:
+                    return m_SByteValue;
+                case TypeCode.Int16:
+                    return m_ShortValue;
+                case TypeCode.UInt16:
+                    return m_UShortValue;
+                case TypeCode.Int32:
+                    return m_IntValue;
+                case TypeCode.UInt32:
+                    return m_UIntValue;
+                case TypeCode.Int64:
+                    return m_LongValue;
+                case TypeCode.UInt64:
+                    return m_ULongValue;
+                case TypeCode.Single:
+                    return m_FloatValue;
+                case TypeCode.Double:
+                    return m_DoubleValue;
+                default:
+                    return default(double);
+            }
+        }
+
+        public short ToInt16(IFormatProvider provider = null)
+        {
+            return (short)ToInt64(provider);
+        }
+
+        public int ToInt32(IFormatProvider provider = null)
+        {
+            return (int)ToInt64(provider);
+        }
+
+        public long ToInt64(IFormatProvider provider = null)
+        {
+            switch (type)
+            {
+                case TypeCode.Boolean:
+                    if (m_BoolValue)
+                        return 1;
+                    return 0;
+                case TypeCode.Char:
+                    return m_CharValue;
+                case TypeCode.Byte:
+                    return m_ByteValue;
+                case TypeCode.SByte:
+                    return m_SByteValue;
+                case TypeCode.Int16:
+                    return m_ShortValue;
+                case TypeCode.UInt16:
+                    return m_UShortValue;
+                case TypeCode.Int32:
+                    return m_IntValue;
+                case TypeCode.UInt32:
+                    return m_UIntValue;
+                case TypeCode.Int64:
+                    return m_LongValue;
+                case TypeCode.UInt64:
+                    return (long)m_ULongValue;
+                case TypeCode.Single:
+                    return (long)m_FloatValue;
+                case TypeCode.Double:
+                    return (long)m_DoubleValue;
                 default:
                     return default(long);
             }
         }
 
-        public float ToFloat()
+        public sbyte ToSByte(IFormatProvider provider = null)
         {
-            switch (valueType)
+            return (sbyte)ToInt64(provider);
+        }
+
+        public float ToSingle(IFormatProvider provider = null)
+        {
+            return (float)ToDouble(provider);
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            return ToString();
+        }
+
+        public object ToType(Type conversionType, IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ushort ToUInt16(IFormatProvider provider = null)
+        {
+            return (ushort)ToUInt64(provider);
+        }
+
+        public uint ToUInt32(IFormatProvider provider = null)
+        {
+            return (uint)ToUInt64(provider);
+        }
+
+        public ulong ToUInt64(IFormatProvider provider = null)
+        {
+            switch (type)
             {
-                case PrimitiveValueType.Bool:
-                    if (boolValue)
+                case TypeCode.Boolean:
+                    if (m_BoolValue)
                         return 1;
                     return 0;
-                case PrimitiveValueType.Char:
-                    return charValue;
-                case PrimitiveValueType.Byte:
-                    return byteValue;
-                case PrimitiveValueType.SByte:
-                    return sbyteValue;
-                case PrimitiveValueType.Short:
-                    return shortValue;
-                case PrimitiveValueType.UShort:
-                    return ushortValue;
-                case PrimitiveValueType.Int:
-                    return intValue;
-                case PrimitiveValueType.UInt:
-                    return uintValue;
-                case PrimitiveValueType.Long:
-                    return longValue;
-                case PrimitiveValueType.ULong:
-                    return ulongValue;
-                case PrimitiveValueType.Float:
-                    return floatValue;
-                case PrimitiveValueType.Double:
-                    return (float)doubleValue;
+                case TypeCode.Char:
+                    return m_CharValue;
+                case TypeCode.Byte:
+                    return m_ByteValue;
+                case TypeCode.SByte:
+                    return (ulong)m_SByteValue;
+                case TypeCode.Int16:
+                    return (ulong)m_ShortValue;
+                case TypeCode.UInt16:
+                    return m_UShortValue;
+                case TypeCode.Int32:
+                    return (ulong)m_IntValue;
+                case TypeCode.UInt32:
+                    return m_UIntValue;
+                case TypeCode.Int64:
+                    return (ulong)m_LongValue;
+                case TypeCode.UInt64:
+                    return m_ULongValue;
+                case TypeCode.Single:
+                    return (ulong)m_FloatValue;
+                case TypeCode.Double:
+                    return (ulong)m_DoubleValue;
                 default:
-                    return default(float);
+                    return default(ulong);
             }
         }
 
-        public double ToDouble()
+        public object ToObject()
         {
-            switch (valueType)
+            switch (m_Type)
             {
-                case PrimitiveValueType.Bool:
-                    if (boolValue)
-                        return 1;
-                    return 0;
-                case PrimitiveValueType.Char:
-                    return charValue;
-                case PrimitiveValueType.Byte:
-                    return byteValue;
-                case PrimitiveValueType.SByte:
-                    return sbyteValue;
-                case PrimitiveValueType.Short:
-                    return shortValue;
-                case PrimitiveValueType.UShort:
-                    return ushortValue;
-                case PrimitiveValueType.Int:
-                    return intValue;
-                case PrimitiveValueType.UInt:
-                    return uintValue;
-                case PrimitiveValueType.Long:
-                    return longValue;
-                case PrimitiveValueType.ULong:
-                    return ulongValue;
-                case PrimitiveValueType.Float:
-                    return floatValue;
-                case PrimitiveValueType.Double:
-                    return doubleValue;
-                default:
-                    return default(double);
+                case TypeCode.Boolean: return m_BoolValue;
+                case TypeCode.Char: return m_CharValue;
+                case TypeCode.Byte: return m_ByteValue;
+                case TypeCode.SByte: return m_SByteValue;
+                case TypeCode.Int16: return m_ShortValue;
+                case TypeCode.UInt16: return m_UShortValue;
+                case TypeCode.Int32: return m_IntValue;
+                case TypeCode.UInt32: return m_UIntValue;
+                case TypeCode.Int64: return m_LongValue;
+                case TypeCode.UInt64: return m_ULongValue;
+                case TypeCode.Single: return m_FloatValue;
+                case TypeCode.Double: return m_DoubleValue;
+                default: return null;
             }
+        }
+
+        public static PrimitiveValue From<TValue>(TValue value)
+            where TValue : struct
+        {
+            var type = typeof(TValue);
+            if (type.IsEnum)
+                type = type.GetEnumUnderlyingType();
+
+            var typeCode = Type.GetTypeCode(type);
+            switch (typeCode)
+            {
+                case TypeCode.Boolean: return new PrimitiveValue(Convert.ToBoolean(value));
+                case TypeCode.Char: return new PrimitiveValue(Convert.ToChar(value));
+                case TypeCode.Byte: return new PrimitiveValue(Convert.ToByte(value));
+                case TypeCode.SByte: return new PrimitiveValue(Convert.ToSByte(value));
+                case TypeCode.Int16: return new PrimitiveValue(Convert.ToInt16(value));
+                case TypeCode.Int32: return new PrimitiveValue(Convert.ToInt32(value));
+                case TypeCode.Int64: return new PrimitiveValue(Convert.ToInt64(value));
+                case TypeCode.UInt16: return new PrimitiveValue(Convert.ToUInt16(value));
+                case TypeCode.UInt32: return new PrimitiveValue(Convert.ToUInt32(value));
+                case TypeCode.UInt64: return new PrimitiveValue(Convert.ToUInt64(value));
+            }
+
+            throw new ArgumentException(
+                $"Cannot convert value '{value}' of type '{typeof(TValue).Name}' to PrimitiveValue", nameof(value));
         }
 
         public static PrimitiveValue FromObject(object value)
@@ -386,36 +526,53 @@ namespace UnityEngine.Experimental.Input.Utilities
             if (value == null)
                 return new PrimitiveValue();
 
-            var stringValue = value as string;
-            if (stringValue != null)
+            if (value is string stringValue)
                 return FromString(stringValue);
 
-            if (value is bool)
-                return new PrimitiveValue((bool)value);
-            if (value is char)
-                return new PrimitiveValue((char)value);
-            if (value is byte)
-                return new PrimitiveValue((byte)value);
-            if (value is sbyte)
-                return new PrimitiveValue((sbyte)value);
-            if (value is short)
-                return new PrimitiveValue((short)value);
-            if (value is ushort)
-                return new PrimitiveValue((ushort)value);
-            if (value is int)
-                return new PrimitiveValue((int)value);
-            if (value is uint)
-                return new PrimitiveValue((uint)value);
-            if (value is long)
-                return new PrimitiveValue((long)value);
-            if (value is ulong)
-                return new PrimitiveValue((ulong)value);
-            if (value is float)
-                return new PrimitiveValue((float)value);
-            if (value is double)
-                return new PrimitiveValue((double)value);
+            if (value is bool b)
+                return new PrimitiveValue(b);
+            if (value is char ch)
+                return new PrimitiveValue(ch);
+            if (value is byte bt)
+                return new PrimitiveValue(bt);
+            if (value is sbyte sbt)
+                return new PrimitiveValue(sbt);
+            if (value is short s)
+                return new PrimitiveValue(s);
+            if (value is ushort us)
+                return new PrimitiveValue(us);
+            if (value is int i)
+                return new PrimitiveValue(i);
+            if (value is uint ui)
+                return new PrimitiveValue(ui);
+            if (value is long l)
+                return new PrimitiveValue(l);
+            if (value is ulong ul)
+                return new PrimitiveValue(ul);
+            if (value is float f)
+                return new PrimitiveValue(f);
+            if (value is double d)
+                return new PrimitiveValue(d);
 
-            throw new ArgumentException(string.Format("Cannot convert '{0}' to primitive value", value), "value");
+            // Enum.
+            if (value is Enum)
+            {
+                var underlyingType = value.GetType().GetEnumUnderlyingType();
+                var underlyingTypeCode = Type.GetTypeCode(underlyingType);
+                switch (underlyingTypeCode)
+                {
+                    case TypeCode.Byte: return new PrimitiveValue((byte)value);
+                    case TypeCode.SByte: return new PrimitiveValue((sbyte)value);
+                    case TypeCode.Int16: return new PrimitiveValue((short)value);
+                    case TypeCode.Int32: return new PrimitiveValue((int)value);
+                    case TypeCode.Int64: return new PrimitiveValue((long)value);
+                    case TypeCode.UInt16: return new PrimitiveValue((ushort)value);
+                    case TypeCode.UInt32: return new PrimitiveValue((uint)value);
+                    case TypeCode.UInt64: return new PrimitiveValue((ulong)value);
+                }
+            }
+
+            throw new ArgumentException($"Cannot convert '{value}' to primitive value", nameof(value));
         }
 
         public static implicit operator PrimitiveValue(bool value)
@@ -476,166 +633,6 @@ namespace UnityEngine.Experimental.Input.Utilities
         public static implicit operator PrimitiveValue(double value)
         {
             return new PrimitiveValue(value);
-        }
-    }
-
-    public struct PrimitiveValueOrArray
-    {
-        ////REVIEW: use InlinedArray<PrimitiveValue>?
-        public PrimitiveValue primitiveValue;
-        public object arrayValue;
-
-        public PrimitiveValueType valueType
-        {
-            get { return primitiveValue.valueType; }
-        }
-
-        public bool isArray
-        {
-            get { return arrayValue != null; }
-        }
-
-        public bool isEmpty
-        {
-            get { return valueType == PrimitiveValueType.None; }
-        }
-
-        public PrimitiveValueOrArray(PrimitiveValue value)
-        {
-            primitiveValue = value;
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(bool value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(char value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(byte value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(sbyte value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(short value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(ushort value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(int value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(uint value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(long value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(ulong value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(float value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public PrimitiveValueOrArray(double value)
-        {
-            primitiveValue = new PrimitiveValue(value);
-            arrayValue = null;
-        }
-
-        public override string ToString()
-        {
-            if (!isArray)
-                return primitiveValue.ToString();
-
-            throw new NotImplementedException();
-        }
-
-        public static PrimitiveValueOrArray FromString(string value)
-        {
-            if (string.IsNullOrEmpty(value))
-                return new PrimitiveValueOrArray();
-
-            ////TODO: array support
-
-            return new PrimitiveValueOrArray
-            {
-                primitiveValue = PrimitiveValue.FromString(value)
-            };
-        }
-
-        public static PrimitiveValueOrArray FromObject(object value)
-        {
-            if (value == null)
-                return new PrimitiveValueOrArray();
-
-            var stringValue = value as string;
-            if (stringValue != null)
-                return FromString(stringValue);
-
-            if (value is bool)
-                return new PrimitiveValueOrArray((bool)value);
-            if (value is char)
-                return new PrimitiveValueOrArray((char)value);
-            if (value is byte)
-                return new PrimitiveValueOrArray((byte)value);
-            if (value is sbyte)
-                return new PrimitiveValueOrArray((sbyte)value);
-            if (value is short)
-                return new PrimitiveValueOrArray((short)value);
-            if (value is ushort)
-                return new PrimitiveValueOrArray((ushort)value);
-            if (value is int)
-                return new PrimitiveValueOrArray((int)value);
-            if (value is uint)
-                return new PrimitiveValueOrArray((uint)value);
-            if (value is long)
-                return new PrimitiveValueOrArray((long)value);
-            if (value is ulong)
-                return new PrimitiveValueOrArray((ulong)value);
-            if (value is float)
-                return new PrimitiveValueOrArray((float)value);
-            if (value is double)
-                return new PrimitiveValueOrArray((double)value);
-
-            ////TODO: arrays
-
-            throw new ArgumentException(string.Format("Cannot convert '{0}' to primitive value or value array", value), "value");
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValueOrArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValueOrArray.cs
@@ -1,0 +1,154 @@
+using System;
+
+namespace UnityEngine.Experimental.Input.Utilities
+{
+    public struct PrimitiveValueOrArray
+    {
+        ////REVIEW: use InlinedArray<PrimitiveValue>?
+        public PrimitiveValue primitiveValue;
+        public object arrayValue;
+
+        public TypeCode valueType => primitiveValue.type;
+
+        public bool isArray => arrayValue != null;
+
+        public bool isEmpty => valueType == TypeCode.Empty;
+
+        public PrimitiveValueOrArray(PrimitiveValue value)
+        {
+            primitiveValue = value;
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(bool value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(char value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(byte value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(sbyte value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(short value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(ushort value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(int value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(uint value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(long value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(ulong value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(float value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public PrimitiveValueOrArray(double value)
+        {
+            primitiveValue = new PrimitiveValue(value);
+            arrayValue = null;
+        }
+
+        public override string ToString()
+        {
+            if (!isArray)
+                return primitiveValue.ToString();
+
+            throw new NotImplementedException();
+        }
+
+        public static PrimitiveValueOrArray FromString(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return new PrimitiveValueOrArray();
+
+            ////TODO: array support
+
+            return new PrimitiveValueOrArray
+            {
+                primitiveValue = PrimitiveValue.FromString(value)
+            };
+        }
+
+        public static PrimitiveValueOrArray FromObject(object value)
+        {
+            if (value == null)
+                return new PrimitiveValueOrArray();
+
+            if (value is string stringValue)
+                return FromString(stringValue);
+
+            if (value is bool b)
+                return new PrimitiveValueOrArray(b);
+            if (value is char c)
+                return new PrimitiveValueOrArray(c);
+            if (value is byte bt)
+                return new PrimitiveValueOrArray(bt);
+            if (value is sbyte sbt)
+                return new PrimitiveValueOrArray(sbt);
+            if (value is short s)
+                return new PrimitiveValueOrArray(s);
+            if (value is ushort us)
+                return new PrimitiveValueOrArray(us);
+            if (value is int i)
+                return new PrimitiveValueOrArray(i);
+            if (value is uint ui)
+                return new PrimitiveValueOrArray(ui);
+            if (value is long l)
+                return new PrimitiveValueOrArray(l);
+            if (value is ulong ul)
+                return new PrimitiveValueOrArray(ul);
+            if (value is float f)
+                return new PrimitiveValueOrArray(f);
+            if (value is double d)
+                return new PrimitiveValueOrArray(d);
+
+            ////TODO: arrays
+
+            throw new ArgumentException($"Cannot convert '{value}' to primitive value or value array", nameof(value));
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValueOrArray.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValueOrArray.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b1e496f52201e45eaac94bbe24809d99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeHelpers.cs
@@ -10,6 +10,22 @@ namespace UnityEngine.Experimental.Input.Utilities
             return (TObject)obj;
         }
 
+        public static bool IsInt(this TypeCode type)
+        {
+            switch (type)
+            {
+                case TypeCode.Byte: return true;
+                case TypeCode.SByte: return true;
+                case TypeCode.Int16: return true;
+                case TypeCode.Int32: return true;
+                case TypeCode.Int64: return true;
+                case TypeCode.UInt16: return true;
+                case TypeCode.UInt32: return true;
+                case TypeCode.UInt64: return true;
+            }
+            return false;
+        }
+
         public static Type GetValueType(MemberInfo member)
         {
             var field = member as FieldInfo;

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Editor.cs
@@ -385,7 +385,7 @@ partial class CoreTests
         // Change to vector2 composite and make sure that we've added two more bindings, changed the names
         // of bindings accordingly, and preserved the existing binding paths and such.
         InputActionSerializationHelpers.ChangeCompositeBindingType(composite,
-            InputControlLayout.ParseNameAndParameters("Dpad(normalize=false)"));
+            NameAndParameters.Parse("Dpad(normalize=false)"));
         obj.ApplyModifiedPropertiesWithoutUndo();
 
         var action1 = asset.actionMaps[0].GetAction("action1");

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Layouts.cs
@@ -231,12 +231,12 @@ partial class CoreTests
 
         var layout = InputSystem.TryLoadLayout("MyDevice");
 
-        Assert.That(layout["analog"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Double));
+        Assert.That(layout["analog"].defaultState.valueType, Is.EqualTo(TypeCode.Double));
         Assert.That(layout["analog"].defaultState.primitiveValue.ToDouble(), Is.EqualTo(0.5).Within(0.000001));
-        Assert.That(layout["digital"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Long));
-        Assert.That(layout["digital"].defaultState.primitiveValue.ToLong(), Is.EqualTo(1234));
-        Assert.That(layout["hexDigital"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Long));
-        Assert.That(layout["hexDigital"].defaultState.primitiveValue.ToLong(), Is.EqualTo(0x1234));
+        Assert.That(layout["digital"].defaultState.valueType, Is.EqualTo(TypeCode.Int32));
+        Assert.That(layout["digital"].defaultState.primitiveValue.ToInt64(), Is.EqualTo(1234));
+        Assert.That(layout["hexDigital"].defaultState.valueType, Is.EqualTo(TypeCode.Int32));
+        Assert.That(layout["hexDigital"].defaultState.primitiveValue.ToInt64(), Is.EqualTo(0x1234));
     }
 
     class TestDeviceWithDefaultState : InputDevice
@@ -253,7 +253,7 @@ partial class CoreTests
 
         var layout = InputSystem.TryLoadLayout("TestDeviceWithDefaultState");
 
-        Assert.That(layout["control"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Double));
+        Assert.That(layout["control"].defaultState.valueType, Is.EqualTo(TypeCode.Double));
         Assert.That(layout["control"].defaultState.primitiveValue.ToDouble(), Is.EqualTo(0.1234).Within(0.00001));
     }
 
@@ -304,11 +304,11 @@ partial class CoreTests
 
         var layout = InputSystem.TryLoadLayout("DerivedLayout");
 
-        Assert.That(layout["control1"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Double));
+        Assert.That(layout["control1"].defaultState.valueType, Is.EqualTo(TypeCode.Double));
         Assert.That(layout["control1"].defaultState.primitiveValue.ToDouble(), Is.EqualTo(0.9876).Within(0.00001));
-        Assert.That(layout["control2"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Double));
+        Assert.That(layout["control2"].defaultState.valueType, Is.EqualTo(TypeCode.Double));
         Assert.That(layout["control2"].defaultState.primitiveValue.ToDouble(), Is.EqualTo(0.3456).Within(0.00001));
-        Assert.That(layout["control3"].defaultState.valueType, Is.EqualTo(PrimitiveValueType.Double));
+        Assert.That(layout["control3"].defaultState.valueType, Is.EqualTo(TypeCode.Double));
         Assert.That(layout["control3"].defaultState.primitiveValue.ToDouble(), Is.EqualTo(0.1234).Within(0.00001));
     }
 
@@ -1348,8 +1348,8 @@ partial class CoreTests
 
         Assert.That(layout["control"].minValue.isEmpty, Is.False);
         Assert.That(layout["control"].maxValue.isEmpty, Is.False);
-        Assert.That(layout["control"].minValue.ToFloat(), Is.EqualTo(0.1234f));
-        Assert.That(layout["control"].maxValue.ToFloat(), Is.EqualTo(0.5432f));
+        Assert.That(layout["control"].minValue.ToSingle(), Is.EqualTo(0.1234f));
+        Assert.That(layout["control"].maxValue.ToSingle(), Is.EqualTo(0.5432f));
     }
 
     [Test]
@@ -1375,8 +1375,8 @@ partial class CoreTests
 
         Assert.That(layout["control"].minValue.isEmpty, Is.False);
         Assert.That(layout["control"].maxValue.isEmpty, Is.False);
-        Assert.That(layout["control"].minValue.ToInt(), Is.EqualTo(-123));
-        Assert.That(layout["control"].maxValue.ToInt(), Is.EqualTo(123));
+        Assert.That(layout["control"].minValue.ToInt32(), Is.EqualTo(-123));
+        Assert.That(layout["control"].maxValue.ToInt32(), Is.EqualTo(123));
     }
 
     class BaseClassWithControl : InputDevice
@@ -1851,65 +1851,6 @@ partial class CoreTests
 
         Assert.That(deviceA["button"].variants, Is.EqualTo("A"));
         Assert.That(deviceB["axis"].variants, Is.EqualTo("B"));
-    }
-
-    [Test]
-    [Category("Layouts")]
-    public void Layouts_ParseNameAndParameters_EmptyParametersResultInEmptyArray()
-    {
-        var nameAndParameters = InputControlLayout.ParseNameAndParameters("name()");
-        Assert.That(nameAndParameters.name, Is.EqualTo("name"));
-        Assert.That(nameAndParameters.parameters, Is.Empty);
-    }
-
-    void Layouts_ParseNameAndParameters_ParametersMatchExpectations<T>(T[] expectedValues, InputControlLayout.ParameterType parameterType, string input) where T : unmanaged
-    {
-        var nameAndParameters = InputControlLayout.ParseNameAndParameters($"name({input})");
-        Assert.That(nameAndParameters.name, Is.EqualTo("name"));
-        Assert.That(nameAndParameters.parameters.Count, Is.EqualTo(expectedValues.Length), "Number of parameters does not match.");
-        unsafe
-        {
-            for (int i = 0; i < expectedValues.Length; i++)
-            {
-                var p = nameAndParameters.parameters[i];
-                Assert.That(p.type, Is.EqualTo(parameterType), $"Unexpected type in parameter {i}");
-                Assert.That(p.name, Is.EqualTo($"p{i}"), $"Unexpected name in parameter {i}");
-                Assert.That(*(T*)p.value, Is.EqualTo(expectedValues[i]), $"Unexpected value in parameter {i}");
-            }
-        }
-    }
-
-    [Test]
-    [Category("Layouts")]
-    public void Layouts_ParseNameAndParameters_BoolParametersMatchExpectations()
-    {
-        Layouts_ParseNameAndParameters_ParametersMatchExpectations(
-            new bool[] { true, false, true, false },
-            InputControlLayout.ParameterType.Boolean,
-            "p0=true,p1=false,p2=TRUE,p3=False"
-        );
-    }
-
-    [Test]
-    [Category("Layouts")]
-    public void Layouts_ParseParameters_IntParametersMatchExpectations()
-    {
-        Layouts_ParseNameAndParameters_ParametersMatchExpectations(
-            new int[] { 0, 0, 1234, -5678, 0 },
-            InputControlLayout.ParameterType.Integer,
-            "p0=0,p1=-0,p2=1234,p3=-5678,p4=12345678901234567890"
-        );
-    }
-
-    [Test]
-    [Category("Layouts")]
-    public void Layouts_ParseParameters_FloatParametersMatchExpectations()
-    {
-        Layouts_ParseNameAndParameters_ParametersMatchExpectations(
-            new float[] { 0, 0, 0.1234f, -0.5678f, 1e10f, -2e-10f, 0, float.PositiveInfinity, float.NegativeInfinity },
-            InputControlLayout.ParameterType.Float,
-            "p0=0.0,p1=-0.0,p2=0.1234,p3=-0.5678,p4=1e10,p5=-2E-10,p6=1e100,p7=Infinity,p8=-Infinity"
-        );
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ParameterValueTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ParameterValueTests.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine.Experimental.Input.Utilities;
+
+// The "parameter" utilities address the problem of storing structured data of unknown format in serialized data.
+// For example, processors (InputProcessor) need to have their configuration data stored in layouts as well as in
+// within action data. This amounts to the need for polymorphism in the serialized data.
+//
+// As a simple solution, the "parameter" form simply stores name/value pairs and puts them inside strings. This simple
+// mechanism is used in a variety of places to make both configuration and serialization painless.
+//
+// Given how widely the mechanism is used, we have a separate suite of tests for the various facilities around it here.
+
+internal class ParameterValueTests
+{
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanParseNameAndParameterList()
+    {
+        Assert.That(NameAndParameters.Parse("name()").name, Is.EqualTo("name"));
+        Assert.That(NameAndParameters.Parse("name()").parameters, Is.Empty);
+        Assert.That(NameAndParameters.Parse("name").name, Is.EqualTo("name"));
+        Assert.That(NameAndParameters.Parse("name").parameters, Is.Empty);
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").name, Is.EqualTo("Name"));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters, Has.Count.EqualTo(3));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[0].name, Is.EqualTo("foo"));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[1].name, Is.EqualTo("Bar"));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[2].name, Is.EqualTo("blub"));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[0].type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[1].type, Is.EqualTo(TypeCode.Int32));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[2].type, Is.EqualTo(TypeCode.Double));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[0].value.ToBoolean(), Is.EqualTo(true));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[1].value.ToInt32(), Is.EqualTo(123));
+        Assert.That(NameAndParameters.Parse("Name(foo,Bar=123,blub=234.56)").parameters[2].value.ToDouble(), Is.EqualTo(234.56).Within(0.0001));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_ParsingNameAndParameterList_RequiresStringToNotBeEmpty()
+    {
+        Assert.That(() => NameAndParameters.Parse("").name,
+            Throws.Exception.With.Message.Contains("Expecting name"));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanParseMultipleNameAndParameterLists()
+    {
+        Assert.That(NameAndParameters.ParseMultiple("a,b").Count(), Is.EqualTo(2));
+        Assert.That(NameAndParameters.ParseMultiple("a,b").ToArray()[0].name, Is.EqualTo("a"));
+        Assert.That(NameAndParameters.ParseMultiple("a,b").ToArray()[0].parameters, Is.Empty);
+        Assert.That(NameAndParameters.ParseMultiple("a,b").ToArray()[1].name, Is.EqualTo("b"));
+        Assert.That(NameAndParameters.ParseMultiple("a,b").ToArray()[1].parameters, Is.Empty);
+
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").Count(), Is.EqualTo(3));
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").ToArray()[0].name, Is.EqualTo("a"));
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").ToArray()[0].parameters, Is.Empty);
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").ToArray()[1].name, Is.EqualTo("b"));
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").ToArray()[1].parameters, Has.Count.EqualTo(2));
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").ToArray()[2].name, Is.EqualTo("c"));
+        Assert.That(NameAndParameters.ParseMultiple("a,b(r=1,t),c").ToArray()[2].parameters, Is.Empty);
+
+        Assert.That(NameAndParameters.ParseMultiple("a(b,c=123)").Count(), Is.EqualTo(1));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanConvertStringToPrimitiveValue()
+    {
+        // Int.
+        Assert.That(PrimitiveValue.FromString("123").type, Is.EqualTo(TypeCode.Int32));
+        Assert.That(PrimitiveValue.FromString("123").ToInt32(), Is.EqualTo(123));
+        Assert.That(PrimitiveValue.FromString("-123456").type, Is.EqualTo(TypeCode.Int32));
+        Assert.That(PrimitiveValue.FromString("-123456").ToInt32(), Is.EqualTo(-123456));
+        Assert.That(PrimitiveValue.FromString("0x1234ABC").type, Is.EqualTo(TypeCode.Int32));
+        Assert.That(PrimitiveValue.FromString("0x1234ABC").ToInt32(), Is.EqualTo(0x1234ABC));
+
+        // Double.
+        Assert.That(PrimitiveValue.FromString("0.0").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("0.0").ToDouble(), Is.EqualTo(0).Within(0.00001));
+        Assert.That(PrimitiveValue.FromString("1.23").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("1.23").ToDouble(), Is.EqualTo(1.23).Within(0.00001));
+        Assert.That(PrimitiveValue.FromString("-1.23456").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("-1.23456").ToDouble(), Is.EqualTo(-1.23456).Within(0.00001));
+        Assert.That(PrimitiveValue.FromString("1e10").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("1e10").ToDouble(), Is.EqualTo(1e10).Within(0.00001));
+        Assert.That(PrimitiveValue.FromString("-2E-10").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("-2E-10").ToDouble(), Is.EqualTo(-2e-10f).Within(0.00001));
+        Assert.That(PrimitiveValue.FromString("Infinity").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("Infinity").ToDouble(), Is.EqualTo(double.PositiveInfinity));
+        Assert.That(PrimitiveValue.FromString("-Infinity").type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromString("-Infinity").ToDouble(), Is.EqualTo(double.NegativeInfinity));
+
+        // Bool.
+        Assert.That(PrimitiveValue.FromString("true").type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromString("true").ToBoolean(), Is.True);
+        Assert.That(PrimitiveValue.FromString("false").type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromString("false").ToBoolean(), Is.False);
+        Assert.That(PrimitiveValue.FromString("True").type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromString("True").ToBoolean(), Is.True);
+        Assert.That(PrimitiveValue.FromString("False").type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromString("False").ToBoolean(), Is.False);
+        Assert.That(PrimitiveValue.FromString("TRUE").type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromString("TRUE").ToBoolean(), Is.True);
+        Assert.That(PrimitiveValue.FromString("FALSE").type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromString("FALSE").ToBoolean(), Is.False);
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanConvertPrimitiveValueToString()
+    {
+        // Bool.
+        Assert.That(new PrimitiveValue(true).ToString(), Is.EqualTo("true"));
+        Assert.That(new PrimitiveValue(false).ToString(), Is.EqualTo("false"));
+
+        // Char.
+        Assert.That(new PrimitiveValue('c').ToString(), Is.EqualTo("'c'"));
+
+        // Int.
+        Assert.That(new PrimitiveValue((byte)123).ToString(), Is.EqualTo("123"));
+        Assert.That(new PrimitiveValue((sbyte)-123).ToString(), Is.EqualTo("-123"));
+        Assert.That(new PrimitiveValue((short)-123).ToString(), Is.EqualTo("-123"));
+        Assert.That(new PrimitiveValue((ushort)123).ToString(), Is.EqualTo("123"));
+        Assert.That(new PrimitiveValue(-123).ToString(), Is.EqualTo("-123"));
+        Assert.That(new PrimitiveValue((uint)123).ToString(), Is.EqualTo("123"));
+        Assert.That(new PrimitiveValue((long)-123).ToString(), Is.EqualTo("-123"));
+        Assert.That(new PrimitiveValue((ulong)123).ToString(), Is.EqualTo("123"));
+
+        // Float.
+        Assert.That(new PrimitiveValue(1.234f).ToString(), Is.EqualTo("1.234"));
+        Assert.That(new PrimitiveValue(1.234).ToString(), Is.EqualTo("1.234"));
+        Assert.That(new PrimitiveValue(double.PositiveInfinity).ToString(), Is.EqualTo("Infinity"));
+        Assert.That(new PrimitiveValue(double.NegativeInfinity).ToString(), Is.EqualTo("-Infinity"));
+    }
+
+    // It is important that we do NOT respect the current culture's floating-point number format but
+    // instead always use culture-invariant notation. Otherwise we'll run into trouble as the ',' separator
+    // used in many cultures as a decimal separator will clash with the use of comma as a separator
+    // between parameters.
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_ConvertingPrimitiveValueToString_DoesNotTakeCultureIntoAccount()
+    {
+        var oldCulture = CultureInfo.CurrentCulture;
+
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            Assert.That(new PrimitiveValue(0.1234f).ToString(), Is.EqualTo("0.1234"));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = oldCulture;
+        }
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanConvertObjectToPrimitiveValue()
+    {
+        Assert.That(PrimitiveValue.FromObject(true).type, Is.EqualTo(TypeCode.Boolean));
+        Assert.That(PrimitiveValue.FromObject(true).ToBoolean(), Is.True);
+
+        Assert.That(PrimitiveValue.FromObject('c').type, Is.EqualTo(TypeCode.Char));
+        Assert.That(PrimitiveValue.FromObject('c').ToByte(), Is.EqualTo('c'));
+
+        Assert.That(PrimitiveValue.FromObject((byte)123).type, Is.EqualTo(TypeCode.Byte));
+        Assert.That(PrimitiveValue.FromObject(123).ToByte(), Is.EqualTo(123));
+
+        Assert.That(PrimitiveValue.FromObject((sbyte)-123).type, Is.EqualTo(TypeCode.SByte));
+        Assert.That(PrimitiveValue.FromObject(-123).ToSByte(), Is.EqualTo(-123));
+
+        Assert.That(PrimitiveValue.FromObject((short)-1234).type, Is.EqualTo(TypeCode.Int16));
+        Assert.That(PrimitiveValue.FromObject(-1234).ToInt16(), Is.EqualTo(-1234));
+
+        Assert.That(PrimitiveValue.FromObject((ushort)1234).type, Is.EqualTo(TypeCode.UInt16));
+        Assert.That(PrimitiveValue.FromObject(1234).ToUInt16(), Is.EqualTo(1234));
+
+        Assert.That(PrimitiveValue.FromObject(-1234).type, Is.EqualTo(TypeCode.Int32));
+        Assert.That(PrimitiveValue.FromObject(-1234).ToInt32(), Is.EqualTo(-1234));
+
+        Assert.That(PrimitiveValue.FromObject((uint)1234).type, Is.EqualTo(TypeCode.UInt32));
+        Assert.That(PrimitiveValue.FromObject(1234).ToUInt32(), Is.EqualTo(1234));
+
+        Assert.That(PrimitiveValue.FromObject((long)-1234).type, Is.EqualTo(TypeCode.Int64));
+        Assert.That(PrimitiveValue.FromObject(-1234).ToInt64(), Is.EqualTo(-1234));
+
+        Assert.That(PrimitiveValue.FromObject((ulong)1234).type, Is.EqualTo(TypeCode.UInt64));
+        Assert.That(PrimitiveValue.FromObject(1234).ToUInt64(), Is.EqualTo(1234));
+
+        Assert.That(PrimitiveValue.FromObject(1.2345f).type, Is.EqualTo(TypeCode.Single));
+        Assert.That(PrimitiveValue.FromObject(1.2345f).ToSingle(), Is.EqualTo(1.2345).Within(0.00001));
+
+        Assert.That(PrimitiveValue.FromObject(1.2345).type, Is.EqualTo(TypeCode.Double));
+        Assert.That(PrimitiveValue.FromObject(1.2345).ToSingle(), Is.EqualTo(1.2345).Within(0.00001));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanConvertPrimitiveValueBetweenTypes()
+    {
+        // bool <-> int.
+        Assert.That(new PrimitiveValue(true).ConvertTo(TypeCode.Int32).ToInt32(), Is.EqualTo(1));
+        Assert.That(new PrimitiveValue(false).ConvertTo(TypeCode.Int32).ToInt32(), Is.EqualTo(0));
+        Assert.That(new PrimitiveValue(123).ConvertTo(TypeCode.Boolean).ToBoolean(), Is.True);
+        Assert.That(new PrimitiveValue(0).ConvertTo(TypeCode.Boolean).ToBoolean(), Is.False);
+
+        // short <-> int.
+        Assert.That(new PrimitiveValue((short)123).ConvertTo(TypeCode.Int32).ToInt32(), Is.EqualTo(123));
+        Assert.That(new PrimitiveValue(123).ConvertTo(TypeCode.Int16).ToInt16(), Is.EqualTo(123));
+
+        // int <-> float.
+        Assert.That(new PrimitiveValue(123).ConvertTo(TypeCode.Single).ToSingle(), Is.EqualTo(123).Within(0.00001));
+        Assert.That(new PrimitiveValue(123f).ConvertTo(TypeCode.Int32).ToInt32(), Is.EqualTo(123));
+
+        // float <-> double.
+        Assert.That(new PrimitiveValue(123.0).ConvertTo(TypeCode.Single).ToSingle(), Is.EqualTo(123).Within(0.00001));
+        Assert.That(new PrimitiveValue(123f).ConvertTo(TypeCode.Double).ToSingle(), Is.EqualTo(123).Within(0.00001));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanConvertEnumValueToPrimitiveValue()
+    {
+        Assert.That(PrimitiveValue.FromObject(TestEnum.One).type, Is.EqualTo(TypeCode.Int16));
+        Assert.That(PrimitiveValue.FromObject(TestEnum.Two).ToInt32(), Is.EqualTo(2));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanSetEnumFieldOnObjectFromPrimitiveValue()
+    {
+        var obj = new TestObject();
+        NamedValue.ApplyAllToObject(obj, new[] { NamedValue.From("enumField", 1)});
+        Assert.That(obj.enumField, Is.EqualTo(TestEnum.One));
+    }
+
+    private enum TestEnum : short
+    {
+        Zero,
+        One,
+        Two,
+    }
+
+    private class TestObject
+    {
+        public TestEnum enumField;
+    }
+}

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ParameterValueTests.cs.meta
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ParameterValueTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3837916f4643144e29536c0c485fee45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Other than the fix, this also includes a long-overdue refactor that pulls the `ParameterValue` code out of `InputControlLayout` (which is why the diff is large for such a simple fix). That was where the concept of "parameters" started but in the end, several other places that had nothing to do with layouts started reusing the code.

Other than pulling the code of out `InputControlLayout`, it also unifies it with `PrimitiveValue` (which was introduced to eventually merge with `ParameterValue`) and reuses .NET `TypeCode` instead of the previous custom `ParameterValueType`.

A side benefit of the refactor is that we need much fewer `switch (whatTypeDoWeHave) { ... }` statements scattered around the code as `PrimitiveValue` can easily be converted between various formats.