### PR TITLE
CHANGE: Replace some `GetXxx` methods in our API with `xxx`  properties.

### DIFF
--- a/Assets/Demo/SimpleDevice.cs
+++ b/Assets/Demo/SimpleDevice.cs
@@ -13,9 +13,9 @@ public struct MyDeviceState : IInputStateTypeInfo
     [InputControl(layout = "Axis")]
     public float axis1;
 
-    public FourCC GetFormat()
+    public FourCC format
     {
-        return new FourCC('M', 'Y', 'D', 'V');
+        get { return new FourCC('M', 'Y', 'D', 'V'); }
     }
 }
 

--- a/Assets/Demo/SteamController/SteamDemoController.cs
+++ b/Assets/Demo/SteamController/SteamDemoController.cs
@@ -123,9 +123,9 @@ public class SteamDemoController : SteamController
 }
 public unsafe struct SteamDemoControllerState : IInputStateTypeInfo
 {
-    public FourCC GetFormat()
+    public FourCC format
     {
-        return new FourCC('S', 't', 'e', 'a');
+        get { return new FourCC('S', 't', 'e', 'a'); }
     }
 
     [InputControl(name = "fire", layout = "Button", bit = 0)]

--- a/Assets/Tests/InputSystem/CoreTests_Analytics.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Analytics.cs
@@ -186,7 +186,7 @@ partial class CoreTests
         Assert.That(receivedData, Is.TypeOf<InputAnalytics.ShutdownEventData>());
 
         var shutdownData = (InputAnalytics.ShutdownEventData)receivedData;
-        var metrics = InputSystem.GetMetrics();
+        var metrics = InputSystem.metrics;
 
         Assert.That(shutdownData.max_num_devices, Is.EqualTo(metrics.maxNumDevices));
         Assert.That(shutdownData.max_state_size_in_bytes, Is.EqualTo(metrics.maxStateSizeInBytes));

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -653,9 +653,9 @@ partial class CoreTests
             this.dpad = dpad;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('C', 'U', 'S', 'T');
+            get { return new FourCC('C', 'U', 'S', 'T'); }
         }
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -1038,9 +1038,9 @@ partial class CoreTests
     {
         public float axis;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC("PART");
+            get { return new FourCC("PART"); }
         }
     }
 
@@ -1049,9 +1049,9 @@ partial class CoreTests
         [InputControl(layout = "Axis", arraySize = 5)]
         public fixed float axis[5];
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC("FULL");
+            get { return new FourCC("FULL"); }
         }
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -188,8 +188,8 @@ partial class CoreTests
 
         Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsManually));
         Assert.That(receivedOnChange, Is.True);
-        Assert.That(InputSystem.GetMetrics().currentStateSizeInBytes,
-            Is.LessThanOrEqualTo(InputSystem.GetMetrics().maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
+        Assert.That(InputSystem.metrics.currentStateSizeInBytes,
+            Is.LessThanOrEqualTo(InputSystem.metrics.maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.False);
@@ -221,8 +221,8 @@ partial class CoreTests
 
         Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsInFixedUpdateOnly));
         Assert.That(receivedOnChange, Is.True);
-        Assert.That(InputSystem.GetMetrics().currentStateSizeInBytes,
-            Is.LessThanOrEqualTo(InputSystem.GetMetrics().maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
+        Assert.That(InputSystem.metrics.currentStateSizeInBytes,
+            Is.LessThanOrEqualTo(InputSystem.metrics.maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.Fixed));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.True);
@@ -271,8 +271,8 @@ partial class CoreTests
 
         Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly));
         Assert.That(receivedOnChange, Is.True);
-        Assert.That(InputSystem.GetMetrics().currentStateSizeInBytes,
-            Is.LessThanOrEqualTo(InputSystem.GetMetrics().maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
+        Assert.That(InputSystem.metrics.currentStateSizeInBytes,
+            Is.LessThanOrEqualTo(InputSystem.metrics.maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.Dynamic));
         Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.False);
@@ -427,7 +427,7 @@ partial class CoreTests
         InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = new Vector2(0.234f, 0.345f)}, 3);
         InputSystem.Update();
 
-        var metrics = InputSystem.GetMetrics();
+        var metrics = InputSystem.metrics;
 
         Assert.That(metrics.averageLagTimePerEvent, Is.EqualTo((9 + 7 + 4 + 0) / 4.0).Within(0.0001));
     }
@@ -651,9 +651,10 @@ partial class CoreTests
     {
         [InputControl(layout = "Axis")]
         [FieldOffset(0)] public ushort value;
-        public FourCC GetFormat()
+
+        public FourCC format
         {
-            return new FourCC('T', 'E', 'S', 'T');
+            get { return new FourCC('T', 'E', 'S', 'T'); }
         }
     }
 
@@ -865,9 +866,9 @@ partial class CoreTests
         public int buttons;
         [InputControl(layout = "Axis")] public float axis2;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('N', 'S', 'T', 'D');
+            get { return new FourCC('N', 'S', 'T', 'D'); }
         }
     }
 
@@ -877,9 +878,9 @@ partial class CoreTests
 
         public CustomNestedDeviceState nested;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('C', 'U', 'S', 'T');
+            get { return new FourCC('C', 'U', 'S', 'T'); }
         }
     }
 
@@ -940,9 +941,9 @@ partial class CoreTests
         public CustomDeviceState baseState;
         public int extra;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return baseState.GetFormat();
+            get { return baseState.format; }
         }
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -1108,9 +1108,9 @@ partial class CoreTests
         // No float as that is the default format for Axis anyway.
         [InputControl(layout = "Axis")] public double doubleAxis;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'E', 'S', 'T');
+            get { return new FourCC('T', 'E', 'S', 'T'); }
         }
     }
 
@@ -1136,9 +1136,9 @@ partial class CoreTests
     {
         [InputControl] public fixed float buffer[2];
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'E', 'S', 'T');
+            get { return new FourCC('T', 'E', 'S', 'T'); }
         }
     }
 
@@ -1847,9 +1847,9 @@ partial class CoreTests
         [InputControl(name = "axis", layout = "Axis", variants = "B")]
         public float axis;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'E', 'S', 'T');
+            get { return new FourCC('T', 'E', 'S', 'T'); }
         }
     }
 
@@ -2098,9 +2098,9 @@ partial class CoreTests
         [InputControl(layout = "Axis")] public float axis;
         public int padding;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC("BASE");
+            get { return new FourCC("BASE"); }
         }
     }
 
@@ -2111,9 +2111,9 @@ partial class CoreTests
 
     private struct DerivedInputState : IInputStateTypeInfo
     {
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC("DERI");
+            get { return new FourCC("DERI"); }
         }
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -625,9 +625,9 @@ partial class CoreTests
             return this;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'E', 'S', 'T');
+            get { return new FourCC('T', 'E', 'S', 'T'); }
         }
     }
 
@@ -914,7 +914,7 @@ partial class CoreTests
     public unsafe void State_CanGetMetrics()
     {
         // Make sure we start out with blank data.
-        var metrics = InputSystem.GetMetrics();
+        var metrics = InputSystem.metrics;
 
         Assert.That(metrics.totalEventCount, Is.Zero);
         Assert.That(metrics.totalEventBytes, Is.Zero);
@@ -931,7 +931,7 @@ partial class CoreTests
         var device3 = InputSystem.AddDevice<Mouse>();
         InputSystem.RemoveDevice(device3);
 
-        metrics = InputSystem.GetMetrics();
+        metrics = InputSystem.metrics;
 
         // Manually compute the size of the combined state buffer so that we
         // have a check that catches if the size changes (for good or no good reason).

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -447,9 +447,9 @@ internal class HIDTests : InputTestFixture
         [FieldOffset(7)] public ushort vx;
         [FieldOffset(9)] public short vy;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('H', 'I', 'D');
+            get { return new FourCC('H', 'I', 'D'); }
         }
     }
 
@@ -977,9 +977,9 @@ internal class HIDTests : InputTestFixture
         [FieldOffset(1)] public ushort x;
         [FieldOffset(3)] public ushort y;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('H', 'I', 'D');
+            get { return new FourCC('H', 'I', 'D'); }
         }
     }
 

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -248,9 +248,9 @@ internal class LinuxTests : InputTestFixture
             return this;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('L', 'J', 'O', 'Y');
+            get { return new FourCC('L', 'J', 'O', 'Y'); }
         }
 
         public static readonly string descriptorString =

--- a/Assets/Tests/InputSystem/Plugins/SteamTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/SteamTests.cs
@@ -124,7 +124,7 @@ internal class SteamTests : InputTestFixture
         Assert.That(m_SteamAPI.controllerData[0].actionSetActivations,
             Is.EquivalentTo(new[] {device.gameplaySetHandle}));
 
-        var current = device.GetCurrentSteamActionSet();
+        var current = device.currentSteamActionSet;
 
         Assert.That(current, Is.EqualTo(device.gameplaySetHandle));
     }
@@ -372,9 +372,9 @@ internal class SteamTests : InputTestFixture
         [InputControl(layout = "Stick")]
         public Vector2 look;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'e', 's', 't');
+            get { return new FourCC('T', 'e', 's', 't'); }
         }
     }
 

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -559,9 +559,9 @@ internal class UITests : InputTestFixture
         [InputControl(name = "select", layout = "Button", offset = 28, sizeInBits = 8)]
         public byte select;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'E', 'S', 'T');
+            get { return new FourCC('T', 'E', 'S', 'T'); }
         }
     }
 
@@ -717,9 +717,9 @@ internal class UITests : InputTestFixture
         [InputControl(name = "touch", layout = "Touch")]
         public TouchState touch;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('T', 'T', 'L', ' ');
+            get { return new FourCC('T', 'T', 'L', ' '); }
         }
     }
 

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -569,9 +569,9 @@ internal class XRTests : InputTestFixture
             };
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('X', 'R', 'S', '0');
+            get { return new FourCC('X', 'R', 'S', '0'); }
         }
     }
 
@@ -705,9 +705,9 @@ internal class XRTests : InputTestFixture
             };
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('X', 'R', 'S', '0');
+            get { return new FourCC('X', 'R', 'S', '0'); }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Changed
 
 - Added icons for PlayerInput, PlayerInputManager, InputSystemUIInputModule and MultiplayerEventSystem components.
+- Replace some `GetXxx` methods in our API with `xxx`  properties.
 
 ## [0.2.10-preview] - 2019-5-17
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -438,7 +438,7 @@ namespace UnityEngine.InputSystem
                 if (control == null)
                     throw new ArgumentNullException(nameof(control));
 
-              return WithCancelingThrough(control.path);
+                return WithCancelingThrough(control.path);
             }
 
             public RebindingOperation WithExpectedControlLayout(string layoutName)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -583,8 +583,7 @@ namespace UnityEngine.InputSystem.Layouts
                 // Get state type code from state struct.
                 if (typeof(IInputStateTypeInfo).IsAssignableFrom(layoutAttribute.stateType))
                 {
-                    stateFormat = ((IInputStateTypeInfo)Activator.CreateInstance(layoutAttribute.stateType))
-                        .GetFormat();
+                    stateFormat = ((IInputStateTypeInfo)Activator.CreateInstance(layoutAttribute.stateType)).format;
                 }
             }
             else

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/DisableDeviceCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/DisableDeviceCommand.cs
@@ -16,9 +16,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static DisableDeviceCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/EnableDeviceCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/EnableDeviceCommand.cs
@@ -16,9 +16,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static EnableDeviceCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/EnableIMECompositionCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/EnableIMECompositionCommand.cs
@@ -27,9 +27,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         byte m_ImeEnabled;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static EnableIMECompositionCommand Create(bool enabled)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/IInputDeviceCommandInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/IInputDeviceCommandInfo.cs
@@ -4,6 +4,6 @@ namespace UnityEngine.InputSystem.LowLevel
 {
     public interface IInputDeviceCommandInfo
     {
-        FourCC GetTypeStatic();
+        FourCC typeStatic { get; }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/InitiateUserAccountPairingCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/InitiateUserAccountPairingCommand.cs
@@ -42,9 +42,9 @@ namespace UnityEngine.InputSystem.LowLevel
             ErrorAlreadyInProgress = -2,
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static InitiateUserAccountPairingCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/InputDeviceCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/InputDeviceCommand.cs
@@ -73,9 +73,9 @@ namespace UnityEngine.InputSystem.LowLevel
             return buffer;
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return new FourCC();
+            get { return new FourCC(); }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryCanRunInBackground.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryCanRunInBackground.cs
@@ -21,9 +21,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public bool canRunInBackground;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryCanRunInBackground Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryDimensionsCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryDimensionsCommand.cs
@@ -22,9 +22,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public Vector2 outDimensions;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryDimensionsCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryEditorWindowCoordinatesCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryEditorWindowCoordinatesCommand.cs
@@ -17,9 +17,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public Vector2 inOutCoordinates;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryEditorWindowCoordinatesCommand Create(Vector2 playerWindowCoordinates)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryEnabledStateCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryEnabledStateCommand.cs
@@ -19,9 +19,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public bool isEnabled;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryEnabledStateCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryKeyNameCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryKeyNameCommand.cs
@@ -32,9 +32,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryKeyNameCommand Create(Key key)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryKeyboardLayoutCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryKeyboardLayoutCommand.cs
@@ -28,9 +28,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryKeyboardLayoutCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryPairedUserAccountCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryPairedUserAccountCommand.cs
@@ -148,9 +148,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryPairedUserAccountCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QuerySamplingFrequencyCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QuerySamplingFrequencyCommand.cs
@@ -16,9 +16,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public float frequency;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QuerySamplingFrequencyCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryUserIdCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/QueryUserIdCommand.cs
@@ -28,9 +28,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static QueryUserIdCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/RequestResetCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/RequestResetCommand.cs
@@ -21,9 +21,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static RequestResetCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/RequestSyncCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/RequestSyncCommand.cs
@@ -21,9 +21,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static RequestSyncCommand Create()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SetIMECursorPositionCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SetIMECursorPositionCommand.cs
@@ -25,9 +25,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         Vector2 m_Position;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static SetIMECursorPositionCommand Create(Vector2 cursorPosition)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SetSamplingFrequencyCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SetSamplingFrequencyCommand.cs
@@ -22,9 +22,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public float frequency;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static SetSamplingFrequencyCommand Create(float frequency)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/WarpMousePositionCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/WarpMousePositionCommand.cs
@@ -16,9 +16,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
         public Vector2 warpPositionInPlayerDisplaySpace;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static WarpMousePositionCommand Create(Vector2 position)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -81,9 +81,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(24)]
         public float rightTrigger;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         public GamepadState(params GamepadButton[] buttons)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Haptics/DualMotorRumbleCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Haptics/DualMotorRumbleCommand.cs
@@ -19,9 +19,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 4)]
         public float highFrequencyMotorSpeed;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static DualMotorRumbleCommand Create(float lowFrequency, float highFrequency)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
@@ -27,9 +27,9 @@ namespace UnityEngine.InputSystem.LowLevel
             Trigger
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
@@ -153,9 +153,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -69,9 +69,9 @@ namespace UnityEngine.InputSystem.LowLevel
             return this;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -72,9 +72,9 @@ namespace UnityEngine.InputSystem.LowLevel
             return this;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -62,9 +62,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(layout = "Digital")]
         public ushort displayIndex;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
@@ -19,9 +19,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(processors = "CompensateDirection", noisy = true)]
         public Vector3 acceleration;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -32,9 +32,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(processors = "CompensateDirection", noisy = true)]
         public Vector3 angularVelocity;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -45,9 +45,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(processors = "CompensateDirection", noisy = true)]
         public Vector3 gravity;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -58,9 +58,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(processors = "CompensateRotation", noisy = true)]
         public Quaternion attitude;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -71,9 +71,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(processors = "CompensateDirection", noisy = true)]
         public Vector3 acceleration;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -53,9 +53,9 @@ namespace UnityEngine.InputSystem.LowLevel
             set => phaseId = (ushort)value;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -116,9 +116,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -487,7 +487,7 @@ namespace UnityEngine.InputSystem.Editor
                 settingsItem.children.Sort((a, b) => string.Compare(a.displayName, b.displayName));
 
                 // Metrics.
-                var metrics = InputSystem.GetMetrics();
+                var metrics = InputSystem.metrics;
                 metricsItem = AddChild(root, "Metrics", ref id);
                 AddChild(metricsItem,
                     "Current State Size in Bytes: " + StringHelpers.NicifyMemorySize(metrics.currentStateSizeInBytes),

--- a/Packages/com.unity.inputsystem/InputSystem/Events/ActionEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/ActionEvent.cs
@@ -123,9 +123,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static int GetEventSizeWithValueSize(int valueSizeInBytes)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
@@ -37,9 +37,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static DeltaStateEvent* From(InputEventPtr ptr)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeviceConfigurationEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeviceConfigurationEvent.cs
@@ -20,9 +20,9 @@ namespace UnityEngine.InputSystem.LowLevel
 
         ////REVIEW: have some kind of payload that allows indicating what changed in the config?
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public unsafe InputEventPtr ToEventPtr()

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeviceRemoveEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeviceRemoveEvent.cs
@@ -21,9 +21,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(0)]
         public InputEvent baseEvent;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public unsafe InputEventPtr ToEventPtr()

--- a/Packages/com.unity.inputsystem/InputSystem/Events/IInputEventTypeInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/IInputEventTypeInfo.cs
@@ -7,6 +7,6 @@ namespace UnityEngine.InputSystem.LowLevel
     // from an instance of the struct without having to go through vtable dispatches.
     public interface IInputEventTypeInfo
     {
-        FourCC GetTypeStatic();
+        FourCC typeStatic { get; }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/IMECompositionEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/IMECompositionEvent.cs
@@ -23,9 +23,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputEvent.kBaseEventSize)]
         public IMECompositionString compositionString;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static IMECompositionEvent Create(int deviceId, string compositionString, double time)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
@@ -133,7 +133,7 @@ namespace UnityEngine.InputSystem.LowLevel
             if (m_EventPtr == null)
                 return false;
 
-            var otherEventTypeCode = new TOtherEvent().GetTypeStatic();
+            var otherEventTypeCode = new TOtherEvent().typeStatic;
             return m_EventPtr->type == otherEventTypeCode;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/StateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/StateEvent.cs
@@ -52,9 +52,9 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static int GetEventSizeWithPayload<TState>()

--- a/Packages/com.unity.inputsystem/InputSystem/Events/TextEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/TextEvent.cs
@@ -21,9 +21,9 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputEvent.kBaseEventSize)]
         public int character;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static unsafe TextEvent* From(InputEventPtr eventPtr)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1122,7 +1122,7 @@ namespace UnityEngine.InputSystem
                 new StateEvent
             {
                 baseEvent = new InputEvent(StateEvent.Type, (int)eventSize, device.id, time),
-                stateFormat = state.GetFormat()
+                stateFormat = state.format
             };
 
             var ptr = eventBuffer.stateEvent.stateData;
@@ -1499,9 +1499,10 @@ namespace UnityEngine.InputSystem
         public static Version version => Assembly.GetExecutingAssembly().GetName().Version;
 
         ////REVIEW: restrict metrics to editor and development builds?
-        public static InputMetrics GetMetrics()
+
+        public static InputMetrics metrics
         {
-            return s_Manager.metrics;
+            get { return s_Manager.metrics; }
         }
 
         internal static InputManager s_Manager;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -43,9 +43,9 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         [InputControl(name = "rightStick/y", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert")]
         public fixed float axis[MaxAxes];
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         public AndroidGameControllerState WithButton(AndroidKeyCode code, bool value = true)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
@@ -119,9 +119,9 @@ namespace UnityEngine.InputSystem.Android.LowLevel
             return this;
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -71,9 +71,9 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
 
         ////TODO: touchpad
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('H', 'I', 'D');
+            get { return new FourCC('H', 'I', 'D'); }
         }
     }
 
@@ -108,9 +108,9 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 8)] public byte blueColor;
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 9)] public fixed byte unknown2[23];
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public void SetMotorSpeeds(float lowFreq, float highFreq)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PS4/DualShockGamepadPS4.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PS4/DualShockGamepadPS4.cs
@@ -109,9 +109,9 @@ namespace UnityEngine.InputSystem.PS4.LowLevel
         [FieldOffset(80)]
         public PS4Touch touch1;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -145,9 +145,9 @@ namespace UnityEngine.InputSystem.PS4.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 4)] public byte greenColor;
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 5)] public byte blueColor;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public void SetMotorSpeeds(float largeMotor, float smallMotor)
@@ -207,9 +207,9 @@ namespace UnityEngine.InputSystem.PS4.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 8)]
         public int userId;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public QueryPS4ControllerInfo WithSlotIndex(int index)
@@ -235,9 +235,10 @@ namespace UnityEngine.InputSystem.PS4.LowLevel
     public struct PS4Touch : IInputStateTypeInfo
     {
         public static FourCC kFormat => new FourCC('P', '4', 'T', 'C');
-        public FourCC GetFormat()
+
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         [FieldOffset(0)] public int touchId;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PS4/MoveControllerPS4.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PS4/MoveControllerPS4.cs
@@ -53,9 +53,9 @@ namespace UnityEngine.InputSystem.PS4.LowLevel
         [FieldOffset(20)]
         public Vector3 gyro;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 
@@ -85,9 +85,9 @@ namespace UnityEngine.InputSystem.PS4.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 3)] public byte greenColor;
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 4)] public byte blueColor;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public void SetMotorSpeed(float motor)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamController.cs
@@ -104,9 +104,9 @@ namespace UnityEngine.InputSystem.Steam
             SteamSupport.GetAPIAndRequireItToBeSet().ActivateActionSet(steamControllerHandle, actionSet);
         }
 
-        public SteamHandle<InputActionMap> GetCurrentSteamActionSet()
+        public SteamHandle<InputActionMap> currentSteamActionSet
         {
-            return SteamSupport.GetAPIAndRequireItToBeSet().GetCurrentActionSet(steamControllerHandle);
+            get { return SteamSupport.GetAPIAndRequireItToBeSet().GetCurrentActionSet(steamControllerHandle); }
         }
 
         public void ActivateSteamActionSetLayer(SteamHandle<InputActionMap> actionSet)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamIGAConverter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamIGAConverter.cs
@@ -365,11 +365,13 @@ namespace UnityEngine.InputSystem.Steam.Editor
             builder.Append(stateStructName);
             builder.Append(" : IInputStateTypeInfo\n");
             builder.Append("{\n");
-            builder.Append("    public FourCC GetFormat()\n");
+            builder.Append("    public FourCC format\n");
             builder.Append("    {\n");
+            builder.Append("        get {\n");
             ////TODO: handle class names that are shorter than 4 characters
             ////TODO: uppercase characters
-            builder.Append(string.Format("        return new FourCC('{0}', '{1}', '{2}', '{3}');\n", className[0], className[1], className[2], className[3]));
+            builder.Append(string.Format("            return new FourCC('{0}', '{1}', '{2}', '{3}');\n", className[0], className[1], className[2], className[3]));
+            builder.Append("        }\n");
             builder.Append("    }\n");
             builder.Append("\n");
             var totalButtonCount = 0;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/NPad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/NPad.cs
@@ -18,9 +18,9 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
     [StructLayout(LayoutKind.Explicit, Size = 60)]
     public struct NPadInputState : IInputStateTypeInfo
     {
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('N', 'P', 'A', 'D');
+            get { return new FourCC('N', 'P', 'A', 'D'); }
         }
 
         [InputControl(name = "dpad")]
@@ -142,9 +142,9 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 20)]
         public int colorRightSub;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static NPadStatusReport Create()
@@ -179,9 +179,9 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
             kStopSixAxisSensor,
         }
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public static NPadControllerSupportCommand Create(NPadControllerSupportCommand.Command _command, int _option = 0)
@@ -204,7 +204,11 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic() { return Type; }
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
+
         public static NpadDeviceIOCTLShowUI Create()
         {
             return new NpadDeviceIOCTLShowUI
@@ -226,7 +230,11 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 0)]
         public NPad.Orientation orientation;
 
-        public FourCC GetTypeStatic() { return Type; }
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
+
         public static NpadDeviceIOCTLSetOrientation Create(NPad.Orientation _orientation)
         {
             return new NpadDeviceIOCTLSetOrientation
@@ -246,7 +254,11 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic() { return Type; }
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
+
         public static NpadDeviceIOCTLStartSixAxisSensor Create()
         {
             return new NpadDeviceIOCTLStartSixAxisSensor
@@ -265,7 +277,11 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(0)]
         public InputDeviceCommand baseCommand;
 
-        public FourCC GetTypeStatic() { return Type; }
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
+
         public static NpadDeviceIOCTLStopSixAxisSensor Create()
         {
             return new NpadDeviceIOCTLStopSixAxisSensor
@@ -309,7 +325,10 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 16)]
         public float frequencyHigh;
 
-        public FourCC GetTypeStatic() { return Type; }
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
 
         public static NPadDeviceIOCTLOutputCommand Create()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLGamepad.cs
@@ -72,9 +72,9 @@ namespace UnityEngine.InputSystem.WebGL.LowLevel
             }
         }
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return new FourCC('H', 'T', 'M', 'L');
+            get { return new FourCC('H', 'T', 'M', 'L'); }
         }
 
         public WebGLGamepadState WithButton(GamepadButton button, float value = 1)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerOSX.cs
@@ -88,9 +88,9 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [FieldOffset(10)] public short rightStickX;
         [FieldOffset(12)] public short rightStickY;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         public XInputControllerOSXState WithButton(Button button)
@@ -169,9 +169,9 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [FieldOffset(5)] public ushort rightStickX;
         [FieldOffset(7)] public ushort rightStickY;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         public XInputControllerWirelessOSXState WithButton(Button button)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct XInputControllerWindowsState : IInputStateTypeInfo
     {
-        public static FourCC format
+        public FourCC format
         {
             get { return new FourCC('X', 'I', 'N', 'P'); }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
     [StructLayout(LayoutKind.Explicit, Size = 4)]
     public struct XInputControllerWindowsState : IInputStateTypeInfo
     {
-        public static FourCC kFormat
+        public static FourCC format
         {
             get { return new FourCC('X', 'I', 'N', 'P'); }
         }
@@ -77,11 +77,6 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [InputControl(name = "rightStick/down", offset = 2, format = "SHRT", parameters = "invert=false,normalize=false")]
         [FieldOffset(8)] public short rightStickX;
         [FieldOffset(10)] public short rightStickY;
-
-        public FourCC GetFormat()
-        {
-            return kFormat;
-        }
 
         public XInputControllerWindowsState WithButton(Button button)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxOneGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxOneGamepad.cs
@@ -92,9 +92,9 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [FieldOffset(24)]
         public float rightTrigger;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         public XboxOneGamepadState WithButton(Button button)
@@ -122,9 +122,9 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 8)] public float leftTriggerMotor;
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 12)] public float rightTriggerMotor;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public void SetMotorSpeeds(float leftMotorLevel, float rightMotorLevel, float leftTriggerMotorLevel, float rightTriggerMotorLevel)
@@ -163,9 +163,9 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + 8)]
         public int userId;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         public QueryXboxControllerInfo WithGamepadId(ulong id)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetCurrentHapticStateCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetCurrentHapticStateCommand.cs
@@ -23,9 +23,9 @@ namespace UnityEngine.InputSystem.XR.Haptics
 
         const int kSize = InputDeviceCommand.kBaseCommandSize + (sizeof(uint) * 2);
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         [FieldOffset(0)]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetHapticCapabilitiesCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetHapticCapabilitiesCommand.cs
@@ -25,9 +25,9 @@ namespace UnityEngine.InputSystem.XR.Haptics
 
         const int kSize = InputDeviceCommand.kBaseCommandSize + sizeof(uint) * 3;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         [FieldOffset(0)]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendBufferedHapticsCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendBufferedHapticsCommand.cs
@@ -13,9 +13,9 @@ namespace UnityEngine.InputSystem.XR.Haptics
         const int kMaxHapticBufferSize = 1024;
         const int kSize = InputDeviceCommand.kBaseCommandSize + (sizeof(int) * 2) + (kMaxHapticBufferSize * sizeof(byte));
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         [FieldOffset(0)]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendHapticImpulseCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendHapticImpulseCommand.cs
@@ -27,9 +27,9 @@ namespace UnityEngine.InputSystem.XR.Haptics
         [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(int) + (sizeof(float)))]
         float duration;
 
-        public FourCC GetTypeStatic()
+        public FourCC typeStatic
         {
-            return Type;
+            get { return Type; }
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -72,9 +72,9 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
         [InputControl(name = "rightStick", offset = (uint)iOSAxis.RightStickX * sizeof(float) + kAxisOffset)]
         public fixed float axisValues[MaxAxis];
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
 
         public iOSGameControllerState WithButton(iOSButton button, bool value = true, float rawValue = 1.0f)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/iOSSensors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/iOSSensors.cs
@@ -15,9 +15,9 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
         [InputControl][FieldOffset(28)] public Vector3 acceleration;
         [InputControl][FieldOffset(40)] public Vector3 rotationRateUnbiased;
 
-        public FourCC GetFormat()
+        public FourCC format
         {
-            return kFormat;
+            get { return kFormat; }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/State/IInputStateTypeInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/IInputStateTypeInfo.cs
@@ -5,6 +5,6 @@ namespace UnityEngine.InputSystem
     // Allows to generically query information from a state struct.
     public interface IInputStateTypeInfo
     {
-        FourCC GetFormat();
+        FourCC format { get; }
     }
 }

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -155,7 +155,7 @@ namespace UnityEngine.InputSystem
                 SetDeviceCommandCallback(deviceId,
                     (id, commandPtr) =>
                     {
-                        if (commandPtr->type == result.GetTypeStatic())
+                        if (commandPtr->type == result.typeStatic)
                         {
                             Assert.That(receivedCommand.HasValue, Is.False);
                             receivedCommand = true;


### PR DESCRIPTION
Fixes `CA1024: Use properties where appropriate`.

I think API wise this analyzer recommendation makes sense, these _are_ better exposed as getters, IMO. but it will cause a disruption to current users. We can also chose to not do this and suppress the warnings, or to offer both (and deprecate the old one?).