### PR TITLE
Add pragmas to suppress obsolete warnings for when we will add obsole…

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -4,6 +4,10 @@ using UnityEngine.InputSystem.Utilities;
 using UnityEngineInternal.Input;
 
 ////REVIEW: can we get rid of the timestamp offsetting in the player and leave that complication for the editor only?
+#if !UNITY_2019_2
+// NativeInputEventType/NativeInputEvent are marked obsolete in 19.1, because they are becoming internal in 19.2
+#pragma warning disable 618
+#endif
 
 namespace UnityEngine.InputSystem.LowLevel
 {

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -8,6 +8,10 @@ using UnityEditor;
 
 // This should be the only file referencing the API at UnityEngineInternal.Input.
 
+#if !UNITY_2019_2
+// The NativeInputSystem APIs are marked obsolete in 19.1, because they are becoming internal in 19.2
+#pragma warning disable 618
+#endif
 namespace UnityEngine.InputSystem.LowLevel
 {
     /// <summary>


### PR DESCRIPTION
…te attributes to the native APIs in 19.1

We are making the native input APIs internal in 19.2, and marking them obsolete in 19.1, to warn anyone who might be using it. To avoid obsolete warnings when using the input system package in 19.1, we are suppressing these warnings.