### PR TITLE
FIX: Fix choosing "Add Action" in action map context menu throwing an…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Saving no longer causes the selection of the current processor or interaction to be lost.
   * This was especially annoying when having "Auto-Save" on as it made editing parameters on interactions and processors very tedious.
 - In locales that use decimal separators other than '.', floating-point parameters on composites, interactions, and processors no longer lead to invalid serialized data being generated.
+- Fix choosing "Add Action" in action map context menu throwing an exception.
 
 ## [0.2.6-preview] - 2019-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -301,7 +301,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 onSelectionChanged = OnActionMapTreeSelectionChanged,
                 onSerializedObjectModified = ApplyAndReloadTrees,
                 drawMinusButton = false,
-                viewToAddActions = m_ActionsTree,
+                onHandleAddNewAction = m_ActionsTree.AddNewAction,
                 title = "Actions Maps",
             };
             m_ActionMapsTree.Reload();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -301,6 +301,7 @@ namespace UnityEngine.Experimental.Input.Editor
                 onSelectionChanged = OnActionMapTreeSelectionChanged,
                 onSerializedObjectModified = ApplyAndReloadTrees,
                 drawMinusButton = false,
+                viewToAddActions = m_ActionsTree,
                 title = "Actions Maps",
             };
             m_ActionMapsTree.Reload();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -825,7 +825,7 @@ namespace UnityEngine.Experimental.Input.Editor
             var canRename = false;
             if (itemType == typeof(ActionMapTreeItem))
             {
-                menu.AddItem(s_AddActionLabel, false, () => {(viewToAddActions ?? this).AddNewAction(); });
+                menu.AddItem(s_AddActionLabel, false, AddNewAction);
             }
             else if (itemType == typeof(ActionTreeItem))
             {
@@ -946,9 +946,14 @@ namespace UnityEngine.Experimental.Input.Editor
 
         public void AddNewAction(SerializedProperty actionMapProperty)
         {
-            var actionProperty = InputActionSerializationHelpers.AddAction(actionMapProperty);
-            InputActionSerializationHelpers.AddBinding(actionProperty, actionMapProperty, groups: bindingGroupForNewBindings);
-            OnNewItemAdded(actionProperty);
+            if (onHandleAddNewAction != null)
+                onHandleAddNewAction(actionMapProperty);
+            else
+            {
+                var actionProperty = InputActionSerializationHelpers.AddAction(actionMapProperty);
+                InputActionSerializationHelpers.AddBinding(actionProperty, actionMapProperty, groups: bindingGroupForNewBindings);
+                OnNewItemAdded(actionProperty);
+            }
         }
 
         public void AddNewBinding()
@@ -1232,7 +1237,7 @@ namespace UnityEngine.Experimental.Input.Editor
         public bool drawMinusButton { get; set; }
         public float foldoutOffset { get; set; }
 
-        public InputActionTreeView viewToAddActions { get; set; }
+        public Action<SerializedProperty> onHandleAddNewAction { get; set; }
         public string title
         {
             get => m_Title?.text;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -825,7 +825,7 @@ namespace UnityEngine.Experimental.Input.Editor
             var canRename = false;
             if (itemType == typeof(ActionMapTreeItem))
             {
-                menu.AddItem(s_AddActionLabel, false, AddNewAction);
+                menu.AddItem(s_AddActionLabel, false, () => {(viewToAddActions ?? this).AddNewAction(); });
             }
             else if (itemType == typeof(ActionTreeItem))
             {
@@ -1232,6 +1232,7 @@ namespace UnityEngine.Experimental.Input.Editor
         public bool drawMinusButton { get; set; }
         public float foldoutOffset { get; set; }
 
+        public InputActionTreeView viewToAddActions { get; set; }
         public string title
         {
             get => m_Title?.text;


### PR DESCRIPTION
… exception.

Not particularly elegant, but cannot think of a better solution (other then maybe dropping that menu item, or making it not select the newly created object?). The problem is that you choose "Create Action" on the context menu in the _Action Map_ Tree View, but the item which needs to be selected is in the _Action_ Tree view, which is different.

Fixes https://fogbugz.unity3d.com/f/cases/1141331/