### PR TITLE
CHANGE: settings improvements

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,12 +34,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change all public API using `IntPtr` to use unsafe pointer types instead.
 - `PlayerInput` will no longer disable any actions not in the currently active action map when disabling input or switching action maps.
 - Change some public fields into properties.
+- Input System project settings are now called "Input System Package" in the project window instead of "Input (NEW)".
 
 ### Fixed
 
 - Adding devices to "Supported Devices" in input preferences not allowing to select certain device types (like "Gamepad").
 - Fixed scrolling in `UIActionInputModule`.
 - Fixed compiling the input system package in Unity 19.2 with ugui being moved to a package now.
+- In the Input System project settings window, you can no longer add a supported device twice.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -15,7 +15,7 @@ namespace UnityEngine.InputSystem.Editor
     internal class InputSettingsProvider : SettingsProvider
     {
         public const string kEditorBuildSettingsConfigKey = "com.unity.input.settings";
-        public const string kSettingsPath = "Project/Input (NEW)";
+        public const string kSettingsPath = "Project/Input System Package";
 
         public static void Open()
         {
@@ -31,7 +31,7 @@ namespace UnityEngine.InputSystem.Editor
         private InputSettingsProvider(string path, SettingsScope scopes)
             : base(path, scopes)
         {
-            label = "Input (NEW)";
+            label = "Input System Package";
             s_Instance = this;
 
             InputSystem.onSettingsChange += OnSettingsChange;
@@ -247,10 +247,17 @@ namespace UnityEngine.InputSystem.Editor
                         path =>
                         {
                             var layoutName = InputControlPath.TryGetDeviceLayout(path) ?? path;
+                            var existingIndex = m_Settings.supportedDevices.IndexOf(x => x == layoutName);
+                            if (existingIndex != -1)
+                            {
+                                m_SupportedDevices.index = existingIndex;
+                                return;
+                            }
                             var numDevices = supportedDevicesProperty.arraySize;
                             supportedDevicesProperty.InsertArrayElementAtIndex(numDevices);
                             supportedDevicesProperty.GetArrayElementAtIndex(numDevices)
                                 .stringValue = layoutName;
+                            m_SupportedDevices.index = numDevices;
                             Apply();
                         },
                         mode: InputControlPicker.Mode.PickDevice);


### PR DESCRIPTION
- Input System project settings are now called "Input System Package" in the project window instead of "Input (NEW)".
- In the Input System project settings window, you can no longer add a supported device twice.