### PR TITLE
Add explicit dependencies to ugui, now that it is a package

### DIFF
--- a/Assets/Demo/Demo.asmdef
+++ b/Assets/Demo/Demo.asmdef
@@ -3,7 +3,8 @@
     "references": [
         "Unity.InputSystem",
         "Unity.TextMeshPro",
-        "Steamworks.NET"
+        "Steamworks.NET",
+        "Unity.ugui"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/Assets/Tests/DemoTests.asmdef
+++ b/Assets/Tests/DemoTests.asmdef
@@ -3,7 +3,8 @@
     "references": [
         "Demo",
         "Unity.InputSystem",
-        "Unity.InputSystem.TestFramework"
+        "Unity.InputSystem.TestFramework",
+        "Unity.ugui"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -2,7 +2,8 @@
     "name": "Unity.InputSystem.Tests",
     "references": [
         "Unity.InputSystem",
-        "Unity.InputSystem.TestFramework"
+        "Unity.InputSystem.TestFramework",
+        "Unity.ugui"
     ],
     "optionalUnityReferences": [
         "TestAssemblies"

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Adding devices to "Supported Devices" in input preferences not allowing to select certain device types (like "Gamepad").
 - Fixed scrolling in `UIActionInputModule`.
+- Fixed compiling the input system package in Unity 19.2 with ugui being moved to a package now.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -1,6 +1,7 @@
 {
     "name": "Unity.InputSystem",
-    "references": [    	
+    "references": [
+		"Unity.ugui"    	
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -19,5 +19,7 @@
 		"vr",
 		"xr"
 	],
-	"dependencies": {}
+	"dependencies": {
+		"com.unity.ugui": "1.0.0"
+	}
 }


### PR DESCRIPTION
Unity 19.2 is changing UGUI to become a package. That means that we now need to explicitly reference it. They have been foresighted enough to add an empty stub ugui package to 19.1, so this should not be a backwards-compatibility problem for us.

The question is if we should try to do without the hard-coded dependency on the ugui package, so you could use input without dragging UI into your project (which itself will drag more things into the project), which is relevant for making small mobile or web games. I believe we can do that using the "conditional version define" feature in asmdef files, where we could add a define to be set for our code if the ugui package is present, and we could thus conditionally not compile any parts of our code base depending on ugui if it is not used in the project.

The question is, do we want to that? It should not be too hard to set it up, but:
- Some functionality in the input system (on screen buttons and sticks) depend on ugui. So you would  lose this functionality if you don't add ugui to your project, which might be confusing.
- UGUI use is scattered around our project enough that it seems likely we'd break the conditional compilation at some point if we don't specifically test this setup. Guess we'd ideally need some setup in our CI to test with and without ugui. This would be some work.

So, with those open questions, I decided to keep it simple first, and keep this in mind as an optional next step. Thoughts?