### PR TITLE
Update InputSettings.cs

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -2,7 +2,6 @@ using UnityEngine.Experimental.Input.Layouts;
 using UnityEngine.Experimental.Input.LowLevel;
 using UnityEngine.Experimental.Input.Processors;
 using UnityEngine.Experimental.Input.Utilities;
-using UnityEngine.Experimental.PlayerLoop;
 
 ////TODO: make sure that alterations made to InputSystem.settings in play mode do not leak out into edit mode or the asset
 


### PR DESCRIPTION
remove unused import.

Now its working in Unity 2019.3.

Before I got this exception:
`Library\PackageCache\com.unity.inputsystem@0.2.8-preview\InputSystem\InputSettings.cs(5,32): error CS0234: The type or namespace name 'PlayerLoop' does not exist in the namespace 'UnityEngine.Experimental' (are you missing an assembly reference?)`