### PR TITLE
FIX: Fixed layout issue with XInput on OSX and Windows Desktops.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Time slicing for fixed updates now works correctly, even when pausing or dropping frames.
 - Make sure we Disable any InputActionAsset when it is being destroyed. Otherwise, callbacks which were not cleaned up would could cause exceptions.
 - DualShock sensors on PS4 are now marked as noisy (#494).
+- IL2CPP causing issues with XInput on windows and osx desktops.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
@@ -99,7 +99,7 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
 
         public XInputControllerOSXState WithButton(Button button)
         {
-            buttons |= (uint)1 << (int)button;
+            buttons |= (ushort)((uint)1 << (int)button);
             return this;
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
@@ -65,7 +65,7 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
         [InputControl(name = "buttonNorth", bit = (uint)Button.Y, displayName = "Y")]
 
         [FieldOffset(2)]
-        public uint buttons;
+        public ushort buttons;
 
         [InputControl(name = "leftTrigger", format = "BYTE")]
         [FieldOffset(4)] public byte leftTrigger;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -50,7 +50,7 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
         [InputControl(name = "buttonNorth", bit = (uint)Button.Y, displayName = "Y")]
 
         [FieldOffset(0)]
-        public uint buttons;
+        public ushort buttons;
 
         [InputControl(name = "leftTrigger", format = "BYTE")]
         [FieldOffset(2)] public byte leftTrigger;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -84,7 +84,7 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
 
         public XInputControllerWindowsState WithButton(Button button)
         {
-            buttons |= (uint)1 << (int)button;
+            buttons |= (ushort)((uint)1 << (int)button);
             return this;
         }
     }


### PR DESCRIPTION
Fixed Xinput on OSX and Windows desktop mappings.  Button field was too big causing overrun.  Symptoms only visible on IL2CPP builds, mono hiding overrun somehow.