### PR TITLE
FIX: Fixed documentation landing page and table of contents.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an internal bug in `InlinedArray.RemoveAtByMovingTailWithCapacity`, which could cause data corruption.
 - Fixed issue of Xbox gamepads on Windows desktop not being able to navigate left and down in a UI.
 - Allow using InputSystem package if the XR, VR or Physics modules are disabled for smaller builds.
+- Fixed documentation landing page and table of contents.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/Documentation~/TableOfContents.md
+++ b/Packages/com.unity.inputsystem/Documentation~/TableOfContents.md
@@ -1,29 +1,21 @@
-# Input System
-
->NOTE: The new input system is still under development and this manual is a work-in-progress. There is still outdated and missing information.
-
-This is the manual for Unity's new input system.
-
-## Guides
-
-* [Installation](Installation.md)
-* [Quick Start Guide](QuickStartGuide.md)
+* Guides
+  * [Installation](Installation.md)
+  * [Quick Start Guide](QuickStartGuide.md)
     * [How Do I...?](HowDoI.md)
     * [Migrate from Old Input System](Migration.md)
-* [PlayerInput Components](Components.md)
-* [Unity UI Support](UISupport.md)
+  * [PlayerInput Components](Components.md)
+  * [Unity UI Support](UISupport.md)
     * [On-Screen Controls](OnScreen.md)
-* [Local Multiplayer Support](LocalMultiplayer.md)
-* [Use In Editor UI](UseInEditor.md)
-* [Debugging Input](Debugging.md)
-* [Testing Input](Testing.md)
-* [Future](Future.md)
-* [Contributing](Contributing.md)
+  * [Local Multiplayer Support](LocalMultiplayer.md)
+  * [Use In Editor UI](UseInEditor.md)
+  * [Debugging Input](Debugging.md)
+  * [Testing Input](Testing.md)
+  * [Future](Future.md)
+  * [Contributing](Contributing.md)
 
-## Reference
-
-* [Input Settings](Settings.md)
-* [Supported Devices](SupportedDevices.md)
+* Reference
+  * [Input Settings](Settings.md)
+  * [Supported Devices](SupportedDevices.md)
     * [Touch](Touch.md)
     * [Keyboard](Keyboard.md)
     * [Mouse](Mouse.md)
@@ -35,7 +27,7 @@ This is the manual for Unity's new input system.
     * [Sensors](Sensors.md)
     * [Haptics](Haptics.md) (e.g. rumble)
     * [HID](HID.md)
-* [Architecture](Architecture.md)
+  * [Architecture](Architecture.md)
     * [Actions](Actions.md)
         * [Assets](ActionAssets.md)
         * [Bindings](ActionBindings.md)

--- a/Packages/com.unity.inputsystem/Documentation~/index.md
+++ b/Packages/com.unity.inputsystem/Documentation~/index.md
@@ -1,0 +1,9 @@
+# Input System
+
+>NOTE: The input system package is still under development and this manual is a work-in-progress. There is still outdated and missing information.
+
+The Input System package implements a system to use any kind of input device to control your Unity content. This is intended to be a more powerful, flexible and configurable replacement for Unity's classic Input Manager (the `UnityEngine.Input` class).
+
+To get started, check the [Installation](Installation.md) and [Quick Start Guide](QuickStartGuide.md) sections.
+
+![MyGameActions](Images/MyGameActions.png)


### PR DESCRIPTION
Currently, we don't generate a TOC sidebar for our docs, and we don't have an index.md. So http://docs.unity3d.com/Packages/com.unity.inputsystem@0.2/ points to the first page in the docs, with no way to navigate to the other pages. This PR intends to fix that.