### PR TITLE
FIX: Fixed exception message when calling `CallbackContext.ReadValue<…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Custom inspector for `PlayerInput` no longer adds duplicates of action events if `Invoke Unity Events` notification behavior is selected.
 - Fixed `Hold` interactions firing immediately before the duration has passed.
 - Fixed editing bindings or processors for `InputAction` fields in the inspector (Changes wouldn't persist before).
+- Fixed exception message when calling `CallbackContext.ReadValue<TValue>()` for an action with a composite binding with `TValue` not matching the composite's value type.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -2030,8 +2030,14 @@ namespace UnityEngine.InputSystem
 
                 var compositeOfType = compositeObject as InputBindingComposite<TValue>;
                 if (compositeOfType == null)
+                {
+                    var compositeType = compositeObject.GetType();
+                    while (compositeType != null && !compositeType.IsGenericType)
+                        compositeType = compositeType.BaseType;
+                        
                     throw new InvalidOperationException(
-                        $"Cannot read value of type '{typeof(TValue).Name}' from composite '{compositeObject}' bound to action '{GetActionOrNull(bindingIndex)}' (composite is a '{compositeIndex.GetType().Name}' with value type '{TypeHelpers.GetNiceTypeName(compositeObject.GetType().GetGenericArguments()[0])}')");
+                        $"Cannot read value of type '{typeof(TValue).Name}' from composite '{compositeObject}' bound to action '{GetActionOrNull(bindingIndex)}' (composite is a '{compositeIndex.GetType().Name}' with value type '{TypeHelpers.GetNiceTypeName(compositeType.GetGenericArguments()[0])}')");
+                }
 
                 var context = new InputBindingCompositeContext
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -2034,7 +2034,7 @@ namespace UnityEngine.InputSystem
                     var compositeType = compositeObject.GetType();
                     while (compositeType != null && !compositeType.IsGenericType)
                         compositeType = compositeType.BaseType;
-                        
+
                     throw new InvalidOperationException(
                         $"Cannot read value of type '{typeof(TValue).Name}' from composite '{compositeObject}' bound to action '{GetActionOrNull(bindingIndex)}' (composite is a '{compositeIndex.GetType().Name}' with value type '{TypeHelpers.GetNiceTypeName(compositeType.GetGenericArguments()[0])}')");
                 }


### PR DESCRIPTION
…TValue>()` for an action with a composite binding with `TValue` not matching the composite's value type.

Fixes https://fogbugz.unity3d.com/f/cases/1133674/