### PR TITLE
FIX: In the action map editor window, switching from renaming an acti…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -57,9 +57,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   * At the toplevel of the the Keyboard device, you now have the choice of either binding by keyboard location or binding by generated/mapped character.
   * Binding by location shows differences between the local keyboard layout and the US reference layout.
   * The control path language has been extended to allow referencing controls by display name. `<Keyboard>/#(a)` binds to the control on a `Keyboard` with the display name `a`.
-
-#### Actions
-
 - `continuous` flag is now ignored for `Press and Release` interactions, as it did not  make sense.
 - Reacting to controls that are already actuated when an action is enabled is now an __optional__ behavior rather than the default behavior. This is a __breaking__ change.
   * Essentially, this change reverts back to the behavior before 0.2-preview.
@@ -79,9 +76,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Actions and bindings disappearing when control schemes have spaces in their names.
 - `InputActionRebindingExceptions.RebindOperation` can now be reused as intended; used to stop working properly the first time a rebind completed or was cancelled.
-
-#### Actions
-
 - `PlayerInput` no longer fails to find actions when using UnityEvents (#500).
 - The `"{...}"` format for referencing action maps and actions using GUIDs as strings has been obsoleted. It will still work but adding the extra braces is no longer necessary.
 - Drag&dropping bindings between other bindings that came before them in the list no longer drops the items at a location one higher up in the list than intended.
@@ -89,6 +83,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Saving no longer causes the selection of the current processor or interaction to be lost.
   * This was especially annoying when having "Auto-Save" on as it made editing parameters on interactions and processors very tedious.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
+- In the action map editor window, switching from renaming an action to renaming an action map will no longer break the UI.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -561,9 +561,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 // Now, our fix to this problem is to force-end and accept any renaming session on the action column if we see 
                 // that the action map column had processed the current event. This is not particularly elegant, but I cannot think
                 // of a better solution as we are limited by the public APIs exposed by TreeView.
-                m_ActionsTree.forceAcceptRename = true;
-                m_ActionsTree.EndRename();
-                m_ActionsTree.forceAcceptRename = false;
+                m_ActionsTree.EndRename(forceAccept: true);
             }
             DrawActionsColumn(columnAreaWidth * 0.38f);
             DrawPropertiesColumn(columnAreaWidth * 0.40f);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -546,7 +546,21 @@ namespace UnityEngine.Experimental.Input.Editor
             var columnAreaWidth = position.width - InputActionTreeView.Styles.backgroundWithBorder.margin.left -
                 InputActionTreeView.Styles.backgroundWithBorder.margin.left -
                 InputActionTreeView.Styles.backgroundWithBorder.margin.right;
-            DrawActionMapsColumn(columnAreaWidth * 0.22f);
+
+            // When renaming an item, TreeViews will capture all mouse Events, and process any clicks outside the item
+            // being renamed to end the renaming process. However, since we have two TreeViews, if the action column is
+            // renaming an item, and then you double click on an item in the action map column, the action map column will
+            // get to use the mouse event before the action collumn gets to see it, which would cause the action map column
+            // to enter rename mode and use the event, before the action column gets a chance to see it and exit rename mode.
+            // Then we end up with two active renaming sessions, which does not work correctly. 
+            // (See https://fogbugz.unity3d.com/f/cases/1140869/). Now this workaround is to disable the action map column
+            // while the action column is renaming, so the action column gets to see clicks on the action map column first,
+            // and gets a chance to exit rename mode. However, we don't want to UI to be visually greyed out, so we don't
+            // disable for repaint events.
+            using (var s = new EditorGUI.DisabledScope(m_ActionsTree.isRenaming && Event.current.type != EventType.Repaint))
+            {
+                DrawActionMapsColumn(columnAreaWidth * 0.22f);
+            }
             DrawActionsColumn(columnAreaWidth * 0.38f);
             DrawPropertiesColumn(columnAreaWidth * 0.40f);
             EditorGUILayout.EndHorizontal();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -38,7 +38,7 @@ namespace UnityEngine.Experimental.Input.Editor
     {
         #region Creation
 
-        internal bool isRenaming { get; private set; }
+        public bool forceAcceptRename { get; set; }
 
         public InputActionTreeView(SerializedObject serializedObject, TreeViewState state = null)
             : base(state ?? new TreeViewState())
@@ -50,8 +50,8 @@ namespace UnityEngine.Experimental.Input.Editor
             drawHeader = true;
             drawPlusButton = true;
             drawMinusButton = true;
+            forceAcceptRename = false;
             m_Title = new GUIContent("");
-            isRenaming = false;
         }
 
         /// <summary>
@@ -366,8 +366,6 @@ namespace UnityEngine.Experimental.Input.Editor
         {
             // If a rename is already in progress, force it to end first.
             EndRename();
-
-            isRenaming = true;
             onBeginRename?.Invoke((ActionTreeItemBase)item);
             base.BeginRename(item);
         }
@@ -379,13 +377,12 @@ namespace UnityEngine.Experimental.Input.Editor
 
         protected override void RenameEnded(RenameEndedArgs args)
         {
-            isRenaming = false;
             if (!(FindItem(args.itemID, rootItem) is ActionTreeItemBase actionItem))
                 return;
 
-            if (!args.acceptedRename || args.originalName == args.newName)
+            if (!(args.acceptedRename || forceAcceptRename) || args.originalName == args.newName)
                 return;
-
+                
             Debug.Assert(actionItem.canRename, "Cannot rename " + actionItem);
 
             actionItem.Rename(args.newName);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -38,6 +38,8 @@ namespace UnityEngine.Experimental.Input.Editor
     {
         #region Creation
 
+        internal bool isRenaming { get; private set; }
+
         public InputActionTreeView(SerializedObject serializedObject, TreeViewState state = null)
             : base(state ?? new TreeViewState())
         {
@@ -49,6 +51,7 @@ namespace UnityEngine.Experimental.Input.Editor
             drawPlusButton = true;
             drawMinusButton = true;
             m_Title = new GUIContent("");
+            isRenaming = false;
         }
 
         /// <summary>
@@ -364,6 +367,7 @@ namespace UnityEngine.Experimental.Input.Editor
             // If a rename is already in progress, force it to end first.
             EndRename();
 
+            isRenaming = true;
             onBeginRename?.Invoke((ActionTreeItemBase)item);
             base.BeginRename(item);
         }
@@ -375,6 +379,7 @@ namespace UnityEngine.Experimental.Input.Editor
 
         protected override void RenameEnded(RenameEndedArgs args)
         {
+            isRenaming = false;
             if (!(FindItem(args.itemID, rootItem) is ActionTreeItemBase actionItem))
                 return;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -38,8 +38,6 @@ namespace UnityEngine.Experimental.Input.Editor
     {
         #region Creation
 
-        public bool forceAcceptRename { get; set; }
-
         public InputActionTreeView(SerializedObject serializedObject, TreeViewState state = null)
             : base(state ?? new TreeViewState())
         {
@@ -50,7 +48,7 @@ namespace UnityEngine.Experimental.Input.Editor
             drawHeader = true;
             drawPlusButton = true;
             drawMinusButton = true;
-            forceAcceptRename = false;
+            m_ForceAcceptRename = false;
             m_Title = new GUIContent("");
         }
 
@@ -380,13 +378,20 @@ namespace UnityEngine.Experimental.Input.Editor
             if (!(FindItem(args.itemID, rootItem) is ActionTreeItemBase actionItem))
                 return;
 
-            if (!(args.acceptedRename || forceAcceptRename) || args.originalName == args.newName)
+            if (!(args.acceptedRename || m_ForceAcceptRename) || args.originalName == args.newName)
                 return;
                 
             Debug.Assert(actionItem.canRename, "Cannot rename " + actionItem);
 
             actionItem.Rename(args.newName);
             OnSerializedObjectModified();
+        }
+
+        public void EndRename(bool forceAccept)
+        {
+            m_ForceAcceptRename = forceAccept;
+            EndRename();
+            m_ForceAcceptRename = false;
         }
 
         protected override void DoubleClickedItem(int id)
@@ -1280,6 +1285,7 @@ namespace UnityEngine.Experimental.Input.Editor
         private FilterCriterion[] m_ItemFilterCriteria;
         private GUIContent m_Title;
         private bool m_InitiateContextMenuOnNextRepaint;
+        private bool m_ForceAcceptRename;
         private int m_SerializedObjectDirtyCount;
 
         private static readonly GUIContent s_AddBindingLabel = EditorGUIUtility.TrTextContent("Add Binding");


### PR DESCRIPTION
…on to renaming an action map will no longer break the UI.

This is to fix https://fogbugz.unity3d.com/f/cases/1140869/

The fix works, but it is not particularly elegant. I cannot think of a better solution, but if someone can, let me know. The problem is that the TreeView does not expose all it's functionality in public APIs, so we are limited in what we know about it's state and in being able to tell it what to do.