### PR TITLE
FIX: No deadzoning on stick.x/y causing noise.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -2948,7 +2948,7 @@ partial class CoreTests
         Set(gamepad.leftStick, Vector2.one);
 
         Assert.That(receivedFloat, Is.Not.Null);
-        Assert.That(receivedFloat.Value, Is.EqualTo(1).Within(0.00001));
+        Assert.That(receivedFloat.Value, Is.EqualTo(new AxisDeadzoneProcessor().Process(1)));
     }
 
     // ReSharper disable once ClassNeverInstantiated.Local
@@ -6868,7 +6868,7 @@ partial class CoreTests
             if (context.control.CheckStateIsAtDefault())
             {
                 Debug.Log("TestInteractionCheckingDefaultState.Process(default)");
-                Assert.That(context.control.ReadValueAsObject(), Is.EqualTo(0.1234).Within(0.00001));
+                Assert.That(context.control.ReadValueAsObject(), Is.EqualTo(new AxisDeadzoneProcessor().Process(0.1234f)).Within(0.00001));
             }
         }
 

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -205,9 +205,6 @@ partial class CoreTests
         InputSystem.RegisterLayout(json);
         var device = (Gamepad)InputSystem.AddDevice("MyDevice");
 
-        ////NOTE: Unfortunately, this relies on an internal method ATM.
-        var processor = device.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
-
         var firstState = new GamepadState {leftStick = new Vector2(0.05f, 0.05f)};
         var secondState = new GamepadState {leftStick = new Vector2(0.5f, 0.5f)};
 
@@ -219,8 +216,13 @@ partial class CoreTests
         InputSystem.QueueStateEvent(device, secondState);
         InputSystem.Update();
 
-        Assert.That(device.leftStick.ReadValue(),
-            Is.EqualTo(processor.Process(new Vector2(0.5f, 0.5f))));
+        var processedVector = new StickDeadzoneProcessor { min = 0.1f, max = 0.9f }.Process(new Vector2(0.5f, 0.5f));
+        Assert.That(device.leftStick.ReadValue(), Is.EqualTo(processedVector));
+
+        // Deadzoning on the stick axes is independent so we shouldn't see equivalent values on
+        // the axes here.
+        Assert.That(device.leftStick.x.ReadValue(), Is.Not.EqualTo(processedVector.x));
+        Assert.That(device.leftStick.y.ReadValue(), Is.Not.EqualTo(processedVector.y));
     }
 
     [Test]
@@ -264,32 +266,22 @@ partial class CoreTests
     {
         // Deadzone processor with no specified min/max should take default values
         // from InputSettings.
-        const string json = @"
-            {
-                ""name"" : ""MyDevice"",
-                ""extend"" : ""Gamepad"",
-                ""controls"" : [
-                    {
-                        ""name"" : ""leftStick"",
-                        ""processors"" : ""stickDeadzone""
-                    }
-                ]
-            }
-        ";
 
-        InputSystem.RegisterLayout(json);
-        var device = (Gamepad)InputSystem.AddDevice("MyDevice");
+        var gamepad = InputSystem.AddDevice<Gamepad>();
 
-        var processor = device.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        InputSystem.settings.defaultDeadzoneMin = 0.1f;
+        InputSystem.settings.defaultDeadzoneMax = 0.9f;
 
-        Assert.That(processor.minOrDefault, Is.EqualTo(InputSystem.settings.defaultDeadzoneMin));
-        Assert.That(processor.maxOrDefault, Is.EqualTo(InputSystem.settings.defaultDeadzoneMax));
+        Set(gamepad.leftStick, new Vector2(0.5f, 0.5f));
 
-        InputSystem.settings.defaultDeadzoneMin = InputSystem.settings.defaultDeadzoneMin + 0.1f;
-        InputSystem.settings.defaultDeadzoneMax = InputSystem.settings.defaultDeadzoneMin - 0.1f;
+        Assert.That(gamepad.leftStick.ReadValue(),
+            Is.EqualTo(new StickDeadzoneProcessor {min = 0.1f, max = 0.9f}.Process(new Vector2(0.5f, 0.5f))));
 
-        Assert.That(processor.minOrDefault, Is.EqualTo(InputSystem.settings.defaultDeadzoneMin));
-        Assert.That(processor.maxOrDefault, Is.EqualTo(InputSystem.settings.defaultDeadzoneMax));
+        InputSystem.settings.defaultDeadzoneMin = 0.2f;
+        InputSystem.settings.defaultDeadzoneMax = 0.8f;
+
+        Assert.That(gamepad.leftStick.ReadValue(),
+            Is.EqualTo(new StickDeadzoneProcessor {min = 0.2f, max = 0.8f}.Process(new Vector2(0.5f, 0.5f))));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -9,6 +9,7 @@ using UnityEngine.Experimental.Input;
 using UnityEngine.Experimental.Input.Controls;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.LowLevel;
+using UnityEngine.Experimental.Input.Processors;
 using UnityEngine.Experimental.Input.Utilities;
 using UnityEngine.TestTools.Constraints;
 using UnityEngine.TestTools.Utils;
@@ -25,13 +26,12 @@ partial class CoreTests
     public void Events_CanUpdateStateOfDeviceWithEvent()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
-        var newState = new GamepadState {leftStick = new Vector2(0.123f, 0.456f)};
+        var newState = new GamepadState {leftTrigger = 0.234f};
 
         InputSystem.QueueStateEvent(gamepad, newState);
         InputSystem.Update();
 
-        Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(0.123f));
-        Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(0.456f));
+        Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.234f).Within(0.000001));
     }
 
     [Test]
@@ -70,10 +70,11 @@ partial class CoreTests
         InputSystem.QueueDeltaStateEvent(gamepad.leftStick, new Vector2(0.5f, 0.5f));
         InputSystem.Update();
 
-        Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(0.5).Within(0.000001));
-        Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(0.5).Within(0.000001));
+        Assert.That(gamepad.leftStick.ReadValue(),
+            Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.5f, 0.5f))));
+        Assert.That(gamepad.rightStick.ReadValue(),
+            Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(1, 1))));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.123).Within(0.000001));
-        Assert.That(gamepad.rightStick.x.ReadValue(), Is.EqualTo(1).Within(0.000001));
     }
 
     [Test]
@@ -117,8 +118,8 @@ partial class CoreTests
         InputSystem.QueueDeltaStateEvent(secondGamepad.leftStick, new Vector2(0.5f, 0.5f));
         InputSystem.Update();
 
-        Assert.That(secondGamepad.leftStick.x.ReadValue(), Is.EqualTo(0.5).Within(0.000001));
-        Assert.That(secondGamepad.leftStick.y.ReadValue(), Is.EqualTo(0.5).Within(0.000001));
+        Assert.That(secondGamepad.leftStick.ReadValue(),
+            Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.5f, 0.5f))));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
@@ -8,6 +8,7 @@ using UnityEngine;
 using UnityEngine.Experimental.Input.Controls;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.LowLevel;
+using UnityEngine.Experimental.Input.Processors;
 using UnityEngine.TestTools.Utils;
 
 internal class AndroidTests : InputTestFixture
@@ -77,12 +78,15 @@ internal class AndroidTests : InputTestFixture
 
         InputSystem.Update();
 
+        var leftStickDeadzone = controller.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        var rightStickDeadzone = controller.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+
+        // Y is upside down on Android.
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(leftStickDeadzone.Process(new Vector2(0.789f, -0.987f))));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(new Vector2(0.654f, -0.321f))));
+
         Assert.That(controller.leftTrigger.ReadValue(), Is.EqualTo(0.123).Within(0.000001));
         Assert.That(controller.rightTrigger.ReadValue(), Is.EqualTo(0.456).Within(0.000001));
-        Assert.That(controller.leftStick.x.ReadValue(), Is.EqualTo(0.789).Within(0.000001));
-        Assert.That(controller.leftStick.y.ReadValue(), Is.EqualTo(-0.987).Within(0.000001)); // Y is upside down on Android.
-        Assert.That(controller.rightStick.x.ReadValue(), Is.EqualTo(0.654).Within(0.000001));
-        Assert.That(controller.rightStick.y.ReadValue(), Is.EqualTo(-0.321).Within(0.000001)); // Y is upside down on Android.
 
         AssertButtonPress(controller, new AndroidGameControllerState().WithButton(AndroidKeyCode.ButtonA), controller.buttonSouth);
         AssertButtonPress(controller, new AndroidGameControllerState().WithButton(AndroidKeyCode.ButtonX), controller.buttonWest);
@@ -228,10 +232,11 @@ internal class AndroidTests : InputTestFixture
 
         InputSystem.Update();
 
+        var rightStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(new Vector2(0.123f, 0.456f))));
+
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(1.0f).Within(0.000001));
         Assert.That(gamepad.rightTrigger.ReadValue(), Is.EqualTo(1.0f).Within(0.000001));
-        Assert.That(gamepad.rightStick.x.ReadValue(), Is.EqualTo(0.123f).Within(0.000001));
-        Assert.That(gamepad.rightStick.y.ReadValue(), Is.EqualTo(0.456f).Within(0.000001));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -40,10 +40,18 @@ internal class DualShockTests : InputTestFixture
             });
         InputSystem.Update();
 
-        Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(NormalizeProcessor.Normalize(32 / 255.0f, 0f, 1f, 0.5f)).Within(0.00001));
-        Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(-NormalizeProcessor.Normalize(64 / 255.0f, 0f, 1f, 0.5f)).Within(0.00001));
-        Assert.That(gamepad.rightStick.x.ReadValue(), Is.EqualTo(NormalizeProcessor.Normalize(128 / 255.0f, 0f, 1f, 0.5f)).Within(0.00001));
-        Assert.That(gamepad.rightStick.y.ReadValue(), Is.EqualTo(-NormalizeProcessor.Normalize(255 / 255.0f, 0f, 1f, 0.5f)).Within(0.00001));
+        var leftStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        var rightStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+
+        Assert.That(gamepad.leftStick.ReadValue(),
+            Is.EqualTo(leftStickDeadzone.Process(
+                new Vector2(NormalizeProcessor.Normalize(32 / 255.0f, 0f, 1f, 0.5f),
+                    -NormalizeProcessor.Normalize(64 / 255.0f, 0f, 1f, 0.5f)))));
+
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(
+            new Vector2(NormalizeProcessor.Normalize(128 / 255.0f, 0f, 1f, 0.5f),
+                -NormalizeProcessor.Normalize(255 / 255.0f, 0f, 1f, 0.5f)))));
+
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(NormalizeProcessor.Normalize(20 / 255.0f, 0f, 1f, 0f)).Within(0.00001));
         Assert.That(gamepad.rightTrigger.ReadValue(), Is.EqualTo(NormalizeProcessor.Normalize(40 / 255.0f, 0f, 1f, 0f)).Within(0.00001));
         ////TODO: test button presses individually

--- a/Assets/Tests/InputSystem/Plugins/PS4Tests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PS4Tests.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.Plugins.PS4;
 using UnityEngine.Experimental.Input.Plugins.PS4.LowLevel;
+using UnityEngine.Experimental.Input.Processors;
 
 public class PS4Tests : InputTestFixture
 {
@@ -59,10 +60,11 @@ public class PS4Tests : InputTestFixture
         Assert.That(gamepad.L3.isPressed);
         Assert.That(gamepad.R3.isPressed);
 
-        Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(0.123).Within(0.00001));
-        Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(0.456).Within(0.00001));
-        Assert.That(gamepad.rightStick.x.ReadValue(), Is.EqualTo(0.789).Within(0.00001));
-        Assert.That(gamepad.rightStick.y.ReadValue(), Is.EqualTo(0.234).Within(0.00001));
+        var leftStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        var rightStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(leftStickDeadzone.Process(new Vector2(0.123f, 0.456f))));
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(new Vector2(0.789f, 0.234f))));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.567).Within(0.00001));
         Assert.That(gamepad.rightTrigger.ReadValue(), Is.EqualTo(0.891).Within(0.00001));
 

--- a/Assets/Tests/InputSystem/Plugins/SwitchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/SwitchTests.cs
@@ -6,6 +6,7 @@ using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Plugins.Switch;
 using UnityEngine.Experimental.Input.Plugins.Switch.LowLevel;
+using UnityEngine.Experimental.Input.Processors;
 
 internal class SwitchTests : InputTestFixture
 {
@@ -35,10 +36,11 @@ internal class SwitchTests : InputTestFixture
             });
         InputSystem.Update();
 
-        Assert.That(controller.leftStick.x.ReadValue(), Is.EqualTo(0.123).Within(0.00001));
-        Assert.That(controller.leftStick.y.ReadValue(), Is.EqualTo(0.456).Within(0.00001));
-        Assert.That(controller.rightStick.x.ReadValue(), Is.EqualTo(0.789).Within(0.00001));
-        Assert.That(controller.rightStick.y.ReadValue(), Is.EqualTo(0.987).Within(0.00001));
+        var leftStickDeadzone = controller.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        var rightStickDeadzone = controller.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(leftStickDeadzone.Process(new Vector2(0.123f, 0.456f))));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(new Vector2(0.789f, 0.987f))));
 
         Assert.That(controller.acceleration.x.ReadValue(), Is.EqualTo(0.987).Within(0.00001));
         Assert.That(controller.acceleration.y.ReadValue(), Is.EqualTo(0.654).Within(0.00001));

--- a/Assets/Tests/InputSystem/Plugins/XInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XInputTests.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.Utilities;
 using System.Runtime.InteropServices;
+using UnityEngine.Experimental.Input.Processors;
 
 #if UNITY_EDITOR || UNITY_XBOXONE || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN
 using UnityEngine.Experimental.Input.Plugins.XInput.LowLevel;
@@ -91,10 +92,11 @@ internal class XInputTests : InputTestFixture
             });
         InputSystem.Update();
 
-        Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(0.123).Within(0.00001));
-        Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(0.456).Within(0.00001));
-        Assert.That(gamepad.rightStick.x.ReadValue(), Is.EqualTo(0.789).Within(0.00001));
-        Assert.That(gamepad.rightStick.y.ReadValue(), Is.EqualTo(0.234).Within(0.00001));
+        var leftStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        var rightStickDeadzone = gamepad.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(leftStickDeadzone.Process(new Vector2(0.123f, 0.456f))));
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(new Vector2(0.789f, 0.234f))));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.567).Within(0.00001));
         Assert.That(gamepad.rightTrigger.ReadValue(), Is.EqualTo(0.891).Within(0.00001));
 

--- a/Assets/Tests/InputSystem/Plugins/iOSTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/iOSTests.cs
@@ -1,9 +1,11 @@
 #if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.Experimental.Input;
 using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.Plugins.iOS;
 using UnityEngine.Experimental.Input.Plugins.iOS.LowLevel;
+using UnityEngine.Experimental.Input.Processors;
 
 internal class iOSTests : InputTestFixture
 {
@@ -32,12 +34,13 @@ internal class iOSTests : InputTestFixture
 
         InputSystem.Update();
 
+        var leftStickDeadzone = controller.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+        var rightStickDeadzone = controller.leftStick.TryGetProcessor<StickDeadzoneProcessor>();
+
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(leftStickDeadzone.Process(new Vector2(0.789f, 0.987f))));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(rightStickDeadzone.Process(new Vector2(0.654f, 0.321f))));
         Assert.That(controller.leftTrigger.ReadValue(), Is.EqualTo(0.123).Within(0.000001));
         Assert.That(controller.rightTrigger.ReadValue(), Is.EqualTo(0.456).Within(0.000001));
-        Assert.That(controller.leftStick.x.ReadValue(), Is.EqualTo(0.789).Within(0.000001));
-        Assert.That(controller.leftStick.y.ReadValue(), Is.EqualTo(0.987).Within(0.000001));
-        Assert.That(controller.rightStick.x.ReadValue(), Is.EqualTo(0.654).Within(0.000001));
-        Assert.That(controller.rightStick.y.ReadValue(), Is.EqualTo(0.321).Within(0.000001));
 
         AssertButtonPress(controller, new iOSGameControllerState().WithButton(iOSButton.A), controller.buttonSouth);
         AssertButtonPress(controller, new iOSGameControllerState().WithButton(iOSButton.X), controller.buttonWest);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the input system package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3-preview] - TBD
+
+### Changed
+
+- `StickControl.x` and `StickControl.y` are now deadzoned, i.e. have `AxisDeadzone` processors on them. This affects all gamepads and joysticks.
+  * __NOTE:__ The deadzoning is __independent__ of the stick. Whereas the stack has a radial deadzones, `x` and `y` have linear deadzones. This means that `leftStick.ReadValue().x` is __not__ necessary equal to `leftStick.x.ReadValue()`.
+  * This change also fixes the problem of noise from sticks not getting filtered out and causing devices such as the PS4 controller to constantly make itself `Gamepad.current`.
+
 ## [0.2.8-preview] - 2019-4-23
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1,6 +1,10 @@
 using System;
 using UnityEngine.Experimental.Input.Utilities;
 
+////FIXME: Whether a control from a binding that's part of a composite appears on an action is currently not consistently enforced.
+////       If it mentions the action, it appears on the action. Otherwise it doesn't. The controls should consistently appear on the
+////       action based on what action the *composite* references.
+
 ////REVIEW: should continuous actions *always* trigger as long as they are enabled? (even if no control is actuated)
 
 ////REVIEW: I think the action system as it is today offers too many ways to shoot yourself in the foot. It has

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -863,20 +863,19 @@ namespace UnityEngine.Experimental.Input
         {
             if (m_ProcessorStack.length > 0)
             {
-                if (m_ProcessorStack.firstValue is TProcessor)
-                    return (TProcessor)m_ProcessorStack.firstValue;
+                if (m_ProcessorStack.firstValue is TProcessor processor)
+                    return processor;
                 if (m_ProcessorStack.additionalValues != null)
                     for (var i = 0; i < m_ProcessorStack.length - 1; ++i)
-                        if (m_ProcessorStack.additionalValues[i] is TProcessor)
-                            return (TProcessor)m_ProcessorStack.additionalValues[i];
+                        if (m_ProcessorStack.additionalValues[i] is TProcessor result)
+                            return result;
             }
             return default;
         }
 
         internal override void AddProcessor(object processor)
         {
-            var processorOfType = processor as InputProcessor<TValue>;
-            if (processorOfType == null)
+            if (!(processor is InputProcessor<TValue> processorOfType))
                 throw new Exception(
                     $"Cannot add processor of type '{processor.GetType().Name}' to control of type '{GetType().Name}'");
             m_ProcessorStack.Append(processorOfType);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -5,8 +5,8 @@ namespace UnityEngine.Experimental.Input.Processors
         public float min;
         public float max;
 
-        public float minOrDefault => min == 0.0f ? InputSystem.settings.defaultDeadzoneMin : min;
-        public float maxOrDefault => max == 0.0f ? InputSystem.settings.defaultDeadzoneMax : max;
+        private float minOrDefault => min == default ? InputSystem.settings.defaultDeadzoneMin : min;
+        private float maxOrDefault => max == default ? InputSystem.settings.defaultDeadzoneMax : max;
 
         public override float Process(float value, InputControl<float> control = null)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -20,8 +20,8 @@ namespace UnityEngine.Experimental.Input.Processors
         public float min;
         public float max;
 
-        public float minOrDefault => min == 0.0f ? InputSystem.settings.defaultDeadzoneMin : min;
-        public float maxOrDefault => max == 0.0f ? InputSystem.settings.defaultDeadzoneMax : max;
+        private float minOrDefault => min == default ? InputSystem.settings.defaultDeadzoneMin : min;
+        private float maxOrDefault => max == default ? InputSystem.settings.defaultDeadzoneMax : max;
 
         public override Vector2 Process(Vector2 vector, InputControl<Vector2> control = null)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/StickControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/StickControl.cs
@@ -16,8 +16,9 @@ namespace UnityEngine.Experimental.Input.Controls
     {
         ////REVIEW: should X and Y have "Horizontal" and "Vertical" as long display names and "X" and "Y" as short names?
         // Set min&max on XY axes.
-        [InputControl(name = "x", minValue = -1f, maxValue = 1f, layout = "Axis")]
-        [InputControl(name = "y", minValue = -1f, maxValue = 1f, layout = "Axis")]
+        // Also put AxisDeadzones on the axes.
+        [InputControl(name = "x", minValue = -1f, maxValue = 1f, layout = "Axis", processors = "axisDeadzone")]
+        [InputControl(name = "y", minValue = -1f, maxValue = 1f, layout = "Axis", processors = "axisDeadzone")]
 
         // Buttons for each of the directions. Allows the stick to function as a dpad.
         // Note that these controls are marked as synthetic as there isn't real buttons for the half-axes

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
@@ -41,12 +41,15 @@ namespace UnityEngine.Experimental.Input.Controls
         {
             x = builder.GetControl<AxisControl>(this, "x");
             y = builder.GetControl<AxisControl>(this, "y");
+
             base.FinishSetup(builder);
         }
 
         public override unsafe Vector2 ReadUnprocessedValueFromState(void* statePtr)
         {
-            return new Vector2(x.ReadValueFromState(statePtr), y.ReadValueFromState(statePtr));
+            return new Vector2(
+                x.ReadUnprocessedValueFromState(statePtr),
+                y.ReadUnprocessedValueFromState(statePtr));
         }
 
         public override unsafe void WriteValueIntoState(Vector2 value, void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
@@ -26,12 +26,16 @@ namespace UnityEngine.Experimental.Input.Controls
             x = builder.GetControl<AxisControl>(this, "x");
             y = builder.GetControl<AxisControl>(this, "y");
             z = builder.GetControl<AxisControl>(this, "z");
+
             base.FinishSetup(builder);
         }
 
         public override unsafe Vector3 ReadUnprocessedValueFromState(void* statePtr)
         {
-            return new Vector3(x.ReadValueFromState(statePtr), y.ReadValueFromState(statePtr), z.ReadValueFromState(statePtr));
+            return new Vector3(
+                x.ReadUnprocessedValueFromState(statePtr),
+                y.ReadUnprocessedValueFromState(statePtr),
+                z.ReadUnprocessedValueFromState(statePtr));
         }
 
         public override unsafe void WriteValueIntoState(Vector3 value, void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
@@ -1,7 +1,7 @@
 #if UNITY_EDITOR
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine.Experimental.Input.Utilities;
@@ -26,13 +26,15 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
             m_Property = property;
             m_Apply = applyAction;
             m_ListOptions = GetOptions();
+
             m_ExpectedControlLayout = expectedControlLayout;
             if (!string.IsNullOrEmpty(m_ExpectedControlLayout))
                 m_ExpectedValueType = EditorInputControlLayoutCache.GetValueType(m_ExpectedControlLayout);
 
             m_ParametersForEachListItem = NameAndParameters.ParseMultiple(m_Property.stringValue).ToArray();
             m_EditableParametersForEachListItem = new ParameterListView[m_ParametersForEachListItem.Length];
-            for (int i = 0; i < m_ParametersForEachListItem.Length; i++)
+
+            for (var i = 0; i < m_ParametersForEachListItem.Length; i++)
             {
                 m_EditableParametersForEachListItem[i] = new ParameterListView { onChange = OnParametersChanged };
                 var typeName = m_ParametersForEachListItem[i].name;
@@ -63,7 +65,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         {
             // Add only original names to the menu and not aliases.
             var menu = new GenericMenu();
-            foreach (var name in m_ListOptions.internedNames.Where(x => !m_ListOptions.aliases.Contains(x)).OrderBy(x => x.ToString()))
+            foreach (var name in m_ListOptions.internedNames.Where(x => !m_ListOptions.ShouldHideInUI(x)).OrderBy(x => x.ToString()))
             {
                 // Skip if not compatible with value type.
                 if (m_ExpectedValueType != null)
@@ -100,7 +102,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
 
         private void OnParametersChanged()
         {
-            for (int i = 0; i < m_ParametersForEachListItem.Length; i++)
+            for (var i = 0; i < m_ParametersForEachListItem.Length; i++)
             {
                 m_ParametersForEachListItem[i] = new NameAndParameters
                 {
@@ -137,7 +139,7 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
         {
             if (m_EditableParametersForEachListItem == null || m_EditableParametersForEachListItem.Length == 0)
             {
-                using (var scope = new EditorGUI.DisabledScope(true))
+                using (new EditorGUI.DisabledScope(true))
                 {
                     EditorGUI.indentLevel++;
                     EditorGUILayout.LabelField($"No {itemName}s have been added.");
@@ -157,12 +159,12 @@ namespace UnityEngine.Experimental.Input.Editor.Lists
                         EditorGUILayout.LabelField(editableParams.name, EditorStyles.boldLabel);
                     }
                     GUILayout.FlexibleSpace();
-                    using (var scope = new EditorGUI.DisabledScope(i == 0))
+                    using (new EditorGUI.DisabledScope(i == 0))
                     {
                         if (GUILayout.Button(m_UpButton, Styles.s_UpDownButtonStyle))
                             SwapEntry(i, i - 1);
                     }
-                    using (var scope = new EditorGUI.DisabledScope(i == m_EditableParametersForEachListItem.Length - 1))
+                    using (new EditorGUI.DisabledScope(i == m_EditableParametersForEachListItem.Length - 1))
                     {
                         if (GUILayout.Button(m_DownButton, Styles.s_UpDownButtonStyle))
                             SwapEntry(i, i + 1);

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -6,8 +6,6 @@ using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.Profiling;
 
-////FIXME: the ring buffer insertion and/or traversal logic is still buggy :(
-
 ////TODO: Use InputEventBuffer
 
 namespace UnityEngine.Experimental.Input.LowLevel

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1468,7 +1468,6 @@ namespace UnityEngine.Experimental.Input
             processors.AddTypeRegistration("ScaleVector3", typeof(ScaleVector3Processor));
             processors.AddTypeRegistration("StickDeadzone", typeof(StickDeadzoneProcessor));
             processors.AddTypeRegistration("AxisDeadzone", typeof(AxisDeadzoneProcessor));
-            //processors.AddTypeRegistration("Curve", typeof(CurveProcessor));
             processors.AddTypeRegistration("CompensateDirection", typeof(CompensateDirectionProcessor));
             processors.AddTypeRegistration("CompensateRotation", typeof(CompensateRotationProcessor));
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
@@ -24,10 +24,7 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput.LowLevel
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct XInputControllerOSXState : IInputStateTypeInfo
     {
-        public static FourCC kFormat
-        {
-            get { return new FourCC('H', 'I', 'D'); }
-        }
+        public static FourCC kFormat => new FourCC('H', 'I', 'D');
 
         public enum Button
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputSupport.cs
@@ -20,6 +20,7 @@ namespace UnityEngine.Experimental.Input.Plugins.XInput
                     .WithDeviceClass("XboxOneGamepad")
                     .WithInterface("Xbox"));
 #endif
+            ////FIXME: layouts should always be available in the editor (mac/win/linux)
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA
             InputSystem.RegisterLayout<XInputControllerWindows>(
                 matches: new InputDeviceMatcher().WithInterface("XInput"));

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeTable.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeTable.cs
@@ -1,6 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+
+#if UNITY_EDITOR
+using System.ComponentModel;
+#endif
 
 namespace UnityEngine.Experimental.Input.Utilities
 {
@@ -65,5 +70,20 @@ namespace UnityEngine.Experimental.Input.Utilities
                 return type;
             return null;
         }
+
+        #if UNITY_EDITOR
+        public bool ShouldHideInUI(string name)
+        {
+            // Always hide aliases.
+            if (aliases.Contains(new InternedString(name)))
+                return true;
+
+            // Hide entries that have [DesignTimeVisible(false)] on the type.
+            var type = LookupTypeRegistration(name);
+            var attribute = type?.GetCustomAttribute<DesignTimeVisibleAttribute>();
+            return attribute?.Visible ?? false;
+        }
+
+        #endif
     }
 }


### PR DESCRIPTION
This adds deadzones to `StickControl.x` and `StickControl.y`.

* Unlike the `StickDeadzoneProcessor` on the stick itself, which has a radial deadzone, the deadzones on `x` and `y` are linear. Means they will not necessary match the `x` and `y` components on the `Vector2` of the stick.
* Fixes the problem with noise coming in through stick axes even though it is suppressed properly on the stick itself.