### PR TITLE
More const name fixes

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -95,7 +95,7 @@ partial class APIVerificationTests
         var incorrectlyNamedConstants = GetInputSystemPublicFields().Where(field => field.IsInitOnly && field.IsStatic && !IsValidNameForConstant(field.Name));
         Assert.That(incorrectlyNamedConstants, Is.Empty);
     }
-    
+
     [Test]
     [Category("API")]
     public void API_EnumValuesAreAppropriatelyNamed()

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -95,8 +95,15 @@ partial class APIVerificationTests
         var incorrectlyNamedConstants = GetInputSystemPublicFields().Where(field => field.IsInitOnly && field.IsStatic && !IsValidNameForConstant(field.Name));
         Assert.That(incorrectlyNamedConstants, Is.Empty);
     }
-
     
+    [Test]
+    [Category("API")]
+    public void API_EnumValuesAreAppropriatelyNamed()
+    {
+        var incorrectlyNamedConstants = GetInputSystemPublicTypes().Where(t => t.IsEnum).SelectMany(t => t.Fields).Where(f => f.IsStatic && !IsValidNameForConstant(f.Name));
+        Assert.That(incorrectlyNamedConstants, Is.Empty);
+    }
+
     [Test]
     [Category("API")]
     public void API_TypesHaveAnAppropriateNamespace()

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -84,11 +84,19 @@ partial class APIVerificationTests
     [Category("API")]
     public void API_ConstantsAreAppropriatelyNamed()
     {
-        // TODO: also check for static readonly types
         var incorrectlyNamedConstants = GetInputSystemPublicFields().Where(field => field.HasConstant && !IsValidNameForConstant(field.Name));
         Assert.That(incorrectlyNamedConstants, Is.Empty);
     }
 
+    [Test]
+    [Category("API")]
+    public void API_StaticReadonlyFieldsAreAppropriatelyNamed()
+    {
+        var incorrectlyNamedConstants = GetInputSystemPublicFields().Where(field => field.IsInitOnly && field.IsStatic && !IsValidNameForConstant(field.Name));
+        Assert.That(incorrectlyNamedConstants, Is.Empty);
+    }
+
+    
     [Test]
     [Category("API")]
     public void API_TypesHaveAnAppropriateNamespace()

--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -164,7 +164,7 @@ partial class CoreTests
         var setup = new InputDeviceBuilder("MyDevice");
         var device = (Gamepad)setup.Finish();
 
-        Assert.That(device.leftStick.x.stateBlock.format, Is.EqualTo(InputStateBlock.TypeByte));
+        Assert.That(device.leftStick.x.stateBlock.format, Is.EqualTo(InputStateBlock.FormatByte));
     }
 
     [Test]
@@ -1126,10 +1126,10 @@ partial class CoreTests
         InputSystem.RegisterLayout<DeviceWithStateStructWithPrimitiveFields>("Test");
         var setup = new InputDeviceBuilder("Test");
 
-        Assert.That(setup.GetControl("byteAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeByte));
-        Assert.That(setup.GetControl("shortAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeShort));
-        Assert.That(setup.GetControl("intAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
-        Assert.That(setup.GetControl("doubleAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeDouble));
+        Assert.That(setup.GetControl("byteAxis").stateBlock.format, Is.EqualTo(InputStateBlock.FormatByte));
+        Assert.That(setup.GetControl("shortAxis").stateBlock.format, Is.EqualTo(InputStateBlock.FormatShort));
+        Assert.That(setup.GetControl("intAxis").stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
+        Assert.That(setup.GetControl("doubleAxis").stateBlock.format, Is.EqualTo(InputStateBlock.FormatDouble));
     }
 
     private unsafe struct StateWithFixedArray : IInputStateTypeInfo
@@ -1403,7 +1403,7 @@ partial class CoreTests
         var derivedLayout = InputSystem.LoadLayout<DerivedClassModifyingControlFromBaseClass>();
 
         Assert.That(baseLayout["controlFromBase"].format, Is.EqualTo(new FourCC())); // Unset in base.
-        Assert.That(derivedLayout["controlFromBase"].format, Is.EqualTo(InputStateBlock.TypeShort));
+        Assert.That(derivedLayout["controlFromBase"].format, Is.EqualTo(InputStateBlock.FormatShort));
 
         // This is probably somewhat counterintuitive but if there's InputControlAttributes on a property or field,
         // there won't be a control generated automatically from the field or property.

--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -164,7 +164,7 @@ partial class CoreTests
         var setup = new InputDeviceBuilder("MyDevice");
         var device = (Gamepad)setup.Finish();
 
-        Assert.That(device.leftStick.x.stateBlock.format, Is.EqualTo(InputStateBlock.kTypeByte));
+        Assert.That(device.leftStick.x.stateBlock.format, Is.EqualTo(InputStateBlock.TypeByte));
     }
 
     [Test]
@@ -1126,10 +1126,10 @@ partial class CoreTests
         InputSystem.RegisterLayout<DeviceWithStateStructWithPrimitiveFields>("Test");
         var setup = new InputDeviceBuilder("Test");
 
-        Assert.That(setup.GetControl("byteAxis").stateBlock.format, Is.EqualTo(InputStateBlock.kTypeByte));
-        Assert.That(setup.GetControl("shortAxis").stateBlock.format, Is.EqualTo(InputStateBlock.kTypeShort));
-        Assert.That(setup.GetControl("intAxis").stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
-        Assert.That(setup.GetControl("doubleAxis").stateBlock.format, Is.EqualTo(InputStateBlock.kTypeDouble));
+        Assert.That(setup.GetControl("byteAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeByte));
+        Assert.That(setup.GetControl("shortAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeShort));
+        Assert.That(setup.GetControl("intAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(setup.GetControl("doubleAxis").stateBlock.format, Is.EqualTo(InputStateBlock.TypeDouble));
     }
 
     private unsafe struct StateWithFixedArray : IInputStateTypeInfo
@@ -1403,7 +1403,7 @@ partial class CoreTests
         var derivedLayout = InputSystem.LoadLayout<DerivedClassModifyingControlFromBaseClass>();
 
         Assert.That(baseLayout["controlFromBase"].format, Is.EqualTo(new FourCC())); // Unset in base.
-        Assert.That(derivedLayout["controlFromBase"].format, Is.EqualTo(InputStateBlock.kTypeShort));
+        Assert.That(derivedLayout["controlFromBase"].format, Is.EqualTo(InputStateBlock.TypeShort));
 
         // This is probably somewhat counterintuitive but if there's InputControlAttributes on a property or field,
         // there won't be a control generated automatically from the field or property.

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -291,7 +291,7 @@ partial class CoreTests
         var setup = new InputDeviceBuilder("CustomGamepad");
         var device = (Gamepad)setup.Finish();
 
-        Assert.That(device.rightTrigger.stateBlock.format, Is.EqualTo(InputStateBlock.kTypeShort));
+        Assert.That(device.rightTrigger.stateBlock.format, Is.EqualTo(InputStateBlock.TypeShort));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -291,7 +291,7 @@ partial class CoreTests
         var setup = new InputDeviceBuilder("CustomGamepad");
         var device = (Gamepad)setup.Finish();
 
-        Assert.That(device.rightTrigger.stateBlock.format, Is.EqualTo(InputStateBlock.TypeShort));
+        Assert.That(device.rightTrigger.stateBlock.format, Is.EqualTo(InputStateBlock.FormatShort));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -38,18 +38,18 @@ internal class LinuxTests : InputTestFixture
         Assert.That(joystick["Base5"], Is.TypeOf<ButtonControl>());
         Assert.That(joystick["Base6"], Is.TypeOf<ButtonControl>());
 
-        Assert.That(joystick["Trigger"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Thumb"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Thumb2"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Top"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Top2"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Pinkie"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Base"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Base2"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Base3"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Base4"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Base5"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
-        Assert.That(joystick["Base6"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Trigger"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Thumb"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Thumb2"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Top"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Top2"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Pinkie"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Base"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Base2"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Base3"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Base4"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Base5"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
+        Assert.That(joystick["Base6"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatBit));
 
         Assert.That(joystick["Trigger"].stateBlock.byteOffset, Is.EqualTo(0));
         Assert.That(joystick["Thumb"].stateBlock.byteOffset, Is.EqualTo(0));
@@ -94,8 +94,8 @@ internal class LinuxTests : InputTestFixture
         Assert.That(joystick["Stick"], Is.TypeOf<StickControl>());
         Assert.That(joystick["Stick"].stateBlock.byteOffset, Is.EqualTo(4));
         Assert.That(joystick["Stick"].stateBlock.sizeInBits, Is.EqualTo(64));
-        Assert.That(joystick["Stick/x"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
-        Assert.That(joystick["Stick/y"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Stick/x"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
+        Assert.That(joystick["Stick/y"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
         Assert.That(joystick["Stick/x"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Stick/y"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Stick/x"].stateBlock.byteOffset, Is.EqualTo(4)); // Parent offset baked in.
@@ -103,11 +103,11 @@ internal class LinuxTests : InputTestFixture
 
         // Axes.
         Assert.That(joystick["RotateZ"], Is.TypeOf<AxisControl>());
-        Assert.That(joystick["RotateZ"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["RotateZ"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
         Assert.That(joystick["RotateZ"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["RotateZ"].stateBlock.byteOffset, Is.EqualTo(12));
         Assert.That(joystick["Throttle"], Is.TypeOf<AxisControl>());
-        Assert.That(joystick["Throttle"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Throttle"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
         Assert.That(joystick["Throttle"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Throttle"].stateBlock.byteOffset, Is.EqualTo(16));
 
@@ -115,10 +115,10 @@ internal class LinuxTests : InputTestFixture
         Assert.That(joystick["Hat"], Is.TypeOf<DpadControl>());
         Assert.That(joystick["Hat"].stateBlock.byteOffset, Is.EqualTo(20));
         Assert.That(joystick["Hat"].stateBlock.sizeInBits, Is.EqualTo(64));
-        Assert.That(joystick["Hat/up"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
-        Assert.That(joystick["Hat/down"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
-        Assert.That(joystick["Hat/left"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
-        Assert.That(joystick["Hat/right"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Hat/up"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
+        Assert.That(joystick["Hat/down"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
+        Assert.That(joystick["Hat/left"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
+        Assert.That(joystick["Hat/right"].stateBlock.format, Is.EqualTo(InputStateBlock.FormatInt));
         Assert.That(joystick["Hat/up"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Hat/down"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Hat/left"].stateBlock.sizeInBits, Is.EqualTo(32));

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -38,18 +38,18 @@ internal class LinuxTests : InputTestFixture
         Assert.That(joystick["Base5"], Is.TypeOf<ButtonControl>());
         Assert.That(joystick["Base6"], Is.TypeOf<ButtonControl>());
 
-        Assert.That(joystick["Trigger"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Thumb"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Thumb2"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Top"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Top2"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Pinkie"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Base"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Base2"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Base3"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Base4"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Base5"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
-        Assert.That(joystick["Base6"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeBit));
+        Assert.That(joystick["Trigger"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Thumb"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Thumb2"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Top"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Top2"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Pinkie"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Base"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Base2"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Base3"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Base4"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Base5"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
+        Assert.That(joystick["Base6"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeBit));
 
         Assert.That(joystick["Trigger"].stateBlock.byteOffset, Is.EqualTo(0));
         Assert.That(joystick["Thumb"].stateBlock.byteOffset, Is.EqualTo(0));
@@ -94,8 +94,8 @@ internal class LinuxTests : InputTestFixture
         Assert.That(joystick["Stick"], Is.TypeOf<StickControl>());
         Assert.That(joystick["Stick"].stateBlock.byteOffset, Is.EqualTo(4));
         Assert.That(joystick["Stick"].stateBlock.sizeInBits, Is.EqualTo(64));
-        Assert.That(joystick["Stick/x"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
-        Assert.That(joystick["Stick/y"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Stick/x"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Stick/y"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
         Assert.That(joystick["Stick/x"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Stick/y"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Stick/x"].stateBlock.byteOffset, Is.EqualTo(4)); // Parent offset baked in.
@@ -103,11 +103,11 @@ internal class LinuxTests : InputTestFixture
 
         // Axes.
         Assert.That(joystick["RotateZ"], Is.TypeOf<AxisControl>());
-        Assert.That(joystick["RotateZ"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["RotateZ"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
         Assert.That(joystick["RotateZ"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["RotateZ"].stateBlock.byteOffset, Is.EqualTo(12));
         Assert.That(joystick["Throttle"], Is.TypeOf<AxisControl>());
-        Assert.That(joystick["Throttle"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Throttle"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
         Assert.That(joystick["Throttle"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Throttle"].stateBlock.byteOffset, Is.EqualTo(16));
 
@@ -115,10 +115,10 @@ internal class LinuxTests : InputTestFixture
         Assert.That(joystick["Hat"], Is.TypeOf<DpadControl>());
         Assert.That(joystick["Hat"].stateBlock.byteOffset, Is.EqualTo(20));
         Assert.That(joystick["Hat"].stateBlock.sizeInBits, Is.EqualTo(64));
-        Assert.That(joystick["Hat/up"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
-        Assert.That(joystick["Hat/down"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
-        Assert.That(joystick["Hat/left"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
-        Assert.That(joystick["Hat/right"].stateBlock.format, Is.EqualTo(InputStateBlock.kTypeInt));
+        Assert.That(joystick["Hat/up"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Hat/down"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Hat/left"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
+        Assert.That(joystick["Hat/right"].stateBlock.format, Is.EqualTo(InputStateBlock.TypeInt));
         Assert.That(joystick["Hat/up"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Hat/down"].stateBlock.sizeInBits, Is.EqualTo(32));
         Assert.That(joystick["Hat/left"].stateBlock.sizeInBits, Is.EqualTo(32));

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AnyKeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AnyKeyControl.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.Controls
         public AnyKeyControl()
         {
             m_StateBlock.sizeInBits = 1; // Should be overridden by whoever uses the control.
-            m_StateBlock.format = InputStateBlock.kTypeBit;
+            m_StateBlock.format = InputStateBlock.TypeBit;
         }
 
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AnyKeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AnyKeyControl.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.Controls
         public AnyKeyControl()
         {
             m_StateBlock.sizeInBits = 1; // Should be overridden by whoever uses the control.
-            m_StateBlock.format = InputStateBlock.TypeBit;
+            m_StateBlock.format = InputStateBlock.FormatBit;
         }
 
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public AxisControl()
         {
-            m_StateBlock.format = InputStateBlock.TypeFloat;
+            m_StateBlock.format = InputStateBlock.FormatFloat;
         }
 
         // Read a floating-point value from the given state. Automatically checks

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public AxisControl()
         {
-            m_StateBlock.format = InputStateBlock.kTypeFloat;
+            m_StateBlock.format = InputStateBlock.TypeFloat;
         }
 
         // Read a floating-point value from the given state. Automatically checks

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public ButtonControl()
         {
-            m_StateBlock.format = InputStateBlock.TypeBit;
+            m_StateBlock.format = InputStateBlock.FormatBit;
             m_MinValue = 0f;
             m_MaxValue = 1f;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public ButtonControl()
         {
-            m_StateBlock.format = InputStateBlock.kTypeBit;
+            m_StateBlock.format = InputStateBlock.TypeBit;
             m_MinValue = 0f;
             m_MaxValue = 1f;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -75,7 +75,7 @@ namespace UnityEngine.InputSystem.Controls
         public DpadControl()
         {
             m_StateBlock.sizeInBits = 4;
-            m_StateBlock.format = InputStateBlock.TypeBit;
+            m_StateBlock.format = InputStateBlock.FormatBit;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -75,7 +75,7 @@ namespace UnityEngine.InputSystem.Controls
         public DpadControl()
         {
             m_StateBlock.sizeInBits = 4;
-            m_StateBlock.format = InputStateBlock.kTypeBit;
+            m_StateBlock.format = InputStateBlock.TypeBit;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/IntegerControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/IntegerControl.cs
@@ -9,7 +9,7 @@ namespace UnityEngine.InputSystem.Controls
     {
         public IntegerControl()
         {
-            m_StateBlock.format = InputStateBlock.TypeInt;
+            m_StateBlock.format = InputStateBlock.FormatInt;
         }
 
         public override unsafe int ReadUnprocessedValueFromState(void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/IntegerControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/IntegerControl.cs
@@ -9,7 +9,7 @@ namespace UnityEngine.InputSystem.Controls
     {
         public IntegerControl()
         {
-            m_StateBlock.format = InputStateBlock.kTypeInt;
+            m_StateBlock.format = InputStateBlock.TypeInt;
         }
 
         public override unsafe int ReadUnprocessedValueFromState(void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/PointerPhaseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/PointerPhaseControl.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.InputSystem.Controls
     {
         public PointerPhaseControl()
         {
-            m_StateBlock.format = InputStateBlock.TypeInt;
+            m_StateBlock.format = InputStateBlock.FormatInt;
         }
 
         public override unsafe PointerPhase ReadUnprocessedValueFromState(void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/PointerPhaseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/PointerPhaseControl.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.InputSystem.Controls
     {
         public PointerPhaseControl()
         {
-            m_StateBlock.format = InputStateBlock.kTypeInt;
+            m_StateBlock.format = InputStateBlock.TypeInt;
         }
 
         public override unsafe PointerPhase ReadUnprocessedValueFromState(void* statePtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
@@ -21,7 +21,7 @@ namespace UnityEngine.InputSystem.Controls
         public QuaternionControl()
         {
             m_StateBlock.sizeInBits = sizeof(float) * 4 * 8;
-            m_StateBlock.format = InputStateBlock.TypeQuaternion;
+            m_StateBlock.format = InputStateBlock.FormatQuaternion;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
@@ -21,7 +21,7 @@ namespace UnityEngine.InputSystem.Controls
         public QuaternionControl()
         {
             m_StateBlock.sizeInBits = sizeof(float) * 4 * 8;
-            m_StateBlock.format = InputStateBlock.kTypeQuaternion;
+            m_StateBlock.format = InputStateBlock.TypeQuaternion;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
@@ -34,7 +34,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public Vector2Control()
         {
-            m_StateBlock.format = InputStateBlock.kTypeVector2;
+            m_StateBlock.format = InputStateBlock.TypeVector2;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
@@ -34,7 +34,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public Vector2Control()
         {
-            m_StateBlock.format = InputStateBlock.TypeVector2;
+            m_StateBlock.format = InputStateBlock.FormatVector2;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
@@ -18,7 +18,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public Vector3Control()
         {
-            m_StateBlock.format = InputStateBlock.kTypeVector3;
+            m_StateBlock.format = InputStateBlock.TypeVector3;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
@@ -18,7 +18,7 @@ namespace UnityEngine.InputSystem.Controls
 
         public Vector3Control()
         {
-            m_StateBlock.format = InputStateBlock.TypeVector3;
+            m_StateBlock.format = InputStateBlock.FormatVector3;
         }
 
         protected override void FinishSetup(InputDeviceBuilder builder)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputControlTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputControlTreeView.cs
@@ -321,7 +321,7 @@ namespace UnityEngine.InputSystem.Editor
                 var format = control.m_StateBlock.format;
 
                 object value = null;
-                if (format == InputStateBlock.TypeBit)
+                if (format == InputStateBlock.FormatBit)
                 {
                     if (control.valueSizeInBytes == 1)
                     {
@@ -332,7 +332,7 @@ namespace UnityEngine.InputSystem.Editor
                         value = MemoryHelpers.ReadIntFromMultipleBits(ptr, control.m_StateBlock.bitOffset, control.m_StateBlock.sizeInBits);
                     }
                 }
-                else if (format == InputStateBlock.TypeSBit)
+                else if (format == InputStateBlock.FormatSBit)
                 {
                     if (control.valueSizeInBytes == 1)
                     {
@@ -345,31 +345,31 @@ namespace UnityEngine.InputSystem.Editor
                         value = fullValue - halfMaxValue;
                     }
                 }
-                else if (format == InputStateBlock.TypeByte || format == InputStateBlock.TypeSByte)
+                else if (format == InputStateBlock.FormatByte || format == InputStateBlock.FormatSByte)
                 {
                     value = *ptr;
                 }
-                else if (format == InputStateBlock.TypeShort)
+                else if (format == InputStateBlock.FormatShort)
                 {
                     value = *(short*)ptr;
                 }
-                else if (format == InputStateBlock.TypeUShort)
+                else if (format == InputStateBlock.FormatUShort)
                 {
                     value = *(ushort*)ptr;
                 }
-                else if (format == InputStateBlock.TypeInt)
+                else if (format == InputStateBlock.FormatInt)
                 {
                     value = *(int*)ptr;
                 }
-                else if (format == InputStateBlock.TypeUInt)
+                else if (format == InputStateBlock.FormatUInt)
                 {
                     value = *(uint*)ptr;
                 }
-                else if (format == InputStateBlock.TypeFloat)
+                else if (format == InputStateBlock.FormatFloat)
                 {
                     value = *(float*)ptr;
                 }
-                else if (format == InputStateBlock.TypeDouble)
+                else if (format == InputStateBlock.FormatDouble)
                 {
                     value = *(double*)ptr;
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputControlTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputControlTreeView.cs
@@ -321,7 +321,7 @@ namespace UnityEngine.InputSystem.Editor
                 var format = control.m_StateBlock.format;
 
                 object value = null;
-                if (format == InputStateBlock.kTypeBit)
+                if (format == InputStateBlock.TypeBit)
                 {
                     if (control.valueSizeInBytes == 1)
                     {
@@ -332,7 +332,7 @@ namespace UnityEngine.InputSystem.Editor
                         value = MemoryHelpers.ReadIntFromMultipleBits(ptr, control.m_StateBlock.bitOffset, control.m_StateBlock.sizeInBits);
                     }
                 }
-                else if (format == InputStateBlock.kTypeSBit)
+                else if (format == InputStateBlock.TypeSBit)
                 {
                     if (control.valueSizeInBytes == 1)
                     {
@@ -345,31 +345,31 @@ namespace UnityEngine.InputSystem.Editor
                         value = fullValue - halfMaxValue;
                     }
                 }
-                else if (format == InputStateBlock.kTypeByte || format == InputStateBlock.kTypeSByte)
+                else if (format == InputStateBlock.TypeByte || format == InputStateBlock.TypeSByte)
                 {
                     value = *ptr;
                 }
-                else if (format == InputStateBlock.kTypeShort)
+                else if (format == InputStateBlock.TypeShort)
                 {
                     value = *(short*)ptr;
                 }
-                else if (format == InputStateBlock.kTypeUShort)
+                else if (format == InputStateBlock.TypeUShort)
                 {
                     value = *(ushort*)ptr;
                 }
-                else if (format == InputStateBlock.kTypeInt)
+                else if (format == InputStateBlock.TypeInt)
                 {
                     value = *(int*)ptr;
                 }
-                else if (format == InputStateBlock.kTypeUInt)
+                else if (format == InputStateBlock.TypeUInt)
                 {
                     value = *(uint*)ptr;
                 }
-                else if (format == InputStateBlock.kTypeFloat)
+                else if (format == InputStateBlock.TypeFloat)
                 {
                     value = *(float*)ptr;
                 }
-                else if (format == InputStateBlock.kTypeDouble)
+                else if (format == InputStateBlock.TypeDouble)
                 {
                     value = *(double*)ptr;
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -371,41 +371,41 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithUsages(new InternedString[] { CommonUsages.Primary2DMotion });
 
                     builder.AddControl(stickName + "/x")
-                        .WithFormat(InputStateBlock.kTypeSBit)
+                        .WithFormat(InputStateBlock.TypeSBit)
                         .WithLayout("Axis")
                         .WithBitOffset(0)
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/y")
-                        .WithFormat(InputStateBlock.kTypeSBit)
+                        .WithFormat(InputStateBlock.TypeSBit)
                         .WithLayout("Axis")
                         .WithBitOffset((uint)(yElement.reportOffsetInBits - xElement.reportOffsetInBits))
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     //Need to handle Up/Down/Left/Right
                     builder.AddControl(stickName + "/up")
-                        .WithFormat(InputStateBlock.kTypeSBit)
+                        .WithFormat(InputStateBlock.TypeSBit)
                         .WithLayout("Button")
                         .WithParameters("clampMin=0,clampMax=1")
                         .WithBitOffset((uint)(yElement.reportOffsetInBits - xElement.reportOffsetInBits))
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/down")
-                        .WithFormat(InputStateBlock.kTypeSBit)
+                        .WithFormat(InputStateBlock.TypeSBit)
                         .WithLayout("Button")
                         .WithParameters("clamp,clampMin=-1,clampMax=0,invert")
                         .WithBitOffset((uint)(yElement.reportOffsetInBits - xElement.reportOffsetInBits))
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/left")
-                        .WithFormat(InputStateBlock.kTypeSBit)
+                        .WithFormat(InputStateBlock.TypeSBit)
                         .WithLayout("Button")
                         .WithParameters("clamp,clampMin=-1,clampMax=0,invert")
                         .WithBitOffset(0)
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/right")
-                        .WithFormat(InputStateBlock.kTypeSBit)
+                        .WithFormat(InputStateBlock.TypeSBit)
                         .WithLayout("Button")
                         .WithParameters("clampMin=0,clampMax=1")
                         .WithBitOffset(0)
@@ -678,19 +678,19 @@ namespace UnityEngine.InputSystem.Plugins.HID
                 {
                     case 8:
                         if (isSigned)
-                            return InputStateBlock.kTypeSByte;
-                        return InputStateBlock.kTypeByte;
+                            return InputStateBlock.TypeSByte;
+                        return InputStateBlock.TypeByte;
                     case 16:
                         if (isSigned)
-                            return InputStateBlock.kTypeShort;
-                        return InputStateBlock.kTypeUShort;
+                            return InputStateBlock.TypeShort;
+                        return InputStateBlock.TypeUShort;
                     case 32:
                         if (isSigned)
-                            return InputStateBlock.kTypeInt;
-                        return InputStateBlock.kTypeUInt;
+                            return InputStateBlock.TypeInt;
+                        return InputStateBlock.TypeUInt;
                     default:
                         // Generic bitfield value.
-                        return InputStateBlock.kTypeBit;
+                        return InputStateBlock.TypeBit;
                 }
             }
 
@@ -794,7 +794,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                     ////REVIEW: this probably only works with hatswitches that have their null value at logicalMax+1
 
                     builder.AddControl(controlName + "/up")
-                        .WithFormat(InputStateBlock.kTypeBit)
+                        .WithFormat(InputStateBlock.TypeBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1},nullValue={2},wrapAtValue={3}",
@@ -803,7 +803,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithSizeInBits((uint)reportSizeInBits);
 
                     builder.AddControl(controlName + "/right")
-                        .WithFormat(InputStateBlock.kTypeBit)
+                        .WithFormat(InputStateBlock.TypeBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1}",
@@ -812,7 +812,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithSizeInBits((uint)reportSizeInBits);
 
                     builder.AddControl(controlName + "/down")
-                        .WithFormat(InputStateBlock.kTypeBit)
+                        .WithFormat(InputStateBlock.TypeBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1}",
@@ -821,7 +821,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithSizeInBits((uint)reportSizeInBits);
 
                     builder.AddControl(controlName + "/left")
-                        .WithFormat(InputStateBlock.kTypeBit)
+                        .WithFormat(InputStateBlock.TypeBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1}",

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -371,41 +371,41 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithUsages(new InternedString[] { CommonUsages.Primary2DMotion });
 
                     builder.AddControl(stickName + "/x")
-                        .WithFormat(InputStateBlock.TypeSBit)
+                        .WithFormat(InputStateBlock.FormatSBit)
                         .WithLayout("Axis")
                         .WithBitOffset(0)
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/y")
-                        .WithFormat(InputStateBlock.TypeSBit)
+                        .WithFormat(InputStateBlock.FormatSBit)
                         .WithLayout("Axis")
                         .WithBitOffset((uint)(yElement.reportOffsetInBits - xElement.reportOffsetInBits))
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     //Need to handle Up/Down/Left/Right
                     builder.AddControl(stickName + "/up")
-                        .WithFormat(InputStateBlock.TypeSBit)
+                        .WithFormat(InputStateBlock.FormatSBit)
                         .WithLayout("Button")
                         .WithParameters("clampMin=0,clampMax=1")
                         .WithBitOffset((uint)(yElement.reportOffsetInBits - xElement.reportOffsetInBits))
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/down")
-                        .WithFormat(InputStateBlock.TypeSBit)
+                        .WithFormat(InputStateBlock.FormatSBit)
                         .WithLayout("Button")
                         .WithParameters("clamp,clampMin=-1,clampMax=0,invert")
                         .WithBitOffset((uint)(yElement.reportOffsetInBits - xElement.reportOffsetInBits))
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/left")
-                        .WithFormat(InputStateBlock.TypeSBit)
+                        .WithFormat(InputStateBlock.FormatSBit)
                         .WithLayout("Button")
                         .WithParameters("clamp,clampMin=-1,clampMax=0,invert")
                         .WithBitOffset(0)
                         .WithSizeInBits((uint)xElement.reportSizeInBits);
 
                     builder.AddControl(stickName + "/right")
-                        .WithFormat(InputStateBlock.TypeSBit)
+                        .WithFormat(InputStateBlock.FormatSBit)
                         .WithLayout("Button")
                         .WithParameters("clampMin=0,clampMax=1")
                         .WithBitOffset(0)
@@ -678,19 +678,19 @@ namespace UnityEngine.InputSystem.Plugins.HID
                 {
                     case 8:
                         if (isSigned)
-                            return InputStateBlock.TypeSByte;
-                        return InputStateBlock.TypeByte;
+                            return InputStateBlock.FormatSByte;
+                        return InputStateBlock.FormatByte;
                     case 16:
                         if (isSigned)
-                            return InputStateBlock.TypeShort;
-                        return InputStateBlock.TypeUShort;
+                            return InputStateBlock.FormatShort;
+                        return InputStateBlock.FormatUShort;
                     case 32:
                         if (isSigned)
-                            return InputStateBlock.TypeInt;
-                        return InputStateBlock.TypeUInt;
+                            return InputStateBlock.FormatInt;
+                        return InputStateBlock.FormatUInt;
                     default:
                         // Generic bitfield value.
-                        return InputStateBlock.TypeBit;
+                        return InputStateBlock.FormatBit;
                 }
             }
 
@@ -794,7 +794,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                     ////REVIEW: this probably only works with hatswitches that have their null value at logicalMax+1
 
                     builder.AddControl(controlName + "/up")
-                        .WithFormat(InputStateBlock.TypeBit)
+                        .WithFormat(InputStateBlock.FormatBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1},nullValue={2},wrapAtValue={3}",
@@ -803,7 +803,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithSizeInBits((uint)reportSizeInBits);
 
                     builder.AddControl(controlName + "/right")
-                        .WithFormat(InputStateBlock.TypeBit)
+                        .WithFormat(InputStateBlock.FormatBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1}",
@@ -812,7 +812,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithSizeInBits((uint)reportSizeInBits);
 
                     builder.AddControl(controlName + "/down")
-                        .WithFormat(InputStateBlock.TypeBit)
+                        .WithFormat(InputStateBlock.FormatBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1}",
@@ -821,7 +821,7 @@ namespace UnityEngine.InputSystem.Plugins.HID
                         .WithSizeInBits((uint)reportSizeInBits);
 
                     builder.AddControl(controlName + "/left")
-                        .WithFormat(InputStateBlock.TypeBit)
+                        .WithFormat(InputStateBlock.FormatBit)
                         .WithLayout("DiscreteButton")
                         .WithParameters(string.Format(CultureInfo.InvariantCulture,
                             "minValue={0},maxValue={1}",

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/SDLDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/SDLDeviceBuilder.cs
@@ -88,42 +88,42 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                 .WithUsages(CommonUsages.Primary2DMotion);
 
             builder.AddControl(stickName + "/x")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Axis")
                 .WithByteOffset(0)
                 .WithSizeInBits((uint)xFeature.size * 8)
                 .WithParameters("clamp,clampMin=-1,clampMax=1,scale,scaleFactor=65538");
 
             builder.AddControl(stickName + "/y")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Axis")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)xFeature.size * 8)
                 .WithParameters("clamp,clampMin=-1,clampMax=1,scale,scaleFactor=65538,invert");
 
             builder.AddControl(stickName + "/up")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=-1,clampMax=0,scale,scaleFactor=65538,invert")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(stickName + "/down")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=0,clampMax=1,scale,scaleFactor=65538,invert=false")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(stickName + "/left")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=-1,clampMax=0,scale,scaleFactor=65538,invert")
                 .WithByteOffset(0)
                 .WithSizeInBits((uint)xFeature.size * 8);
 
             builder.AddControl(stickName + "/right")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=0,clampMax=1,scale,scaleFactor=65538")
                 .WithByteOffset(0)
@@ -168,28 +168,28 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                 .WithUsages(CommonUsages.Hatswitch);
 
             builder.AddControl(hatName + "/up")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=-1,clampMax=0,invert")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(hatName + "/down")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=0,clampMax=1")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(hatName + "/left")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=-1,clampMax=0,invert")
                 .WithByteOffset(0)
                 .WithSizeInBits((uint)xFeature.size * 8);
 
             builder.AddControl(hatName + "/right")
-                .WithFormat(InputStateBlock.TypeInt)
+                .WithFormat(InputStateBlock.FormatInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=0,clampMax=1")
                 .WithByteOffset(0)
@@ -233,7 +233,7 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                         var control = builder.AddControl(featureName)
                             .WithLayout("Analog")
                             .WithByteOffset((uint)feature.offset)
-                            .WithFormat(InputStateBlock.TypeInt)
+                            .WithFormat(InputStateBlock.FormatInt)
                             .WithParameters(parameters);
 
                         if (IsAxis(feature, SDLAxisUsage.RotateZ))
@@ -257,7 +257,7 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                                 .WithLayout("Button")
                                 .WithByteOffset((uint)feature.offset)
                                 .WithBitOffset((uint)feature.bit)
-                                .WithFormat(InputStateBlock.TypeBit);
+                                .WithFormat(InputStateBlock.FormatBit);
                         }
                         break;
                     }
@@ -285,7 +285,7 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                         builder.AddControl(featureName)
                             .WithLayout("Analog")
                             .WithByteOffset((uint)feature.offset)
-                            .WithFormat(InputStateBlock.TypeInt)
+                            .WithFormat(InputStateBlock.FormatInt)
                             .WithParameters(parameters);
                         break;
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/SDLDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/SDLDeviceBuilder.cs
@@ -88,42 +88,42 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                 .WithUsages(CommonUsages.Primary2DMotion);
 
             builder.AddControl(stickName + "/x")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Axis")
                 .WithByteOffset(0)
                 .WithSizeInBits((uint)xFeature.size * 8)
                 .WithParameters("clamp,clampMin=-1,clampMax=1,scale,scaleFactor=65538");
 
             builder.AddControl(stickName + "/y")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Axis")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)xFeature.size * 8)
                 .WithParameters("clamp,clampMin=-1,clampMax=1,scale,scaleFactor=65538,invert");
 
             builder.AddControl(stickName + "/up")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=-1,clampMax=0,scale,scaleFactor=65538,invert")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(stickName + "/down")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=0,clampMax=1,scale,scaleFactor=65538,invert=false")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(stickName + "/left")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=-1,clampMax=0,scale,scaleFactor=65538,invert")
                 .WithByteOffset(0)
                 .WithSizeInBits((uint)xFeature.size * 8);
 
             builder.AddControl(stickName + "/right")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("clamp,clampMin=0,clampMax=1,scale,scaleFactor=65538")
                 .WithByteOffset(0)
@@ -168,28 +168,28 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                 .WithUsages(CommonUsages.Hatswitch);
 
             builder.AddControl(hatName + "/up")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=-1,clampMax=0,invert")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(hatName + "/down")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=0,clampMax=1")
                 .WithByteOffset(4)
                 .WithSizeInBits((uint)yFeature.size * 8);
 
             builder.AddControl(hatName + "/left")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=-1,clampMax=0,invert")
                 .WithByteOffset(0)
                 .WithSizeInBits((uint)xFeature.size * 8);
 
             builder.AddControl(hatName + "/right")
-                .WithFormat(InputStateBlock.kTypeInt)
+                .WithFormat(InputStateBlock.TypeInt)
                 .WithLayout("Button")
                 .WithParameters("scale,scaleFactor=2147483647,clamp,clampMin=0,clampMax=1")
                 .WithByteOffset(0)
@@ -233,7 +233,7 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                         var control = builder.AddControl(featureName)
                             .WithLayout("Analog")
                             .WithByteOffset((uint)feature.offset)
-                            .WithFormat(InputStateBlock.kTypeInt)
+                            .WithFormat(InputStateBlock.TypeInt)
                             .WithParameters(parameters);
 
                         if (IsAxis(feature, SDLAxisUsage.RotateZ))
@@ -257,7 +257,7 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                                 .WithLayout("Button")
                                 .WithByteOffset((uint)feature.offset)
                                 .WithBitOffset((uint)feature.bit)
-                                .WithFormat(InputStateBlock.kTypeBit);
+                                .WithFormat(InputStateBlock.TypeBit);
                         }
                         break;
                     }
@@ -285,7 +285,7 @@ namespace UnityEngine.InputSystem.Plugins.Linux
                         builder.AddControl(featureName)
                             .WithLayout("Analog")
                             .WithByteOffset((uint)feature.offset)
-                            .WithFormat(InputStateBlock.kTypeInt)
+                            .WithFormat(InputStateBlock.TypeInt)
                             .WithParameters(parameters);
                         break;
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRTemplateBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRTemplateBuilder.cs
@@ -188,7 +188,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Button")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.TypeBit)
+                            .WithFormat(InputStateBlock.FormatBit)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -197,7 +197,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Integer")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.TypeInt)
+                            .WithFormat(InputStateBlock.FormatInt)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -206,7 +206,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Analog")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.TypeFloat)
+                            .WithFormat(InputStateBlock.FormatFloat)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -215,7 +215,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Vector2")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.TypeVector2)
+                            .WithFormat(InputStateBlock.FormatVector2)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -224,7 +224,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Vector3")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.TypeVector3)
+                            .WithFormat(InputStateBlock.FormatVector3)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -233,7 +233,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Quaternion")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.TypeQuaternion)
+                            .WithFormat(InputStateBlock.FormatQuaternion)
                             .WithUsages(currentUsages);
                         break;
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRTemplateBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRTemplateBuilder.cs
@@ -188,7 +188,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Button")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.kTypeBit)
+                            .WithFormat(InputStateBlock.TypeBit)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -197,7 +197,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Integer")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.kTypeInt)
+                            .WithFormat(InputStateBlock.TypeInt)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -206,7 +206,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Analog")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.kTypeFloat)
+                            .WithFormat(InputStateBlock.TypeFloat)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -215,7 +215,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Vector2")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.kTypeVector2)
+                            .WithFormat(InputStateBlock.TypeVector2)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -224,7 +224,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Vector3")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.kTypeVector3)
+                            .WithFormat(InputStateBlock.TypeVector3)
                             .WithUsages(currentUsages);
                         break;
                     }
@@ -233,7 +233,7 @@ namespace UnityEngine.InputSystem.Plugins.XR
                         builder.AddControl(featureName)
                             .WithLayout("Quaternion")
                             .WithByteOffset(currentOffset)
-                            .WithFormat(InputStateBlock.kTypeQuaternion)
+                            .WithFormat(InputStateBlock.TypeQuaternion)
                             .WithUsages(currentUsages);
                         break;
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem.LowLevel
     ///
     /// State memory is bit-addressable, meaning that it can be offset from a byte address in bits (<see cref="bitOffset"/>)
     /// and is sized in bits instead of bytes (<see cref="sizeInBits"/>). However, in practice, bit-addressing
-    /// memory reads and writes are only supported on the <see cref="kTypeBit">bitfield primitive format</see>.
+    /// memory reads and writes are only supported on the <see cref="TypeBit">bitfield primitive format</see>.
     ///
     /// Input state memory is restricted to a maximum of 4GB in size. Offsets are recorded in 32 bits.
     /// </remarks>
@@ -42,57 +42,57 @@ namespace UnityEngine.InputSystem.LowLevel
         public const uint AutomaticOffset = 0xfffffffe;
 
         // Primitive state type codes.
-        public static readonly FourCC kTypeBit = new FourCC('B', 'I', 'T');
-        public static readonly FourCC kTypeSBit = new FourCC('S', 'B', 'I', 'T');
-        public static readonly FourCC kTypeInt = new FourCC('I', 'N', 'T');
-        public static readonly FourCC kTypeUInt = new FourCC('U', 'I', 'N', 'T');
-        public static readonly FourCC kTypeShort = new FourCC('S', 'H', 'R', 'T');
-        public static readonly FourCC kTypeUShort = new FourCC('U', 'S', 'H', 'T');
-        public static readonly FourCC kTypeByte = new FourCC('B', 'Y', 'T', 'E');
-        public static readonly FourCC kTypeSByte = new FourCC('S', 'B', 'Y', 'T');
-        public static readonly FourCC kTypeLong = new FourCC('L', 'N', 'G');
-        public static readonly FourCC kTypeULong = new FourCC('U', 'L', 'N', 'G');
-        public static readonly FourCC kTypeFloat = new FourCC('F', 'L', 'T');
-        public static readonly FourCC kTypeDouble = new FourCC('D', 'B', 'L');
+        public static readonly FourCC TypeBit = new FourCC('B', 'I', 'T');
+        public static readonly FourCC TypeSBit = new FourCC('S', 'B', 'I', 'T');
+        public static readonly FourCC TypeInt = new FourCC('I', 'N', 'T');
+        public static readonly FourCC TypeUInt = new FourCC('U', 'I', 'N', 'T');
+        public static readonly FourCC TypeShort = new FourCC('S', 'H', 'R', 'T');
+        public static readonly FourCC TypeUShort = new FourCC('U', 'S', 'H', 'T');
+        public static readonly FourCC TypeByte = new FourCC('B', 'Y', 'T', 'E');
+        public static readonly FourCC TypeSByte = new FourCC('S', 'B', 'Y', 'T');
+        public static readonly FourCC TypeLong = new FourCC('L', 'N', 'G');
+        public static readonly FourCC TypeULong = new FourCC('U', 'L', 'N', 'G');
+        public static readonly FourCC TypeFloat = new FourCC('F', 'L', 'T');
+        public static readonly FourCC TypeDouble = new FourCC('D', 'B', 'L');
 
         ////REVIEW: are these really useful?
-        public static readonly FourCC kTypeVector2 = new FourCC('V', 'E', 'C', '2');
-        public static readonly FourCC kTypeVector3 = new FourCC('V', 'E', 'C', '3');
-        public static readonly FourCC kTypeQuaternion = new FourCC('Q', 'U', 'A', 'T');
-        public static readonly FourCC kTypeVector2Short = new FourCC('V', 'C', '2', 'S');
-        public static readonly FourCC kTypeVector3Short = new FourCC('V', 'C', '3', 'S');
-        public static readonly FourCC kTypeVector2Byte = new FourCC('V', 'C', '2', 'B');
-        public static readonly FourCC kTypeVector3Byte = new FourCC('V', 'C', '3', 'B');
+        public static readonly FourCC TypeVector2 = new FourCC('V', 'E', 'C', '2');
+        public static readonly FourCC TypeVector3 = new FourCC('V', 'E', 'C', '3');
+        public static readonly FourCC TypeQuaternion = new FourCC('Q', 'U', 'A', 'T');
+        public static readonly FourCC TypeVector2Short = new FourCC('V', 'C', '2', 'S');
+        public static readonly FourCC TypeVector3Short = new FourCC('V', 'C', '3', 'S');
+        public static readonly FourCC TypeVector2Byte = new FourCC('V', 'C', '2', 'B');
+        public static readonly FourCC TypeVector3Byte = new FourCC('V', 'C', '3', 'B');
 
         public static int GetSizeOfPrimitiveFormatInBits(FourCC type)
         {
-            if (type == kTypeBit || type == kTypeSBit)
+            if (type == TypeBit || type == TypeSBit)
                 return 1;
-            if (type == kTypeInt || type == kTypeUInt)
+            if (type == TypeInt || type == TypeUInt)
                 return 4 * 8;
-            if (type == kTypeShort || type == kTypeUShort)
+            if (type == TypeShort || type == TypeUShort)
                 return 2 * 8;
-            if (type == kTypeByte || type == kTypeSByte)
+            if (type == TypeByte || type == TypeSByte)
                 return 1 * 8;
-            if (type == kTypeFloat)
+            if (type == TypeFloat)
                 return 4 * 8;
-            if (type == kTypeDouble)
+            if (type == TypeDouble)
                 return 8 * 8;
-            if (type == kTypeLong || type == kTypeULong)
+            if (type == TypeLong || type == TypeULong)
                 return 8 * 8;
-            if (type == kTypeVector2)
+            if (type == TypeVector2)
                 return 2 * 4 * 8;
-            if (type == kTypeVector3)
+            if (type == TypeVector3)
                 return 3 * 4 * 8;
-            if (type == kTypeQuaternion)
+            if (type == TypeQuaternion)
                 return 4 * 4 * 8;
-            if (type == kTypeVector2Short)
+            if (type == TypeVector2Short)
                 return 2 * 2 * 8;
-            if (type == kTypeVector3Short)
+            if (type == TypeVector3Short)
                 return 3 * 2 * 8;
-            if (type == kTypeVector2Byte)
+            if (type == TypeVector2Byte)
                 return 2 * 1 * 8;
-            if (type == kTypeVector3Byte)
+            if (type == TypeVector3Byte)
                 return 3 * 1 * 8;
             return -1;
         }
@@ -100,31 +100,31 @@ namespace UnityEngine.InputSystem.LowLevel
         public static FourCC GetPrimitiveFormatFromType(Type type)
         {
             if (ReferenceEquals(type, typeof(int)))
-                return kTypeInt;
+                return TypeInt;
             if (ReferenceEquals(type, typeof(uint)))
-                return kTypeUInt;
+                return TypeUInt;
             if (ReferenceEquals(type, typeof(short)))
-                return kTypeShort;
+                return TypeShort;
             if (ReferenceEquals(type, typeof(ushort)))
-                return kTypeUShort;
+                return TypeUShort;
             if (ReferenceEquals(type, typeof(byte)))
-                return kTypeByte;
+                return TypeByte;
             if (ReferenceEquals(type, typeof(sbyte)))
-                return kTypeSByte;
+                return TypeSByte;
             if (ReferenceEquals(type, typeof(float)))
-                return kTypeFloat;
+                return TypeFloat;
             if (ReferenceEquals(type, typeof(double)))
-                return kTypeDouble;
+                return TypeDouble;
             if (ReferenceEquals(type, typeof(long)))
-                return kTypeLong;
+                return TypeLong;
             if (ReferenceEquals(type, typeof(ulong)))
-                return kTypeULong;
+                return TypeULong;
             if (ReferenceEquals(type, typeof(Vector2)))
-                return kTypeVector2;
+                return TypeVector2;
             if (ReferenceEquals(type, typeof(Vector3)))
-                return kTypeVector3;
+                return TypeVector3;
             if (ReferenceEquals(type, typeof(Quaternion)))
-                return kTypeQuaternion;
+                return TypeQuaternion;
             return new FourCC();
         }
 
@@ -165,20 +165,20 @@ namespace UnityEngine.InputSystem.LowLevel
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
             int value;
-            if (format == kTypeInt || format == kTypeUInt)
+            if (format == TypeInt || format == TypeUInt)
             {
                 Debug.Assert(sizeInBits == 32, "INT and UINT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "INT and UINT state must be byte-aligned");
                 value = *(int*)valuePtr;
             }
-            else if (format == kTypeBit)
+            else if (format == TypeBit)
             {
                 if (sizeInBits == 1)
                     value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1 : 0;
                 else
                     value = MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
             }
-            else if (format == kTypeSBit)
+            else if (format == TypeSBit)
             {
                 if (sizeInBits == 1)
                 {
@@ -191,25 +191,25 @@ namespace UnityEngine.InputSystem.LowLevel
                     value = unsignedValue - halfMax;
                 }
             }
-            else if (format == kTypeByte)
+            else if (format == TypeByte)
             {
                 Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
                 value = *valuePtr;
             }
-            else if (format == kTypeSByte)
+            else if (format == TypeSByte)
             {
                 Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
                 value = *(sbyte*)valuePtr;
             }
-            else if (format == kTypeShort)
+            else if (format == TypeShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
                 value = *(short*)valuePtr;
             }
-            else if (format == kTypeUShort)
+            else if (format == TypeUShort)
             {
                 Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
@@ -235,23 +235,23 @@ namespace UnityEngine.InputSystem.LowLevel
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
             float value;
-            if (format == kTypeFloat)
+            if (format == TypeFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");
                 value = *(float*)valuePtr;
             }
-            else if (format == kTypeBit || format == kTypeSBit)
+            else if (format == TypeBit || format == TypeSBit)
             {
                 if (sizeInBits == 1)
                 {
-                    value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1.0f : (format == kTypeSBit ? -1.0f : 0.0f);
+                    value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1.0f : (format == TypeSBit ? -1.0f : 0.0f);
                 }
                 else if (sizeInBits != 31)
                 {
                     var maxValue = (float)(1 << (int)sizeInBits);
                     var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
-                    if (format == kTypeSBit)
+                    if (format == TypeSBit)
                     {
                         var unclampedValue = (((rawValue / maxValue) * 2.0f) - 1.0f);
                         value = Mathf.Clamp(unclampedValue, -1.0f, 1.0f);
@@ -269,7 +269,7 @@ namespace UnityEngine.InputSystem.LowLevel
             // If a control with an integer-based representation does not use the full range
             // of its integer size (e.g. only goes from [0..128]), processors or the parameters
             // above have to be used to re-process the resulting float values.
-            else if (format == kTypeShort)
+            else if (format == TypeShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
@@ -277,32 +277,32 @@ namespace UnityEngine.InputSystem.LowLevel
                 ////        Should we cut off at -32767? Or just live with the fact that 0.999 is as high as it gets?
                 value = *(short*)valuePtr / 32768.0f;
             }
-            else if (format == kTypeUShort)
+            else if (format == TypeUShort)
             {
                 Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
                 value = *(ushort*)valuePtr / 65535.0f;
             }
-            else if (format == kTypeByte)
+            else if (format == TypeByte)
             {
                 Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
                 value = *valuePtr / 255.0f;
             }
-            else if (format == kTypeSByte)
+            else if (format == TypeSByte)
             {
                 Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
                 ////REVIEW: Same problem here as with 'short'
                 value = *(sbyte*)valuePtr / 128.0f;
             }
-            else if (format == kTypeInt)
+            else if (format == TypeInt)
             {
                 Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
                 value = *(Int32*)valuePtr / 2147483647.0f;
             }
-            else if (format == kTypeUInt)
+            else if (format == TypeUInt)
             {
                 Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
@@ -320,13 +320,13 @@ namespace UnityEngine.InputSystem.LowLevel
         {
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
-            if (format == kTypeFloat)
+            if (format == TypeFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");
                 *(float*)valuePtr = value;
             }
-            else if (format == kTypeBit)
+            else if (format == TypeBit)
             {
                 if (sizeInBits == 1)
                 {
@@ -339,25 +339,25 @@ namespace UnityEngine.InputSystem.LowLevel
                     MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, intValue);
                 }
             }
-            else if (format == kTypeShort)
+            else if (format == TypeShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
                 *(short*)valuePtr = (short)(value * 32768.0f);
             }
-            else if (format == kTypeUShort)
+            else if (format == TypeUShort)
             {
                 Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
                 *(ushort*)valuePtr = (ushort)(value * 65535.0f);
             }
-            else if (format == kTypeByte)
+            else if (format == TypeByte)
             {
                 Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
                 *valuePtr = (byte)(value * 255.0f);
             }
-            else if (format == kTypeSByte)
+            else if (format == TypeSByte)
             {
                 Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
@@ -378,7 +378,7 @@ namespace UnityEngine.InputSystem.LowLevel
         {
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
-            if (format == kTypeBit || format == kTypeSBit)
+            if (format == TypeBit || format == TypeSBit)
             {
                 if (sizeInBits > 32)
                     throw new NotImplementedException(
@@ -389,7 +389,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 else
                     MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value.ToInt32());
             }
-            else if (format == kTypeFloat)
+            else if (format == TypeFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem.LowLevel
     ///
     /// State memory is bit-addressable, meaning that it can be offset from a byte address in bits (<see cref="bitOffset"/>)
     /// and is sized in bits instead of bytes (<see cref="sizeInBits"/>). However, in practice, bit-addressing
-    /// memory reads and writes are only supported on the <see cref="TypeBit">bitfield primitive format</see>.
+    /// memory reads and writes are only supported on the <see cref="FormatBit">bitfield primitive format</see>.
     ///
     /// Input state memory is restricted to a maximum of 4GB in size. Offsets are recorded in 32 bits.
     /// </remarks>
@@ -42,57 +42,57 @@ namespace UnityEngine.InputSystem.LowLevel
         public const uint AutomaticOffset = 0xfffffffe;
 
         // Primitive state type codes.
-        public static readonly FourCC TypeBit = new FourCC('B', 'I', 'T');
-        public static readonly FourCC TypeSBit = new FourCC('S', 'B', 'I', 'T');
-        public static readonly FourCC TypeInt = new FourCC('I', 'N', 'T');
-        public static readonly FourCC TypeUInt = new FourCC('U', 'I', 'N', 'T');
-        public static readonly FourCC TypeShort = new FourCC('S', 'H', 'R', 'T');
-        public static readonly FourCC TypeUShort = new FourCC('U', 'S', 'H', 'T');
-        public static readonly FourCC TypeByte = new FourCC('B', 'Y', 'T', 'E');
-        public static readonly FourCC TypeSByte = new FourCC('S', 'B', 'Y', 'T');
-        public static readonly FourCC TypeLong = new FourCC('L', 'N', 'G');
-        public static readonly FourCC TypeULong = new FourCC('U', 'L', 'N', 'G');
-        public static readonly FourCC TypeFloat = new FourCC('F', 'L', 'T');
-        public static readonly FourCC TypeDouble = new FourCC('D', 'B', 'L');
+        public static readonly FourCC FormatBit = new FourCC('B', 'I', 'T');
+        public static readonly FourCC FormatSBit = new FourCC('S', 'B', 'I', 'T');
+        public static readonly FourCC FormatInt = new FourCC('I', 'N', 'T');
+        public static readonly FourCC FormatUInt = new FourCC('U', 'I', 'N', 'T');
+        public static readonly FourCC FormatShort = new FourCC('S', 'H', 'R', 'T');
+        public static readonly FourCC FormatUShort = new FourCC('U', 'S', 'H', 'T');
+        public static readonly FourCC FormatByte = new FourCC('B', 'Y', 'T', 'E');
+        public static readonly FourCC FormatSByte = new FourCC('S', 'B', 'Y', 'T');
+        public static readonly FourCC FormatLong = new FourCC('L', 'N', 'G');
+        public static readonly FourCC FormatULong = new FourCC('U', 'L', 'N', 'G');
+        public static readonly FourCC FormatFloat = new FourCC('F', 'L', 'T');
+        public static readonly FourCC FormatDouble = new FourCC('D', 'B', 'L');
 
         ////REVIEW: are these really useful?
-        public static readonly FourCC TypeVector2 = new FourCC('V', 'E', 'C', '2');
-        public static readonly FourCC TypeVector3 = new FourCC('V', 'E', 'C', '3');
-        public static readonly FourCC TypeQuaternion = new FourCC('Q', 'U', 'A', 'T');
-        public static readonly FourCC TypeVector2Short = new FourCC('V', 'C', '2', 'S');
-        public static readonly FourCC TypeVector3Short = new FourCC('V', 'C', '3', 'S');
-        public static readonly FourCC TypeVector2Byte = new FourCC('V', 'C', '2', 'B');
-        public static readonly FourCC TypeVector3Byte = new FourCC('V', 'C', '3', 'B');
+        public static readonly FourCC FormatVector2 = new FourCC('V', 'E', 'C', '2');
+        public static readonly FourCC FormatVector3 = new FourCC('V', 'E', 'C', '3');
+        public static readonly FourCC FormatQuaternion = new FourCC('Q', 'U', 'A', 'T');
+        public static readonly FourCC FormatVector2Short = new FourCC('V', 'C', '2', 'S');
+        public static readonly FourCC FormatVector3Short = new FourCC('V', 'C', '3', 'S');
+        public static readonly FourCC FormatVector2Byte = new FourCC('V', 'C', '2', 'B');
+        public static readonly FourCC FormatVector3Byte = new FourCC('V', 'C', '3', 'B');
 
         public static int GetSizeOfPrimitiveFormatInBits(FourCC type)
         {
-            if (type == TypeBit || type == TypeSBit)
+            if (type == FormatBit || type == FormatSBit)
                 return 1;
-            if (type == TypeInt || type == TypeUInt)
+            if (type == FormatInt || type == FormatUInt)
                 return 4 * 8;
-            if (type == TypeShort || type == TypeUShort)
+            if (type == FormatShort || type == FormatUShort)
                 return 2 * 8;
-            if (type == TypeByte || type == TypeSByte)
+            if (type == FormatByte || type == FormatSByte)
                 return 1 * 8;
-            if (type == TypeFloat)
+            if (type == FormatFloat)
                 return 4 * 8;
-            if (type == TypeDouble)
+            if (type == FormatDouble)
                 return 8 * 8;
-            if (type == TypeLong || type == TypeULong)
+            if (type == FormatLong || type == FormatULong)
                 return 8 * 8;
-            if (type == TypeVector2)
+            if (type == FormatVector2)
                 return 2 * 4 * 8;
-            if (type == TypeVector3)
+            if (type == FormatVector3)
                 return 3 * 4 * 8;
-            if (type == TypeQuaternion)
+            if (type == FormatQuaternion)
                 return 4 * 4 * 8;
-            if (type == TypeVector2Short)
+            if (type == FormatVector2Short)
                 return 2 * 2 * 8;
-            if (type == TypeVector3Short)
+            if (type == FormatVector3Short)
                 return 3 * 2 * 8;
-            if (type == TypeVector2Byte)
+            if (type == FormatVector2Byte)
                 return 2 * 1 * 8;
-            if (type == TypeVector3Byte)
+            if (type == FormatVector3Byte)
                 return 3 * 1 * 8;
             return -1;
         }
@@ -100,31 +100,31 @@ namespace UnityEngine.InputSystem.LowLevel
         public static FourCC GetPrimitiveFormatFromType(Type type)
         {
             if (ReferenceEquals(type, typeof(int)))
-                return TypeInt;
+                return FormatInt;
             if (ReferenceEquals(type, typeof(uint)))
-                return TypeUInt;
+                return FormatUInt;
             if (ReferenceEquals(type, typeof(short)))
-                return TypeShort;
+                return FormatShort;
             if (ReferenceEquals(type, typeof(ushort)))
-                return TypeUShort;
+                return FormatUShort;
             if (ReferenceEquals(type, typeof(byte)))
-                return TypeByte;
+                return FormatByte;
             if (ReferenceEquals(type, typeof(sbyte)))
-                return TypeSByte;
+                return FormatSByte;
             if (ReferenceEquals(type, typeof(float)))
-                return TypeFloat;
+                return FormatFloat;
             if (ReferenceEquals(type, typeof(double)))
-                return TypeDouble;
+                return FormatDouble;
             if (ReferenceEquals(type, typeof(long)))
-                return TypeLong;
+                return FormatLong;
             if (ReferenceEquals(type, typeof(ulong)))
-                return TypeULong;
+                return FormatULong;
             if (ReferenceEquals(type, typeof(Vector2)))
-                return TypeVector2;
+                return FormatVector2;
             if (ReferenceEquals(type, typeof(Vector3)))
-                return TypeVector3;
+                return FormatVector3;
             if (ReferenceEquals(type, typeof(Quaternion)))
-                return TypeQuaternion;
+                return FormatQuaternion;
             return new FourCC();
         }
 
@@ -165,20 +165,20 @@ namespace UnityEngine.InputSystem.LowLevel
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
             int value;
-            if (format == TypeInt || format == TypeUInt)
+            if (format == FormatInt || format == FormatUInt)
             {
                 Debug.Assert(sizeInBits == 32, "INT and UINT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "INT and UINT state must be byte-aligned");
                 value = *(int*)valuePtr;
             }
-            else if (format == TypeBit)
+            else if (format == FormatBit)
             {
                 if (sizeInBits == 1)
                     value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1 : 0;
                 else
                     value = MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
             }
-            else if (format == TypeSBit)
+            else if (format == FormatSBit)
             {
                 if (sizeInBits == 1)
                 {
@@ -191,25 +191,25 @@ namespace UnityEngine.InputSystem.LowLevel
                     value = unsignedValue - halfMax;
                 }
             }
-            else if (format == TypeByte)
+            else if (format == FormatByte)
             {
                 Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
                 value = *valuePtr;
             }
-            else if (format == TypeSByte)
+            else if (format == FormatSByte)
             {
                 Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
                 value = *(sbyte*)valuePtr;
             }
-            else if (format == TypeShort)
+            else if (format == FormatShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
                 value = *(short*)valuePtr;
             }
-            else if (format == TypeUShort)
+            else if (format == FormatUShort)
             {
                 Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
@@ -235,23 +235,23 @@ namespace UnityEngine.InputSystem.LowLevel
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
             float value;
-            if (format == TypeFloat)
+            if (format == FormatFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");
                 value = *(float*)valuePtr;
             }
-            else if (format == TypeBit || format == TypeSBit)
+            else if (format == FormatBit || format == FormatSBit)
             {
                 if (sizeInBits == 1)
                 {
-                    value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1.0f : (format == TypeSBit ? -1.0f : 0.0f);
+                    value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1.0f : (format == FormatSBit ? -1.0f : 0.0f);
                 }
                 else if (sizeInBits != 31)
                 {
                     var maxValue = (float)(1 << (int)sizeInBits);
                     var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
-                    if (format == TypeSBit)
+                    if (format == FormatSBit)
                     {
                         var unclampedValue = (((rawValue / maxValue) * 2.0f) - 1.0f);
                         value = Mathf.Clamp(unclampedValue, -1.0f, 1.0f);
@@ -269,7 +269,7 @@ namespace UnityEngine.InputSystem.LowLevel
             // If a control with an integer-based representation does not use the full range
             // of its integer size (e.g. only goes from [0..128]), processors or the parameters
             // above have to be used to re-process the resulting float values.
-            else if (format == TypeShort)
+            else if (format == FormatShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
@@ -277,32 +277,32 @@ namespace UnityEngine.InputSystem.LowLevel
                 ////        Should we cut off at -32767? Or just live with the fact that 0.999 is as high as it gets?
                 value = *(short*)valuePtr / 32768.0f;
             }
-            else if (format == TypeUShort)
+            else if (format == FormatUShort)
             {
                 Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
                 value = *(ushort*)valuePtr / 65535.0f;
             }
-            else if (format == TypeByte)
+            else if (format == FormatByte)
             {
                 Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
                 value = *valuePtr / 255.0f;
             }
-            else if (format == TypeSByte)
+            else if (format == FormatSByte)
             {
                 Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
                 ////REVIEW: Same problem here as with 'short'
                 value = *(sbyte*)valuePtr / 128.0f;
             }
-            else if (format == TypeInt)
+            else if (format == FormatInt)
             {
                 Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
                 value = *(Int32*)valuePtr / 2147483647.0f;
             }
-            else if (format == TypeUInt)
+            else if (format == FormatUInt)
             {
                 Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
@@ -320,13 +320,13 @@ namespace UnityEngine.InputSystem.LowLevel
         {
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
-            if (format == TypeFloat)
+            if (format == FormatFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");
                 *(float*)valuePtr = value;
             }
-            else if (format == TypeBit)
+            else if (format == FormatBit)
             {
                 if (sizeInBits == 1)
                 {
@@ -339,25 +339,25 @@ namespace UnityEngine.InputSystem.LowLevel
                     MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, intValue);
                 }
             }
-            else if (format == TypeShort)
+            else if (format == FormatShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
                 *(short*)valuePtr = (short)(value * 32768.0f);
             }
-            else if (format == TypeUShort)
+            else if (format == FormatUShort)
             {
                 Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                 Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
                 *(ushort*)valuePtr = (ushort)(value * 65535.0f);
             }
-            else if (format == TypeByte)
+            else if (format == FormatByte)
             {
                 Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
                 *valuePtr = (byte)(value * 255.0f);
             }
-            else if (format == TypeSByte)
+            else if (format == FormatSByte)
             {
                 Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                 Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
@@ -378,7 +378,7 @@ namespace UnityEngine.InputSystem.LowLevel
         {
             var valuePtr = (byte*)statePtr + (int)byteOffset;
 
-            if (format == TypeBit || format == TypeSBit)
+            if (format == FormatBit || format == FormatSBit)
             {
                 if (sizeInBits > 32)
                     throw new NotImplementedException(
@@ -389,7 +389,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 else
                     MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value.ToInt32());
             }
-            else if (format == TypeFloat)
+            else if (format == FormatFloat)
             {
                 Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
                 Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");


### PR DESCRIPTION
This prior PR updated the names of all `const` fields to match Unity conventions: https://github.com/Unity-Technologies/InputSystem/commit/3a3988db691ececdbc646a9ac269423bcc867df0

However, there are some types of constants which are not `const` fields, and were thus not caught by the API test:
-`static readonly` fields
-`enum` values

This PR adds tests for those cases, and renames the ones which did not match conventions (was only the case for some `static readonly` fields).