### PR TITLE
Multiplayer ui

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -297,7 +297,7 @@ internal class UITests : InputTestFixture
         foreach (var player in players)
             player.eventSystem.InvokeUpdate();
 
-        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].leftGameObject));
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.SameAs(players[0].leftGameObject));
         Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.Null);
 
         // Click right gameObject of player 1
@@ -309,8 +309,8 @@ internal class UITests : InputTestFixture
         foreach (var player in players)
             player.eventSystem.InvokeUpdate();
 
-        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].leftGameObject));
-        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].rightGameObject));
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.SameAs(players[0].leftGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.SameAs(players[1].rightGameObject));
 
         // Click right gameObject of player 0
         InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(400, 100), buttons = 1 << (int)MouseButton.Left });
@@ -320,8 +320,8 @@ internal class UITests : InputTestFixture
         foreach (var player in players)
             player.eventSystem.InvokeUpdate();
 
-        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].rightGameObject));
-        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].rightGameObject));
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.SameAs(players[0].rightGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.SameAs(players[1].rightGameObject));
     }
 
     [UnityTest]
@@ -360,8 +360,8 @@ internal class UITests : InputTestFixture
         // We need to wait a frame to let the underlying canvas update and properly order the graphics images for raycasting.
         yield return null;
 
-        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].leftGameObject));
-        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].leftGameObject));
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.SameAs(players[0].leftGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.SameAs(players[1].leftGameObject));
 
         // Reset initial selection
         players[0].leftChildReceiver.Reset();
@@ -378,8 +378,8 @@ internal class UITests : InputTestFixture
             player.eventSystem.InvokeUpdate();
         }
 
-        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].rightGameObject));
-        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].leftGameObject));
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.SameAs(players[0].rightGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.SameAs(players[1].leftGameObject));
 
         Assert.That(players[0].leftChildReceiver.events, Has.Count.EqualTo(2));
         Assert.That(players[0].leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
@@ -481,6 +481,7 @@ internal class UITests : InputTestFixture
         Assert.That(rightChildReceiver.events, Has.Count.EqualTo(0));
 
         // Check Move Axes
+        // Fixme: replacing this with Set(gamepads[0].leftStick, new Vector2(1, 0)); throws a NRE.
         InputSystem.QueueDeltaStateEvent(gamepad.leftStick, new Vector2(1.0f, 0.0f));
         InputSystem.Update();
         eventSystem.InvokeUpdate();

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -104,7 +104,7 @@ internal class UITests : InputTestFixture
         rightChildTransform.anchoredPosition = new Vector2(640 / 4, 0); //(maxY + minY) / 2 - 240);
         rightChildTransform.sizeDelta = new Vector2(320, maxY - minY);
 
-        objects.eventSystem.playerRootTransform = parentTransform;
+        objects.eventSystem.playerRoot = parentGameObject;
         objects.eventSystem.firstSelectedGameObject = leftChildGameObject;
         objects.eventSystem.InvokeUpdate(); // Initial update only sets current module.
 
@@ -248,7 +248,7 @@ internal class UITests : InputTestFixture
     [UnityTest]
     [Category("Actions")]
     // Check that two players can have separate UI, and that both selections will stay active when clicking on UI with the mouse,
-    // using MultiPlayerEventSystem.playerRootTransform to match UI to the players.
+    // using MultiPlayerEventSystem.playerRoot to match UI to the players.
     public IEnumerator MouseActions_MultiplayerEventSystemKeepsPerPlayerSelection()
     {
         // Create devices.

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -23,14 +23,17 @@ internal class UITests : InputTestFixture
     {
         internal UIActionInputModule uiModule;
         internal TestEventSystem eventSystem;
+        internal RectTransform parentTransform;
         internal GameObject leftGameObject;
         internal GameObject rightGameObject;
+        internal UICallbackReceiver leftChildReceiver;
+        internal UICallbackReceiver rightChildReceiver;
     }
 
     // Set up a UIActionInputModule with a full roster of actions and inputs
     // and then see if we can generate all the various events expected by the UI
     // from activity on input devices.
-    private static TestObjects CreateScene()
+    private static TestObjects CreateScene(int minY = 0 , int maxY = 480)
     {
         var objects = new TestObjects();
 
@@ -41,53 +44,69 @@ internal class UITests : InputTestFixture
         uiModule.sendEventsWhenInBackground = true;
         objects.uiModule = uiModule;
         objects.eventSystem.UpdateModules();
-        objects.eventSystem.InvokeUpdate(); // Initial update only sets current module.
 
-        // Set up camera and canvas on which we can perform raycasts.
-        var cameraObject = new GameObject("Camera");
-        var camera = cameraObject.AddComponent<Camera>();
-        camera.stereoTargetEye = StereoTargetEyeMask.None;
-        camera.pixelRect = new Rect(0, 0, 640, 480);
+        var cameraObject = GameObject.Find("Camera");
+        Camera camera;
+        if (cameraObject == null)
+        {
+            // Set up camera and canvas on which we can perform raycasts.
+            cameraObject = new GameObject("Camera");
+            camera = cameraObject.AddComponent<Camera>();
+            camera.stereoTargetEye = StereoTargetEyeMask.None;
+            camera.pixelRect = new Rect(0, 0, 640, 480);
+        }
+        else
+            camera = cameraObject.GetComponent<Camera>();
 
-        var canvasObject = new GameObject("Canvas");
-        var canvas = canvasObject.AddComponent<Canvas>();
-        canvas.renderMode = RenderMode.ScreenSpaceCamera;
-        canvasObject.AddComponent<GraphicRaycaster>();
-        canvasObject.AddComponent<TrackedDeviceRaycaster>();
-        canvas.worldCamera = camera;
+        var canvasObject = GameObject.Find("Canvas");
+        if (canvasObject == null)
+        {
+            canvasObject = new GameObject("Canvas");
+            var canvas = canvasObject.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceCamera;
+            canvasObject.AddComponent<GraphicRaycaster>();
+            canvasObject.AddComponent<TrackedDeviceRaycaster>();
+            canvas.worldCamera = camera;
+        }
 
         // Set up a GameObject hierarchy that we send events to. In a real setup,
         // this would be a hierarchy involving UI components.
         var parentGameObject = new GameObject("Parent");
         var parentTransform = parentGameObject.AddComponent<RectTransform>();
+        objects.parentTransform = parentTransform;
         parentGameObject.AddComponent<UICallbackReceiver>();
 
         var leftChildGameObject = new GameObject("Left Child");
         var leftChildTransform = leftChildGameObject.AddComponent<RectTransform>();
         leftChildGameObject.AddComponent<Image>();
-        leftChildGameObject.AddComponent<UICallbackReceiver>();
+        objects.leftChildReceiver = leftChildGameObject.AddComponent<UICallbackReceiver>();
         objects.leftGameObject = leftChildGameObject;
 
         var rightChildGameObject = new GameObject("Right Child");
         var rightChildTransform = rightChildGameObject.AddComponent<RectTransform>();
         rightChildGameObject.AddComponent<Image>();
-        rightChildGameObject.AddComponent<UICallbackReceiver>();
+        objects.rightChildReceiver = rightChildGameObject.AddComponent<UICallbackReceiver>();
         objects.rightGameObject = rightChildGameObject;
 
-        parentTransform.SetParent(canvas.transform, worldPositionStays: false);
+        parentTransform.SetParent(canvasObject.transform, worldPositionStays: false);
         leftChildTransform.SetParent(parentTransform, worldPositionStays: false);
         rightChildTransform.SetParent(parentTransform, worldPositionStays: false);
 
         // Parent occupies full space of canvas.
-        parentTransform.sizeDelta = new Vector2(640, 480);
+        parentTransform.sizeDelta = new Vector2(640, maxY - minY);
+        parentTransform.anchoredPosition = new Vector2(0, (maxY + minY) / 2 - 240);
 
         // Left child occupies left half of parent.
-        leftChildTransform.anchoredPosition = new Vector2(-(640 / 4), 0);
-        leftChildTransform.sizeDelta = new Vector2(320, 480);
+        leftChildTransform.anchoredPosition = new Vector2(-(640 / 4), 0); //(maxY + minY)/2 - 240);
+        leftChildTransform.sizeDelta = new Vector2(320, maxY - minY);
 
         // Right child occupies right half of parent.
-        rightChildTransform.anchoredPosition = new Vector2(640 / 4, 0);
-        rightChildTransform.sizeDelta = new Vector2(320, 480);
+        rightChildTransform.anchoredPosition = new Vector2(640 / 4, 0); //(maxY + minY) / 2 - 240);
+        rightChildTransform.sizeDelta = new Vector2(320, maxY - minY);
+
+        objects.eventSystem.playerRootTransform = parentTransform;
+        objects.eventSystem.firstSelectedGameObject = leftChildGameObject;
+        objects.eventSystem.InvokeUpdate(); // Initial update only sets current module.
 
         return objects;
     }
@@ -135,6 +154,9 @@ internal class UITests : InputTestFixture
 
         // We need to wait a frame to let the underlying canvas update and properly order the graphics images for raycasting.
         yield return null;
+
+        // Reset initial selection
+        leftChildReceiver.Reset();
 
         // Move mouse over left child.
         InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(100, 100) });
@@ -221,6 +243,194 @@ internal class UITests : InputTestFixture
         Assert.That(rightChildReceiver.events, Has.Count.EqualTo(1));
         Assert.That(rightChildReceiver.events[0].type, Is.EqualTo(EventType.Scroll));
         rightChildReceiver.Reset();
+    }
+
+    [UnityTest]
+    [Category("Actions")]
+    // Check that two players can have separate UI, and that both selections will stay active when clicking on UI with the mouse,
+    // using MultiPlayerEventSystem.playerRootTransform to match UI to the players.
+    public IEnumerator MouseActions_MultiplayerEventSystemKeepsPerPlayerSelection()
+    {
+        // Create devices.
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        var players = new[] { CreateScene(0, 240), CreateScene(240, 480) };
+
+        // Create actions.
+        var map = new InputActionMap();
+        var pointAction = map.AddAction("point");
+        var leftClickAction = map.AddAction("leftClick");
+        var rightClickAction = map.AddAction("rightClick");
+        var middleClickAction = map.AddAction("middleClick");
+        var scrollAction = map.AddAction("scroll");
+
+        // Create bindings.
+        pointAction.AddBinding(mouse.position);
+        leftClickAction.AddBinding(mouse.leftButton);
+        rightClickAction.AddBinding(mouse.rightButton);
+        middleClickAction.AddBinding(mouse.middleButton);
+        scrollAction.AddBinding(mouse.scroll);
+
+        // Wire up actions.
+        // NOTE: In a normal usage scenario, the user would wire these up in the inspector.
+        foreach (var player in players)
+        {
+            player.uiModule.point = new InputActionProperty(pointAction);
+            player.uiModule.leftClick = new InputActionProperty(leftClickAction);
+            player.uiModule.middleClick = new InputActionProperty(middleClickAction);
+            player.uiModule.rightClick = new InputActionProperty(rightClickAction);
+            player.uiModule.scrollWheel = new InputActionProperty(scrollAction);
+            player.eventSystem.SetSelectedGameObject(null);
+        }
+
+        // Enable the whole thing.
+        map.Enable();
+
+        // We need to wait a frame to let the underlying canvas update and properly order the graphics images for raycasting.
+        yield return null;
+
+        // Click left gameObject of player 0
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(100, 100), buttons = 1 << (int)MouseButton.Left });
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(100, 100), buttons = 0 });
+        InputSystem.Update();
+
+        foreach (var player in players)
+            player.eventSystem.InvokeUpdate();
+
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].leftGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.Null);
+
+        // Click right gameObject of player 1
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(400, 300), buttons = 1 << (int)MouseButton.Left });
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(400, 300), buttons = 0 });
+
+        InputSystem.Update();
+
+        foreach (var player in players)
+            player.eventSystem.InvokeUpdate();
+
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].leftGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].rightGameObject));
+
+        // Click right gameObject of player 0
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(400, 100), buttons = 1 << (int)MouseButton.Left });
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(400, 100), buttons = 0 });
+        InputSystem.Update();
+
+        foreach (var player in players)
+            player.eventSystem.InvokeUpdate();
+
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].rightGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].rightGameObject));
+    }
+
+    [UnityTest]
+    [Category("Actions")]
+    // Check that two players can have separate UI and control it using separate gamepads, using MultiplayerEventSystem.
+    public IEnumerator JoystickActions_MultiplayerEventSystemKeepsPerPlayerSelection()
+    {
+        // Create devices.
+        var gamepads = new[] { InputSystem.AddDevice<Gamepad>(), InputSystem.AddDevice<Gamepad>() };
+        var players = new[] { CreateScene(0, 240), CreateScene(240, 480) };
+
+        for (var i = 0; i < 2; i++)
+        {
+            var map = new InputActionMap();
+            var moveAction = map.AddAction("move");
+            var submitAction = map.AddAction("submit");
+            var cancelAction = map.AddAction("cancel");
+
+            // Create bindings.
+            moveAction.AddBinding(gamepads[i].leftStick);
+            submitAction.AddBinding(gamepads[i].buttonSouth);
+            cancelAction.AddBinding(gamepads[i].buttonEast);
+
+            // Wire up actions.
+            players[i].uiModule.move = new InputActionProperty(moveAction);
+            players[i].uiModule.submit = new InputActionProperty(submitAction);
+            players[i].uiModule.cancel = new InputActionProperty(cancelAction);
+
+            players[i].leftChildReceiver.moveTo = players[i].rightGameObject;
+            players[i].rightChildReceiver.moveTo = players[i].leftGameObject;
+
+            // Enable the whole thing.
+            map.Enable();
+        }
+
+        // We need to wait a frame to let the underlying canvas update and properly order the graphics images for raycasting.
+        yield return null;
+
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].leftGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].leftGameObject));
+
+        // Reset initial selection
+        players[0].leftChildReceiver.Reset();
+        players[1].leftChildReceiver.Reset();
+
+        // Check Player 0 Move Axes
+        InputSystem.QueueDeltaStateEvent(gamepads[0].leftStick, new Vector2(1.0f, 0.0f));
+        InputSystem.Update();
+
+        foreach (var player in players)
+        {
+            Assert.That(player.leftChildReceiver.events, Has.Count.EqualTo(0));
+            Assert.That(player.rightChildReceiver.events, Has.Count.EqualTo(0));
+            player.eventSystem.InvokeUpdate();
+        }
+
+        Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.EqualTo(players[0].rightGameObject));
+        Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.EqualTo(players[1].leftGameObject));
+
+        Assert.That(players[0].leftChildReceiver.events, Has.Count.EqualTo(2));
+        Assert.That(players[0].leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
+        Assert.That(players[0].leftChildReceiver.events[1].type, Is.EqualTo(EventType.Deselect));
+        players[0].leftChildReceiver.Reset();
+
+        Assert.That(players[0].rightChildReceiver.events, Has.Count.EqualTo(1));
+        Assert.That(players[0].rightChildReceiver.events[0].type, Is.EqualTo(EventType.Select));
+        players[0].rightChildReceiver.Reset();
+
+        foreach (var player in players)
+        {
+            Assert.That(player.leftChildReceiver.events, Has.Count.EqualTo(0));
+            Assert.That(player.rightChildReceiver.events, Has.Count.EqualTo(0));
+            player.eventSystem.InvokeUpdate();
+        }
+
+        // Check Player 0 Submit
+        InputSystem.QueueStateEvent(gamepads[0], new GamepadState { buttons = 1 << (int)GamepadButton.South });
+        InputSystem.Update();
+
+        foreach (var player in players)
+        {
+            Assert.That(player.leftChildReceiver.events, Has.Count.EqualTo(0));
+            Assert.That(player.rightChildReceiver.events, Has.Count.EqualTo(0));
+            player.eventSystem.InvokeUpdate();
+        }
+
+        Assert.That(players[0].rightChildReceiver.events, Has.Count.EqualTo(1));
+        Assert.That(players[0].rightChildReceiver.events[0].type, Is.EqualTo(EventType.Submit));
+        players[0].rightChildReceiver.Reset();
+
+        // Check Player 1 Submit
+        InputSystem.QueueStateEvent(gamepads[1], new GamepadState { buttons = 1 << (int)GamepadButton.South });
+        InputSystem.Update();
+
+        foreach (var player in players)
+        {
+            Assert.That(player.leftChildReceiver.events, Has.Count.EqualTo(0));
+            Assert.That(player.rightChildReceiver.events, Has.Count.EqualTo(0));
+            player.eventSystem.InvokeUpdate();
+        }
+        Assert.That(players[1].leftChildReceiver.events, Has.Count.EqualTo(1));
+        Assert.That(players[1].leftChildReceiver.events[0].type, Is.EqualTo(EventType.Submit));
+        players[1].leftChildReceiver.Reset();
+
+        foreach (var player in players)
+        {
+            Assert.That(player.leftChildReceiver.events, Has.Count.EqualTo(0));
+            Assert.That(player.rightChildReceiver.events, Has.Count.EqualTo(0));
+        }
     }
 
     [UnityTest]
@@ -545,6 +755,9 @@ internal class UITests : InputTestFixture
         // We need to wait a frame to let the underlying canvas update and properly order the graphics images for raycasting.
         yield return null;
 
+        // Reset initial selection
+        leftChildReceiver.Reset();
+
         // Move mouse over left child.
         InputSystem.QueueDeltaStateEvent(touchDevice.touch, new TouchState { position = new Vector2(0, 0), phase = PointerPhase.Began });
         InputSystem.QueueDeltaStateEvent(touchDevice.touch, new TouchState { position = new Vector2(100, 100), phase = PointerPhase.Moved });
@@ -603,13 +816,15 @@ internal class UITests : InputTestFixture
         InputSystem.Update();
         eventSystem.InvokeUpdate();
 
-        Assert.That(leftChildReceiver.events, Has.Count.EqualTo(0));
+        Assert.That(leftChildReceiver.events, Has.Count.EqualTo(1));
+        Assert.That(leftChildReceiver.events[0].type, Is.EqualTo(EventType.Deselect));
         leftChildReceiver.Reset();
-        Assert.That(rightChildReceiver.events, Has.Count.EqualTo(4));
+        Assert.That(rightChildReceiver.events, Has.Count.EqualTo(5));
         Assert.That(rightChildReceiver.events[0].type, Is.EqualTo(EventType.Down));
         Assert.That(rightChildReceiver.events[1].type, Is.EqualTo(EventType.PotentialDrag));
         Assert.That(rightChildReceiver.events[2].type, Is.EqualTo(EventType.Up));
         Assert.That(rightChildReceiver.events[3].type, Is.EqualTo(EventType.Click));
+        Assert.That(rightChildReceiver.events[4].type, Is.EqualTo(EventType.Select));
     }
 
     [Test]
@@ -688,6 +903,7 @@ internal class UITests : InputTestFixture
         }
 
         public List<Event> events = new List<Event>();
+        public GameObject moveTo;
 
         public void Reset()
         {
@@ -697,6 +913,7 @@ internal class UITests : InputTestFixture
         public void OnPointerClick(PointerEventData eventData)
         {
             events.Add(new Event(EventType.Click, ClonePointerEventData(eventData)));
+            EventSystem.current.SetSelectedGameObject(gameObject, eventData);
         }
 
         public void OnPointerDown(PointerEventData eventData)
@@ -722,6 +939,8 @@ internal class UITests : InputTestFixture
         public void OnMove(AxisEventData eventData)
         {
             events.Add(new Event(EventType.Move, CloneAxisEventData(eventData)));
+            if (moveTo != null)
+                EventSystem.current.SetSelectedGameObject(moveTo, eventData);
         }
 
         public void OnSubmit(BaseEventData eventData)
@@ -809,11 +1028,10 @@ internal class UITests : InputTestFixture
         }
     }
 
-    private class TestEventSystem : EventSystem
+    private class TestEventSystem : MultiplayerEventSystem
     {
         public void InvokeUpdate()
         {
-            current = this; // Needs to be current to be allowed to update.
             Update();
         }
     }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.3-preview] - TBD
 
+### Added
+
+- Added a `MultiplayerEventSystem` class, which allows you use multiple UI event systems to control different parts of the UI by different players.
+
+
 ### Changed
 
 - `StickControl.x` and `StickControl.y` are now deadzoned, i.e. have `AxisDeadzone` processors on them. This affects all gamepads and joysticks.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -1,16 +1,34 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 
-public class MultiplayerEventSystem : EventSystem
+namespace UnityEngine.Experimental.Input.Plugins.UI
 {
-    [Tooltip("If set, only process mouse events for any game objects which are children of this game object.")]
-    public GameObject playerRoot;
-
-    protected override void Update()
+    /// <summary>
+    /// A modified EventSystem class, which allows multiple players to have their own instances of a UI,
+    /// each with it's own selection.
+    /// </summary>
+    /// <remarks>
+    /// You can use the `playerRoot` property on MultiPlayerEventSystem to specify a part of the hierarchy belonging to the current player.
+    /// Mouse selection will ignore any game objects not within this hierarchy. For gamepad/keyboard selection, you need to make sure that
+    /// the navigation links stay within the player's hierarchy.
+    /// </remarks>
+    public class MultiplayerEventSystem : EventSystem
     {
-        EventSystem originalCurrent = EventSystem.current;
-        current = this; // in order to avoid reimplementing half of the EventSystem class, just temporarily assign this EventSystem to be the globally current one
-        base.Update();
-        current = originalCurrent;
+        [Tooltip("If set, only process mouse events for any game objects which are children of this game object.")]
+        public GameObject playerRoot;
+
+        protected override void Update()
+        {
+            EventSystem originalCurrent = EventSystem.current;
+            current = this; // in order to avoid reimplementing half of the EventSystem class, just temporarily assign this EventSystem to be the globally current one
+            try
+            {
+                base.Update();
+            }
+            finally
+            {
+                current = originalCurrent;
+            }
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class MultiplayerEventSystem : EventSystem
+{
+    [Tooltip("If set, only process mouse events for any game objects which are children of this transform.")]
+    public Transform playerRootTransform;
+
+    protected override void Update()
+    {
+        EventSystem originalCurrent = EventSystem.current;
+        current = this; // in order to avoid reimplementing half of the EventSystem class, just temporarily assign this EventSystem to be the globally current one
+        base.Update();
+        current = originalCurrent;
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -3,8 +3,8 @@ using UnityEngine.EventSystems;
 
 public class MultiplayerEventSystem : EventSystem
 {
-    [Tooltip("If set, only process mouse events for any game objects which are children of this transform.")]
-    public Transform playerRootTransform;
+    [Tooltip("If set, only process mouse events for any game objects which are children of this game object.")]
+    public GameObject playerRoot;
 
     protected override void Update()
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b16c6f78230fa4964a222622d8aae332
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
@@ -106,8 +106,8 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
             {
                 var mes = eventSystem as MultiplayerEventSystem;
 
-                if (mes.playerRootTransform != null)
-                    if (!t.IsChildOf(mes.playerRootTransform))
+                if (mes.playerRoot != null)
+                    if (!t.IsChildOf(mes.playerRoot.transform))
                         return true;
             }
             return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
@@ -106,7 +106,7 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
             {
                 var mes = eventSystem as MultiplayerEventSystem;
 
-                if (mes.playerRootCanvas != null)
+                if (mes.playerRootTransform != null)
                     if (!t.IsChildOf(mes.playerRootTransform))
                         return true;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
@@ -16,6 +16,17 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
     /// </remarks>
     public abstract class UIInputModule : BaseInputModule
     {
+        public override void ActivateModule()
+        {
+            base.ActivateModule();
+
+            var toSelect = eventSystem.currentSelectedGameObject;
+            if (toSelect == null)
+                toSelect = eventSystem.firstSelectedGameObject;
+
+            eventSystem.SetSelectedGameObject(toSelect, GetBaseEventData());
+        }
+
         private RaycastResult PerformRaycast(PointerEventData eventData)
         {
             if (eventData == null)
@@ -87,6 +98,21 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
             mouseState.OnFrameFinished();
         }
 
+        // if we are using a MultiplayerEventSystem, ignore any transforms
+        // not under the current MultiplayerEventSystem's root.
+        private bool MouseShouldIgnoreTransform(Transform t)
+        {
+            if (eventSystem is MultiplayerEventSystem)
+            {
+                var mes = eventSystem as MultiplayerEventSystem;
+
+                if (mes.playerRootCanvas != null)
+                    if (!t.IsChildOf(mes.playerRootTransform))
+                        return true;
+            }
+            return false;
+        }
+
         private void ProcessMouseMovement(PointerEventData eventData)
         {
             var currentPointerTarget = eventData.pointerCurrentRaycast.gameObject;
@@ -137,7 +163,7 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
             {
                 var t = currentPointerTarget.transform;
 
-                while (t != null && t.gameObject != commonRoot)
+                while (t != null && t.gameObject != commonRoot && !MouseShouldIgnoreTransform(t))
                 {
                     ExecuteEvents.Execute(t.gameObject, eventData, ExecuteEvents.pointerEnterHandler);
 
@@ -151,6 +177,9 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
         private void ProcessMouseButton(ButtonDeltaState mouseButtonChanges, PointerEventData eventData)
         {
             var currentOverGo = eventData.pointerCurrentRaycast.gameObject;
+
+            if (currentOverGo != null && MouseShouldIgnoreTransform(currentOverGo.transform))
+                return;
 
             if ((mouseButtonChanges & ButtonDeltaState.Pressed) != 0)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
@@ -100,7 +100,7 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
 
         // if we are using a MultiplayerEventSystem, ignore any transforms
         // not under the current MultiplayerEventSystem's root.
-        private bool MouseShouldIgnoreTransform(Transform t)
+        private bool PointerShouldIgnoreTransform(Transform t)
         {
             if (eventSystem is MultiplayerEventSystem)
             {
@@ -163,7 +163,7 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
             {
                 var t = currentPointerTarget.transform;
 
-                while (t != null && t.gameObject != commonRoot && !MouseShouldIgnoreTransform(t))
+                while (t != null && t.gameObject != commonRoot && !PointerShouldIgnoreTransform(t))
                 {
                     ExecuteEvents.Execute(t.gameObject, eventData, ExecuteEvents.pointerEnterHandler);
 
@@ -178,7 +178,7 @@ namespace UnityEngine.Experimental.Input.Plugins.UI
         {
             var currentOverGo = eventData.pointerCurrentRaycast.gameObject;
 
-            if (currentOverGo != null && MouseShouldIgnoreTransform(currentOverGo.transform))
+            if (currentOverGo != null && PointerShouldIgnoreTransform(currentOverGo.transform))
                 return;
 
             if ((mouseButtonChanges & ButtonDeltaState.Pressed) != 0)


### PR DESCRIPTION
Added a `MultiplayerEventSystem` class, which allows you use multiple UI event systems to control different parts of the UI by different players. That way, each player can keep separate selections and state.

You can use the `playerRoot` property on MultiPlayerEventSystem to specify a part of the hierarchy belonging to this player. Mouse selection will ignore any game objects not within this hierarchy. For gamepad/keyboard selection, you need to make sure that the navigation links stay within the player's hierarchy.

Q: `playerRoot` is implemented by our input module, and will not work with e.g.  StandaloneInputModule. So it might be more logical to have this property on UIInputModule and not on the MultiplayerEventSystem. *But*: this is very similar to (and related to) EventSystem.firstSelected, which also needs to be implemented by the input modules (it actually did not work with `UIInputModule`, which this PR also fixes). So I figured it would be more consistent to have both on the EventSystem. Any opinions on this?
