### PR TITLE
Fix IDisposable-related anaylizer warnings

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -67,7 +67,6 @@ namespace UnityEngine.InputSystem
     /// </remarks>
     [Serializable]
     public sealed class InputAction : ICloneable, IDisposable
-        ////REVIEW: should this class be IDisposable? how do we guarantee that actions are disabled in time?
     {
         /// <summary>
         /// Name of the action.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -66,7 +66,7 @@ namespace UnityEngine.InputSystem
     /// Actions are not supported in edit mode.
     /// </remarks>
     [Serializable]
-    public class InputAction : ICloneable, IDisposable
+    public sealed class InputAction : ICloneable, IDisposable
         ////REVIEW: should this class be IDisposable? how do we guarantee that actions are disabled in time?
     {
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -29,7 +29,7 @@ namespace UnityEngine.InputSystem
     /// on whether the player is walking or driving around.
     /// </remarks>
     [Serializable]
-    public class InputActionMap : ICloneable, ISerializationCallbackReceiver, IInputActionCollection, IDisposable
+    public sealed class InputActionMap : ICloneable, ISerializationCallbackReceiver, IInputActionCollection, IDisposable
     {
         /// <summary>
         /// Name of the action map.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -337,7 +337,7 @@ namespace UnityEngine.InputSystem
         /// Note that not all types of controls make sense to perform interactive rebinding on. For example, TODO
         /// </remarks>
         /// <seealso cref="InputActionRebindingExtensions.PerformInteractiveRebinding"/>
-        public class RebindingOperation : IDisposable
+        public sealed class RebindingOperation : IDisposable
         {
             public const float kDefaultMagnitudeThreshold = 0.2f;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionTrace.cs
@@ -89,7 +89,7 @@ namespace UnityEngine.InputSystem
     /// <seealso cref="InputAction.performed"/>
     /// <seealso cref="InputAction.canceled"/>
     /// <seealso cref="InputSystem.onActionChange"/>
-    public class InputActionTrace : IEnumerable<InputActionTrace.ActionEventPtr>, IDisposable
+    public sealed class InputActionTrace : IEnumerable<InputActionTrace.ActionEventPtr>, IDisposable
     {
         ////REVIEW: this is of limited use without having access to ActionEvent
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem.Editor
     /// around for editing.
     /// </summary>
     [Serializable]
-    internal class InputActionAssetManager
+    internal class InputActionAssetManager : IDisposable
     {
         [SerializeField] internal InputActionAsset m_AssetObjectForEditing;
         [SerializeField] private InputActionAsset m_ImportedAssetObject;
@@ -74,6 +74,11 @@ namespace UnityEngine.InputSystem.Editor
             {
                 m_SerializedObject = new SerializedObject(m_AssetObjectForEditing);
             }
+        }
+
+        public void Dispose()
+        {
+            m_SerializedObject?.Dispose();
         }
 
         public bool ReInitializeIfAssetHasChanged()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -26,7 +26,7 @@ namespace UnityEngine.InputSystem.Editor
     /// The .inputactions editor code does not really separate between model and view. Selection state is contained
     /// in the tree views and persistent across domain reloads via <see cref="TreeViewState"/>.
     /// </remarks>
-    internal class InputActionEditorWindow : EditorWindow
+    internal class InputActionEditorWindow : EditorWindow, IDisposable
     {
         /// <summary>
         /// Open window if someone clicks on an .inputactions asset or an action inside of it or
@@ -712,6 +712,11 @@ namespace UnityEngine.InputSystem.Editor
         {
             titleContent = dirty ? m_DirtyTitle : m_Title;
             m_Toolbar.isDirty = dirty;
+        }
+
+        public void Dispose()
+        {
+            m_BindingPropertyView?.Dispose();
         }
 
         [SerializeField] private TreeViewState m_ActionMapsTreeState;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.Editor
     /// UI for editing properties of an <see cref="InputBinding"/>. Right-most pane in action editor when
     /// binding is selected in middle pane.
     /// </summary>
-    internal class InputBindingPropertiesView : PropertiesViewBase
+    internal class InputBindingPropertiesView : PropertiesViewBase, IDisposable
     {
         public static FourCC k_GroupsChanged => new FourCC("GRPS");
         public static FourCC k_PathChanged => new FourCC("PATH");
@@ -53,6 +53,11 @@ namespace UnityEngine.InputSystem.Editor
                 if (controlPathsToMatch != null)
                     m_ControlPathEditor.SetControlPathsToMatch(controlPathsToMatch);
             }
+        }
+
+        public void Dispose()
+        {
+            m_ControlPathEditor?.Dispose();
         }
 
         protected override void DrawGeneralProperties()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.Editor
     /// greater control is required than is offered by the <see cref="PropertyDrawer"/> mechanism. In particular,
     /// it allows applying additional constraints such as requiring control paths to match ...
     /// </remarks>
-    public class InputControlPathEditor
+    public sealed class InputControlPathEditor : IDisposable
     {
         /// <summary>
         ///
@@ -34,6 +34,11 @@ namespace UnityEngine.InputSystem.Editor
 
             this.onModified = onModified;
             m_PickerState = pickerState ?? new InputControlPickerState();
+        }
+
+        public void Dispose()
+        {
+            m_PickerDropdown?.Dispose();
         }
 
         public void SetControlPathsToMatch(IEnumerable<string> controlPaths)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPicker.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPicker.cs
@@ -8,7 +8,7 @@ namespace UnityEngine.InputSystem.Editor
     /// <summary>
     /// A popup that allows picking input controls graphically.
     /// </summary>
-    public class InputControlPicker
+    public sealed class InputControlPicker : IDisposable
     {
         public InputControlPicker(Mode mode, Action<string> onPick, InputControlPickerState state)
         {
@@ -19,6 +19,11 @@ namespace UnityEngine.InputSystem.Editor
         public void Show(Rect rect)
         {
             m_Dropdown.Show(rect);
+        }
+
+        public void Dispose()
+        {
+            m_Dropdown?.Dispose();
         }
 
         public InputControlPickerState state => m_State;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -14,7 +14,7 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Editor
 {
-    internal class InputControlPickerDropdown : AdvancedDropdown
+    internal class InputControlPickerDropdown : AdvancedDropdown, IDisposable
     {
         public InputControlPickerDropdown(
             InputControlPickerState state,
@@ -50,6 +50,11 @@ namespace UnityEngine.InputSystem.Editor
         {
             m_RebindingOperation?.Dispose();
             m_RebindingOperation = null;
+        }
+
+        public void Dispose()
+        {
+            m_RebindingOperation?.Dispose();
         }
 
         protected override AdvancedDropdownItem BuildRoot()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputControlPathDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputControlPathDrawer.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR
+using System;
 using UnityEditor;
 using UnityEngine.InputSystem.Layouts;
 
@@ -21,10 +22,15 @@ namespace UnityEngine.InputSystem.Editor
     /// </example>
     /// </remarks>
     [CustomPropertyDrawer(typeof(InputControlAttribute))]
-    public class InputControlPathDrawer : PropertyDrawer
+    public sealed class InputControlPathDrawer : PropertyDrawer, IDisposable
     {
         private InputControlPathEditor m_Editor;
         private InputControlPickerState m_PickerState;
+
+        public void Dispose()
+        {
+            m_Editor?.Dispose();
+        }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -12,7 +12,7 @@ using UnityEngine.InputSystem.Utilities;
 #pragma warning disable CS0414
 namespace UnityEngine.InputSystem.Editor
 {
-    internal class InputSettingsProvider : SettingsProvider
+    internal class InputSettingsProvider : SettingsProvider, IDisposable
     {
         public const string kEditorBuildSettingsConfigKey = "com.unity.input.settings";
         public const string kSettingsPath = "Project/Input System Package";
@@ -35,6 +35,11 @@ namespace UnityEngine.InputSystem.Editor
             s_Instance = this;
 
             InputSystem.onSettingsChange += OnSettingsChange;
+        }
+
+        public void Dispose()
+        {
+            m_SettingsObject?.Dispose();
         }
 
         public override void OnTitleBarGUI()

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -13,7 +13,7 @@ namespace UnityEngine.InputSystem.LowLevel
     // Helper to simplify recording events. Can record events for a specific device
     // or all events coming in.
     [Serializable]
-    public class InputEventTrace : IDisposable, IEnumerable<InputEventPtr>
+    public sealed class InputEventTrace : IDisposable, IEnumerable<InputEventPtr>
     {
         private const int kDefaultBufferSize = 1024 * 1024;
 


### PR DESCRIPTION
Fixes:

`CA1001: Types that own disposable fields should be disposable`
`CA1063: Implement IDisposable correctly` - This one is about making sure that classes which implement `IDisposable` and can be derived from also implement `protected void Dispose(bool)` for the deriving class to use in its `Dispose` implementation. Now, I "solved" this the easy way by sealing our disposable classes, simply because I don't see a need for users to inherit from these, and this leaves less margin for mistakes. However, if you think that this is too restrictive, then I can fix this by implementing `protected void Dispose(bool)`. In general, should we default to sealing our classes if we don't specifically develop them with inheritance in mind?