### PR TITLE
FIX: Disabling and enabling actions in action callbacks should work correctly now.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Saving no longer causes the selection of the current processor or interaction to be lost.
   * This was especially annoying when having "Auto-Save" on as it made editing parameters on interactions and processors very tedious.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
+- Disabling and enabling actions in action callbacks should work correctly now.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2972,11 +2972,10 @@ namespace UnityEngine.Experimental.Input
                 {
                     var listener = listeners[i];
                     listener.monitor.NotifyControlStateChanged(listener.control, time, eventPtr, listener.monitorIndex);
-                    signals.ClearBit(i);
                 }
             }
 
-            m_StateChangeMonitors[deviceIndex].signalled = signals;
+            m_StateChangeMonitors[deviceIndex].signalled.ClearAll();
         }
 
         private void ProcessStateChangeMonitorTimeouts()

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DynamicBitfield.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DynamicBitfield.cs
@@ -51,6 +51,12 @@ namespace UnityEngine.Experimental.Input
             array[bitIndex / 64] &= ~((ulong)1 << (bitIndex % 64));
         }
 
+        public void ClearAll()
+        {
+            for (var i = 0; i < length / 64; i++)
+                array[i] = 0;
+        }
+
         private static int BitCountToULongCount(int bitCount)
         {
             return (bitCount + 63) / 64;

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/CoreTests_Actions.cs
@@ -1168,6 +1168,59 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_CanDisableAndEnableOtherActionInCallback()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var receivedCalls = 0;
+
+        var action = new InputAction(binding: "/gamepad/buttonSouth");
+        action.performed +=
+            ctx =>
+            {
+                ++receivedCalls;
+            };
+        action.Enable();
+
+        var disableAction = new InputAction(binding: "/gamepad/buttonEast");
+        disableAction.performed +=
+            ctx =>
+            {
+                action.Disable();
+            };
+        disableAction.Enable();
+
+        var enableAction = new InputAction(binding: "/gamepad/buttonWest");
+        enableAction.performed +=
+            ctx =>
+            {
+                action.Enable();
+            };
+        enableAction.Enable();
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState(GamepadButton.South));
+        InputSystem.Update();
+        Assert.That(receivedCalls, Is.EqualTo(1));
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState(GamepadButton.East));
+        InputSystem.Update();
+        Assert.That(action.enabled, Is.False);
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState(GamepadButton.South));
+        InputSystem.Update();
+        Assert.That(receivedCalls, Is.EqualTo(1));
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState(GamepadButton.West));
+        InputSystem.Update();
+        Assert.That(action.enabled, Is.True);
+
+        InputSystem.QueueStateEvent(gamepad, new GamepadState(GamepadButton.South));
+        InputSystem.Update();
+        Assert.That(receivedCalls, Is.EqualTo(2));
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_CanMonitorTriggeredActionsOnActionMap()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();


### PR DESCRIPTION
Fixes https://fogbugz.unity3d.com/f/cases/1140861/

This did not work, because if a callback changed the enabled actions, it would change `m_StateChangeMonitors[deviceIndex].signalled`, but we would then later overwrite that change when `FireStateChangeNotifications` is done. Now we clear all bits instead of overwriting, which fixes this problem.