### PR TITLE
Remove plugin initialization APIs from public API by default

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to the input system package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3-preview] - TBD
+Due to package verification, the latest version below is the unpublished version and the date is meaningless.
+however, it has to be formatted properly to pass verification tests.
+
+## [0.2.9-preview] - 2020-1-1
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 // Keep this in sync with "Packages/com.unity.inputsystem/package.json".
 // NOTE: Unfortunately, System.Version doesn't use semantic versioning so we can't include
 //       "-preview" suffixes here.
-[assembly: AssemblyVersion("0.2.8")]
+[assembly: AssemblyVersion("0.2.9")]
 
 [assembly: InternalsVisibleTo("Unity.InputSystem.TestFramework")]
 [assembly: InternalsVisibleTo("Unity.InputSystem.Tests.Editor")]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
@@ -10,7 +10,12 @@ namespace UnityEngine.InputSystem.Plugins.Android
     /// Initializes custom android devices.
     /// You can use 'adb shell dumpsys input' from terminal to output information about all input devices.
     /// </summary>
-    public static class AndroidSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    class AndroidSupport
     {
         internal const string kAndroidInterface = "Android";
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -5,7 +5,12 @@ namespace UnityEngine.InputSystem.Plugins.DualShock
     /// <summary>
     /// Adds support for PS4 DualShock controllers.
     /// </summary>
-    public static class DualShockSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class DualShockSupport
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDSupport.cs
@@ -54,7 +54,12 @@ namespace UnityEngine.InputSystem.Plugins.HID
         /// <summary>
         /// Add support for generic HIDs to InputSystem.
         /// </summary>
-        public static void Initialize()
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+        public
+#else
+        internal
+#endif
+        static void Initialize()
         {
             s_ShouldCreateHID.Append(DefaultShouldCreateHIDCallback);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/LinuxSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/LinuxSupport.cs
@@ -112,7 +112,12 @@ namespace UnityEngine.InputSystem.Plugins.Linux
     /// <summary>
     /// A small helper class to aid in initializing and registering SDL devices and layout builders.
     /// </summary>
-    public static class LinuxSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class LinuxSupport
     {
         /// <summary>
         /// The current interface code sent with devices to identify as Linux SDL devices.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenSupport.cs
@@ -9,7 +9,12 @@ namespace UnityEngine.InputSystem.Plugins.OnScreen
     /// mechanisms like <see cref="OnScreenKeyboard"/> or through manually arranged control setups
     /// in the form of <see cref="OnScreenControl">OnScreenControls</see>.
     /// </remarks>
-    public static class OnScreenSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class OnScreenSupport
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PS4/PS4Support.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PS4/PS4Support.cs
@@ -5,7 +5,12 @@ namespace UnityEngine.InputSystem.Plugins.PS4
     /// <summary>
     /// Adds support for PS4 controllers.
     /// </summary>
-    public static class PS4Support
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class PS4Support
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamSupport.cs
@@ -8,7 +8,12 @@ namespace UnityEngine.InputSystem.Plugins.Steam
     /// <summary>
     /// Adds support for Steam controllers.
     /// </summary>
-    public static class SteamSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class SteamSupport
     {
         /// <summary>
         /// Wrapper around the Steam controller API.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupport.cs
@@ -6,7 +6,12 @@ namespace UnityEngine.InputSystem.Plugins.Switch
     /// <summary>
     /// Adds support for Switch NPad controllers.
     /// </summary>
-    public static class SwitchSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class SwitchSupport
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLSupport.cs
@@ -3,7 +3,12 @@ using UnityEngine.InputSystem.Layouts;
 
 namespace UnityEngine.InputSystem.Plugins.WebGL
 {
-    public static class WebGLSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class WebGLSupport
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputSupport.cs
@@ -7,7 +7,12 @@ namespace UnityEngine.InputSystem.Plugins.XInput
     /// <summary>
     /// Adds support for XInput controllers.
     /// </summary>
-    public static class XInputSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class XInputSupport
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
@@ -93,7 +93,12 @@ namespace UnityEngine.InputSystem.Plugins.XR
     /// <summary>
     /// A small helper class to aid in initializing and registering XR devices and layout builders.
     /// </summary>
-    public static class XRSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class XRSupport
     {
         /// <summary>
         /// Registers all initial templates and the generalized layout builder with the InputSystem.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/iOSSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/iOSSupport.cs
@@ -3,7 +3,12 @@ using UnityEngine.InputSystem.Layouts;
 
 namespace UnityEngine.InputSystem.Plugins.iOS
 {
-    public static class iOSSupport
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class iOSSupport
     {
         public static void Initialize()
         {

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "0.2.8-preview",
+	"version": "0.2.9-preview",
 	"unity": "2019.1",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Each plugin has a `PluginName.Initialize` method in public API.

But with the  default compilation setup, the user should never call this, as the input system does so itself. These are only relevant if the `UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION` define is set. So my thinking is that - for the sake of a cleaner, less confusing API, and to prevent user mistakes - these APIs should not be in public API unless that define is set either.

This PR changes that.