### PR TITLE
FIX: Xbox gamepad sticks for down and left could not navigate UI.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Validate all parameters on public APIs.
 - Fixed an internal bug in `InlinedArray.RemoveAtByMovingTailWithCapacity`, which could cause data corruption.
+- Fixed issue of Xbox gamepads on Windows desktop not being able to navigate left and down in a UI.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -60,21 +60,21 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2S")]
         [InputControl(name = "leftStick/x", offset = 0, format = "SHRT", parameters = "clamp=false,invert=false,normalize=false")]
-        [InputControl(name = "leftStick/left", offset = 0, format = "SHRT", parameters = "invert=false,normalize=false")]
-        [InputControl(name = "leftStick/right", offset = 0, format = "SHRT", parameters = "invert=false,normalize=false")]
+        [InputControl(name = "leftStick/left", offset = 0, format = "SHRT")]
+        [InputControl(name = "leftStick/right", offset = 0, format = "SHRT")]
         [InputControl(name = "leftStick/y", offset = 2, format = "SHRT", parameters = "clamp=false,invert=false,normalize=false")]
-        [InputControl(name = "leftStick/up", offset = 2, format = "SHRT", parameters = "invert=false,normalize=false")]
-        [InputControl(name = "leftStick/down", offset = 2, format = "SHRT", parameters = "invert=false,normalize=false")]
+        [InputControl(name = "leftStick/up", offset = 2, format = "SHRT")]
+        [InputControl(name = "leftStick/down", offset = 2, format = "SHRT")]
         [FieldOffset(4)] public short leftStickX;
         [FieldOffset(6)] public short leftStickY;
 
         [InputControl(name = "rightStick", layout = "Stick", format = "VC2S")]
         [InputControl(name = "rightStick/x", offset = 0, format = "SHRT", parameters = "clamp=false,invert=false,normalize=false")]
-        [InputControl(name = "rightStick/left", offset = 0, format = "SHRT", parameters = "invert=false,normalize=false")]
-        [InputControl(name = "rightStick/right", offset = 0, format = "SHRT", parameters = "invert=false,normalize=false")]
+        [InputControl(name = "rightStick/left", offset = 0, format = "SHRT")]
+        [InputControl(name = "rightStick/right", offset = 0, format = "SHRT")]
         [InputControl(name = "rightStick/y", offset = 2, format = "SHRT", parameters = "clamp=false,invert=false,normalize=false")]
-        [InputControl(name = "rightStick/up", offset = 2, format = "SHRT", parameters = "invert=false,normalize=false")]
-        [InputControl(name = "rightStick/down", offset = 2, format = "SHRT", parameters = "invert=false,normalize=false")]
+        [InputControl(name = "rightStick/up", offset = 2, format = "SHRT")]
+        [InputControl(name = "rightStick/down", offset = 2, format = "SHRT")]
         [FieldOffset(8)] public short rightStickX;
         [FieldOffset(10)] public short rightStickY;
 


### PR DESCRIPTION
The xbox gamepad on windows desktop could not navigate the new input system UI left or down movements.   