### PR TITLE
encapsulate MonoBehaviour fields in properties

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -15,7 +15,13 @@ namespace UnityEngine.InputSystem.Plugins.UI
     public class MultiplayerEventSystem : EventSystem
     {
         [Tooltip("If set, only process mouse events for any game objects which are children of this game object.")]
-        public GameObject playerRoot;
+        [SerializeField] private GameObject m_PlayerRoot;
+
+        public GameObject playerRoot
+        {
+            get => m_PlayerRoot;
+            set => m_PlayerRoot = value;
+        }
 
         protected override void Update()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
@@ -470,17 +470,37 @@ namespace UnityEngine.InputSystem.Plugins.UI
         }
 
         [Tooltip("The Initial delay (in seconds) between an initial move action and a repeated move action.")]
-        public float repeatDelay = 0.5f;
+        [SerializeField]
+        private float m_RepeatDelay = 0.5f;
 
         [Tooltip("The speed (in seconds) that the move action repeats itself once repeating.")]
-        public float repeatRate = 0.1f;
+        [SerializeField]
+        private float m_RepeatRate = 0.1f;
 
         [Tooltip("Scales the Eventsystem.DragThreshold, for tracked devices, to make selection easier.")]
-        [HideInInspector] // Hide this while we still have to figure out what to do with this.
-        public float trackedDeviceDragThresholdMultiplier = 2.0f;
+        // Hide this while we still have to figure out what to do with this.
+        private float m_TrackedDeviceDragThresholdMultiplier = 2.0f;
 
         private AxisEventData m_CachedAxisEvent;
         private PointerEventData m_CachedPointerEvent;
         private TrackedPointerEventData m_CachedTrackedPointerEventData;
+
+        public float repeatDelay
+        {
+            get { return m_RepeatDelay; }
+            set { m_RepeatDelay = value; }
+        }
+
+        public float repeatRate
+        {
+            get { return m_RepeatRate; }
+            set { m_RepeatRate = value; }
+        }
+
+        public float trackedDeviceDragThresholdMultiplier
+        {
+            get { return m_TrackedDeviceDragThresholdMultiplier; }
+            set { m_TrackedDeviceDragThresholdMultiplier = value; }
+        }
     }
 }


### PR DESCRIPTION
This PR reduces the fields we expose and replaces them with properties: https://github.com/Unity-Technologies/InputSystem/pull/595

In the discussion on that PR, I suggested to also convert to properties:
1. MonoBehaviour public fields
2. Fields on Processors and other types which have values serialized by `NamedValue`, and change `NamedValue` to use properties.

This PR does 1. 
I decided not to do 2. Changing `NamedValue` to know about properties is easy, but the problem is that by using properties in the reflection code, we will only ever reference the getter function in our code and call the setter only through reflection. This can cause bytecode stripping to kill the setter, causing it all to break.