### PR TITLE
FIX: input action asset editor save dialog fixes

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -89,6 +89,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Saving no longer causes the selection of the current processor or interaction to be lost.
   * This was especially annoying when having "Auto-Save" on as it made editing parameters on interactions and processors very tedious.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
+- The input action asset editor window will no longer fail saving if the asset has been moved.
+- The input action asset editor window will now show the name of the asset being edited when asking for saving changes. 
+- Clicking "Cancel" in the save changes dialog for the input action asset editor window will now cancel quitting the editor.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
@@ -23,7 +23,7 @@ namespace UnityEngine.Experimental.Input.Editor
 
         public string guid => m_AssetGUID;
 
-        public string path { get; set; }
+        public string path { get => m_AssetPath; set => m_AssetPath = value; }
 
         public string name
         {


### PR DESCRIPTION
I found some issues related to input action asset saving, and fixed them:

- The input action asset editor window will no longer fail saving if the asset has been moved.
- The input action asset editor window will now show the name of the asset being edited when asking for saving changes. 
- Clicking "Cancel" in the save changes dialog for the input action asset editor window will now cancel quitting the editor.
