### PR TITLE
 Rename cancelled -> canceled (US spelling)

### DIFF
--- a/Assets/Demo/DemoControls.cs
+++ b/Assets/Demo/DemoControls.cs
@@ -540,38 +540,38 @@ public class DemoControls : IInputActionCollection
             {
                 fire.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
                 fire.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
-                fire.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
+                fire.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
                 move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
                 move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                move.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
                 look.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
                 look.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
-                look.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
+                look.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
                 menu.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMenu;
                 menu.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMenu;
-                menu.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMenu;
+                menu.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMenu;
                 steamEnterMenu.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnSteamEnterMenu;
                 steamEnterMenu.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnSteamEnterMenu;
-                steamEnterMenu.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnSteamEnterMenu;
+                steamEnterMenu.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnSteamEnterMenu;
             }
             m_Wrapper.m_GameplayActionsCallbackInterface = instance;
             if (instance != null)
             {
                 fire.started += instance.OnFire;
                 fire.performed += instance.OnFire;
-                fire.cancelled += instance.OnFire;
+                fire.canceled += instance.OnFire;
                 move.started += instance.OnMove;
                 move.performed += instance.OnMove;
-                move.cancelled += instance.OnMove;
+                move.canceled += instance.OnMove;
                 look.started += instance.OnLook;
                 look.performed += instance.OnLook;
-                look.cancelled += instance.OnLook;
+                look.canceled += instance.OnLook;
                 menu.started += instance.OnMenu;
                 menu.performed += instance.OnMenu;
-                menu.cancelled += instance.OnMenu;
+                menu.canceled += instance.OnMenu;
                 steamEnterMenu.started += instance.OnSteamEnterMenu;
                 steamEnterMenu.performed += instance.OnSteamEnterMenu;
-                steamEnterMenu.cancelled += instance.OnSteamEnterMenu;
+                steamEnterMenu.canceled += instance.OnSteamEnterMenu;
             }
         }
     }
@@ -612,38 +612,38 @@ public class DemoControls : IInputActionCollection
             {
                 navigate.started -= m_Wrapper.m_MenuActionsCallbackInterface.OnNavigate;
                 navigate.performed -= m_Wrapper.m_MenuActionsCallbackInterface.OnNavigate;
-                navigate.cancelled -= m_Wrapper.m_MenuActionsCallbackInterface.OnNavigate;
+                navigate.canceled -= m_Wrapper.m_MenuActionsCallbackInterface.OnNavigate;
                 click.started -= m_Wrapper.m_MenuActionsCallbackInterface.OnClick;
                 click.performed -= m_Wrapper.m_MenuActionsCallbackInterface.OnClick;
-                click.cancelled -= m_Wrapper.m_MenuActionsCallbackInterface.OnClick;
+                click.canceled -= m_Wrapper.m_MenuActionsCallbackInterface.OnClick;
                 steamExitMenu.started -= m_Wrapper.m_MenuActionsCallbackInterface.OnSteamExitMenu;
                 steamExitMenu.performed -= m_Wrapper.m_MenuActionsCallbackInterface.OnSteamExitMenu;
-                steamExitMenu.cancelled -= m_Wrapper.m_MenuActionsCallbackInterface.OnSteamExitMenu;
+                steamExitMenu.canceled -= m_Wrapper.m_MenuActionsCallbackInterface.OnSteamExitMenu;
                 submit.started -= m_Wrapper.m_MenuActionsCallbackInterface.OnSubmit;
                 submit.performed -= m_Wrapper.m_MenuActionsCallbackInterface.OnSubmit;
-                submit.cancelled -= m_Wrapper.m_MenuActionsCallbackInterface.OnSubmit;
+                submit.canceled -= m_Wrapper.m_MenuActionsCallbackInterface.OnSubmit;
                 point.started -= m_Wrapper.m_MenuActionsCallbackInterface.OnPoint;
                 point.performed -= m_Wrapper.m_MenuActionsCallbackInterface.OnPoint;
-                point.cancelled -= m_Wrapper.m_MenuActionsCallbackInterface.OnPoint;
+                point.canceled -= m_Wrapper.m_MenuActionsCallbackInterface.OnPoint;
             }
             m_Wrapper.m_MenuActionsCallbackInterface = instance;
             if (instance != null)
             {
                 navigate.started += instance.OnNavigate;
                 navigate.performed += instance.OnNavigate;
-                navigate.cancelled += instance.OnNavigate;
+                navigate.canceled += instance.OnNavigate;
                 click.started += instance.OnClick;
                 click.performed += instance.OnClick;
-                click.cancelled += instance.OnClick;
+                click.canceled += instance.OnClick;
                 steamExitMenu.started += instance.OnSteamExitMenu;
                 steamExitMenu.performed += instance.OnSteamExitMenu;
-                steamExitMenu.cancelled += instance.OnSteamExitMenu;
+                steamExitMenu.canceled += instance.OnSteamExitMenu;
                 submit.started += instance.OnSubmit;
                 submit.performed += instance.OnSubmit;
-                submit.cancelled += instance.OnSubmit;
+                submit.canceled += instance.OnSubmit;
                 point.started += instance.OnPoint;
                 point.performed += instance.OnPoint;
-                point.cancelled += instance.OnPoint;
+                point.canceled += instance.OnPoint;
             }
         }
     }

--- a/Assets/Demo/DemoGame.cs
+++ b/Assets/Demo/DemoGame.cs
@@ -403,12 +403,12 @@ public class DemoGame : MonoBehaviour
                 break;
             }
 
-            // If the user has cancelled account selection, we remove the user if there's no devices
+            // If the user has canceled account selection, we remove the user if there's no devices
             // already paired to it. This usually happens when a player initiates a join on a device on
             // Xbox or Switch, has the account picker come up, but then cancels instead of making an
             // account selection. In this case, we want to cancel the join.
             // NOTE: We are only adding DemoPlayerControllers once device pairing is complete
-            case InputUserChange.AccountSelectionCancelled:
+            case InputUserChange.AccountSelectionCanceled:
             {
                 if (user.pairedDevices.Count == 0)
                 {

--- a/Assets/Demo/DemoPlayerController.cs
+++ b/Assets/Demo/DemoPlayerController.cs
@@ -294,7 +294,7 @@ public class DemoPlayerController : MonoBehaviour, DemoControls.IGameplayActions
                         m_Charging = false;
                         break;
 
-                    case InputActionPhase.Cancelled:
+                    case InputActionPhase.Canceled:
                         m_Charging = false;
                         break;
                 }

--- a/Assets/Demo/SimpleDemo/SimpleController_UsingActionEventQueue.cs
+++ b/Assets/Demo/SimpleDemo/SimpleController_UsingActionEventQueue.cs
@@ -71,7 +71,7 @@ public class SimpleController_UsingActionQueue : MonoBehaviour
                             m_Charging = true;
                         break;
 
-                    case InputActionPhase.Cancelled:
+                    case InputActionPhase.Canceled:
                         m_Charging = false;
                         break;
                 }

--- a/Assets/Demo/SimpleDemo/SimpleController_UsingActions.cs
+++ b/Assets/Demo/SimpleDemo/SimpleController_UsingActions.cs
@@ -25,8 +25,8 @@ public class SimpleController_UsingActions : MonoBehaviour
     {
         moveAction.performed += ctx => m_Move = ctx.ReadValue<Vector2>();
         lookAction.performed += ctx => m_Look = ctx.ReadValue<Vector2>();
-        moveAction.cancelled += ctx => m_Move = Vector2.zero;
-        lookAction.cancelled += ctx => m_Look = Vector2.zero;
+        moveAction.canceled += ctx => m_Move = Vector2.zero;
+        lookAction.canceled += ctx => m_Look = Vector2.zero;
 
         fireAction.performed +=
             ctx =>
@@ -47,7 +47,7 @@ public class SimpleController_UsingActions : MonoBehaviour
             if (ctx.interaction is SlowTapInteraction)
                 m_Charging = true;
         };
-        fireAction.cancelled +=
+        fireAction.canceled +=
             ctx =>
         {
             m_Charging = false;

--- a/Assets/Demo/SimpleDemo/SimpleController_UsingActions_InAsset.cs
+++ b/Assets/Demo/SimpleDemo/SimpleController_UsingActions_InAsset.cs
@@ -43,8 +43,8 @@ public class SimpleController_UsingActions_InAsset : MonoBehaviour
         controls = new SimpleControls();
         controls.gameplay.move.performed += ctx => m_Move = ctx.ReadValue<Vector2>();
         controls.gameplay.look.performed += ctx => m_Look = ctx.ReadValue<Vector2>();
-        controls.gameplay.move.cancelled += ctx => m_Move = Vector2.zero;
-        controls.gameplay.look.cancelled += ctx => m_Look = Vector2.zero;
+        controls.gameplay.move.canceled += ctx => m_Move = Vector2.zero;
+        controls.gameplay.look.canceled += ctx => m_Look = Vector2.zero;
 
         controls.gameplay.fire.performed +=
             ctx =>
@@ -65,7 +65,7 @@ public class SimpleController_UsingActions_InAsset : MonoBehaviour
             if (ctx.interaction is SlowTapInteraction)
                 m_Charging = true;
         };
-        controls.gameplay.fire.cancelled +=
+        controls.gameplay.fire.canceled +=
             ctx =>
         {
             m_Charging = false;

--- a/Assets/Demo/SimpleDemo/SimpleControls.cs
+++ b/Assets/Demo/SimpleDemo/SimpleControls.cs
@@ -320,32 +320,32 @@ public class SimpleControls : IInputActionCollection
             {
                 fire.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
                 fire.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
-                fire.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
+                fire.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
                 move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
                 move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                move.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
                 look.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
                 look.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
-                look.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
+                look.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
                 jump.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
                 jump.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
-                jump.cancelled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
+                jump.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnJump;
             }
             m_Wrapper.m_GameplayActionsCallbackInterface = instance;
             if (instance != null)
             {
                 fire.started += instance.OnFire;
                 fire.performed += instance.OnFire;
-                fire.cancelled += instance.OnFire;
+                fire.canceled += instance.OnFire;
                 move.started += instance.OnMove;
                 move.performed += instance.OnMove;
-                move.cancelled += instance.OnMove;
+                move.canceled += instance.OnMove;
                 look.started += instance.OnLook;
                 look.performed += instance.OnLook;
-                look.cancelled += instance.OnLook;
+                look.canceled += instance.OnLook;
                 jump.started += instance.OnJump;
                 jump.performed += instance.OnJump;
-                jump.cancelled += instance.OnJump;
+                jump.canceled += instance.OnJump;
             }
         }
     }

--- a/Assets/Plugins/Steamworks.NET/autogen/SteamEnums.cs
+++ b/Assets/Plugins/Steamworks.NET/autogen/SteamEnums.cs
@@ -1013,7 +1013,7 @@ namespace Steamworks
         k_EResultPasswordRequiredToKickSession = 49,// You are already logged in elsewhere, this cached credential login has failed.
         k_EResultAlreadyLoggedInElsewhere = 50,     // You are already logged in elsewhere, you must wait
         k_EResultSuspended = 51,                    // Long running operation (content download) suspended/paused
-        k_EResultCancelled = 52,                    // Operation canceled (typically by user: content download)
+        k_EResultCanceled = 52,                    // Operation canceled (typically by user: content download)
         k_EResultDataCorruption = 53,               // Operation canceled because data is ill formed or unrecoverable
         k_EResultDiskFull = 54,                     // Operation canceled - not enough disk space.
         k_EResultRemoteCallFailed = 55,             // an remote call or IPC call failed

--- a/Assets/QA/Input_Test/Scripts/Input/ControllerDiagramISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/ControllerDiagramISX.cs
@@ -9,17 +9,17 @@ public class ControllerDiagramISX : GamepadISX
     {
         m_buttonAction = new InputAction(name: "ButtonPressAction", binding: "*/<button>");
         m_buttonAction.performed += callbackContext => OnButtonPress(callbackContext.control as ButtonControl);
-        m_buttonAction.cancelled += callbackContext => OnButtonPress(callbackContext.control as ButtonControl);
+        m_buttonAction.canceled += callbackContext => OnButtonPress(callbackContext.control as ButtonControl);
         m_buttonAction.Enable();
 
         m_dPadAction = new InputAction(name: "Dpadpressaction", binding: "*/<dpad>");
         m_dPadAction.performed += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
-        m_dPadAction.cancelled += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
+        m_dPadAction.canceled += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
         m_dPadAction.Enable();
 
         m_stickMoveAction = new InputAction(name: "StickMoveAction", binding: "*/<stick>");
         m_stickMoveAction.performed += callbackContext => StickMove(callbackContext.control as StickControl);
-        m_stickMoveAction.cancelled += callbackContext => StickMove(callbackContext.control as StickControl);
+        m_stickMoveAction.canceled += callbackContext => StickMove(callbackContext.control as StickControl);
         m_stickMoveAction.Enable();
     }
 

--- a/Assets/QA/Input_Test/Scripts/Input/DualShockISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/DualShockISX.cs
@@ -16,22 +16,22 @@ public class DualShockISX : GamepadISX
     {
         //m_discreteButtonAction = new InputAction(name: "DualShockButtonAction", binding: "*DualShock*/<discreteButton>");
         //m_discreteButtonAction.performed += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
-        //m_discreteButtonAction.cancelled += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
+        //m_discreteButtonAction.canceled += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
         //m_discreteButtonAction.Enable();
 
         m_buttonAction = new InputAction(name: "DualShockButtonAction", binding: "*DualShock*/<button>");
         m_buttonAction.performed += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
-        m_buttonAction.cancelled += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
+        m_buttonAction.canceled += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
         m_buttonAction.Enable();
 
         m_dPadAction = new InputAction(name: "DualShockDpadAction", binding: "*DualShock*/<dpad>");
         m_dPadAction.performed += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
-        m_dPadAction.cancelled += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
+        m_dPadAction.canceled += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
         m_dPadAction.Enable();
 
         m_stickMoveAction = new InputAction(name: "DualShockStickMoveAction", binding: "*DualShock*/<stick>");
         m_stickMoveAction.performed += callbackContext => StickMove(callbackContext.control as StickControl);
-        m_stickMoveAction.cancelled += callbackContext => StickMove(callbackContext.control as StickControl);
+        m_stickMoveAction.canceled += callbackContext => StickMove(callbackContext.control as StickControl);
         m_stickMoveAction.Enable();
     }
 

--- a/Assets/QA/Input_Test/Scripts/Input/JoystickISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/JoystickISX.cs
@@ -15,7 +15,7 @@ public class JoystickISX : MonoBehaviour
     {
         m_stickAction = new InputAction(name: "StickAction", binding: "<joystick>/<stick>");
         m_stickAction.performed += callbackContext => OnStickMove(callbackContext.control as StickControl);
-        m_stickAction.cancelled += callbackContext => OnStickMove(callbackContext.control as StickControl);
+        m_stickAction.canceled += callbackContext => OnStickMove(callbackContext.control as StickControl);
         m_stickAction.Enable();
     }
 

--- a/Assets/QA/Input_Test/Scripts/Input/KeyboardMouseISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/KeyboardMouseISX.cs
@@ -29,12 +29,12 @@ public class KeyboardMouseISX : MonoBehaviour
     {
         m_keyboardAction = new InputAction(name: "KeyboardPressAction", binding: "<keyboard>/<key>") { passThrough = true };
         m_keyboardAction.performed += callbackContext => KeyboardKeyPress(callbackContext.control as KeyControl);
-        //m_keyboardAction.cancelled += callbackContext => KeyboardKeyPress(callbackContext.control as KeyControl);
+        //m_keyboardAction.canceled += callbackContext => KeyboardKeyPress(callbackContext.control as KeyControl);
         m_keyboardAction.Enable();
 
         m_mouseAction = new InputAction(name: "MousePressAction", binding: "<mouse>/<button>") {passThrough = true};
         m_mouseAction.performed += callbackContext => MouseKeyPress(callbackContext.control.device as Mouse);
-        //m_mouseAction.cancelled += callbackContext => MouseKeyPress(callbackContext.control.device as Mouse);
+        //m_mouseAction.canceled += callbackContext => MouseKeyPress(callbackContext.control.device as Mouse);
         m_mouseAction.Enable();
     }
 

--- a/Assets/QA/Input_Test/Scripts/Input/PenISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/PenISX.cs
@@ -46,7 +46,7 @@ public class PenISX : MonoBehaviour
 
         m_penAction = new InputAction(name: "PenButtonAction", binding: "<pen>/<button>");
         m_penAction.performed += callbackContext => ButtonPress(callbackContext.control as ButtonControl);
-        m_penAction.cancelled += callbackContext => ButtonPress(callbackContext.control as ButtonControl);
+        m_penAction.canceled += callbackContext => ButtonPress(callbackContext.control as ButtonControl);
         m_penAction.Enable();
     }
 

--- a/Assets/QA/Input_Test/Scripts/Input/TouchISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/TouchISX.cs
@@ -18,7 +18,7 @@ public class TouchISX : MonoBehaviour
     {
         m_touchAction = new InputAction(name: "TouchAction", binding: "<touchscreen>/<touch>");
         m_touchAction.performed += callbackContext => TouchInput(callbackContext.control as TouchControl);
-        m_touchAction.cancelled += callbackContext => TouchInput(callbackContext.control as TouchControl);
+        m_touchAction.canceled += callbackContext => TouchInput(callbackContext.control as TouchControl);
         m_touchAction.Enable();
     }
 
@@ -43,7 +43,7 @@ public class TouchISX : MonoBehaviour
             case PointerPhase.Moved:
                 UpdateTouchInput(control);
                 break;
-            case PointerPhase.Cancelled:
+            case PointerPhase.Canceled:
             case PointerPhase.Ended:
                 EndTouchInput(control);
                 break;

--- a/Assets/QA/Input_Test/Scripts/Input/XboxISX.cs
+++ b/Assets/QA/Input_Test/Scripts/Input/XboxISX.cs
@@ -16,17 +16,17 @@ public class XboxISX : GamepadISX
 
         m_buttonAction = new InputAction(name: "XboxButtonAction", binding: "XInputController*/<button>");
         m_buttonAction.performed += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isXbox: true);
-        m_buttonAction.cancelled += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isXbox: true);
+        m_buttonAction.canceled += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isXbox: true);
         m_buttonAction.Enable();
 
         m_dPadAction = new InputAction(name: "XboxDpadAction", binding: "XInputController*/<dpad>");
         m_dPadAction.performed += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
-        m_dPadAction.cancelled += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
+        m_dPadAction.canceled += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
         m_dPadAction.Enable();
 
         m_stickMoveAction = new InputAction(name: "XboxStickMoveAction", binding: "XInputController*/<stick>");
         m_stickMoveAction.performed += callbackContext => StickMove(callbackContext.control as StickControl);
-        m_stickMoveAction.cancelled += callbackContext => StickMove(callbackContext.control as StickControl);
+        m_stickMoveAction.canceled += callbackContext => StickMove(callbackContext.control as StickControl);
         m_stickMoveAction.Enable();
     }
 

--- a/Assets/QA/Tests/XRDeviceActions/_SharedScripts/AxisControlActionStatus.cs
+++ b/Assets/QA/Tests/XRDeviceActions/_SharedScripts/AxisControlActionStatus.cs
@@ -18,7 +18,7 @@ public class AxisControlActionStatus : MonoBehaviour
         axisAction.Enable();
         axisAction.performed += UpdateAxis;
         axisAction.started += UpdateAxis;
-        axisAction.cancelled += UpdateAxis;
+        axisAction.canceled += UpdateAxis;
 
         ReadOnlyArray<InputControl> controls = axisAction.controls;
         for (int i = 0; i < controls.Count; i++)
@@ -41,7 +41,7 @@ public class AxisControlActionStatus : MonoBehaviour
         axisAction.Disable();
         axisAction.performed -= UpdateAxis;
         axisAction.started -= UpdateAxis;
-        axisAction.cancelled -= UpdateAxis;
+        axisAction.canceled -= UpdateAxis;
     }
 
     private void UpdateAxis(InputAction.CallbackContext context)

--- a/Assets/QA/Tests/XRDeviceActions/_SharedScripts/ButtonControlActionStatus.cs
+++ b/Assets/QA/Tests/XRDeviceActions/_SharedScripts/ButtonControlActionStatus.cs
@@ -22,7 +22,7 @@ public class ButtonControlActionStatus : MonoBehaviour
     {
         buttonTouchAction.performed += UpdateTouchStatus;
         buttonTouchAction.started += UpdateTouchStatus;
-        buttonTouchAction.cancelled += UpdateTouchStatus;
+        buttonTouchAction.canceled += UpdateTouchStatus;
         buttonTouchAction.Enable();
 
         ReadOnlyArray<InputControl> controls = buttonTouchAction.controls;
@@ -39,7 +39,7 @@ public class ButtonControlActionStatus : MonoBehaviour
 
         buttonPressAction.performed += UpdatePressStatus;
         buttonPressAction.started += UpdatePressStatus;
-        buttonPressAction.cancelled += UpdatePressStatus;
+        buttonPressAction.canceled += UpdatePressStatus;
         buttonPressAction.Enable();
 
         controls = buttonPressAction.controls;
@@ -62,12 +62,12 @@ public class ButtonControlActionStatus : MonoBehaviour
         buttonTouchAction.Disable();
         buttonTouchAction.performed -= UpdateTouchStatus;
         buttonTouchAction.started -= UpdateTouchStatus;
-        buttonTouchAction.cancelled -= UpdateTouchStatus;
+        buttonTouchAction.canceled -= UpdateTouchStatus;
 
         buttonPressAction.Disable();
         buttonPressAction.performed -= UpdatePressStatus;
         buttonPressAction.started -= UpdatePressStatus;
-        buttonPressAction.cancelled -= UpdatePressStatus;
+        buttonPressAction.canceled -= UpdatePressStatus;
     }
 
     private void UpdatePressStatus(InputAction.CallbackContext context)

--- a/Assets/QA/Tests/XRDeviceActions/_SharedScripts/IntegerControlActionStatus.cs
+++ b/Assets/QA/Tests/XRDeviceActions/_SharedScripts/IntegerControlActionStatus.cs
@@ -17,7 +17,7 @@ public class IntegerControlActionStatus : MonoBehaviour
     {
         IntegerAction.performed += UpdateInteger;
         IntegerAction.started += UpdateInteger;
-        IntegerAction.cancelled += UpdateInteger;
+        IntegerAction.canceled += UpdateInteger;
         IntegerAction.Enable();
 
         ReadOnlyArray<InputControl> controls = IntegerAction.controls;
@@ -41,7 +41,7 @@ public class IntegerControlActionStatus : MonoBehaviour
         IntegerAction.Disable();
         IntegerAction.performed -= UpdateInteger;
         IntegerAction.started -= UpdateInteger;
-        IntegerAction.cancelled -= UpdateInteger;
+        IntegerAction.canceled -= UpdateInteger;
     }
 
     private void UpdateInteger(InputAction.CallbackContext context)

--- a/Assets/QA/Tests/XRDeviceActions/_SharedScripts/QuaternionControlActionStatus.cs
+++ b/Assets/QA/Tests/XRDeviceActions/_SharedScripts/QuaternionControlActionStatus.cs
@@ -18,7 +18,7 @@ public class QuaternionControlActionStatus : MonoBehaviour
         quaternionAction.Enable();
         quaternionAction.performed += UpdateQuaternion;
         quaternionAction.started += UpdateQuaternion;
-        quaternionAction.cancelled += UpdateQuaternion;
+        quaternionAction.canceled += UpdateQuaternion;
 
         ReadOnlyArray<InputControl> controls = quaternionAction.controls;
         for (int i = 0; i < controls.Count; i++)
@@ -41,7 +41,7 @@ public class QuaternionControlActionStatus : MonoBehaviour
         quaternionAction.Disable();
         quaternionAction.performed -= UpdateQuaternion;
         quaternionAction.started -= UpdateQuaternion;
-        quaternionAction.cancelled -= UpdateQuaternion;
+        quaternionAction.canceled -= UpdateQuaternion;
     }
 
     private void UpdateQuaternion(InputAction.CallbackContext context)

--- a/Assets/QA/Tests/XRDeviceActions/_SharedScripts/Vector2ControlActionStatus.cs
+++ b/Assets/QA/Tests/XRDeviceActions/_SharedScripts/Vector2ControlActionStatus.cs
@@ -19,7 +19,7 @@ public class Vector2ControlActionStatus : MonoBehaviour
         vector2Action.Enable();
         vector2Action.performed += UpdateVector2;
         vector2Action.started += UpdateVector2;
-        vector2Action.cancelled += UpdateVector2;
+        vector2Action.canceled += UpdateVector2;
 
         ReadOnlyArray<InputControl> controls = vector2Action.controls;
         for (int i = 0; i < controls.Count; i++)
@@ -43,7 +43,7 @@ public class Vector2ControlActionStatus : MonoBehaviour
         vector2Action.Disable();
         vector2Action.performed -= UpdateVector2;
         vector2Action.started -= UpdateVector2;
-        vector2Action.cancelled -= UpdateVector2;
+        vector2Action.canceled -= UpdateVector2;
     }
 
     private void UpdateVector2(InputAction.CallbackContext context)

--- a/Assets/QA/Tests/XRDeviceActions/_SharedScripts/Vector3ControlActionStatus.cs
+++ b/Assets/QA/Tests/XRDeviceActions/_SharedScripts/Vector3ControlActionStatus.cs
@@ -18,7 +18,7 @@ public class Vector3ControlActionStatus : MonoBehaviour
         vector3Action.Enable();
         vector3Action.performed += UpdateVector3;
         vector3Action.started += UpdateVector3;
-        vector3Action.cancelled += UpdateVector3;
+        vector3Action.canceled += UpdateVector3;
 
         ReadOnlyArray<InputControl> controls = vector3Action.controls;
         for (int i = 0; i < controls.Count; i++)
@@ -41,7 +41,7 @@ public class Vector3ControlActionStatus : MonoBehaviour
         vector3Action.Disable();
         vector3Action.performed -= UpdateVector3;
         vector3Action.started -= UpdateVector3;
-        vector3Action.cancelled -= UpdateVector3;
+        vector3Action.canceled -= UpdateVector3;
     }
 
     private void UpdateVector3(InputAction.CallbackContext context)

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -158,12 +158,12 @@ partial class CoreTests
             var actions = trace.ToArray();
 
             Assert.That(actions.Length, Is.EqualTo(2));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].time, Is.EqualTo(0.234).Within(0.00001));
             Assert.That(actions[0].action, Is.SameAs(action1));
             Assert.That(actions[0].control, Is.SameAs(gamepad.buttonSouth));
             Assert.That(actions[0].interaction, Is.TypeOf<HoldInteraction>());
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[1].time, Is.EqualTo(0.234).Within(0.00001));
             Assert.That(actions[1].action, Is.SameAs(action2));
             Assert.That(actions[1].control, Is.SameAs(gamepad.leftStick));
@@ -703,8 +703,8 @@ partial class CoreTests
             actions = trace.ToArray();
             Assert.That(actions.Length, Is.EqualTo(6));
 
-            // map1/action1 should have been cancelled.
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            // map1/action1 should have been canceled.
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].action, Is.SameAs(action1));
             Assert.That(actions[0].ReadValue<Vector2>(),
                 Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(-1, 1))
@@ -772,16 +772,16 @@ partial class CoreTests
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(3));
 
-            // map2/action3 should have been cancelled.
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            // map2/action3 should have been canceled.
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].action, Is.SameAs(action3));
             Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
             Assert.That(actions[0].interaction, Is.TypeOf<TapInteraction>());
             Assert.That(actions[0].control, Is.SameAs(gamepad.buttonSouth));
             Assert.That(actions[0].time, Is.EqualTo(runtime.currentTime).Within(0.00001));
 
-            // map3/action3 should have been cancelled.
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            // map3/action3 should have been canceled.
+            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[1].action, Is.SameAs(action4));
             Assert.That(actions[1].ReadValue<Vector2>,
                 Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.234f, 0.345f)) * new Vector2(1, -1))
@@ -790,8 +790,8 @@ partial class CoreTests
             Assert.That(actions[1].control, Is.SameAs(gamepad.leftStick));
             Assert.That(actions[1].time, Is.EqualTo(runtime.currentTime).Within(0.00001));
 
-            // map3/action5 should have been cancelled.
-            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            // map3/action5 should have been canceled.
+            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[2].action, Is.SameAs(action5));
             Assert.That(actions[2].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
             Assert.That(actions[2].interaction, Is.TypeOf<TapInteraction>());
@@ -1047,12 +1047,12 @@ partial class CoreTests
 
             Assert.That(trace, Is.Empty);
 
-            // Finally, reset the right stick. stickAction should be cancelled.
+            // Finally, reset the right stick. stickAction should be canceled.
             Set(gamepad.rightStick, Vector2.zero);
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].control, Is.SameAs(gamepad.rightStick));
             Assert.That(actions[0].action, Is.SameAs(stickAction));
             Assert.That(actions[0].ReadValue<Vector2>(),
@@ -1099,7 +1099,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             // Same as above. Conflict resolution locks us to first control in composite.
             Assert.That(actions[0].control, Is.SameAs(gamepad.dpad.left));
             Assert.That(actions[0].action, Is.SameAs(compositeAction));
@@ -1140,7 +1140,7 @@ partial class CoreTests
             trace.Clear();
 
             // Press all face buttons and then release them one by one. After the last was released,
-            // buttonAction should be cancelled.
+            // buttonAction should be canceled.
             Press(gamepad.buttonSouth);
             Press(gamepad.buttonNorth);
             Press(gamepad.buttonEast);
@@ -1180,7 +1180,7 @@ partial class CoreTests
             Assert.That(actions[3].control, Is.SameAs(gamepad.buttonNorth));
             Assert.That(actions[3].action, Is.SameAs(buttonAction));
             Assert.That(actions[3].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
-            Assert.That(actions[4].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[4].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[4].control, Is.SameAs(gamepad.buttonNorth));
             Assert.That(actions[4].action, Is.SameAs(buttonAction));
             Assert.That(actions[4].ReadValue<float>(), Is.Zero.Within(0.00001));
@@ -1366,7 +1366,7 @@ partial class CoreTests
 
         var wasStarted = false;
         var wasPerformed = false;
-        var wasCancelled = false;
+        var wasCanceled = false;
 
         map.actionTriggered +=
             ctx =>
@@ -1379,20 +1379,20 @@ partial class CoreTests
                 case InputActionPhase.Started:
                     Assert.That(wasStarted, Is.False);
                     Assert.That(wasPerformed, Is.False);
-                    Assert.That(wasCancelled, Is.False);
+                    Assert.That(wasCanceled, Is.False);
                     wasStarted = true;
                     break;
                 case InputActionPhase.Performed:
                     Assert.That(wasStarted, Is.True);
                     Assert.That(wasPerformed, Is.False);
-                    Assert.That(wasCancelled, Is.False);
+                    Assert.That(wasCanceled, Is.False);
                     wasPerformed = true;
                     break;
-                case InputActionPhase.Cancelled:
+                case InputActionPhase.Canceled:
                     Assert.That(wasStarted, Is.True);
                     Assert.That(wasPerformed, Is.True);
-                    Assert.That(wasCancelled, Is.False);
-                    wasCancelled = true;
+                    Assert.That(wasCanceled, Is.False);
+                    wasCanceled = true;
                     break;
             }
         };
@@ -1403,11 +1403,11 @@ partial class CoreTests
 
         Assert.That(wasStarted, Is.True);
         Assert.That(wasPerformed, Is.True);
-        Assert.That(wasCancelled, Is.False);
+        Assert.That(wasCanceled, Is.False);
 
         Set(gamepad.leftTrigger, 0);
 
-        Assert.That(wasCancelled, Is.True);
+        Assert.That(wasCanceled, Is.True);
     }
 
     [Test]
@@ -1421,11 +1421,11 @@ partial class CoreTests
 
         var receivedStarted = false;
         var receivedPerformed = false;
-        var receivedCancelled = false;
+        var receivedCanceled = false;
 
         action.started += ctx => receivedStarted = true;
         action.performed += ctx => receivedPerformed = true;
-        action.cancelled += ctx => receivedCancelled = true;
+        action.canceled += ctx => receivedCanceled = true;
 
         var receivedChanges = new List<InputActionChange>();
         InputSystem.onActionChange +=
@@ -1439,8 +1439,8 @@ partial class CoreTests
                 case InputActionPhase.Started:
                     Assert.That(receivedStarted, Is.False);
                     break;
-                case InputActionPhase.Cancelled:
-                    Assert.That(receivedCancelled, Is.False);
+                case InputActionPhase.Canceled:
+                    Assert.That(receivedCanceled, Is.False);
                     break;
                 case InputActionPhase.Performed:
                     Assert.That(receivedPerformed, Is.False);
@@ -1458,12 +1458,12 @@ partial class CoreTests
         receivedChanges.Clear();
         receivedStarted = false;
         receivedPerformed = false;
-        receivedCancelled = false;
+        receivedCanceled = false;
 
         Set(gamepad.leftTrigger, 0);
 
         Assert.That(receivedChanges,
-            Is.EquivalentTo(new[] {InputActionChange.ActionCancelled}));
+            Is.EquivalentTo(new[] {InputActionChange.ActionCanceled}));
     }
 
     [Test]
@@ -1622,7 +1622,7 @@ partial class CoreTests
             Assert.That(actions[0].control, Is.EqualTo(gamepad.buttonSouth));
             Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Performed));
             Assert.That(actions[1].control, Is.EqualTo(gamepad.buttonSouth));
-            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[2].control, Is.EqualTo(gamepad.buttonSouth));
             // The second start-perform-cancel cycle comes from the fact that we are changing the
             // binding mask. Doing so will cancel all ongoing actions. But because the gamepad button
@@ -1632,13 +1632,13 @@ partial class CoreTests
             Assert.That(actions[3].control, Is.EqualTo(gamepad.buttonSouth));
             Assert.That(actions[4].phase, Is.EqualTo(InputActionPhase.Performed));
             Assert.That(actions[4].control, Is.EqualTo(gamepad.buttonSouth));
-            Assert.That(actions[5].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[5].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[5].control, Is.EqualTo(gamepad.buttonSouth));
             Assert.That(actions[6].phase, Is.EqualTo(InputActionPhase.Started));
             Assert.That(actions[6].control, Is.EqualTo(keyboard.aKey));
             Assert.That(actions[7].phase, Is.EqualTo(InputActionPhase.Performed));
             Assert.That(actions[7].control, Is.EqualTo(keyboard.aKey));
-            Assert.That(actions[8].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[8].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[8].control, Is.EqualTo(keyboard.aKey));
         }
     }
@@ -1893,9 +1893,9 @@ partial class CoreTests
         InputAction startedAction = null;
         InputControl startedControl = null;
 
-        var cancelledReceivedCalls = 0;
-        InputAction cancelledAction = null;
-        InputControl cancelledControl = null;
+        var canceledReceivedCalls = 0;
+        InputAction canceledAction = null;
+        InputControl canceledControl = null;
 
         var action = new InputAction(binding: "<Gamepad>/{primaryAction}", interactions: "hold(duration=0.4)");
         action.performed +=
@@ -1916,14 +1916,14 @@ partial class CoreTests
 
             Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         };
-        action.cancelled +=
+        action.canceled +=
             ctx =>
         {
-            ++cancelledReceivedCalls;
-            cancelledAction = ctx.action;
-            cancelledControl = ctx.control;
+            ++canceledReceivedCalls;
+            canceledAction = ctx.action;
+            canceledControl = ctx.control;
 
-            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Canceled));
         };
         action.Enable();
 
@@ -1932,7 +1932,7 @@ partial class CoreTests
 
         Assert.That(startedReceivedCalls, Is.EqualTo(1));
         Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(cancelledReceivedCalls, Is.Zero);
+        Assert.That(canceledReceivedCalls, Is.Zero);
         Assert.That(startedAction, Is.SameAs(action));
         Assert.That(startedControl, Is.SameAs(gamepad.buttonSouth));
 
@@ -1943,19 +1943,19 @@ partial class CoreTests
 
         Assert.That(startedReceivedCalls, Is.Zero);
         Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(cancelledReceivedCalls, Is.EqualTo(1));
-        Assert.That(cancelledAction, Is.SameAs(action));
-        Assert.That(cancelledControl, Is.SameAs(gamepad.buttonSouth));
+        Assert.That(canceledReceivedCalls, Is.EqualTo(1));
+        Assert.That(canceledAction, Is.SameAs(action));
+        Assert.That(canceledControl, Is.SameAs(gamepad.buttonSouth));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
 
-        cancelledReceivedCalls = 0;
+        canceledReceivedCalls = 0;
 
         InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 10.5);
         InputSystem.Update();
 
         Assert.That(startedReceivedCalls, Is.EqualTo(1));
         Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(cancelledReceivedCalls, Is.Zero);
+        Assert.That(canceledReceivedCalls, Is.Zero);
         Assert.That(startedAction, Is.SameAs(action));
         Assert.That(startedControl, Is.SameAs(gamepad.buttonSouth));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
@@ -1967,7 +1967,7 @@ partial class CoreTests
 
         Assert.That(startedReceivedCalls, Is.Zero);
         Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(cancelledReceivedCalls, Is.Zero);
+        Assert.That(canceledReceivedCalls, Is.Zero);
         Assert.That(startedAction, Is.SameAs(action));
         Assert.That(startedControl, Is.SameAs(gamepad.buttonSouth));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
@@ -1977,7 +1977,7 @@ partial class CoreTests
 
         Assert.That(startedReceivedCalls, Is.Zero);
         Assert.That(performedReceivedCalls, Is.EqualTo(1));
-        Assert.That(cancelledReceivedCalls, Is.Zero);
+        Assert.That(canceledReceivedCalls, Is.Zero);
         Assert.That(performedAction, Is.SameAs(action));
         Assert.That(performedControl, Is.SameAs(gamepad.buttonSouth));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
@@ -2077,7 +2077,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].interaction, Is.TypeOf<MultiTapInteraction>());
             Assert.That(actions[0].control, Is.SameAs(gamepad.buttonSouth));
             Assert.That(actions[0].time, Is.EqualTo(1.75).Within(0.00001));
@@ -2107,7 +2107,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].interaction, Is.TypeOf<MultiTapInteraction>());
             Assert.That(actions[0].control, Is.SameAs(gamepad.buttonSouth));
             Assert.That(actions[0].time, Is.EqualTo(4).Within(0.00001));
@@ -2116,7 +2116,7 @@ partial class CoreTests
             trace.Clear();
 
             // Now press and release within tap time. Then press again within delay time but release
-            // only after tap time. Should we started and cancelled.
+            // only after tap time. Should we started and canceled.
             runtime.currentTime = 6;
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 4.7);
             InputSystem.QueueStateEvent(gamepad, new GamepadState(), 4.9);
@@ -2131,7 +2131,7 @@ partial class CoreTests
             Assert.That(actions[0].control, Is.SameAs(gamepad.buttonSouth));
             Assert.That(actions[0].time, Is.EqualTo(4.7).Within(0.00001));
             Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[1].interaction, Is.TypeOf<MultiTapInteraction>());
             Assert.That(actions[1].control, Is.SameAs(gamepad.buttonSouth));
             Assert.That(actions[1].time, Is.EqualTo(5.9).Within(0.00001));
@@ -2790,7 +2790,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].control, Is.SameAs(gamepad1.leftStick));
             Assert.That(actions[0].ReadValue<Vector2>(),
                 Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)))
@@ -2858,7 +2858,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].control, Is.SameAs(gamepad1.leftStick));
             Assert.That(actions[0].ReadValue<Vector2>(),
                 Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)))
@@ -3215,7 +3215,7 @@ partial class CoreTests
 
         action.started += ctx => phases.Add(InputActionPhase.Started);
         action.performed += ctx => phases.Add(InputActionPhase.Performed);
-        action.cancelled += ctx => phases.Add(InputActionPhase.Cancelled);
+        action.canceled += ctx => phases.Add(InputActionPhase.Canceled);
 
         // Actuate leftStick below deadzone threshold.
         Set(gamepad.leftStick, new Vector2(0.01f, 0.002f));
@@ -3247,7 +3247,7 @@ partial class CoreTests
         // And go back to default.
         Set(gamepad.leftStick, Vector2.zero);
 
-        Assert.That(phases, Is.EquivalentTo(new[] { InputActionPhase.Cancelled }));
+        Assert.That(phases, Is.EquivalentTo(new[] { InputActionPhase.Canceled }));
     }
 
     [Test]
@@ -3322,7 +3322,7 @@ partial class CoreTests
             // Reset to default state should result in a single cancellation.
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.0001));
             Assert.That(actions[0].time, Is.EqualTo(0.567).Within(0.0001));
             Assert.That(actions[0].control, Is.SameAs(gamepad.rightTrigger));
@@ -3398,7 +3398,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].control, Is.SameAs(gamepad.rightTrigger));
             Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.00001));
 
@@ -3512,12 +3512,12 @@ partial class CoreTests
                 2.0 + InputSystem.settings.defaultSlowTapTime + 0.0001);
             InputSystem.Update();
 
-            // First tap was started, then cancelled, then slow tap was started, and then performed.
+            // First tap was started, then canceled, then slow tap was started, and then performed.
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(4));
             Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Started));
             Assert.That(actions[0].interaction, Is.TypeOf<TapInteraction>());
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[1].interaction, Is.TypeOf<TapInteraction>());
             Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Started));
             Assert.That(actions[2].interaction, Is.TypeOf<SlowTapInteraction>());
@@ -4804,7 +4804,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].control, Is.EqualTo(gamepad.rightTrigger));
             Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.00001));
         }
@@ -4853,7 +4853,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.00001));
 
             trace.Clear();
@@ -4885,7 +4885,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(4));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(0.234f).Within(0.00001));
             Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Started));
             Assert.That(actions[1].ReadValue<float>(), Is.EqualTo(-0.123f).Within(0.00001));
@@ -5000,7 +5000,7 @@ partial class CoreTests
 
         Vector2? value = null;
         action.performed += ctx => { value = ctx.ReadValue<Vector2>(); };
-        action.cancelled += ctx => { value = ctx.ReadValue<Vector2>(); };
+        action.canceled += ctx => { value = ctx.ReadValue<Vector2>(); };
 
         var pressPoint = gamepad.leftStick.up.pressPointOrDefault;
 
@@ -5087,7 +5087,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(0));
 
             trace.Clear();
@@ -5250,7 +5250,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.000001));
         }
     }
@@ -5747,7 +5747,7 @@ partial class CoreTests
             Assert.That(action.bindings[0].path, Is.EqualTo("<Gamepad>/buttonSouth"));
             Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/buttonNorth"));
             Assert.That(rebind.completed, Is.True);
-            Assert.That(rebind.cancelled, Is.False);
+            Assert.That(rebind.canceled, Is.False);
             Assert.That(receivedCompleteCallback, Is.True);
         }
     }
@@ -5782,7 +5782,7 @@ partial class CoreTests
                                Assert.That(receivedCancelCallback, Is.False);
                                receivedCancelCallback = true;
                            })
-                       .WithCancellingThrough(keyboard.escapeKey)
+                       .WithCancelingThrough(keyboard.escapeKey)
                        .Start())
         {
             InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.Escape));
@@ -5792,7 +5792,7 @@ partial class CoreTests
             Assert.That(action.bindings[0].path, Is.EqualTo("<Keyboard>/space"));
             Assert.That(action.bindings[0].overridePath, Is.Null);
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.cancelled, Is.True);
+            Assert.That(rebind.canceled, Is.True);
             Assert.That(receivedCancelCallback, Is.True);
         }
     }
@@ -5825,7 +5825,7 @@ partial class CoreTests
             Assert.That(action.bindings[0].path, Is.EqualTo("<Keyboard>/space"));
             Assert.That(action.bindings[0].overridePath, Is.Null);
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.cancelled, Is.True);
+            Assert.That(rebind.canceled, Is.True);
             Assert.That(receivedCancelCallback, Is.True);
         }
     }
@@ -6125,7 +6125,7 @@ partial class CoreTests
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.cancelled, Is.False);
+            Assert.That(rebind.canceled, Is.False);
             Assert.That(action.bindings[0].path, Is.EqualTo("<Gamepad>/buttonSouth"));
             Assert.That(action.bindings[0].overridePath, Is.Null);
 
@@ -6134,7 +6134,7 @@ partial class CoreTests
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
-            Assert.That(rebind.cancelled, Is.False);
+            Assert.That(rebind.canceled, Is.False);
             Assert.That(action.bindings[0].path, Is.EqualTo("<Gamepad>/buttonSouth"));
             Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/leftTrigger"));
         }
@@ -6494,7 +6494,7 @@ partial class CoreTests
     }
 
     // Optionally, a fixed timeout on the entire operation can be specified. If no relevant input registers
-    // within the given time, the operation is automatically cancelled.
+    // within the given time, the operation is automatically canceled.
     [Test]
     [Category("Actions")]
     [Ignore("TODO")]
@@ -6694,7 +6694,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(3));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<Vector2>(), Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
             Assert.That(actions[0].control, Is.SameAs(gamepad.leftStick));
             Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Started));
@@ -6713,7 +6713,7 @@ partial class CoreTests
 
             actions = trace.ToArray();
             Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Cancelled));
+            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
             Assert.That(actions[0].ReadValue<Vector2>(), Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
             Assert.That(actions[0].control, Is.SameAs(mouse.delta));
         }

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -2337,16 +2337,16 @@ partial class CoreTests
         InputSystem.QueueDeltaStateEvent(device.allTouchControls[1],
             new TouchState
             {
-                phase = PointerPhase.Cancelled,
+                phase = PointerPhase.Canceled,
                 touchId = 5,
             });
         InputSystem.Update();
 
-        // For one frame, the ended and cancelled touches should stick around on the active touches list
+        // For one frame, the ended and canceled touches should stick around on the active touches list
 
         Assert.That(device.activeTouches.Count, Is.EqualTo(2));
         Assert.That(device.allTouchControls[0].phase.ReadValue(), Is.EqualTo(PointerPhase.Ended));
-        Assert.That(device.allTouchControls[1].phase.ReadValue(), Is.EqualTo(PointerPhase.Cancelled));
+        Assert.That(device.allTouchControls[1].phase.ReadValue(), Is.EqualTo(PointerPhase.Canceled));
 
         // But then they should disappear from the list.
 
@@ -3489,7 +3489,7 @@ partial class CoreTests
     }
 
     #if UNITY_2019_1_OR_NEWER
-    // NOTE: The focus logic will also implicitly take care of cancelling and restarting actions.
+    // NOTE: The focus logic will also implicitly take care of canceling and restarting actions.
     [Test]
     [Category("Devices")]
     public unsafe void Devices_WhenFocusChanges_AllConnectedDevicesAreResetOnce()

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -626,7 +626,7 @@ internal class PlayerInputTests : InputTestFixture
 
     [Test]
     [Category("PlayerInput")]
-    public void PlayerInput_CanReceiveMessageWhenContinuousActionIsCancelled()
+    public void PlayerInput_CanReceiveMessageWhenContinuousActionIsCanceled()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
 

--- a/Assets/Tests/InputSystem/Plugins/UserTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UserTests.cs
@@ -150,7 +150,7 @@ internal class UserTests : InputTestFixture
         var returnUserAccountHandle = 0;
         var returnUserAccountName = "";
         var returnUserAccountId = "";
-        var returnUserAccountSelectionCancelled = false;
+        var returnUserAccountSelectionCanceled = false;
 
         var gamepadId = runtime.AllocateDeviceId();
         var receivedPairingRequest = false;
@@ -171,8 +171,8 @@ internal class UserTests : InputTestFixture
                         result |= (long)QueryPairedUserAccountCommand.Result.DevicePairedToUserAccount;
                     }
 
-                    if (returnUserAccountSelectionCancelled)
-                        result |= (long)QueryPairedUserAccountCommand.Result.UserAccountSelectionCancelled;
+                    if (returnUserAccountSelectionCanceled)
+                        result |= (long)QueryPairedUserAccountCommand.Result.UserAccountSelectionCanceled;
                     return result;
                 }
                 if (command->type == InitiateUserAccountPairingCommand.Type)
@@ -258,7 +258,7 @@ internal class UserTests : InputTestFixture
         receivedChanges.Clear();
 
         // Cancel account selection.
-        returnUserAccountSelectionCancelled = true;
+        returnUserAccountSelectionCanceled = true;
 
         InputSystem.QueueConfigChangeEvent(gamepad);
         InputSystem.Update();
@@ -271,7 +271,7 @@ internal class UserTests : InputTestFixture
         Assert.That(receivedPairingRequest, Is.False);
         Assert.That(receivedChanges, Is.EquivalentTo(new[]
         {
-            new UserChange(user, InputUserChange.AccountSelectionCancelled, gamepad)
+            new UserChange(user, InputUserChange.AccountSelectionCanceled, gamepad)
         }));
 
         receivedUserIdRequest = false;
@@ -298,7 +298,7 @@ internal class UserTests : InputTestFixture
         returnUserAccountHandle = 2;
         returnUserAccountName = "OtherUser";
         returnUserAccountId = "OtherId";
-        returnUserAccountSelectionCancelled = false;
+        returnUserAccountSelectionCanceled = false;
 
         InputSystem.QueueConfigChangeEvent(gamepad);
         InputSystem.Update();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to the input system package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.3-preview] - TBD
+Due to package verification, the latest version below is the unpublished version and the date is meaningless.
+however, it has to be formatted properly to pass verification tests.
+
+## [0.2.9-preview] - 2020-1-1
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `PlayerInput` will no longer disable any actions not in the currently active action map when disabling input or switching action maps.
 - Change some public fields into properties.
 - Input System project settings are now called "Input System Package" in the project window instead of "Input (NEW)".
+- Rename "Cancelled" -> "Canceled" (US spelling) in all APIs.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -12,7 +12,7 @@ using UnityEngine.InputSystem.Utilities;
 ////        have to come preconfigured and work robustly for the user without requiring much understanding of how
 ////        the system fits together.
 
-////REVIEW: have single delegate instead of separate performed/started/cancelled callbacks?
+////REVIEW: have single delegate instead of separate performed/started/canceled callbacks?
 
 ////REVIEW: remove everything on InputAction that isn't about being an endpoint? (i.e. 'controls' and 'bindings')
 
@@ -325,13 +325,13 @@ namespace UnityEngine.InputSystem
 
         /// <summary>
         /// Event that is triggered when the action has been <see cref="started"/>
-        /// but then cancelled before being fully <see cref="performed"/>.
+        /// but then canceled before being fully <see cref="performed"/>.
         /// </summary>
-        /// <see cref="InputActionPhase.Cancelled"/>
-        public event Action<CallbackContext> cancelled
+        /// <see cref="InputActionPhase.Canceled"/>
+        public event Action<CallbackContext> canceled
         {
-            add => m_OnCancelled.Append(value);
-            remove => m_OnCancelled.Remove(value);
+            add => m_OnCanceled.Append(value);
+            remove => m_OnCanceled.Remove(value);
         }
 
         /// <summary>
@@ -488,7 +488,7 @@ namespace UnityEngine.InputSystem
 
         // Listeners. No array allocations if only a single listener.
         [NonSerialized] internal InlinedArray<Action<CallbackContext>> m_OnStarted;
-        [NonSerialized] internal InlinedArray<Action<CallbackContext>> m_OnCancelled;
+        [NonSerialized] internal InlinedArray<Action<CallbackContext>> m_OnCanceled;
         [NonSerialized] internal InlinedArray<Action<CallbackContext>> m_OnPerformed;
 
         /// <summary>
@@ -600,7 +600,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <seealso cref="performed"/>
         /// <seealso cref="started"/>
-        /// <seealso cref="cancelled"/>
+        /// <seealso cref="canceled"/>
         /// <seealso cref="InputActionMap.actionTriggered"/>
         public struct CallbackContext
         {
@@ -626,7 +626,7 @@ namespace UnityEngine.InputSystem
 
             public bool performed => phase == InputActionPhase.Performed;
 
-            public bool cancelled => phase == InputActionPhase.Cancelled;
+            public bool canceled => phase == InputActionPhase.Canceled;
 
             /// <summary>
             /// The action that got triggered.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionChange.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionChange.cs
@@ -45,11 +45,11 @@ namespace UnityEngine.InputSystem
         ActionPerformed,
 
         /// <summary>
-        /// An <see cref="InputAction"/> was cancelled.
+        /// An <see cref="InputAction"/> was canceled.
         /// </summary>
-        /// <seealso cref="InputAction.cancelled"/>
-        /// <seealso cref="InputActionPhase.Cancelled"/>
-        ActionCancelled,
+        /// <seealso cref="InputAction.canceled"/>
+        /// <seealso cref="InputActionPhase.Canceled"/>
+        ActionCanceled,
 
         /// <summary>
         ///

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -180,7 +180,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <seealso cref="InputAction.started"/>
         /// <seealso cref="InputAction.performed"/>
-        /// <seealso cref="InputAction.cancelled"/>
+        /// <seealso cref="InputAction.canceled"/>
         public event Action<InputAction.CallbackContext> actionTriggered
         {
             add => m_ActionCallbacks.AppendWithCapacity(value);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionPhase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionPhase.cs
@@ -14,7 +14,7 @@ namespace UnityEngine.InputSystem
     /// 'slow tap'</see> will put an action into <see cref="Started"/> phase when a button
     /// the action is bound to is pressed. At that point, however, the action still
     /// has to wait for the expiration of a timer in order to make it a 'slow tap'. If
-    /// the button is release before the timer expires, the action will be <see cref="Cancelled"/>
+    /// the button is release before the timer expires, the action will be <see cref="Canceled"/>
     /// whereas if the button is held long enough, the action will be <see cref="Performed"/>.
     /// </remarks>
     public enum InputActionPhase
@@ -29,7 +29,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <remarks>
         /// This is the phase that an action goes back to once it has been <see cref="Performed"/>
-        /// or <see cref="Cancelled"/>.
+        /// or <see cref="Canceled"/>.
         /// </remarks>
         Waiting,
 
@@ -47,7 +47,7 @@ namespace UnityEngine.InputSystem
         /// When the button it is bound to is pressed, the associated action goes into the <see cref="Started"/>
         /// phase. At this point, the interaction does not yet know whether the button press will result in just
         /// a tap or will indeed result in slow tap. If the button is released before the time it takes to
-        /// recognize a slow tap, then the action will go to <see cref="Cancelled"/> and then back to <see cref="Waiting"/>.
+        /// recognize a slow tap, then the action will go to <see cref="Canceled"/> and then back to <see cref="Waiting"/>.
         /// If, however, the button is held long enough for it to qualify as a slow tap, the action will progress
         /// to <see cref="Performed"/> and then go back to <see cref="Waiting"/>.
         ///
@@ -65,7 +65,7 @@ namespace UnityEngine.InputSystem
         ///             weaponChargeStartTime = ctx.time;
         ///         }
         ///     }
-        /// fireAction.cancelled +=
+        /// fireAction.canceled +=
         ///     ctx =>
         ///     {
         ///         weaponCharging = false;
@@ -89,7 +89,7 @@ namespace UnityEngine.InputSystem
         /// <summary>
         ///
         /// </summary>
-        /// <seealso cref="InputAction.cancelled"/>
-        Cancelled
+        /// <seealso cref="InputAction.canceled"/>
+        Canceled
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -390,7 +390,7 @@ namespace UnityEngine.InputSystem
 
             public bool completed => (m_Flags & Flags.Completed) != 0;
 
-            public bool cancelled => (m_Flags & Flags.Cancelled) != 0;
+            public bool canceled => (m_Flags & Flags.Canceled) != 0;
 
             public double startTime => m_StartTime;
 
@@ -421,15 +421,15 @@ namespace UnityEngine.InputSystem
                 throw new NotImplementedException();
             }
 
-            public RebindingOperation WithCancellingThrough(string binding)
+            public RebindingOperation WithCancelingThrough(string binding)
             {
                 m_CancelBinding = binding;
                 return this;
             }
 
-            public RebindingOperation WithCancellingThrough(InputControl control)
+            public RebindingOperation WithCancelingThrough(InputControl control)
             {
-                return WithCancellingThrough(control.path);
+                return WithCancelingThrough(control.path);
             }
 
             public RebindingOperation WithExpectedControlLayout(string layoutName)
@@ -630,7 +630,7 @@ namespace UnityEngine.InputSystem
                 HookOnEvent();
 
                 m_Flags |= Flags.Started;
-                m_Flags &= ~Flags.Cancelled;
+                m_Flags &= ~Flags.Canceled;
                 m_Flags &= ~Flags.Completed;
 
                 return this;
@@ -850,7 +850,7 @@ namespace UnityEngine.InputSystem
                     }
                 }
 
-                if (haveChangedCandidates && !cancelled)
+                if (haveChangedCandidates && !canceled)
                 {
                     // If we have a callback that wants to control matching, leave it to the callback to decide
                     // whether the rebind is complete or not. Otherwise, just complete.
@@ -1014,7 +1014,7 @@ namespace UnityEngine.InputSystem
 
             private void OnCancel()
             {
-                m_Flags |= Flags.Cancelled;
+                m_Flags |= Flags.Canceled;
 
                 m_OnCancel?.Invoke(this);
 
@@ -1095,7 +1095,7 @@ namespace UnityEngine.InputSystem
             {
                 Started = 1 << 0,
                 Completed = 1 << 1,
-                Cancelled = 1 << 2,
+                Canceled = 1 << 2,
                 OnEventHooked = 1 << 3,
                 OnAfterUpdateHooked = 1 << 4,
                 OverwritePath = 1 << 5,

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -423,7 +423,7 @@ namespace UnityEngine.InputSystem
                     Debug.Assert(bindingStates[actionState->bindingIndex].interactionCount == 0,
                         "Action has been triggered but apparently not from an interaction yet there's interactions on the binding that got triggered?!?");
 
-                    ChangePhaseOfAction(InputActionPhase.Cancelled, ref actionStates[actionIndex]);
+                    ChangePhaseOfAction(InputActionPhase.Canceled, ref actionStates[actionIndex]);
                 }
             }
 
@@ -804,7 +804,7 @@ namespace UnityEngine.InputSystem
                 // Trigger the action and go back to its current phase (may be
                 actionStates[actionIndex].time = time;
                 ChangePhaseOfAction(InputActionPhase.Performed, ref actionStates[actionIndex],
-                    phaseAfterPerformedOrCancelled: currentPhase);
+                    phaseAfterPerformedOrCanceled: currentPhase);
             }
 
             // All actions that are currently in the list become the actions we update by default
@@ -1319,7 +1319,7 @@ namespace UnityEngine.InputSystem
                     if (trigger.passThrough)
                     {
                         ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
-                            phaseAfterPerformedOrCancelled: InputActionPhase.Waiting);
+                            phaseAfterPerformedOrCanceled: InputActionPhase.Waiting);
                         break;
                     }
 
@@ -1329,7 +1329,7 @@ namespace UnityEngine.InputSystem
                         // Go into started, then perform and then go back to started.
                         ChangePhaseOfAction(InputActionPhase.Started, ref trigger);
                         ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
-                            phaseAfterPerformedOrCancelled: InputActionPhase.Started);
+                            phaseAfterPerformedOrCanceled: InputActionPhase.Started);
                     }
 
                     break;
@@ -1340,13 +1340,13 @@ namespace UnityEngine.InputSystem
                     if (!IsActuated(ref trigger))
                     {
                         // Control went back to below actuation threshold. Cancel interaction.
-                        ChangePhaseOfAction(InputActionPhase.Cancelled, ref trigger);
+                        ChangePhaseOfAction(InputActionPhase.Canceled, ref trigger);
                     }
                     else
                     {
                         // Control changed value above magnitude threshold. Perform and remain started.
                         ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
-                            phaseAfterPerformedOrCancelled: InputActionPhase.Started);
+                            phaseAfterPerformedOrCanceled: InputActionPhase.Started);
                     }
                     break;
                 }
@@ -1467,7 +1467,7 @@ namespace UnityEngine.InputSystem
         /// this determines which phase to transition to after the action has been performed. This would usually be
         /// <see cref="InputActionPhase.Waiting"/> (default), <see cref="InputActionPhase.Started"/> (if the action is supposed
         /// to be oscillate between started and performed), or <see cref="InputActionPhase.Performed"/> (if the action is
-        /// supposed to perform over and over again until cancelled).</param>
+        /// supposed to perform over and over again until canceled).</param>
         /// <remarks>
         /// Multiple interactions on the same binding can be started concurrently but the
         /// first interaction that starts will get to drive an action until it either cancels
@@ -1491,12 +1491,12 @@ namespace UnityEngine.InputSystem
             Debug.Assert(interactionIndex >= 0 && interactionIndex < totalInteractionCount, "Interaction index out of range");
             Debug.Assert(bindingIndex >= 0 && bindingIndex < totalBindingCount, "Binding index out of range");
 
-            ////TODO: need to make sure that performed and cancelled phase changes happen on the *same* binding&control
+            ////TODO: need to make sure that performed and canceled phase changes happen on the *same* binding&control
             ////      as the start of the phase
 
-            var phaseAfterPerformedOrCancelled = InputActionPhase.Waiting;
+            var phaseAfterPerformedOrCanceled = InputActionPhase.Waiting;
             if (newPhase == InputActionPhase.Performed)
-                phaseAfterPerformedOrCancelled = phaseAfterPerformed;
+                phaseAfterPerformedOrCanceled = phaseAfterPerformed;
 
             // Any time an interaction changes phase, we cancel all pending timeouts.
             if (interactionStates[interactionIndex].isTimerRunning)
@@ -1517,11 +1517,11 @@ namespace UnityEngine.InputSystem
                 {
                     // We're the first interaction to go to the start phase.
                     ChangePhaseOfAction(newPhase, ref trigger,
-                        phaseAfterPerformedOrCancelled: phaseAfterPerformedOrCancelled);
+                        phaseAfterPerformedOrCanceled: phaseAfterPerformedOrCanceled);
                 }
-                else if (newPhase == InputActionPhase.Cancelled && actionStates[actionIndex].interactionIndex == trigger.interactionIndex)
+                else if (newPhase == InputActionPhase.Canceled && actionStates[actionIndex].interactionIndex == trigger.interactionIndex)
                 {
-                    // We're cancelling but maybe there's another interaction ready
+                    // We're canceling but maybe there's another interaction ready
                     // to go into start phase.
 
                     ChangePhaseOfAction(newPhase, ref trigger);
@@ -1552,7 +1552,7 @@ namespace UnityEngine.InputSystem
                 {
                     // Any other phase change goes to action if we're the interaction driving
                     // the current phase.
-                    ChangePhaseOfAction(newPhase, ref trigger, phaseAfterPerformedOrCancelled);
+                    ChangePhaseOfAction(newPhase, ref trigger, phaseAfterPerformedOrCanceled);
 
                     // We're the interaction driving the action and we performed the action,
                     // so reset any other interaction to waiting state.
@@ -1570,7 +1570,7 @@ namespace UnityEngine.InputSystem
                 }
             }
 
-            // If the interaction performed or cancelled, go back to waiting.
+            // If the interaction performed or canceled, go back to waiting.
             // Exception: if it was performed and we're to remain in started state, set the interaction
             //            to started. Note that for that phase transition, there are no callbacks being
             //            triggered (i.e. we don't call 'started' every time after 'performed').
@@ -1578,7 +1578,7 @@ namespace UnityEngine.InputSystem
             {
                 interactionStates[interactionIndex].phase = phaseAfterPerformed;
             }
-            else if (newPhase == InputActionPhase.Performed || newPhase == InputActionPhase.Cancelled)
+            else if (newPhase == InputActionPhase.Performed || newPhase == InputActionPhase.Canceled)
             {
                 ResetInteractionState(trigger.mapIndex, trigger.bindingIndex, trigger.interactionIndex);
             }
@@ -1590,17 +1590,17 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <param name="newPhase">New phase to transition to.</param>
         /// <param name="trigger">Trigger that caused the change in phase.</param>
-        /// <param name="phaseAfterPerformedOrCancelled"></param>
+        /// <param name="phaseAfterPerformedOrCanceled"></param>
         /// <remarks>
         /// The change in phase is visible to observers, i.e. on the various callbacks and notifications.
         ///
-        /// If <paramref name="newPhase"/> is <see cref="InputActionPhase.Performed"/> or <see cref="InputActionPhase.Cancelled"/>,
-        /// the action will subsequently immediately transition to <paramref name="phaseAfterPerformedOrCancelled"/>
+        /// If <paramref name="newPhase"/> is <see cref="InputActionPhase.Performed"/> or <see cref="InputActionPhase.Canceled"/>,
+        /// the action will subsequently immediately transition to <paramref name="phaseAfterPerformedOrCanceled"/>
         /// (<see cref="InputActionPhase.Waiting"/> by default). This change is not visible to observers, i.e. there won't
         /// be another run through callbacks.
         /// </remarks>
         private void ChangePhaseOfAction(InputActionPhase newPhase, ref TriggerState trigger,
-            InputActionPhase phaseAfterPerformedOrCancelled = InputActionPhase.Waiting)
+            InputActionPhase phaseAfterPerformedOrCanceled = InputActionPhase.Waiting)
         {
             Debug.Assert(newPhase != InputActionPhase.Disabled, "Should not disable an action using this method");
             Debug.Assert(trigger.mapIndex >= 0 && trigger.mapIndex < totalMapCount, "Map index out of range");
@@ -1645,12 +1645,12 @@ namespace UnityEngine.InputSystem
                     CallActionListeners(actionIndex, map, newPhase, ref action.m_OnPerformed);
                     if (actionState->phase != InputActionPhase.Disabled) // Action may have been disabled in callback.
                     {
-                        actionState->phase = phaseAfterPerformedOrCancelled;
+                        actionState->phase = phaseAfterPerformedOrCanceled;
 
                         // If the action is continuous and remains in performed or started state, make sure the action
                         // is on the list of continuous actions that we check every update.
-                        if ((phaseAfterPerformedOrCancelled == InputActionPhase.Started ||
-                             phaseAfterPerformedOrCancelled == InputActionPhase.Performed) &&
+                        if ((phaseAfterPerformedOrCanceled == InputActionPhase.Started ||
+                             phaseAfterPerformedOrCanceled == InputActionPhase.Performed) &&
                             actionState->continuous &&
                             !actionState->onContinuousList)
                         {
@@ -1660,12 +1660,12 @@ namespace UnityEngine.InputSystem
                     break;
                 }
 
-                case InputActionPhase.Cancelled:
+                case InputActionPhase.Canceled:
                 {
-                    CallActionListeners(actionIndex, map, newPhase, ref action.m_OnCancelled);
+                    CallActionListeners(actionIndex, map, newPhase, ref action.m_OnCanceled);
                     if (actionState->phase != InputActionPhase.Disabled) // Action may have been disabled in callback.
                     {
-                        actionState->phase = phaseAfterPerformedOrCancelled;
+                        actionState->phase = phaseAfterPerformedOrCanceled;
 
                         // Remove from list of continuous actions, if necessary.
                         if (actionState->onContinuousList)
@@ -1720,8 +1720,8 @@ namespace UnityEngine.InputSystem
                     case InputActionPhase.Performed:
                         change = InputActionChange.ActionPerformed;
                         break;
-                    case InputActionPhase.Cancelled:
-                        change = InputActionChange.ActionCancelled;
+                    case InputActionPhase.Canceled:
+                        change = InputActionChange.ActionCanceled;
                         break;
                     default:
                         Debug.Assert(false, "Should not reach here");
@@ -1847,7 +1847,7 @@ namespace UnityEngine.InputSystem
                 {
                     case InputActionPhase.Started:
                     case InputActionPhase.Performed:
-                        ChangePhaseOfInteraction(InputActionPhase.Cancelled, ref actionStates[actionIndex]);
+                        ChangePhaseOfInteraction(InputActionPhase.Canceled, ref actionStates[actionIndex]);
                         break;
                 }
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionTrace.cs
@@ -87,7 +87,7 @@ namespace UnityEngine.InputSystem
     /// </remarks>
     /// <seealso cref="InputAction.started"/>
     /// <seealso cref="InputAction.performed"/>
-    /// <seealso cref="InputAction.cancelled"/>
+    /// <seealso cref="InputAction.canceled"/>
     /// <seealso cref="InputSystem.onActionChange"/>
     public class InputActionTrace : IEnumerable<InputActionTrace.ActionEventPtr>, IDisposable
     {
@@ -165,7 +165,7 @@ namespace UnityEngine.InputSystem
 
             action.performed += m_CallbackDelegate;
             action.started += m_CallbackDelegate;
-            action.cancelled += m_CallbackDelegate;
+            action.canceled += m_CallbackDelegate;
 
             m_SubscribedActions.AppendWithCapacity(action);
         }
@@ -193,7 +193,7 @@ namespace UnityEngine.InputSystem
 
             action.performed -= m_CallbackDelegate;
             action.started -= m_CallbackDelegate;
-            action.cancelled -= m_CallbackDelegate;
+            action.canceled -= m_CallbackDelegate;
 
             var index = m_SubscribedActions.IndexOfReference(action);
             if (index != -1)
@@ -221,7 +221,7 @@ namespace UnityEngine.InputSystem
         /// <param name="context"></param>
         /// <see cref="InputAction.performed"/>
         /// <see cref="InputAction.started"/>
-        /// <see cref="InputAction.cancelled"/>
+        /// <see cref="InputAction.canceled"/>
         /// <see cref="InputActionMap.actionTriggered"/>
         public unsafe void RecordAction(InputAction.CallbackContext context)
         {
@@ -338,7 +338,7 @@ namespace UnityEngine.InputSystem
                 {
                     case InputActionChange.ActionStarted:
                     case InputActionChange.ActionPerformed:
-                    case InputActionChange.ActionCancelled:
+                    case InputActionChange.ActionCanceled:
                         Debug.Assert(actionOrMap is InputAction, "Expected an action");
                         var triggeredAction = (InputAction)actionOrMap;
                         var actionIndex = triggeredAction.m_ActionIndex;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputInteractionContext.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputInteractionContext.cs
@@ -95,7 +95,7 @@ namespace UnityEngine.InputSystem
         /// Note that this affects the current interaction only. There may be multiple interactions on a binding
         /// and arbitrary many interactions may concurrently be in started state. However, only one interaction
         /// (usually the one that starts first) is allowed to drive the action's state as a whole. If an interaction
-        /// that is currently driving an action is cancelled, however, the next interaction in the list that has
+        /// that is currently driving an action is canceled, however, the next interaction in the list that has
         /// been started will take over and continue driving the action.
         ///
         /// <example>
@@ -147,9 +147,9 @@ namespace UnityEngine.InputSystem
                 phaseAfterPerformed: InputActionPhase.Performed);
         }
 
-        public void Cancelled()
+        public void Canceled()
         {
-            m_State.ChangePhaseOfInteraction(InputActionPhase.Cancelled, ref m_TriggerState);
+            m_State.ChangePhaseOfInteraction(InputActionPhase.Canceled, ref m_TriggerState);
         }
 
         public void Waiting()

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -75,7 +75,7 @@ namespace UnityEngine.InputSystem.Interactions
                     {
                         // Control is no longer actuated and we haven't performed a hold yet,
                         // so cancel.
-                        context.Cancelled();
+                        context.Canceled();
                     }
                     break;
 
@@ -87,7 +87,7 @@ namespace UnityEngine.InputSystem.Interactions
                     }
                     else
                     {
-                        context.Cancelled();
+                        context.Canceled();
                     }
                     break;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -13,14 +13,14 @@ namespace UnityEngine.InputSystem.Interactions
     /// The interaction goes into <see cref="InputActionPhase.Started"/> on the first press and then will not
     /// trigger again until either the full tap sequence is performed (in which case the interaction triggers
     /// <see cref="InputActionPhase.Performed"/>) or the multi-tap is aborted by a timeout being hit (in which
-    /// case the interaction will trigger <see cref="InputActionPhase.Cancelled"/>).
+    /// case the interaction will trigger <see cref="InputActionPhase.Canceled"/>).
     /// </remarks>
     public class MultiTapInteraction : IInputInteraction<float>
     {
         [Tooltip("The maximum time (in seconds) allowed to elapse between pressing and releasing a control for it to register as a tap.")]
         public float tapTime;
 
-        [Tooltip("The maximum delay (in seconds) allowed between each tap. If this time is exceeded, the multi-tap is cancelled.")]
+        [Tooltip("The maximum delay (in seconds) allowed between each tap. If this time is exceeded, the multi-tap is canceled.")]
         public float tapDelay;
 
         [Tooltip("How many taps need to be performed in succession. Two means double-tap, three means triple-tap, and so on.")]
@@ -38,7 +38,7 @@ namespace UnityEngine.InputSystem.Interactions
             {
                 // We use timers multiple times but no matter what, if they expire it means
                 // that we didn't get input in time.
-                context.Cancelled();
+                context.Canceled();
                 return;
             }
 
@@ -73,7 +73,7 @@ namespace UnityEngine.InputSystem.Interactions
                         }
                         else
                         {
-                            context.Cancelled();
+                            context.Canceled();
                         }
                     }
                     break;
@@ -89,7 +89,7 @@ namespace UnityEngine.InputSystem.Interactions
                         }
                         else
                         {
-                            context.Cancelled();
+                            context.Canceled();
                         }
                     }
                     break;
@@ -127,11 +127,11 @@ namespace UnityEngine.InputSystem.Interactions
         {
             m_TapTimeSetting.Initialize("Max Tap Duration",
                 "Time (in seconds) within with a control has to be released again for it to register as a tap. If the control is held "
-                + "for longer than this time, the tap is cancelled.",
+                + "for longer than this time, the tap is canceled.",
                 "Default Tap Time",
                 () => target.tapTime, x => target.tapTime = x, () => InputSystem.settings.defaultTapTime);
             m_TapDelaySetting.Initialize("Max Tap Spacing",
-                "The maximum delay (in seconds) allowed between each tap. If this time is exceeded, the multi-tap is cancelled.",
+                "The maximum delay (in seconds) allowed between each tap. If this time is exceeded, the multi-tap is canceled.",
                 "Default Tap Spacing",
                 () => target.tapDelay, x => target.tapDelay = x, () => target.tapDelayOrDefault,
                 defaultComesFromInputSettings: false);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.InputSystem.Interactions
 
         [Tooltip("Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
             + "With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is performed on press and "
-            + "cancelled on release.")]
+            + "canceled on release.")]
         public PressBehavior behavior;
 
         private float pressPointOrDefault => pressPoint > 0 ? pressPoint : InputSystem.settings.defaultButtonPressPoint;
@@ -165,7 +165,7 @@ namespace UnityEngine.InputSystem.Interactions
         private static readonly GUIContent s_PressBehaviorLabel = EditorGUIUtility.TrTextContent("Trigger Behavior",
             "Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
             + "With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is performed on press and "
-            + "cancelled on release.");
+            + "canceled on release.");
     }
     #endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
@@ -37,7 +37,7 @@ namespace UnityEngine.InputSystem.Interactions
                     context.PerformedAndGoBackToWaiting();
                 else
                     ////REVIEW: does it matter to cancel right after expiration of 'duration' or is it enough to cancel on button up like here?
-                    context.Cancelled();
+                    context.Canceled();
             }
         }
 
@@ -54,7 +54,7 @@ namespace UnityEngine.InputSystem.Interactions
         {
             m_DurationSetting.Initialize("Min Tap Duration",
                 "Minimum time (in seconds) that a control has to be held for it to register as a slow tap. If the control is released "
-                + "before this time, the slow tap is cancelled.",
+                + "before this time, the slow tap is canceled.",
                 "Default Slow Tap Time",
                 () => target.duration, x => target.duration = x, () => InputSystem.settings.defaultSlowTapTime);
             m_PressPointSetting.Initialize("Press Point",

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.InputSystem.Interactions
         {
             if (context.timerHasExpired)
             {
-                context.Cancelled();
+                context.Canceled();
                 return;
             }
 
@@ -47,7 +47,7 @@ namespace UnityEngine.InputSystem.Interactions
                 else
                 {
                     ////REVIEW: does it matter to cancel right after expiration of 'duration' or is it enough to cancel on button up like here?
-                    context.Cancelled();
+                    context.Canceled();
                 }
             }
         }
@@ -65,7 +65,7 @@ namespace UnityEngine.InputSystem.Interactions
         {
             m_DurationSetting.Initialize("Max Tap Duration",
                 "Time (in seconds) within with a control has to be released again for it to register as a tap. If the control is held "
-                + "for longer than this time, the tap is cancelled.",
+                + "for longer than this time, the tap is canceled.",
                 "Default Tap Time",
                 () => target.duration, x => target.duration = x, () => InputSystem.settings.defaultTapTime);
             m_PressPointSetting.Initialize("Press Point",

--- a/Packages/com.unity.inputsystem/InputSystem/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/AssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 // Keep this in sync with "Packages/com.unity.inputsystem/package.json".
 // NOTE: Unfortunately, System.Version doesn't use semantic versioning so we can't include
 //       "-preview" suffixes here.
-[assembly: AssemblyVersion("0.2.8")]
+[assembly: AssemblyVersion("0.2.9")]
 
 [assembly: InternalsVisibleTo("Unity.InputSystem.TestFramework")]
 [assembly: InternalsVisibleTo("Unity.InputSystem.Tests.Editor")]

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -345,7 +345,7 @@ namespace UnityEngine.InputSystem
         /// Magnitudes do not make sense for all types of controls. For example, for a control that represents
         /// an enumeration of values (such as <see cref="PointerPhaseControl"/>), there is no meaningful
         /// linear ordering of values (one could derive a linear ordering through the actual enum values but
-        /// their assignment may be entirely arbitrary; it is unclear whether a state of <see cref="PointerPhase.Cancelled"/>
+        /// their assignment may be entirely arbitrary; it is unclear whether a state of <see cref="PointerPhase.Canceled"/>
         /// has a higher or lower "magnitude" as a state of <see cref="PointerPhase.Began"/>).
         ///
         /// Controls that have no meaningful magnitude will return -1 when calling this method. Any negative

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryPairedUserAccountCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryPairedUserAccountCommand.cs
@@ -64,7 +64,7 @@ namespace UnityEngine.InputSystem.LowLevel
             /// The system had been displaying a prompt
             /// </summary>
             /// <seealso cref="InitiateUserAccountPairingCommand"/>
-            UserAccountSelectionCancelled = 1 << 4,
+            UserAccountSelectionCanceled = 1 << 4,
         }
 
         [FieldOffset(0)]

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -82,7 +82,7 @@ namespace UnityEngine.InputSystem
         Began,
         Moved,
         Ended,
-        Cancelled,
+        Canceled,
         Stationary,
     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -147,7 +147,7 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// This array only contains touches that are either in progress, i.e. have a phase of <see cref="PointerPhase.Began"/>
         /// or <see cref="PointerPhase.Moved"/> or <see cref="PointerPhase.Stationary"/>, or that have just ended, i.e. moved to
-        /// <see cref="PointerPhase.Ended"/> or <see cref="PointerPhase.Cancelled"/> this frame.
+        /// <see cref="PointerPhase.Ended"/> or <see cref="PointerPhase.Canceled"/> this frame.
         ///
         /// Does not allocate GC memory.
         /// </remarks>
@@ -169,7 +169,7 @@ namespace UnityEngine.InputSystem
                     {
                         isActive = true;
                     }
-                    else if (phase == PointerPhase.Ended || phase == PointerPhase.Cancelled)
+                    else if (phase == PointerPhase.Ended || phase == PointerPhase.Canceled)
                     {
                         // Touch has ended but we want to have it on the active list for one frame
                         // before "retiring" the touch again.
@@ -178,7 +178,7 @@ namespace UnityEngine.InputSystem
                         if (hadActivityThisFrame.Value)
                         {
                             var previousPhase = phaseControl.ReadValueFromPreviousFrame();
-                            if (previousPhase != PointerPhase.Ended && previousPhase != PointerPhase.Cancelled)
+                            if (previousPhase != PointerPhase.Ended && previousPhase != PointerPhase.Canceled)
                                 isActive = true;
                         }
                     }
@@ -284,7 +284,7 @@ namespace UnityEngine.InputSystem
                 switch (phase)
                 {
                     case PointerPhase.Ended:
-                    case PointerPhase.Cancelled:
+                    case PointerPhase.Canceled:
                         touchStatePtr->phase = PointerPhase.None;
                         touchStatePtr->delta = Vector2.zero;
                         haveChangedState = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -755,7 +755,7 @@ namespace UnityEngine.InputSystem.Editor
                             "Yes, Delete", "No, Cancel");
                         if (!result)
                         {
-                            // User cancelled. Stop the deletion.
+                            // User canceled. Stop the deletion.
                             return AssetDeleteResult.FailedDelete;
                         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using UnityEngine.InputSystem.Utilities;
 using UnityEditor;
 
-////TODO: unify the generated events so that performed, cancelled, and started all go into a single event
+////TODO: unify the generated events so that performed, canceled, and started all go into a single event
 
 ////TODO: look up actions and maps by ID rather than by name
 
@@ -233,7 +233,7 @@ namespace UnityEngine.InputSystem.Editor
 
                     writer.WriteLine($"{actionName}.started -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
                     writer.WriteLine($"{actionName}.performed -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
-                    writer.WriteLine($"{actionName}.cancelled -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
+                    writer.WriteLine($"{actionName}.canceled -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
                 }
                 writer.EndBlock();
 
@@ -248,7 +248,7 @@ namespace UnityEngine.InputSystem.Editor
 
                     writer.WriteLine($"{actionName}.started += instance.On{actionTypeName};");
                     writer.WriteLine($"{actionName}.performed += instance.On{actionTypeName};");
-                    writer.WriteLine($"{actionName}.cancelled += instance.On{actionTypeName};");
+                    writer.WriteLine($"{actionName}.canceled += instance.On{actionTypeName};");
                 }
                 writer.EndBlock();
                 writer.EndBlock();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -711,7 +711,7 @@ namespace UnityEngine.InputSystem.Plugins.PlayerInput
                             {
                                 ////REVIEW: really wish we had a single callback
                                 action.performed += actionEvent.Invoke;
-                                action.cancelled += actionEvent.Invoke;
+                                action.canceled += actionEvent.Invoke;
                                 action.started += actionEvent.Invoke;
                             }
                             else
@@ -762,7 +762,7 @@ namespace UnityEngine.InputSystem.Plugins.PlayerInput
                     {
                         ////REVIEW: really wish we had a single callback
                         action.performed -= actionEvent.Invoke;
-                        action.cancelled -= actionEvent.Invoke;
+                        action.canceled -= actionEvent.Invoke;
                         action.started -= actionEvent.Invoke;
                     }
                 }
@@ -781,9 +781,9 @@ namespace UnityEngine.InputSystem.Plugins.PlayerInput
             if (m_NotificationBehavior == PlayerNotifications.InvokeUnityEvents)
                 return;
 
-            // ATM we only care about `performed` and, in the case of continuous actions, `cancelled`.
+            // ATM we only care about `performed` and, in the case of continuous actions, `canceled`.
             var action = context.action;
-            if (!(context.performed || (context.cancelled && action.continuous)))
+            if (!(context.performed || (context.canceled && action.continuous)))
                 return;
 
             // Find message name for action.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -28,7 +28,7 @@ namespace UnityEngine.InputSystem.Plugins.UI
             if (property != null && actionsHooked)
             {
                 property.action.performed -= actionCallback;
-                property.action.cancelled -= actionCallback;
+                property.action.canceled -= actionCallback;
             }
 
             property = newValue;
@@ -36,7 +36,7 @@ namespace UnityEngine.InputSystem.Plugins.UI
             if (newValue != null && actionsHooked)
             {
                 property.action.performed += actionCallback;
-                property.action.cancelled += actionCallback;
+                property.action.canceled += actionCallback;
             }
         }
 
@@ -46,7 +46,7 @@ namespace UnityEngine.InputSystem.Plugins.UI
             if (property != null && actionsHooked)
             {
                 property.action.performed -= actionCallback;
-                property.action.cancelled -= actionCallback;
+                property.action.canceled -= actionCallback;
             }
 
             property = newValue;
@@ -54,7 +54,7 @@ namespace UnityEngine.InputSystem.Plugins.UI
             if (newValue != null && actionsHooked)
             {
                 property.action.performed += actionCallback;
-                property.action.cancelled += actionCallback;
+                property.action.canceled += actionCallback;
             }
         }
 
@@ -101,14 +101,14 @@ namespace UnityEngine.InputSystem.Plugins.UI
                 if (positionAction != null)
                 {
                     positionAction.performed += actionCallback;
-                    positionAction.cancelled += actionCallback;
+                    positionAction.canceled += actionCallback;
                 }
 
                 var phaseAction = m_Phase.action;
                 if (phaseAction != null)
                 {
                     phaseAction.performed += actionCallback;
-                    phaseAction.cancelled += actionCallback;
+                    phaseAction.canceled += actionCallback;
                 }
             }
 
@@ -123,14 +123,14 @@ namespace UnityEngine.InputSystem.Plugins.UI
                 if (positionAction != null)
                 {
                     positionAction.performed -= actionCallback;
-                    positionAction.cancelled -= actionCallback;
+                    positionAction.canceled -= actionCallback;
                 }
 
                 var phaseAction = m_Phase.action;
                 if (phaseAction != null)
                 {
                     phaseAction.performed -= actionCallback;
-                    phaseAction.cancelled -= actionCallback;
+                    phaseAction.canceled -= actionCallback;
                 }
             }
 
@@ -190,21 +190,21 @@ namespace UnityEngine.InputSystem.Plugins.UI
                 if (positionAction != null)
                 {
                     positionAction.performed += actionCallback;
-                    positionAction.cancelled += actionCallback;
+                    positionAction.canceled += actionCallback;
                 }
 
                 var orientationAction = m_Orientation.action;
                 if (orientationAction != null)
                 {
                     orientationAction.performed += actionCallback;
-                    orientationAction.cancelled += actionCallback;
+                    orientationAction.canceled += actionCallback;
                 }
 
                 var selectAction = m_Select.action;
                 if (selectAction != null)
                 {
                     selectAction.performed += actionCallback;
-                    selectAction.cancelled += actionCallback;
+                    selectAction.canceled += actionCallback;
                 }
             }
 
@@ -219,21 +219,21 @@ namespace UnityEngine.InputSystem.Plugins.UI
                 if (positionAction != null)
                 {
                     positionAction.performed -= actionCallback;
-                    positionAction.cancelled -= actionCallback;
+                    positionAction.canceled -= actionCallback;
                 }
 
                 var orientationAction = m_Orientation.action;
                 if (orientationAction != null)
                 {
                     orientationAction.performed -= actionCallback;
-                    orientationAction.cancelled -= actionCallback;
+                    orientationAction.canceled -= actionCallback;
                 }
 
                 var selectAction = m_Orientation.action;
                 if (selectAction != null)
                 {
                     selectAction.performed -= actionCallback;
-                    selectAction.cancelled -= actionCallback;
+                    selectAction.canceled -= actionCallback;
                 }
             }
 
@@ -692,56 +692,56 @@ namespace UnityEngine.InputSystem.Plugins.UI
             if (pointAction != null)
             {
                 pointAction.performed += m_OnActionDelegate;
-                pointAction.cancelled += m_OnActionDelegate;
+                pointAction.canceled += m_OnActionDelegate;
             }
 
             var moveAction = m_MoveAction?.action;
             if (moveAction != null)
             {
                 moveAction.performed += m_OnActionDelegate;
-                moveAction.cancelled += m_OnActionDelegate;
+                moveAction.canceled += m_OnActionDelegate;
             }
 
             var leftClickAction = m_LeftClickAction?.action;
             if (leftClickAction != null)
             {
                 leftClickAction.performed += m_OnActionDelegate;
-                leftClickAction.cancelled += m_OnActionDelegate;
+                leftClickAction.canceled += m_OnActionDelegate;
             }
 
             var rightClickAction = m_RightClickAction?.action;
             if (rightClickAction != null)
             {
                 rightClickAction.performed += m_OnActionDelegate;
-                rightClickAction.cancelled += m_OnActionDelegate;
+                rightClickAction.canceled += m_OnActionDelegate;
             }
 
             var middleClickAction = m_MiddleClickAction?.action;
             if (middleClickAction != null)
             {
                 middleClickAction.performed += m_OnActionDelegate;
-                middleClickAction.cancelled += m_OnActionDelegate;
+                middleClickAction.canceled += m_OnActionDelegate;
             }
 
             var submitAction = m_SubmitAction?.action;
             if (submitAction != null)
             {
                 submitAction.performed += m_OnActionDelegate;
-                submitAction.cancelled += m_OnActionDelegate;
+                submitAction.canceled += m_OnActionDelegate;
             }
 
             var cancelAction = m_CancelAction?.action;
             if (cancelAction != null)
             {
                 cancelAction.performed += m_OnActionDelegate;
-                cancelAction.cancelled += m_OnActionDelegate;
+                cancelAction.canceled += m_OnActionDelegate;
             }
 
             var scrollAction = m_ScrollWheelAction?.action;
             if (scrollAction != null)
             {
                 scrollAction.performed += m_OnActionDelegate;
-                scrollAction.cancelled += m_OnActionDelegate;
+                scrollAction.canceled += m_OnActionDelegate;
             }
 
             for (var i = 0; i < m_Touches.Count; i++)
@@ -770,56 +770,56 @@ namespace UnityEngine.InputSystem.Plugins.UI
             if (pointAction != null)
             {
                 pointAction.performed -= m_OnActionDelegate;
-                pointAction.cancelled -= m_OnActionDelegate;
+                pointAction.canceled -= m_OnActionDelegate;
             }
 
             var moveAction = m_MoveAction?.action;
             if (moveAction != null)
             {
                 moveAction.performed -= m_OnActionDelegate;
-                moveAction.cancelled -= m_OnActionDelegate;
+                moveAction.canceled -= m_OnActionDelegate;
             }
 
             var leftClickAction = m_LeftClickAction?.action;
             if (leftClickAction != null)
             {
                 leftClickAction.performed -= m_OnActionDelegate;
-                leftClickAction.cancelled -= m_OnActionDelegate;
+                leftClickAction.canceled -= m_OnActionDelegate;
             }
 
             var rightClickAction = m_RightClickAction?.action;
             if (rightClickAction != null)
             {
                 rightClickAction.performed -= m_OnActionDelegate;
-                rightClickAction.cancelled -= m_OnActionDelegate;
+                rightClickAction.canceled -= m_OnActionDelegate;
             }
 
             var middleClickAction = m_MiddleClickAction?.action;
             if (middleClickAction != null)
             {
                 middleClickAction.performed -= m_OnActionDelegate;
-                middleClickAction.cancelled -= m_OnActionDelegate;
+                middleClickAction.canceled -= m_OnActionDelegate;
             }
 
             var submitAction = m_SubmitAction?.action;
             if (submitAction != null)
             {
                 submitAction.performed -= m_OnActionDelegate;
-                submitAction.cancelled -= m_OnActionDelegate;
+                submitAction.canceled -= m_OnActionDelegate;
             }
 
             var cancelAction = m_CancelAction?.action;
             if (cancelAction != null)
             {
                 cancelAction.performed -= m_OnActionDelegate;
-                cancelAction.cancelled -= m_OnActionDelegate;
+                cancelAction.canceled -= m_OnActionDelegate;
             }
 
             var scrollAction = m_ScrollWheelAction?.action;
             if (scrollAction != null)
             {
                 scrollAction.performed += m_OnActionDelegate;
-                scrollAction.cancelled += m_OnActionDelegate;
+                scrollAction.canceled += m_OnActionDelegate;
             }
 
             for (var i = 0; i < m_Touches.Count; i++)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/TouchModel.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/TouchModel.cs
@@ -84,7 +84,7 @@ namespace UnityEngine.InputSystem.Plugins.UI
                     if (value == PointerPhase.Began)
                         selectDelta |= ButtonDeltaState.Pressed;
 
-                    if (value == PointerPhase.Ended || value == PointerPhase.Cancelled)
+                    if (value == PointerPhase.Ended || value == PointerPhase.Canceled)
                         selectDelta |= ButtonDeltaState.Released;
 
                     m_SelectPhase = value;
@@ -126,7 +126,7 @@ namespace UnityEngine.InputSystem.Plugins.UI
 
             m_Position = deltaPosition = Vector2.zero;
 
-            m_SelectPhase = PointerPhase.Cancelled;
+            m_SelectPhase = PointerPhase.Canceled;
             changedThisFrame = false;
             selectDelta = ButtonDeltaState.NoChange;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/UIInputModule.cs
@@ -300,9 +300,9 @@ namespace UnityEngine.InputSystem.Plugins.UI
 
             touchState.CopyTo(eventData);
 
-            if (touchState.selectPhase == PointerPhase.Cancelled)
+            if (touchState.selectPhase == PointerPhase.Canceled)
             {
-                eventData.pointerCurrentRaycast = (touchState.selectPhase == PointerPhase.Cancelled) ? new RaycastResult() : PerformRaycast(eventData);
+                eventData.pointerCurrentRaycast = (touchState.selectPhase == PointerPhase.Canceled) ? new RaycastResult() : PerformRaycast(eventData);
             }
             else
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -816,7 +816,7 @@ namespace UnityEngine.InputSystem.Plugins.Users
         /// to the user. Instead, pairing is deferred to until after an account selection has been made by the user.
         /// In this case, <see cref="InputUserChange.AccountSelectionInProgress"/> will be signalled through <see cref="onChange"/>
         /// and <see cref="InputUserChange.AccountChanged"/> will be signalled once the user has selected an account or
-        /// <see cref="InputUserChange.AccountSelectionCancelled"/> will be signalled if the user cancels account
+        /// <see cref="InputUserChange.AccountSelectionCanceled"/> will be signalled if the user cancels account
         /// selection. The device will be paired to the user once account selection is complete.
         ///
         /// This behavior is most useful on Xbox and Switch to require the user to choose which account to play with. Note that
@@ -1374,7 +1374,7 @@ namespace UnityEngine.InputSystem.Plugins.Users
                 // weird for the device to no signal it does not support querying user account, but
                 // just to be safe, we check.
                 if ((s_AllUserData[userIndex].flags & UserFlags.UserAccountSelectionInProgress) != 0)
-                    Notify(userIndex, InputUserChange.AccountSelectionCancelled, null);
+                    Notify(userIndex, InputUserChange.AccountSelectionCanceled, null);
 
                 s_AllUserData[userIndex].platformUserAccountHandle = null;
                 s_AllUserData[userIndex].platformUserAccountName = null;
@@ -1392,10 +1392,10 @@ namespace UnityEngine.InputSystem.Plugins.Users
                 {
                     // No, still in progress.
                 }
-                else if ((queryResult & QueryPairedUserAccountCommand.Result.UserAccountSelectionCancelled) != 0)
+                else if ((queryResult & QueryPairedUserAccountCommand.Result.UserAccountSelectionCanceled) != 0)
                 {
-                    // Got cancelled.
-                    Notify(userIndex, InputUserChange.AccountSelectionCancelled, device);
+                    // Got canceled.
+                    Notify(userIndex, InputUserChange.AccountSelectionCanceled, device);
                 }
                 else
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUserChange.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUserChange.cs
@@ -108,9 +108,9 @@ namespace UnityEngine.InputSystem.Plugins.Users
         AccountSelectionInProgress,
 
         /// <summary>
-        /// The user cancelled the account selection process that was initiated.
+        /// The user canceled the account selection process that was initiated.
         /// </summary>
-        AccountSelectionCancelled,
+        AccountSelectionCanceled,
 
         /// <summary>
         /// The user completed the account selection process.

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestFixture.cs
@@ -168,9 +168,9 @@ namespace UnityEngine.InputSystem
             return new ActionConstraint(InputActionPhase.Performed, action, control);
         }
 
-        public ActionConstraint Cancelled(InputAction action, InputControl control = null)
+        public ActionConstraint Canceled(InputAction action, InputControl control = null)
         {
-            return new ActionConstraint(InputActionPhase.Cancelled, action, control);
+            return new ActionConstraint(InputActionPhase.Canceled, action, control);
         }
 
         public ActionConstraint Started<TInteraction>(InputAction action, InputControl control = null)
@@ -185,10 +185,10 @@ namespace UnityEngine.InputSystem
             return new ActionConstraint(InputActionPhase.Performed, action, control, interaction: typeof(TInteraction));
         }
 
-        public ActionConstraint Cancelled<TInteraction>(InputAction action, InputControl control = null)
+        public ActionConstraint Canceled<TInteraction>(InputAction action, InputControl control = null)
             where TInteraction : IInputInteraction
         {
-            return new ActionConstraint(InputActionPhase.Cancelled, action, control, interaction: typeof(TInteraction));
+            return new ActionConstraint(InputActionPhase.Canceled, action, control, interaction: typeof(TInteraction));
         }
 
         // ReSharper disable once MemberCanBeProtected.Global

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "0.2.8-preview",
+	"version": "0.2.9-preview",
 	"unity": "2019.1",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This was pointed out by the Code analyzer. "Cancelled" is the UK spelling, "Canceled" is the preferred US spelling.

We don't want to have another "MonoBehaviour" stuck in our API.