### PR TITLE
NEW:  UPM-CI publishing cutover

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -1,0 +1,76 @@
+test_editors:
+  - version: 2019.1
+test_platforms:
+  - name: win
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: m1.large
+---
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+promotion_test_{{ platform.name }}_{{ editor.version }}:
+  name : Promotion Test {{ editor.version }} on {{ platform.name }}
+  agent:
+    type: {{ platform.type }}
+    image: {{ platform.image }}
+    flavor: {{ platform.flavor}}
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }}
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% endfor %}
+{% endfor %}
+
+promotion_test_trigger:
+  name: Promotion Tests Trigger
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: m1.large
+  artifacts:
+    logs:
+      paths:
+        - "upm-ci~/test-results/**/*"
+    packages:
+      paths:
+        - "upm-ci~/packages/**/*"
+  dependencies:
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
+{% endfor %}
+{% endfor %}
+
+promote:
+  name: Promote to Production
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: m1.large
+  variables:
+    UPMCI_PROMOTION: 1
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package promote --package-path ./Packages/com.unity.inputsystem/
+  triggers:
+    tags:
+      only:
+        - /^(r|R)elease-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+{% for editor in test_editors %}
+{% for platform in test_platforms %}
+    - .yamato/promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}
+{% endfor %}
+{% endfor %}

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -58,6 +58,7 @@ promote:
     UPMCI_PROMOTION: 1
   commands:
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package promote --package-path ./Packages/com.unity.inputsystem/
   triggers:
     tags:
@@ -68,7 +69,6 @@ promote:
       paths:
         - "upm-ci~/packages/*.tgz"
   dependencies:
-    - .yamato/upm-ci.yml#pack
 {% for editor in test_editors %}
 {% for platform in test_platforms %}
     - .yamato/promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -43,3 +43,28 @@ platforms:
         - "upm-ci~/test-results/**/*"
 {% endfor %}
 {% endfor %}
+
+publish:
+  name: Publish to Internal Registry
+  agent:
+    type: Unity::VM
+    image: package-ci/win10:stable
+    flavor: m1.large
+  commands:
+    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package publish --package-path ./Packages/com.unity.inputsystem/
+  triggers:
+    tags:
+      only:
+        - /^(r|R)(c|C)-\d+\.\d+\.\d+(-preview(\.\d+)?)?$/
+  artifacts:
+    artifacts:
+      paths:
+        - "upm-ci~/packages/*.tgz"
+  dependencies:
+    - .yamato/upm-ci.yml#pack
+    {% for editor in test_editors %}
+    {% for platform in test_platforms %}
+    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
+    {% endfor %}
+    {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -52,6 +52,7 @@ publish:
     flavor: m1.large
   commands:
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package publish --package-path ./Packages/com.unity.inputsystem/
   triggers:
     tags:
@@ -61,10 +62,3 @@ publish:
     artifacts:
       paths:
         - "upm-ci~/packages/*.tgz"
-  dependencies:
-    - .yamato/upm-ci.yml#pack
-    {% for editor in test_editors %}
-    {% for platform in test_platforms %}
-    - .yamato/upm-ci.yml#test_{{ platform.name }}_{{ editor.version }}
-    {% endfor %}
-    {% endfor %}


### PR DESCRIPTION
Starting July 16, packages must be published thru the upm-ci system and not manually.  The changes below satisfy those requirements.   Based on 
https://confluence.hq.unity3d.com/display/PAK/Getting+your+package+published   

per above guidance ,publish to staging happens in upm-ci.yml and promotion to production happens in the new promotion.yml script.
  