### PR TITLE
FIX: Events being lost due to incomplete change in 91847a568301cb908e71457ca082efcd9985b54a.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -42,9 +42,6 @@ namespace UnityEngine.Experimental.Input.LowLevel
             set
             {
                 if (value != null)
-                // This is 2019.2 (i.e. trunk at this point in time) only while we figure out how to get this
-                // working properly.
-                    #if UNITY_2019_2_OR_NEWER
                     NativeInputSystem.onUpdate =
                         (updateType, eventBufferPtr) =>
                     {
@@ -80,34 +77,6 @@ namespace UnityEngine.Experimental.Input.LowLevel
                             eventBufferPtr->sizeInBytes = 0;
                         }
                     };
-                    #else
-                    // 2019.1 has the native API change but we need to fix the code in InputManager first
-                    // before we can fully migrate to the new update code. For now, just manually reset
-                    // the buffer here every time.
-                    NativeInputSystem.onUpdate =
-                        (updateType, eventBufferPtr) =>
-                    {
-                        var buffer = new InputEventBuffer((InputEvent*)eventBufferPtr->eventBuffer,
-                            eventBufferPtr->eventCount,
-                            sizeInBytes: eventBufferPtr->sizeInBytes,
-                            capacityInBytes: eventBufferPtr->capacityInBytes);
-
-                        try
-                        {
-                            value((InputUpdateType)updateType, ref buffer);
-                        }
-                        finally
-                        {
-                            // Need to account for the oddity of before render updates. This all goes
-                            // away once we have the kinks worked out in InputManager.OnUpdate().
-                            if (updateType != NativeInputUpdateType.BeforeRender)
-                            {
-                                eventBufferPtr->eventCount = 0;
-                                eventBufferPtr->sizeInBytes = 0;
-                            }
-                        }
-                    };
-                    #endif
                 else
                     NativeInputSystem.onUpdate = null;
             }


### PR DESCRIPTION
Luckily that change landed after we bundled the package so the bug here actually didn't make it out.

What happened was when I removed the #ifs around the code for event timeslicing, I missed one piece of code in `NativeInputRuntime` (which unfortunately also meant the tests didn't catch it). So the old code stayed in place there. That led to `InputManager` sometimes retaining events for the next update and `NativeInputRuntime` just killing and thus losing them.