### PR TITLE
FIX: Fixed a bug where the event buffer used by `InputEventTrace` cou…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Make sure we Disable any InputActionAsset when it is being destroyed. Otherwise, callbacks which were not cleaned up would could cause exceptions.
 - DualShock sensors on PS4 are now marked as noisy (#494).
 - IL2CPP causing issues with XInput on windows and osx desktops.
+- Fixed a bug where the event buffer used by `InputEventTrace` could get corrupted.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -211,6 +211,11 @@ namespace UnityEngine.Experimental.Input.LowLevel
                     m_EventBufferTail = m_EventBuffer;
                     newTail = new IntPtr(m_EventBuffer.ToInt64() + eventSize);
 
+                    // If the tail overtook both the head and the end of the buffer, 
+                    // we need to make sure the head is wrapped around as well.
+                    if (newTailOvertakesHead)
+                        m_EventBufferHead = m_EventBuffer;
+
                     // Recheck whether we're overtaking head.
                     newTailOvertakesHead = newTail.ToInt64() > m_EventBufferHead.ToInt64();
                 }


### PR DESCRIPTION
…ld get corrupted.

Fixes https://fogbugz.unity3d.com/f/cases/1145616/