### PR TITLE
FIX: Fixed an internal bug in `InlinedArray.RemoveAtByMovingTailWithC…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Validate all parameters on public APIs.
+- Fixed an internal bug in `InlinedArray.RemoveAtByMovingTailWithCapacity`, which could cause data corruption.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InlinedArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InlinedArray.cs
@@ -322,12 +322,13 @@ namespace UnityEngine.InputSystem.Utilities
             if (index < 0 || index >= length)
                 throw new ArgumentOutOfRangeException(nameof(index));
 
+            var numAdditionalValues = length - 1;
             if (index == 0)
             {
                 if (length > 1)
                 {
-                    firstValue = additionalValues[length - 1];
-                    additionalValues[length - 1] = default;
+                    firstValue = additionalValues[numAdditionalValues - 1];
+                    additionalValues[numAdditionalValues - 1] = default;
                 }
                 else
                 {
@@ -338,7 +339,6 @@ namespace UnityEngine.InputSystem.Utilities
             {
                 Debug.Assert(additionalValues != null);
 
-                var numAdditionalValues = length - 1;
                 ArrayHelpers.EraseAtByMovingTail(additionalValues, ref numAdditionalValues, index - 1);
             }
 


### PR DESCRIPTION
…apacity`, which could cause data corruption.

Fixes https://fogbugz.unity3d.com/f/cases/1157221/, and possibly other issues.