### PR TITLE
FIX: Calling Enable/Disable from action callbacks corrupting internal state (#472).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * This was especially annoying when having "Auto-Save" on as it made editing parameters on interactions and processors very tedious.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
 - Fixed calling Enable/Disable from within action callbacks sometimes leading to corruption of state which would then lead to actions not getting triggered (#472).
+- Fixed setting of "Auto-Save" toggle in action editor getting lost on domain reload.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -79,9 +79,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Actions and bindings disappearing when control schemes have spaces in their names.
 - `InputActionRebindingExceptions.RebindOperation` can now be reused as intended; used to stop working properly the first time a rebind completed or was cancelled.
-
-#### Actions
-
 - `PlayerInput` no longer fails to find actions when using UnityEvents (#500).
 - The `"{...}"` format for referencing action maps and actions using GUIDs as strings has been obsoleted. It will still work but adding the extra braces is no longer necessary.
 - Drag&dropping bindings between other bindings that came before them in the list no longer drops the items at a location one higher up in the list than intended.
@@ -89,6 +86,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Saving no longer causes the selection of the current processor or interaction to be lost.
   * This was especially annoying when having "Auto-Save" on as it made editing parameters on interactions and processors very tedious.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
+- Fixed calling Enable/Disable from within action callbacks sometimes leading to corruption of state which would then lead to actions not getting triggered (#472).
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
 - Fixed calling Enable/Disable from within action callbacks sometimes leading to corruption of state which would then lead to actions not getting triggered (#472).
 - Fixed setting of "Auto-Save" toggle in action editor getting lost on domain reload.
+- Fixed blurry icons in editor for imported .inputactions assets and actions in them.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
@@ -118,6 +118,17 @@ namespace UnityEngine.Experimental.Input
             }
         }
 
+        public InputAction this[string actionNameOrId]
+        {
+            get
+            {
+                var action = FindAction(actionNameOrId);
+                if (action == null)
+                    throw new KeyNotFoundException($"Cannot find action '{actionNameOrId}' in '{this}'");
+                return action;
+            }
+        }
+
         /// <summary>
         /// Return a JSON representation of the asset.
         /// </summary>
@@ -169,13 +180,15 @@ namespace UnityEngine.Experimental.Input
         /// Find an <see cref="InputAction">action</see> by its name in of of the <see cref="InputActionMap">
         /// action maps</see> in the asset.
         /// </summary>
-        /// <param name="name">Name of the action as either a "map/action" combination (e.g. "gameplay/fire") or
+        /// <param name="actionNameOrId">Name of the action as either a "map/action" combination (e.g. "gameplay/fire") or
         /// a simple name. In the former case, the name is split at the '/' slash and the first part is used to find
         /// a map with that name and the second part is used to find an action with that name inside the map. In the
         /// latter case, all maps are searched in order and the first action that has the given name in any of the maps
-        /// is returned. Note that name comparisons are case-insensitive.</param>
+        /// is returned. Note that name comparisons are case-insensitive.
+        ///
+        /// Alternatively, the given string can be a GUID as given by <see cref="InputAction.id"/>.</param>
         /// <returns>The action with the corresponding name or null if no matching action could be found.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="name"/> is null or empty.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="actionNameOrId"/> is null or empty.</exception>
         /// <remarks>
         /// Does not allocate.
         /// </remarks>
@@ -209,22 +222,22 @@ namespace UnityEngine.Experimental.Input
         /// asset.FindAction(action3.id.ToString()) // Returns action3.
         /// </code>
         /// </example>
-        public InputAction FindAction(string name)
+        public InputAction FindAction(string actionNameOrId)
         {
-            if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException(nameof(name));
+            if (string.IsNullOrEmpty(actionNameOrId))
+                throw new ArgumentNullException(nameof(actionNameOrId));
 
             if (m_ActionMaps == null)
                 return null;
 
             // Check if we have a "map/action" path.
-            var indexOfSlash = name.IndexOf('/');
+            var indexOfSlash = actionNameOrId.IndexOf('/');
             if (indexOfSlash == -1)
             {
                 // No slash so it's just a simple action name.
                 for (var i = 0; i < m_ActionMaps.Length; ++i)
                 {
-                    var action = m_ActionMaps[i].TryGetAction(name);
+                    var action = m_ActionMaps[i].TryGetAction(actionNameOrId);
                     if (action != null)
                         return action;
                 }
@@ -232,11 +245,11 @@ namespace UnityEngine.Experimental.Input
             else
             {
                 // Have a path. First search for the map, then for the action.
-                var mapName = new Substring(name, 0, indexOfSlash);
-                var actionName = new Substring(name, indexOfSlash + 1);
+                var mapName = new Substring(actionNameOrId, 0, indexOfSlash);
+                var actionName = new Substring(actionNameOrId, indexOfSlash + 1);
 
                 if (mapName.isEmpty || actionName.isEmpty)
-                    throw new ArgumentException("Malformed action path: " + name, nameof(name));
+                    throw new ArgumentException("Malformed action path: " + actionNameOrId, nameof(actionNameOrId));
 
                 for (var i = 0; i < m_ActionMaps.Length; ++i)
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -449,7 +449,7 @@ namespace UnityEngine.Experimental.Input
         /// <summary>
         /// GUID converted from <see cref="m_Id"/>.
         /// </summary>
-        [NonSerialized] internal Guid m_Guid;
+        [NonSerialized] private Guid m_Guid;
 
         // Action sets that are created internally by singleton actions to hold their data
         // are never exposed and never serialized so there is no point allocating an m_Actions
@@ -915,7 +915,8 @@ namespace UnityEngine.Experimental.Input
             public string processors;
             public string groups;
             public string action;
-            public bool chainWithPrevious;
+            ////TODO: re-enable when chained bindings are implemented
+            //public bool chainWithPrevious;
             public bool isComposite;
             public bool isPartOfComposite;
 
@@ -934,7 +935,7 @@ namespace UnityEngine.Experimental.Input
                     interactions = string.IsNullOrEmpty(interactions) ? (!string.IsNullOrEmpty(modifiers) ? modifiers : null) : interactions,
                     processors = string.IsNullOrEmpty(processors) ? null : processors,
                     groups = string.IsNullOrEmpty(groups) ? null : groups,
-                    chainWithPrevious = chainWithPrevious,
+                    //chainWithPrevious = chainWithPrevious,
                     isComposite = isComposite,
                     isPartOfComposite = isPartOfComposite,
                 };
@@ -951,7 +952,7 @@ namespace UnityEngine.Experimental.Input
                     interactions = binding.interactions,
                     processors = binding.processors,
                     groups = binding.groups,
-                    chainWithPrevious = binding.chainWithPrevious,
+                    //chainWithPrevious = binding.chainWithPrevious,
                     isComposite = binding.isComposite,
                     isPartOfComposite = binding.isPartOfComposite,
                 };

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -688,7 +688,7 @@ namespace UnityEngine.Experimental.Input
 
                 var candidateCount = m_Candidates.Count;
                 m_Candidates.RemoveAt(index);
-                ArrayHelpers.EraseAtWithCapacity(ref m_Scores, ref candidateCount, index);
+                ArrayHelpers.EraseAtWithCapacity(m_Scores, ref candidateCount, index);
             }
 
             public void Dispose()

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -853,7 +853,7 @@ namespace UnityEngine.Experimental.Input
                 count: m_ContinuousActionCount);
             Debug.Assert(index != -1, "Action not found in list of continuous actions");
 
-            ArrayHelpers.EraseAtWithCapacity(ref m_ContinuousActions, ref m_ContinuousActionCount, index);
+            ArrayHelpers.EraseAtWithCapacity(m_ContinuousActions, ref m_ContinuousActionCount, index);
             actionStates[actionIndex].onContinuousList = false;
 
             // If the action was in the part of the list that continuous actions we have carried
@@ -885,7 +885,7 @@ namespace UnityEngine.Experimental.Input
             if (index < m_ContinuousActionCountFromPreviousUpdate)
             {
                 // Move to end of list.
-                ArrayHelpers.EraseAtWithCapacity(ref m_ContinuousActions, ref m_ContinuousActionCount, index);
+                ArrayHelpers.EraseAtWithCapacity(m_ContinuousActions, ref m_ContinuousActionCount, index);
                 --m_ContinuousActionCountFromPreviousUpdate;
                 ArrayHelpers.AppendWithCapacity(ref m_ContinuousActions, ref m_ContinuousActionCount, actionIndex);
             }
@@ -1590,6 +1590,7 @@ namespace UnityEngine.Experimental.Input
         private void ChangePhaseOfAction(InputActionPhase newPhase, ref TriggerState trigger,
             InputActionPhase phaseAfterPerformedOrCancelled = InputActionPhase.Waiting)
         {
+            Debug.Assert(newPhase != InputActionPhase.Disabled, "Should not disable an action using this method");
             Debug.Assert(trigger.mapIndex >= 0 && trigger.mapIndex < totalMapCount, "Map index out of range");
             Debug.Assert(trigger.controlIndex >= 0 && trigger.controlIndex < totalControlCount, "Control index out of range");
             Debug.Assert(trigger.bindingIndex >= 0 && trigger.bindingIndex < totalBindingCount, "Binding index out of range");
@@ -1598,8 +1599,12 @@ namespace UnityEngine.Experimental.Input
             if (actionIndex == kInvalidIndex)
                 return; // No action associated with binding.
 
-            // Update action state.
+            // Ignore if action is disabled.
             var actionState = &actionStates[actionIndex];
+            if (actionState->phase == InputActionPhase.Disabled)
+                return;
+
+            // Update action state.
             Debug.Assert(trigger.mapIndex == actionState->mapIndex,
                 "Map index on trigger does not correspond to map index of trigger state");
             var newState = trigger;
@@ -1626,16 +1631,19 @@ namespace UnityEngine.Experimental.Input
                 case InputActionPhase.Performed:
                 {
                     CallActionListeners(actionIndex, map, newPhase, ref action.m_OnPerformed);
-                    actionState->phase = phaseAfterPerformedOrCancelled;
-
-                    // If the action is continuous and remains in performed or started state, make sure the action
-                    // is on the list of continuous actions that we check every update.
-                    if ((phaseAfterPerformedOrCancelled == InputActionPhase.Started ||
-                         phaseAfterPerformedOrCancelled == InputActionPhase.Performed) &&
-                        actionState->continuous &&
-                        !actionState->onContinuousList)
+                    if (actionState->phase != InputActionPhase.Disabled) // Action may have been disabled in callback.
                     {
-                        AddContinuousAction(actionIndex);
+                        actionState->phase = phaseAfterPerformedOrCancelled;
+
+                        // If the action is continuous and remains in performed or started state, make sure the action
+                        // is on the list of continuous actions that we check every update.
+                        if ((phaseAfterPerformedOrCancelled == InputActionPhase.Started ||
+                             phaseAfterPerformedOrCancelled == InputActionPhase.Performed) &&
+                            actionState->continuous &&
+                            !actionState->onContinuousList)
+                        {
+                            AddContinuousAction(actionIndex);
+                        }
                     }
                     break;
                 }
@@ -1643,11 +1651,14 @@ namespace UnityEngine.Experimental.Input
                 case InputActionPhase.Cancelled:
                 {
                     CallActionListeners(actionIndex, map, newPhase, ref action.m_OnCancelled);
-                    actionState->phase = phaseAfterPerformedOrCancelled;
+                    if (actionState->phase != InputActionPhase.Disabled) // Action may have been disabled in callback.
+                    {
+                        actionState->phase = phaseAfterPerformedOrCancelled;
 
-                    // Remove from list of continuous actions, if necessary.
-                    if (actionState->onContinuousList)
-                        RemoveContinuousAction(actionIndex);
+                        // Remove from list of continuous actions, if necessary.
+                        if (actionState->onContinuousList)
+                            RemoveContinuousAction(actionIndex);
+                    }
                     break;
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlList.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlList.cs
@@ -227,7 +227,7 @@ namespace UnityEngine.Experimental.Input
             {
                 if (m_Indices[i] == index)
                 {
-                    ArrayHelpers.EraseAtWithCapacity(ref m_Indices, ref m_Count, i);
+                    ArrayHelpers.EraseAtWithCapacity(m_Indices, ref m_Count, i);
                     return true;
                 }
             }
@@ -241,7 +241,7 @@ namespace UnityEngine.Experimental.Input
                 throw new ArgumentException(
                     $"Index {index} is out of range in list with {m_Count} elements", nameof(index));
 
-            ArrayHelpers.EraseAtWithCapacity(ref m_Indices, ref m_Count, index);
+            ArrayHelpers.EraseAtWithCapacity(m_Indices, ref m_Count, index);
         }
 
         public void CopyTo(TControl[] array, int arrayIndex)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -644,7 +644,6 @@ namespace UnityEngine.Experimental.Input.Editor
             Repaint();
         }
 
-        #if UNITY_2019_1_OR_NEWER
         ////TODO: show shortcuts in tooltips
         ////FIXME: the shortcuts seem to have focus problems; often requires clicking away and then back to the window
         [Shortcut("Input Action Editor/Save", typeof(InputActionEditorWindow), KeyCode.S, ShortcutModifiers.Alt)]
@@ -674,8 +673,6 @@ namespace UnityEngine.Experimental.Input.Editor
             var window = (InputActionEditorWindow)arguments.context;
             window.AddNewBinding();
         }
-
-        #endif
 
         private void OnDirtyChanged(bool dirty)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -20,10 +20,10 @@ namespace UnityEngine.Experimental.Input.Editor
     {
         private const int kVersion = 6;
 
-        private const string kActionIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/Add Action.png";
-        private const string kAssetIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/Add ActionMap.png";
-        private const string kActionIconDark = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_Add Action.png";
-        private const string kAssetIconDark = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_Add ActionMap.png";
+        private const string kActionIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/Add Action@4x.png";
+        private const string kAssetIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/Add ActionMap@4x.png";
+        private const string kActionIconDark = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_Add Action@4x.png";
+        private const string kAssetIconDark = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_Add ActionMap@4x.png";
 
         [SerializeField] private bool m_GenerateWrapperCode;
         [SerializeField] private string m_WrapperCodePath;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1616,9 +1616,8 @@ namespace UnityEngine.Experimental.Input
                 s_SystemObject.hideFlags = HideFlags.HideAndDontSave;
 
                 // See if we have a remembered settings object.
-                InputSettings settingsAsset;
                 if (EditorBuildSettings.TryGetConfigObject(InputSettingsProvider.kEditorBuildSettingsConfigKey,
-                    out settingsAsset))
+                    out InputSettings settingsAsset))
                 {
                     if (s_Manager.m_Settings.hideFlags == HideFlags.HideAndDontSave)
                         ScriptableObject.DestroyImmediate(s_Manager.m_Settings);

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1640,9 +1640,11 @@ namespace UnityEngine.Experimental.Input
             EditorApplication.projectChanged += OnProjectChange;
 
             // If native backends for new input system aren't enabled, ask user whether we should
-            // enable them (requires restart). We only ask once per session.
+            // enable them (requires restart). We only ask once per session and don't ask when
+            // running in batch mode.
             if (!s_SystemObject.newInputBackendsCheckedAsEnabled &&
-                !EditorPlayerSettingHelpers.newSystemBackendsEnabled)
+                !EditorPlayerSettingHelpers.newSystemBackendsEnabled &&
+                !Application.isBatchMode)
             {
                 const string dialogText = "This project is using the new input system package but the native platform backends for the new input system are not enabled in the player settings. " +
                     "This means that no input from native devices will come through." +

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystemObject.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystemObject.cs
@@ -1,4 +1,6 @@
 #if UNITY_EDITOR
+using UnityEngine.Experimental.Input.Editor;
+
 namespace UnityEngine.Experimental.Input
 {
     /// <summary>
@@ -22,6 +24,7 @@ namespace UnityEngine.Experimental.Input
             systemState.remoteConnection = InputSystem.s_RemoteConnection;
             systemState.managerState = InputSystem.s_Manager.SaveState();
             systemState.remotingState = InputSystem.s_Remote.SaveState();
+            systemState.userSettings = InputEditorUserSettings.s_Settings;
         }
 
         public void OnAfterDeserialize()

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1073,7 +1073,7 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput
             // Remove from global list.
             var index = ArrayHelpers.IndexOfReference(s_AllActivePlayers, this, s_AllActivePlayersCount);
             if (index != -1)
-                ArrayHelpers.EraseAtWithCapacity(ref s_AllActivePlayers, ref s_AllActivePlayersCount, index);
+                ArrayHelpers.EraseAtWithCapacity(s_AllActivePlayers, ref s_AllActivePlayersCount, index);
 
             // Unhook from change notifications if we're the last player.
             if (s_AllActivePlayersCount == 0 && s_UserChangeDelegate != null)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -247,7 +247,7 @@ namespace UnityEngine.Experimental.Input.Plugins.Users
         /// and <see cref="controlSchemeMatch"/>).
         ///
         /// Note that is generally does not make sense for users to share actions. Instead, each user should
-        /// receive a set of actions private to the user. 
+        /// receive a set of actions private to the user.
         ///
         /// If <see cref="settings"/> are applied with customized bindings (<see cref="InputUserSettings.customBindings"/>),
         /// these are applied automatically to the actions.
@@ -1060,8 +1060,8 @@ namespace UnityEngine.Experimental.Input.Plugins.Users
 
             // Remove.
             var userCount = s_AllUserCount;
-            ArrayHelpers.EraseAtWithCapacity(ref s_AllUsers, ref userCount, userIndex);
-            ArrayHelpers.EraseAtWithCapacity(ref s_AllUserData, ref s_AllUserCount, userIndex);
+            ArrayHelpers.EraseAtWithCapacity(s_AllUsers, ref userCount, userIndex);
+            ArrayHelpers.EraseAtWithCapacity(s_AllUserData, ref s_AllUserCount, userIndex);
 
             // Remove our hook if we no longer need it.
             if (s_AllUserCount == 0 && s_ListenForUnpairedDeviceActivity == 0)
@@ -1221,13 +1221,13 @@ namespace UnityEngine.Experimental.Input.Plugins.Users
 
             if (asLostDevice)
             {
-                ArrayHelpers.EraseAtWithCapacity(ref s_AllLostDevices, ref s_AllLostDeviceCount, deviceIndex);
+                ArrayHelpers.EraseAtWithCapacity(s_AllLostDevices, ref s_AllLostDeviceCount, deviceIndex);
                 --s_AllUserData[userIndex].lostDeviceCount;
             }
             else
             {
                 --s_PairingStateVersion;
-                ArrayHelpers.EraseAtWithCapacity(ref s_AllPairedDevices, ref s_AllPairedDeviceCount, deviceIndex);
+                ArrayHelpers.EraseAtWithCapacity(s_AllPairedDevices, ref s_AllPairedDeviceCount, deviceIndex);
                 --s_AllUserData[userIndex].deviceCount;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
@@ -510,7 +510,7 @@ namespace UnityEngine.Experimental.Input.Utilities
             Array.Resize(ref array, length - 1);
         }
 
-        public static void EraseAtWithCapacity<TValue>(ref TValue[] array, ref int count, int index)
+        public static void EraseAtWithCapacity<TValue>(TValue[] array, ref int count, int index)
         {
             Debug.Assert(array != null);
             Debug.Assert(count <= array.Length);
@@ -527,7 +527,7 @@ namespace UnityEngine.Experimental.Input.Utilities
             --count;
         }
 
-        public static unsafe void EraseAtWithCapacity<TValue>(ref NativeArray<TValue> array, ref int count, int index)
+        public static unsafe void EraseAtWithCapacity<TValue>(NativeArray<TValue> array, ref int count, int index)
             where TValue : struct
         {
             Debug.Assert(array.IsCreated);

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InlinedArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InlinedArray.cs
@@ -246,13 +246,13 @@ namespace UnityEngine.Experimental.Input.Utilities
                     Debug.Assert(length > 2);
                     firstValue = additionalValues[0];
                     var numAdditional = length - 1;
-                    ArrayHelpers.EraseAtWithCapacity(ref additionalValues, ref numAdditional, 0);
+                    ArrayHelpers.EraseAtWithCapacity(additionalValues, ref numAdditional, 0);
                 }
             }
             else
             {
                 var numAdditional = length - 1;
-                ArrayHelpers.EraseAtWithCapacity(ref additionalValues, ref numAdditional, index - 1);
+                ArrayHelpers.EraseAtWithCapacity(additionalValues, ref numAdditional, index - 1);
             }
 
             --length;

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Devices.cs
@@ -1421,6 +1421,8 @@ partial class CoreTests
             // Make sure InputManager kept the gamepad.
             Assert.That(manager.devices.Count, Is.EqualTo(1));
             Assert.That(manager.devices, Has.Exactly(1).TypeOf<Gamepad>());
+
+            LogAssert.NoUnexpectedReceived();
         }
     }
 

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestFixture.cs
@@ -163,6 +163,12 @@ namespace UnityEngine.Experimental.Input
             Set(button, 0, absoluteTime, timeOffset);
         }
 
+        public void PressAndRelease(ButtonControl button, double absoluteTime = -1, double timeOffset = 0)
+        {
+            Press(button, absoluteTime, timeOffset);
+            Release(button, absoluteTime, timeOffset);
+        }
+
         /// <summary>
         /// Set the control to the given value by sending a state event with the value to the
         /// control's device.

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ArrayHelperTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ArrayHelperTests.cs
@@ -33,9 +33,9 @@ internal class ArrayHelperTests
         var array2Length = 8;
         var array3Length = 4;
 
-        ArrayHelpers.EraseAtWithCapacity(ref array1, ref array1Length, 2);
-        ArrayHelpers.EraseAtWithCapacity(ref array2, ref array2Length, 7);
-        ArrayHelpers.EraseAtWithCapacity(ref array3, ref array3Length, 0);
+        ArrayHelpers.EraseAtWithCapacity(array1, ref array1Length, 2);
+        ArrayHelpers.EraseAtWithCapacity(array2, ref array2Length, 7);
+        ArrayHelpers.EraseAtWithCapacity(array3, ref array3Length, 0);
 
         Assert.That(array1, Is.EquivalentTo(new[] {1, 2, 4, 5, 0, 0, 0, 0}));
         Assert.That(array2, Is.EquivalentTo(new[] {1, 2, 3, 4, 5, 6, 7, 0}));
@@ -60,9 +60,9 @@ internal class ArrayHelperTests
 
         try
         {
-            ArrayHelpers.EraseAtWithCapacity(ref array1, ref array1Length, 2);
-            ArrayHelpers.EraseAtWithCapacity(ref array2, ref array2Length, 7);
-            ArrayHelpers.EraseAtWithCapacity(ref array3, ref array3Length, 0);
+            ArrayHelpers.EraseAtWithCapacity(array1, ref array1Length, 2);
+            ArrayHelpers.EraseAtWithCapacity(array2, ref array2Length, 7);
+            ArrayHelpers.EraseAtWithCapacity(array3, ref array3Length, 0);
 
             // For NativeArray, we don't clear memory.
             Assert.That(array1, Is.EquivalentTo(new[] {1, 2, 4, 5, 5, 0, 0, 0}));

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ParameterValueTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/Utilities/ParameterValueTests.cs
@@ -248,6 +248,8 @@ internal class ParameterValueTests
 
     private class TestObject
     {
+#pragma warning disable 649
         public TestEnum enumField;
+#pragma warning restore 649
     }
 }


### PR DESCRIPTION
What I found was that adding and removing state monitors while in state monitor callbacks wasn't safe. This led to actions seemingly not triggering anymore even though `Enable` had been called on them. Changed the code such that calling Enable/Disable from callbacks is now safe.

Also fixes
* Blurry icons on .inputactions assets and actions in them
* Failing warnings tests.
* Auto-Save toggle in action editor resetting on domain reload (also every other local user input setting).