### PR TITLE
Make Input System package compile with Unity 19.3

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Remoting.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Remoting.cs
@@ -243,7 +243,7 @@ partial class CoreTests
         {
             m_DisconnectionListeners.RemoveListener(callback);
         }
-        
+
         public void Receive(Guid messageId, byte[] data)
         {
             MessageEvent msgEvent;

--- a/Assets/Tests/InputSystem/CoreTests_Remoting.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Remoting.cs
@@ -234,6 +234,16 @@ partial class CoreTests
             m_DisconnectionListeners.AddListener(callback);
         }
 
+        public void UnregisterConnection(UnityAction<int> callback)
+        {
+            m_ConnectionListeners.RemoveListener(callback);
+        }
+
+        public void UnregisterDisconnection(UnityAction<int> callback)
+        {
+            m_DisconnectionListeners.RemoveListener(callback);
+        }
+        
         public void Receive(Guid messageId, byte[] data)
         {
             MessageEvent msgEvent;

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -177,7 +177,7 @@ internal class XRTests : InputTestFixture
     [TestCase("VIVE Tracker Pro PVT S/N LHR-OBDAA26C", "HTC", typeof(ViveTracker))]
     [TestCase("OPenVR Controller(VIVE Tracker Pro PVT)", "HTC", typeof(HandedViveTracker))]
     [TestCase("HTC V2-XD/XE", "HTC", typeof(ViveLighthouse))]
-    [TestCase("OpenVR Controller(Knuckles EV3.0 Left) - Left","Valve", typeof(KnucklesController))]
+    [TestCase("OpenVR Controller(Knuckles EV3.0 Left) - Left", "Valve", typeof(KnucklesController))]
     public void Devices_KnownDevice_UsesSpecializedDeviceType(string name, string manufacturer, Type expectedDeviceType)
     {
         var deviceDescription = CreateSimpleDeviceDescriptionByRole(DeviceRole.Generic);

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -2,7 +2,6 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine.Experimental.PlayerLoop;
 
 ////TODO: make sure that alterations made to InputSystem.settings in play mode do not leak out into edit mode or the asset
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Vive.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Vive.cs
@@ -97,11 +97,10 @@ namespace UnityEngine.InputSystem.Plugins.XR
     [InputControlLayout]
     public class KnucklesController : XRControllerWithRumble
     {
- 
         [InputControl(aliases = new[] { "B",  "Primary"})]
         public ButtonControl primaryButton { get; private set; }
 
-        [InputControl(aliases = new[] { "JoystickOrPadPressed" })]        
+        [InputControl(aliases = new[] { "JoystickOrPadPressed" })]
         public ButtonControl trackpadPressed { get; private set; }
         [InputControl(aliases = new[] { "JoystickOrPadTouched" })]
         public ButtonControl trackpadTouched { get; private set; }
@@ -125,14 +124,12 @@ namespace UnityEngine.InputSystem.Plugins.XR
         public Vector3Control deviceAngularVelocity { get; private set; }
 
 
-
-
         protected override void FinishSetup(InputDeviceBuilder builder)
         {
             base.FinishSetup(builder);
-                    
+
             gripPressed = builder.GetControl<ButtonControl>("gripPressed");
-            primaryButton = builder.GetControl<ButtonControl>("primary");            
+            primaryButton = builder.GetControl<ButtonControl>("primary");
             trackpadPressed = builder.GetControl<ButtonControl>("trackpadPressed");
             trackpadTouched = builder.GetControl<ButtonControl>("trackpadTouched");
             trackpad = builder.GetControl<Vector2Control>("trackpad");


### PR DESCRIPTION
1. IEditorPlayerConnection has been changed to add Unregister methods
2. UnityEngine.Experimental.PlayerLoop is removed - and it was not used in this file anyways