### PR TITLE
Fix some more warnings

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
@@ -117,7 +117,7 @@ namespace UnityEngine.InputSystem
         {
             return action;
         }
-        
+
         public static InputActionReference Create(InputAction action)
         {
             if (action == null)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
@@ -113,6 +113,11 @@ namespace UnityEngine.InputSystem
             return reference?.action;
         }
 
+        public InputAction ToInputAction()
+        {
+            return action;
+        }
+        
         public static InputActionReference Create(InputAction action)
         {
             if (action == null)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputControlScheme.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputControlScheme.cs
@@ -507,6 +507,7 @@ namespace UnityEngine.InputSystem
             /// <remarks>
             /// Links the control that was matched with the respective device requirement.
             /// </remarks>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1724:TypeNamesShouldNotMatchNamespaces", Justification = "Conflicts with UnityEngine.Networking.Match, which is deprecated and will go away.")]
             public struct Match
             {
                 /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -243,6 +243,7 @@ namespace UnityEngine.InputSystem
             return OnReceiveStateWithDifferentFormat(statePtr, stateFormat, stateSize, ref offsetToStoreAt);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Cannot satisfy both CA1801 and CA1033 (the latter requires adding this method)")]
         protected unsafe bool OnReceiveStateWithDifferentFormat(void* statePtr, FourCC stateFormat, uint stateSize, ref uint offsetToStoreAt)
         {
             return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -317,6 +317,7 @@ namespace UnityEngine.InputSystem
             return OnCarryStateForward(statePtr);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Cannot satisfy both CA1801 and CA1033 (the latter requires adding this method)")]
         protected unsafe new bool OnReceiveStateWithDifferentFormat(void* statePtr, FourCC stateFormat, uint stateSize,
             ref uint offsetToStoreAt)
         {
@@ -387,6 +388,7 @@ namespace UnityEngine.InputSystem
         {
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "Cannot satisfy both CA1801 and CA1033 (the latter requires adding this method)")]
         protected unsafe new void OnBeforeWriteNewState(void* oldStatePtr, void* newStatePtr)
         {
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
@@ -190,7 +190,17 @@ namespace UnityEngine.InputSystem.LowLevel
             return new InputEventPtr(eventPtr);
         }
 
+        public static InputEventPtr From(InputEvent* eventPtr)
+        {
+            return new InputEventPtr(eventPtr);
+        }
+        
         public static implicit operator InputEvent*(InputEventPtr eventPtr)
+        {
+            return eventPtr.data;
+        }
+
+        public static InputEvent* FromInputEventPtr(InputEventPtr eventPtr)
         {
             return eventPtr.data;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
@@ -194,7 +194,7 @@ namespace UnityEngine.InputSystem.LowLevel
         {
             return new InputEventPtr(eventPtr);
         }
-        
+
         public static implicit operator InputEvent*(InputEventPtr eventPtr)
         {
             return eventPtr.data;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
@@ -37,22 +37,22 @@ namespace UnityEngine.InputSystem.Utilities
         {
             return fourCC.m_Code;
         }
-        
+
         public static int ToInt32(FourCC fourCC)
         {
             return fourCC.m_Code;
-        }        
+        }
 
         public static implicit operator FourCC(int i)
         {
             var fourCC = new FourCC {m_Code = i};
             return fourCC;
         }
-        
+
         public static FourCC FromInt32(int i)
         {
             return i;
-        }         
+        }
 
         public override string ToString()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
@@ -37,12 +37,22 @@ namespace UnityEngine.InputSystem.Utilities
         {
             return fourCC.m_Code;
         }
+        
+        public static int ToInt32(FourCC fourCC)
+        {
+            return fourCC.m_Code;
+        }        
 
         public static implicit operator FourCC(int i)
         {
             var fourCC = new FourCC {m_Code = i};
             return fourCC;
         }
+        
+        public static FourCC FromInt32(int i)
+        {
+            return i;
+        }         
 
         public override string ToString()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
@@ -634,7 +634,7 @@ namespace UnityEngine.InputSystem.Utilities
         {
             return new PrimitiveValue(value);
         }
-        
+
         public static PrimitiveValue FromBoolean(bool value)
         {
             return new PrimitiveValue(value);
@@ -693,6 +693,6 @@ namespace UnityEngine.InputSystem.Utilities
         public static PrimitiveValue FromDouble(double value)
         {
             return new PrimitiveValue(value);
-        }        
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
@@ -634,5 +634,65 @@ namespace UnityEngine.InputSystem.Utilities
         {
             return new PrimitiveValue(value);
         }
+        
+        public static PrimitiveValue FromBoolean(bool value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromChar(char value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromByte(byte value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromSByte(sbyte value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromInt16(short value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromUInt16(ushort value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromInt32(int value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromUInt32(uint value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromInt64(long value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromUInt64(ulong value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromSingle(float value)
+        {
+            return new PrimitiveValue(value);
+        }
+
+        public static PrimitiveValue FromDouble(double value)
+        {
+            return new PrimitiveValue(value);
+        }        
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -82,6 +82,7 @@ namespace UnityEngine.InputSystem.Utilities
             return GetEnumerator();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2225:OperatorOverloadsHaveNamedAlternates", Justification = "`ToXXX` message only really makes sense as static, which is not recommended for generic types.")]
         public static implicit operator ReadOnlyArray<TValue>(TValue[] array)
         {
             return new ReadOnlyArray<TValue>(array);

--- a/Tools/CodeAnalyzerTestProject/InputSystem.ruleset
+++ b/Tools/CodeAnalyzerTestProject/InputSystem.ruleset
@@ -5,9 +5,8 @@
     <Rule Id="CA1051" Action="None" />
     <Rule Id="CA1724" Action="None" />
     <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1030" Action="None" /> <!-- false positive due to our event property syntax -->    
     <!-- The ones below did not show up in the older version of the analyzer used, so are not fixed or suppressed yet. Review these later. -->
     <Rule Id="CA1801" Action="None" />
-    <Rule Id="CA2225" Action="None" />
-    <Rule Id="CA1030" Action="None" />
   </Rules>
 </RuleSet>

--- a/Tools/CodeAnalyzerTestProject/InputSystem.ruleset
+++ b/Tools/CodeAnalyzerTestProject/InputSystem.ruleset
@@ -3,7 +3,7 @@
   <Include Path="api-analyzers/UnityEngineAndUnityEditorCodeInPackages.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1051" Action="None" />  <!-- We have many instance fields, which we cannot easily turn into properties due to needs of serialization systems and il2cpp stripping requirements. -->
-    <Rule Id="CA1815" Action="None" />
+    <Rule Id="CA1815" Action="None" /> <!-- Can fix later -->
     <Rule Id="CA1030" Action="None" /> <!-- false positive due to our event property syntax -->    
   </Rules>
 </RuleSet>

--- a/Tools/CodeAnalyzerTestProject/InputSystem.ruleset
+++ b/Tools/CodeAnalyzerTestProject/InputSystem.ruleset
@@ -2,11 +2,8 @@
 <RuleSet Name="Ruleset for Unity package code in the UnityEngine and UnityEditor namespaces" Description="Code analysis rules for code published by Unity Technologies." ToolsVersion="15.0">
   <Include Path="api-analyzers/UnityEngineAndUnityEditorCodeInPackages.ruleset" Action="Default" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CA1051" Action="None" />
-    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1051" Action="None" />  <!-- We have many instance fields, which we cannot easily turn into properties due to needs of serialization systems and il2cpp stripping requirements. -->
     <Rule Id="CA1815" Action="None" />
     <Rule Id="CA1030" Action="None" /> <!-- false positive due to our event property syntax -->    
-    <!-- The ones below did not show up in the older version of the analyzer used, so are not fixed or suppressed yet. Review these later. -->
-    <Rule Id="CA1801" Action="None" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Some analyzer warning sneaked into the repo when I turned on CI, partially because some of the fixes generated new warnings, partially because (I think) the version of the analyzers used in CI is a little different than the one I used locally. I disabled these warning types in the ruleset when turning on the analyzer for CI. This PR properly fixes (or suppresses) them.
