### PR TITLE
ifdefs reference to UnityEngine.XR

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -1,5 +1,7 @@
 using System;
+#if ENABLE_VR
 using UnityEngine.XR;
+#endif
 
 namespace UnityEngine.Experimental.Input.Plugins.XR
 {


### PR DESCRIPTION
tautvdyas requested that i ifdef references to UnityEngine.XR as there are compile issues with platforms that this is not defined for. 