### PR TITLE
FIX: PlayerInputEditor duplicating action event entries several times.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the input system package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3-preview] - TBD
+
+### Fixed
+
+#### Actions
+
+- Custom inspector for `PlayerInput` no longer adds duplicates of action events if `Invoke Unity Events` notification behavior is selected.
+
 ## [0.2.8-preview] - 2019-4-23
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -376,8 +376,20 @@ namespace UnityEngine.Experimental.Input.Editor
                 InputSystem.ListEnabledActions(m_EnabledActions);
                 if (m_EnabledActions.Count > 0)
                 {
-                    actionsItem = AddChild(root, $"Actions ({m_EnabledActions.Count})", ref id);
+                    actionsItem = AddChild(root, "", ref id);
                     AddEnabledActions(actionsItem, ref id);
+
+                    if (!actionsItem.hasChildren)
+                    {
+                        // We are culling actions that are assigned to users so we may end up with an empty
+                        // list even if we have enabled actions. If we do, remove the "Actions" item from the tree.
+                        root.children.Remove(actionsItem);
+                    }
+                    else
+                    {
+                        // Update title to include action count.
+                        actionsItem.displayName = $"Actions ({actionsItem.children.Count})";
+                    }
                 }
 
                 // Users.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -607,11 +607,13 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput
             return playerInput;
         }
 
-        [Tooltip("Input actions associated with the player. TODO")]
+        [Tooltip("Input actions associated with the player.")]
         [SerializeField] internal InputActionAsset m_Actions;
+        [Tooltip("Determine how notifications should be sent when an input-related event associated with the player happens.")]
         [SerializeField] internal PlayerNotifications m_NotificationBehavior;
         [Tooltip("UI EventSystem that should receive input from the actions associated with the player. TODO")]
         [SerializeField] internal EventSystem m_UIEventSystem;
+        [Tooltip("Event that is triggered when the PlayerInput loses a paired device (e.g. its battery runs out).")]
         [SerializeField] internal DeviceLostEvent m_DeviceLostEvent;
         [SerializeField] internal DeviceRegainedEvent m_DeviceRegainedEvent;
         [SerializeField] internal ActionEvent[] m_ActionEvents;
@@ -619,6 +621,8 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput
         [SerializeField] internal string m_DefaultControlScheme;////REVIEW: should we have IDs for these so we can rename safely?
         [SerializeField] internal string m_DefaultActionMap;
         [SerializeField] internal int m_SplitScreenIndex = -1;
+        [Tooltip("Reference to the player's view camera. Note that this is only required when using split-screen and/or "
+            + "per-player UIs. Otherwise it is safe to leave this property uninitialized.")]
         [SerializeField] internal Camera m_Camera;
 
         // Value object we use when sending messages via SendMessage() or BroadcastMessage(). Can be ignored

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -408,7 +408,7 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput.Editor
 
                 void AddEntry(InputAction action, PlayerInput.ActionEvent actionEvent)
                 {
-                    newActionNames.Add(new GUIContent(action.name + " Action"));
+                    newActionNames.Add(new GUIContent(action.name));
                     newActionEvents.Add(actionEvent);
 
                     var actionMapIndex = asset.actionMaps.IndexOfReference(action.actionMap);
@@ -558,10 +558,18 @@ namespace UnityEngine.Experimental.Input.Plugins.PlayerInput.Editor
         [NonSerialized] private readonly GUIContent m_AddInputModuleText = EditorGUIUtility.TrTextContent("Add UI Input Module");
         [NonSerialized] private readonly GUIContent m_OpenSettingsText = EditorGUIUtility.TrTextContent("Open Input Settings");
         [NonSerialized] private readonly GUIContent m_OpenDebuggerText = EditorGUIUtility.TrTextContent("Open Input Debugger");
-        [NonSerialized] private readonly GUIContent m_EventsGroupText = EditorGUIUtility.TrTextContent("Events");
-        [NonSerialized] private readonly GUIContent m_NotificationBehaviorText = EditorGUIUtility.TrTextContent("Behavior");
-        [NonSerialized] private readonly GUIContent m_DefaultControlSchemeText = EditorGUIUtility.TrTextContent("Default Control Scheme");
-        [NonSerialized] private readonly GUIContent m_DefaultActionMapText = EditorGUIUtility.TrTextContent("Default Action Map");
+        [NonSerialized] private readonly GUIContent m_EventsGroupText =
+            EditorGUIUtility.TrTextContent("Events", "UnityEvents triggered by the PlayerInput component");
+        [NonSerialized] private readonly GUIContent m_NotificationBehaviorText =
+            EditorGUIUtility.TrTextContent("Behavior",
+                "Determine how notifications should be sent when an input-related event associated with the player happens.");
+        [NonSerialized] private readonly GUIContent m_DefaultControlSchemeText =
+            EditorGUIUtility.TrTextContent("Default Control Scheme", "Which control scheme to try by default. If not set, PlayerInput "
+                + "will simply go through all control schemes in the action asset and try one after the other. If set, PlayerInput will try "
+                + "the given scheme first but if using that fails (e.g. when not required devices are missing) will fall back to trying the other "
+                + "control schemes in order.");
+        [NonSerialized] private readonly GUIContent m_DefaultActionMapText =
+            EditorGUIUtility.TrTextContent("Default Action Map", "Action map to enable by default. If not set, no actions will be enabled by default.");
         [NonSerialized] private readonly GUIContent m_DebugText = EditorGUIUtility.TrTextContent("Debug");
         [NonSerialized] private GUIContent m_UIPropertyText;
         [NonSerialized] private GUIContent m_CameraPropertyText;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -725,7 +725,7 @@ namespace UnityEngine.Experimental.Input.Plugins.Users
             {
                 // If it's in s_AllPairedDevices, there is *some* user that is using the device.
                 // We don't care which one it is here.
-                if (ArrayHelpers.ContainsReferenceTo(s_AllPairedDevices, s_AllPairedDeviceCount, device))
+                if (ArrayHelpers.ContainsReference(s_AllPairedDevices, s_AllPairedDeviceCount, device))
                     continue;
 
                 list.Add(device);
@@ -1598,7 +1598,7 @@ namespace UnityEngine.Experimental.Input.Plugins.Users
                         return;
 
                     // See if it's a device not belonging to any user.
-                    if (ArrayHelpers.ContainsReferenceTo(s_AllPairedDevices, s_AllPairedDeviceCount, device))
+                    if (ArrayHelpers.ContainsReference(s_AllPairedDevices, s_AllPairedDeviceCount, device))
                     {
                         // No, it's a device already paired to a player so do nothing.
                         return;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
@@ -76,26 +76,19 @@ namespace UnityEngine.Experimental.Input.Utilities
             return false;
         }
 
-        public static bool ContainsReferenceTo<TValue>(TValue[] array, TValue value)
+        public static bool ContainsReference<TValue>(TValue[] array, TValue value)
             where TValue : class
         {
             if (array == null)
                 return false;
 
-            return ContainsReferenceTo(array, array.Length, value);
+            return ContainsReference(array, array.Length, value);
         }
 
-        public static bool ContainsReferenceTo<TValue>(TValue[] array, int count, TValue value)
+        public static bool ContainsReference<TValue>(TValue[] array, int count, TValue value)
             where TValue : class
         {
-            if (array == null)
-                return false;
-
-            for (var i = 0; i < count; ++i)
-                if (ReferenceEquals(array[i], value))
-                    return true;
-
-            return false;
+            return IndexOfReference(array, value, count) != -1;
         }
 
         public static bool HaveEqualElements<TValue>(TValue[] first, TValue[] second)
@@ -355,6 +348,15 @@ namespace UnityEngine.Experimental.Input.Utilities
                 Array.Copy(array, index, array, index + 1, oldLength - index);
 
             array[index] = value;
+        }
+
+        public static void PutAtIfNotSet<TValue>(ref TValue[] array, int index, Func<TValue> valueFn)
+        {
+            if (array.LengthSafe() < index + 1)
+                Array.Resize(ref array, index + 1);
+
+            if (EqualityComparer<TValue>.Default.Equals(array[index], default(TValue)))
+                array[index] = valueFn();
         }
 
         // Adds 'count' entries to the array. Returns first index of newly added entries.

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -171,10 +171,16 @@ namespace UnityEngine.Experimental.Input.Utilities
         public static bool ContainsReference<TValue>(this ReadOnlyArray<TValue> array, TValue value)
             where TValue : class
         {
+            return IndexOfReference(array, value) != -1;
+        }
+
+        public static int IndexOfReference<TValue>(this ReadOnlyArray<TValue> array, TValue value)
+            where TValue : class
+        {
             for (var i = 0; i < array.m_Length; ++i)
                 if (ReferenceEquals(array.m_Array[array.m_StartIndex + i], value))
-                    return true;
-            return false;
+                    return i;
+            return -1;
         }
     }
 }


### PR DESCRIPTION
Also rearranged the UI slightly such that the events are now grouped by action map rather than being one big flat list.

![image](https://user-images.githubusercontent.com/3418347/56745866-713d6c80-677b-11e9-850e-75bb5ee194b0.png)
