### PR TITLE
CHANGE: Remove ProcessEventsInBothFixedAndDynamicUpdate.

### DIFF
--- a/Assets/Demo/SimpleDemo/SimpleController_UsingActions_InAsset.cs
+++ b/Assets/Demo/SimpleDemo/SimpleController_UsingActions_InAsset.cs
@@ -24,13 +24,6 @@ public class SimpleController_UsingActions_InAsset : MonoBehaviour
     private void Start()
     {
         m_Rigidbody = GetComponent<Rigidbody>();
-
-        ////FIXME: Solve this properly. ATM, if we have both fixed and dynamic updates enabled, then
-        ////       we run into problems as actions will fire in updates while the actual processing of input
-        ////       happens in Update(). So, if we're looking at m_Look, for example, we will see mouse deltas
-        ////       on it but then also see the deltas get reset between updates meaning that most of the time
-        ////       Update() will end up with a zero m_Look vector.
-        InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly;
     }
 
     void OnCollisionStay()

--- a/Assets/Tests/InputSystem/CoreTests_Analytics.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Analytics.cs
@@ -146,6 +146,7 @@ partial class CoreTests
 
     #endif
 
+    ////FIXME: these don't seem to actually make it out and to the analytics server
     [Test]
     [Category("Analytics")]
     public void Analytics_ReceivesEventOnShutdown()
@@ -156,10 +157,10 @@ partial class CoreTests
 
         InputSystem.QueueStateEvent(gamepad, new GamepadState());
         InputSystem.QueueStateEvent(gamepad, new GamepadState());
-        InputSystem.Update(InputUpdateType.Dynamic);
+        InputSystem.Update();
 
         InputSystem.QueueStateEvent(gamepad, new GamepadState());
-        InputSystem.Update(InputUpdateType.Fixed);
+        InputSystem.Update();
 
         var registeredNames = new List<string>();
         string receivedName = null;

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -150,35 +150,10 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    [Property("TimesliceEvents", "Off")]
-    public void Events_AreProcessedInBothFixedAndDynamicUpdateByDefault()
-    {
-        var mouse = InputSystem.AddDevice<Mouse>();
-
-        Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsInBothFixedAndDynamicUpdate));
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.True);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.True);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.False);
-
-        // Push event through in fixed update.
-        InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Left));
-        InputSystem.Update(InputUpdateType.Fixed);
-
-        Assert.That(mouse.leftButton.isPressed, Is.True);
-
-        // Push event through in dynamic update.
-        InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Right));
-        InputSystem.Update(InputUpdateType.Dynamic);
-
-        Assert.That(mouse.leftButton.isPressed, Is.False);
-        Assert.That(mouse.rightButton.isPressed, Is.True);
-    }
-
-    [Test]
-    [Category("Events")]
-    [Property("TimesliceEvents", "Off")]
     public void Events_CanSwitchToFullyManualUpdates()
     {
+        InputSystem.settings.timesliceEvents = false;
+
         var mouse = InputSystem.AddDevice<Mouse>();
 
         var receivedOnChange = true;
@@ -188,13 +163,6 @@ partial class CoreTests
 
         Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsManually));
         Assert.That(receivedOnChange, Is.True);
-        Assert.That(InputSystem.metrics.currentStateSizeInBytes,
-            Is.LessThanOrEqualTo(InputSystem.metrics.maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
-        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
-        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.False);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.False);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.True);
 
         #if UNITY_EDITOR
         // Edit mode updates shouldn't have been disabled in editor.
@@ -205,34 +173,36 @@ partial class CoreTests
         InputSystem.Update(InputUpdateType.Manual);
 
         Assert.That(mouse.leftButton.isPressed, Is.True);
+
+        Assert.That(() => InputSystem.Update(InputUpdateType.Fixed), Throws.InvalidOperationException);
+        Assert.That(() => InputSystem.Update(InputUpdateType.Dynamic), Throws.InvalidOperationException);
     }
 
     [Test]
     [Category("Events")]
-    [Property("TimesliceEvents", "Off")]
-    public void Events_CanSwitchToProcessingInFixedUpdatesOnly()
+    public void Events_CanSwitchToProcessingInFixedUpdates()
     {
+        InputSystem.settings.timesliceEvents = false;
+
         var mouse = InputSystem.AddDevice<Mouse>();
 
         var receivedOnChange = true;
         InputSystem.onSettingsChange += () => receivedOnChange = true;
 
-        InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInFixedUpdateOnly;
+        InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
 
-        Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsInFixedUpdateOnly));
+        Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsInFixedUpdate));
         Assert.That(receivedOnChange, Is.True);
-        Assert.That(InputSystem.metrics.currentStateSizeInBytes,
-            Is.LessThanOrEqualTo(InputSystem.metrics.maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.Fixed));
         Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.None));
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.True);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.False);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.False);
 
         InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Left));
         InputSystem.Update(InputUpdateType.Fixed);
 
         Assert.That(mouse.leftButton.isPressed, Is.True);
+
+        Assert.That(() => InputSystem.Update(InputUpdateType.Dynamic), Throws.InvalidOperationException);
+        Assert.That(() => InputSystem.Update(InputUpdateType.Manual), Throws.InvalidOperationException);
     }
 
     [Test]
@@ -260,35 +230,10 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    public void Events_CanSwitchToProcessingInDynamicUpdatesOnly()
-    {
-        var mouse = InputSystem.AddDevice<Mouse>();
-
-        var receivedOnChange = true;
-        InputSystem.onSettingsChange += () => receivedOnChange = true;
-
-        InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly;
-
-        Assert.That(InputSystem.settings.updateMode, Is.EqualTo(InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly));
-        Assert.That(receivedOnChange, Is.True);
-        Assert.That(InputSystem.metrics.currentStateSizeInBytes,
-            Is.LessThanOrEqualTo(InputSystem.metrics.maxStateSizeInBytes - mouse.stateBlock.alignedSizeInBytes));
-        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Fixed, Is.EqualTo(InputUpdateType.None));
-        Assert.That(InputSystem.s_Manager.updateMask & InputUpdateType.Dynamic, Is.EqualTo(InputUpdateType.Dynamic));
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Fixed).valid, Is.False);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Dynamic).valid, Is.True);
-        Assert.That(InputSystem.s_Manager.m_StateBuffers.GetDoubleBuffersFor(InputUpdateType.Manual).valid, Is.False);
-
-        InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Left));
-        InputSystem.Update(InputUpdateType.Dynamic);
-
-        Assert.That(mouse.leftButton.isPressed, Is.True);
-    }
-
-    [Test]
-    [Category("Events")]
     public unsafe void Events_AreTimeslicedByDefault()
     {
+        InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
+
         runtime.currentTimeForFixedUpdate = 1;
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -373,6 +318,9 @@ partial class CoreTests
     [Category("Events")]
     public unsafe void Events_TimeslicingCanBeTurnedOff()
     {
+        InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
+        InputSystem.settings.timesliceEvents = true;
+
         // Get first update out of the way with timeslicing on. First fixed update will consume all
         // input so we can't really tell the difference.
         InputSystem.Update(InputUpdateType.Fixed);
@@ -394,8 +342,8 @@ partial class CoreTests
 
         InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0.1234f }, 3 + 0.001);
         InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0.2345f }, 3 + 0.002);
-        InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.3456f}, 3 + 1.0 / 60 + 0.001);
-        InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.4567f}, 3 + 2 * (1.0 / 60) + 0.001);
+        InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0.3456f }, 3 + 1.0 / 60 + 0.001);
+        InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0.4567f }, 3 + 2 * (1.0 / 60) + 0.001);
 
         InputSystem.Update(InputUpdateType.Fixed);
 
@@ -434,7 +382,7 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    public unsafe void Events_CanInitializeStateEventFromDevice()
+    public unsafe void Events_CanCreateStateEventFromDevice()
     {
         var mouse = InputSystem.AddDevice<Mouse>();
 
@@ -443,13 +391,14 @@ partial class CoreTests
 
         using (var buffer = StateEvent.From(mouse, out var eventPtr))
         {
-            Assert.IsTrue(mouse.delta.x.ReadValueFromEvent(eventPtr, out var xVal));
+            Assert.That(mouse.delta.x.ReadValueFromEvent(eventPtr, out var xVal), Is.True);
             Assert.That(xVal, Is.EqualTo(1).Within(0.00001));
 
-            Assert.IsTrue(mouse.delta.y.ReadValueFromEvent(eventPtr, out var yVal));
+            Assert.That(mouse.delta.y.ReadValueFromEvent(eventPtr, out var yVal), Is.True);
             Assert.That(yVal, Is.EqualTo(1).Within(0.00001));
 
             var stateEventPtr = StateEvent.From(eventPtr);
+
             Assert.That(stateEventPtr->baseEvent.deviceId, Is.EqualTo(mouse.id));
             Assert.That(stateEventPtr->baseEvent.time, Is.EqualTo(runtime.currentTime));
             Assert.That(stateEventPtr->baseEvent.sizeInBytes, Is.EqualTo(buffer.Length));
@@ -462,9 +411,23 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    [Property("TimesliceEvents", "Off")]
     public void Events_SendingStateToDeviceWithoutBeforeRenderEnabled_DoesNothingInBeforeRenderUpdate()
     {
+        InputSystem.settings.timesliceEvents = false;
+
+        // We need one device that has before-render updates enabled for the update to enable
+        // at all.
+        const string deviceJson = @"
+            {
+                ""name"" : ""CustomGamepad"",
+                ""extend"" : ""Gamepad"",
+                ""beforeRender"" : ""Update""
+            }
+        ";
+
+        InputSystem.RegisterLayout(deviceJson);
+        InputSystem.AddDevice("CustomGamepad");
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
         var newState = new GamepadState {leftStick = new Vector2(0.123f, 0.456f)};
 
@@ -866,10 +829,7 @@ partial class CoreTests
         public int buttons;
         [InputControl(layout = "Axis")] public float axis2;
 
-        public FourCC format
-        {
-            get { return new FourCC('N', 'S', 'T', 'D'); }
-        }
+        public FourCC format => new FourCC('N', 'S', 'T', 'D');
     }
 
     private struct CustomDeviceState : IInputStateTypeInfo
@@ -878,10 +838,7 @@ partial class CoreTests
 
         public CustomNestedDeviceState nested;
 
-        public FourCC format
-        {
-            get { return new FourCC('C', 'U', 'S', 'T'); }
-        }
+        public FourCC format => new FourCC('C', 'U', 'S', 'T');
     }
 
     [InputControlLayout(stateType = typeof(CustomDeviceState))]
@@ -941,10 +898,7 @@ partial class CoreTests
         public CustomDeviceState baseState;
         public int extra;
 
-        public FourCC format
-        {
-            get { return baseState.format; }
-        }
+        public FourCC format => baseState.format;
     }
 
     // HIDs rely on this behavior as we may only use a subset of a HID's set of

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -31,6 +31,12 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 
+- **The system no longer supports processing input in __BOTH__ fixed and dynamic updates**. Instead, a choice has to be made whether to process input before each `FixedUpdate()` or before each `Update()`.
+  * Rationale: the existing code that supported having both updates receive input independently still had several holes and became increasingly complex and brittle. Our solution was based on not actually processing input twice but on channeling input concurrently into both the state of both updates. Together with the fact that specific inputs have to reset (and possibly accumulate) correctly with respect to their update time slices, this became increasingly hard to do right. This, together with the fact that we've come to increasingly question the value of this feature, led us to removing the capability while preserving the ability to determine where input is processed.
+  * NOTE: Timeslicing is NOT affected by this. You can still switch to `ProcessEventInFixedUpdates` and get events timesliced to individual `FixedUpdate` periods according to their timestamps.
+  * `InputSettings.UpdateMode.ProcessEventsInBothFixedAndDynamicUpdate` has been removed.
+  * `InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly` has been renamed to `InputSettings.UpdateMode.ProcessEventsInDynamicUpdate` and is now the default.
+  * `InputSettings.UpdateMode.ProcessEventsInFixedUpdateOnly` has been renamed to `InputSettings.UpdateMode.ProcessEventsInFixedUpdate`.
 - Added icons for PlayerInput, PlayerInputManager, InputSystemUIInputModule and MultiplayerEventSystem components.
 - Changed `Keyboard` IME properties (`imeEnabled`, `imeCursorPosition`) to methods (`SetIMEEnabled`, `SetIMECursorPosition`).
 - Added getters to all `IInputRuntime` properties.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -51,7 +51,7 @@ namespace UnityEngine.InputSystem
     /// identifies both where the control stores its state as well as the format it stores it in.
     /// </remarks>
     /// <seealso cref="InputDevice"/>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public abstract class InputControl
     {
         ////REVIEW: we could allow the parenthetical characters if we require escaping them in paths

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -114,13 +114,9 @@ namespace UnityEngine.InputSystem
         {
             get
             {
-#if UNITY_2019_1_OR_NEWER
                 var command = QueryCanRunInBackground.Create();
                 if (ExecuteCommand(ref command) >= 0)
-                {
                     return command.canRunInBackground;
-                }
-#endif
                 return false;
             }
         }
@@ -198,20 +194,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         public double lastUpdateTime => m_LastUpdateTimeInternal - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
 
-        public bool wasUpdatedThisFrame
-        {
-            get
-            {
-                var updateType = InputUpdate.s_LastUpdateType;
-                if (updateType == InputUpdateType.Dynamic || updateType == InputUpdateType.BeforeRender)
-                    return m_CurrentDynamicUpdateCount == InputUpdate.s_DynamicUpdateCount;
-                if (updateType == InputUpdateType.Fixed)
-                    return m_CurrentFixedUpdateCount == InputUpdate.s_FixedUpdateCount;
-
-                ////REVIEW: how should this behave in the editor
-                return false;
-            }
-        }
+        public bool wasUpdatedThisFrame => m_CurrentUpdateStepCount == InputUpdate.s_UpdateStepCount;
 
         /// <summary>
         /// A flattened list of controls that make up the device.
@@ -279,12 +262,11 @@ namespace UnityEngine.InputSystem
         public override unsafe void ReadValueFromStateIntoBuffer(void* statePtr, void* bufferPtr, int bufferSize)
         {
             if (statePtr == null)
-                throw new ArgumentNullException("statePtr");
+                throw new ArgumentNullException(nameof(statePtr));
             if (bufferPtr == null)
-                throw new ArgumentNullException("bufferPtr");
+                throw new ArgumentNullException(nameof(bufferPtr));
             if (bufferSize < valueSizeInBytes)
-                throw new ArgumentException(string.Format("Buffer tool small (expected: {0}, actual: {1}",
-                    valueSizeInBytes, bufferSize));
+                throw new ArgumentException($"Buffer too small (expected: {valueSizeInBytes}, actual: {bufferSize}");
 
             var adjustedStatePtr = (byte*)statePtr + m_StateBlock.byteOffset;
             UnsafeUtility.MemCpy(bufferPtr, adjustedStatePtr, m_StateBlock.alignedSizeInBytes);
@@ -293,9 +275,9 @@ namespace UnityEngine.InputSystem
         public override unsafe bool CompareValue(void* firstStatePtr, void* secondStatePtr)
         {
             if (firstStatePtr == null)
-                throw new ArgumentNullException("firstStatePtr");
+                throw new ArgumentNullException(nameof(firstStatePtr));
             if (secondStatePtr == null)
-                throw new ArgumentNullException("secondStatePtr");
+                throw new ArgumentNullException(nameof(secondStatePtr));
 
             var adjustedFirstStatePtr = (byte*)firstStatePtr + m_StateBlock.byteOffset;
             var adjustedSecondStatePtr = (byte*)firstStatePtr + m_StateBlock.byteOffset;
@@ -402,11 +384,9 @@ namespace UnityEngine.InputSystem
         /// <seealso cref="InputEvent.time"/>
         internal double m_LastUpdateTimeInternal;
 
-        // The dynamic and fixed update count corresponding to the current
-        // front buffers that are active on the device. We use this to know
-        // when to flip buffers.
-        internal uint m_CurrentDynamicUpdateCount;
-        internal uint m_CurrentFixedUpdateCount;
+        // Update count corresponding to the current front buffers that are active on the device.
+        // We use this to know when to flip buffers.
+        internal uint m_CurrentUpdateStepCount;
 
         // List of aliases for all controls. Each control gets a slice of this array.
         // See 'InputControl.aliases'.
@@ -433,7 +413,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         internal bool hasControlsWithDefaultState
         {
-            get { return (m_DeviceFlags & DeviceFlags.HasControlsWithDefaultState) == DeviceFlags.HasControlsWithDefaultState; }
+            get => (m_DeviceFlags & DeviceFlags.HasControlsWithDefaultState) == DeviceFlags.HasControlsWithDefaultState;
             set
             {
                 if (value)
@@ -446,7 +426,7 @@ namespace UnityEngine.InputSystem
         internal void SetUsage(InternedString usage)
         {
             // Make last entry in m_UsagesForEachControl be our device usage string.
-            var numControlUsages = m_UsageToControl != null ? m_UsageToControl.Length : 0;
+            var numControlUsages = m_UsageToControl?.Length ?? 0;
             Array.Resize(ref m_UsagesForEachControl, numControlUsages + 1);
             m_UsagesForEachControl[numControlUsages] = usage;
             m_UsagesReadOnly = new ReadOnlyArray<InternedString>(m_UsagesForEachControl, numControlUsages, 1);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
@@ -133,29 +133,21 @@ namespace UnityEngine.InputSystem.Editor
 
             switch (selector)
             {
-                case BufferSelector.DynamicUpdateFrontBuffer:
-                    if (manager.m_StateBuffers.m_DynamicUpdateBuffers.valid)
-                        return manager.m_StateBuffers.m_DynamicUpdateBuffers.GetFrontBuffer(deviceIndex);
+                case BufferSelector.PlayerUpdateFrontBuffer:
+                    if (manager.m_StateBuffers.m_PlayerStateBuffers.valid)
+                        return manager.m_StateBuffers.m_PlayerStateBuffers.GetFrontBuffer(deviceIndex);
                     break;
-                case BufferSelector.DynamicUpdateBackBuffer:
-                    if (manager.m_StateBuffers.m_DynamicUpdateBuffers.valid)
-                        return manager.m_StateBuffers.m_DynamicUpdateBuffers.GetBackBuffer(deviceIndex);
-                    break;
-                case BufferSelector.FixedUpdateFrontBuffer:
-                    if (manager.m_StateBuffers.m_FixedUpdateBuffers.valid)
-                        return manager.m_StateBuffers.m_FixedUpdateBuffers.GetFrontBuffer(deviceIndex);
-                    break;
-                case BufferSelector.FixedUpdateBackBuffer:
-                    if (manager.m_StateBuffers.m_FixedUpdateBuffers.valid)
-                        return manager.m_StateBuffers.m_FixedUpdateBuffers.GetBackBuffer(deviceIndex);
+                case BufferSelector.PlayerUpdateBackBuffer:
+                    if (manager.m_StateBuffers.m_PlayerStateBuffers.valid)
+                        return manager.m_StateBuffers.m_PlayerStateBuffers.GetBackBuffer(deviceIndex);
                     break;
                 case BufferSelector.EditorUpdateFrontBuffer:
-                    if (manager.m_StateBuffers.m_EditorUpdateBuffers.valid)
-                        return manager.m_StateBuffers.m_EditorUpdateBuffers.GetFrontBuffer(deviceIndex);
+                    if (manager.m_StateBuffers.m_EditorStateBuffers.valid)
+                        return manager.m_StateBuffers.m_EditorStateBuffers.GetFrontBuffer(deviceIndex);
                     break;
                 case BufferSelector.EditorUpdateBackBuffer:
-                    if (manager.m_StateBuffers.m_EditorUpdateBuffers.valid)
-                        return manager.m_StateBuffers.m_EditorUpdateBuffers.GetBackBuffer(deviceIndex);
+                    if (manager.m_StateBuffers.m_EditorStateBuffers.valid)
+                        return manager.m_StateBuffers.m_EditorStateBuffers.GetBackBuffer(deviceIndex);
                     break;
             }
 
@@ -307,14 +299,14 @@ namespace UnityEngine.InputSystem.Editor
 
         private enum BufferSelector
         {
-            DynamicUpdateFrontBuffer,
-            DynamicUpdateBackBuffer,
+            PlayerUpdateFrontBuffer,
+            PlayerUpdateBackBuffer,
             FixedUpdateFrontBuffer,
             FixedUpdateBackBuffer,
             EditorUpdateFrontBuffer,
             EditorUpdateBackBuffer,
             COUNT,
-            Default = DynamicUpdateFrontBuffer
+            Default = PlayerUpdateFrontBuffer
         }
 
         private static class Styles

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -46,7 +46,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (EditorGUILayout.DropdownButton(EditorGUIUtility.IconContent("_Popup"), FocusType.Passive, EditorStyles.label))
             {
-                GenericMenu menu = new GenericMenu();
+                var menu = new GenericMenu();
                 menu.AddDisabledItem(new GUIContent("Available Settings Assets:"));
                 menu.AddSeparator("");
                 for (var i = 0; i < m_AvailableSettingsAssetsOptions.Length; i++)
@@ -75,7 +75,7 @@ namespace UnityEngine.InputSystem.Editor
                 GUILayout.Space(20);
             }
 
-            using (var disabled = new EditorGUI.DisabledScope(m_AvailableInputSettingsAssets.Length == 0))
+            using (new EditorGUI.DisabledScope(m_AvailableInputSettingsAssets.Length == 0))
             {
                 EditorGUILayout.HelpBox(
                     "Please note that the new input system is still under development and not all features are fully functional or stable yet.\n\n"
@@ -91,17 +91,7 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUI.BeginChangeCheck();
 
                 EditorGUILayout.PropertyField(m_UpdateMode);
-                var updateMode = (InputSettings.UpdateMode)m_UpdateMode.intValue;
-                if (updateMode == InputSettings.UpdateMode.ProcessEventsInBothFixedAndDynamicUpdate)
-                {
-                    // Choosing action update mode only makes sense if we have an ambiguous situation, i.e.
-                    // when we have both dynamic and fixed updates in the picture.
-                    ////TODO: enable when action update mode is properly sorted
-                    //EditorGUILayout.PropertyField(m_ActionUpdateMode);
-                }
-
-                ////TODO: enable when backported
-                //EditorGUILayout.PropertyField(m_TimesliceEvents);
+                EditorGUILayout.PropertyField(m_TimesliceEvents);
 
                 EditorGUILayout.PropertyField(m_FilterNoiseOnCurrent);
                 EditorGUILayout.PropertyField(m_CompensateForScreenOrientation);
@@ -225,7 +215,6 @@ namespace UnityEngine.InputSystem.Editor
             // Look up properties.
             m_SettingsObject = new SerializedObject(m_Settings);
             m_UpdateMode = m_SettingsObject.FindProperty("m_UpdateMode");
-            m_ActionUpdateMode = m_SettingsObject.FindProperty("m_ActionUpdateMode");
             m_TimesliceEvents = m_SettingsObject.FindProperty("m_TimesliceEvents");
             m_CompensateForScreenOrientation = m_SettingsObject.FindProperty("m_CompensateForScreenOrientation");
             m_FilterNoiseOnCurrent = m_SettingsObject.FindProperty("m_FilterNoiseOnCurrent");
@@ -302,10 +291,7 @@ namespace UnityEngine.InputSystem.Editor
                 InitializeWithCurrentSettings();
 
             ////REVIEW: leads to double-repaint when the settings change is initiated by us; problem?
-            ////FIXME: doesn't seem like there's a way to issue a repaint with the 2018.3 API
-            #if UNITY_2019_1_OR_NEWER
             Repaint();
-            #endif
         }
 
         /// <summary>
@@ -323,7 +309,6 @@ namespace UnityEngine.InputSystem.Editor
 
         [NonSerialized] private SerializedObject m_SettingsObject;
         [NonSerialized] private SerializedProperty m_UpdateMode;
-        [NonSerialized] private SerializedProperty m_ActionUpdateMode;
         [NonSerialized] private SerializedProperty m_TimesliceEvents;
         [NonSerialized] private SerializedProperty m_RunUpdatesManually;
         [NonSerialized] private SerializedProperty m_CompensateForScreenOrientation;
@@ -340,7 +325,6 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private GUIContent[] m_AvailableSettingsAssetsOptions;
         [NonSerialized] private int m_CurrentSelectedInputSettingsAsset;
 
-        [NonSerialized] private GUIContent m_NewAssetButtonText = EditorGUIUtility.TrTextContent("New");
         [NonSerialized] private GUIContent m_SupportedDevicesText = EditorGUIUtility.TrTextContent("Supported Devices");
         [NonSerialized] private GUIStyle m_NewAssetButtonStyle;
 
@@ -352,9 +336,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 // Force next OnGUI() to re-initialize.
                 s_Instance.m_Settings = null;
-                #if UNITY_2019_1_OR_NEWER
                 s_Instance.Repaint();
-                #endif
             }
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -131,7 +131,7 @@ namespace UnityEngine.InputSystem.LowLevel
             set => m_Event.time = value;
         }
 
-
+        ////FIXME: this API isn't consistent; time seems to be internalTime whereas time property is external time
         public InputEvent(FourCC type, int sizeInBytes, int deviceId, double time = -1)
         {
             if (time < 0)
@@ -180,7 +180,7 @@ namespace UnityEngine.InputSystem.LowLevel
         internal static unsafe InputEvent* GetNextInMemory(InputEvent* currentPtr)
         {
             Debug.Assert(currentPtr != null);
-            var alignedSizeInBytes = NumberHelpers.AlignToMultiple(currentPtr->sizeInBytes, kAlignment);
+            var alignedSizeInBytes = currentPtr->sizeInBytes.AlignToMultipleOf(kAlignment);
             return (InputEvent*)((byte*)currentPtr + alignedSizeInBytes);
         }
 
@@ -197,7 +197,7 @@ namespace UnityEngine.InputSystem.LowLevel
             Debug.Assert(currentPtr != null);
             Debug.Assert(buffer.Contains(currentPtr), "Given event is not contained in given event buffer");
 
-            var alignedSizeInBytes = NumberHelpers.AlignToMultiple(currentPtr->sizeInBytes, kAlignment);
+            var alignedSizeInBytes = currentPtr->sizeInBytes.AlignToMultipleOf(kAlignment);
             var nextPtr = (InputEvent*)((byte*)currentPtr + alignedSizeInBytes);
 
             if (!buffer.Contains(nextPtr))

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
@@ -138,7 +138,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     $"sizeInBytes must be >= sizeof(InputEvent) == {InputEvent.kBaseEventSize} (was {sizeInBytes})",
                     nameof(sizeInBytes));
 
-            var alignedSizeInBytes = NumberHelpers.AlignToMultiple(sizeInBytes, InputEvent.kAlignment);
+            var alignedSizeInBytes = sizeInBytes.AlignToMultipleOf(InputEvent.kAlignment);
 
             // See if we need to enlarge our buffer.
             var currentCapacity = capacityInBytes;
@@ -243,7 +243,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 var numBytes = currentReadPos->sizeInBytes;
                 if (currentReadPos != currentWritePos)
                     UnsafeUtility.MemMove(currentWritePos, currentReadPos, numBytes);
-                currentWritePos = (InputEvent*)((byte*)currentWritePos + NumberHelpers.AlignToMultiple(numBytes, 4));
+                currentWritePos = (InputEvent*)((byte*)currentWritePos + numBytes.AlignToMultipleOf(4));
                 ++numEventsRetainedInBuffer;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -105,7 +105,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// Set delegate to call when the application changes focus.
         /// </summary>
         /// <seealso cref="Application.onFocusChanged"/>
-        Action<bool> onFocusChanged { get; set; }
+        Action<bool> onPlayerFocusChanged { get; set; }
 
         /// <summary>
         /// Set delegate to invoke when system is shutting down.
@@ -153,8 +153,6 @@ namespace UnityEngine.InputSystem.LowLevel
         double currentTimeOffsetToRealtimeSinceStartup { get; }
 
         ScreenOrientation screenOrientation { get; }
-        Vector2 screenSize { get; }
-        int frameCount { get; }
 
         // If analytics are enabled, the runtime receives analytics events from the input manager.
         // See InputAnalytics.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1785,7 +1785,7 @@ namespace UnityEngine.InputSystem
 
             // Allocate new buffers.
             var newBuffers = new InputStateBuffers();
-            var newStateBlockOffsets = newBuffers.AllocateAll(m_UpdateMask, m_Devices, m_DevicesCount);
+            var newStateBlockOffsets = newBuffers.AllocateAll(m_Devices, m_DevicesCount);
 
             // Migrate state.
             newBuffers.MigrateAll(m_Devices, m_DevicesCount, newStateBlockOffsets, oldBuffers, oldDeviceIndices);

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -125,6 +125,30 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        public InputUpdateType defaultUpdateType
+        {
+            get
+            {
+                ////TODO: if we're *inside* an update, this should use the current update type
+
+                #if UNITY_EDITOR
+                if (!gameIsPlayingAndHasFocus)
+                    return InputUpdateType.Editor;
+                #endif
+
+                if ((m_UpdateMask & InputUpdateType.Manual) != 0)
+                    return InputUpdateType.Manual;
+
+                if ((m_UpdateMask & InputUpdateType.Dynamic) != 0)
+                    return InputUpdateType.Dynamic;
+
+                if ((m_UpdateMask & InputUpdateType.Fixed) != 0)
+                    return InputUpdateType.Fixed;
+
+                return InputUpdateType.None;
+            }
+        }
+
         public float pollingFrequency
         {
             get => m_PollingFrequency;
@@ -1314,8 +1338,7 @@ namespace UnityEngine.InputSystem
 
         public void Update()
         {
-            ////FIXME: This is nonsense; dynamic updates may not even be enabled; make a more appropriate choice here
-            Update(InputUpdateType.Dynamic);
+            Update(defaultUpdateType);
         }
 
         public void Update(InputUpdateType updateType)
@@ -1348,27 +1371,7 @@ namespace UnityEngine.InputSystem
             m_StateBuffers.FreeAll();
 
             // Uninstall globals.
-            if (ReferenceEquals(InputControlLayout.s_Layouts.baseLayoutTable, m_Layouts.baseLayoutTable))
-                InputControlLayout.s_Layouts = new InputControlLayout.Collection();
-            if (ReferenceEquals(InputProcessor.s_Processors.table, m_Processors.table))
-                InputProcessor.s_Processors = new TypeTable();
-            if (ReferenceEquals(InputInteraction.s_Interactions.table, m_Interactions.table))
-                InputInteraction.s_Interactions = new TypeTable();
-            if (ReferenceEquals(InputBindingComposite.s_Composites.table, m_Composites.table))
-                InputBindingComposite.s_Composites = new TypeTable();
-
-            // Detach from runtime.
-            if (m_Runtime != null)
-            {
-                m_Runtime.onUpdate = null;
-                m_Runtime.onDeviceDiscovered = null;
-                m_Runtime.onBeforeUpdate = null;
-                m_Runtime.onFocusChanged = null;
-                m_Runtime.onShouldRunUpdate = null;
-
-                if (ReferenceEquals(InputRuntime.s_Instance, m_Runtime))
-                    InputRuntime.s_Instance = null;
-            }
+            UninstallGlobals();
 
             // Destroy settings if they are temporary.
             if (m_Settings != null && m_Settings.hideFlags == HideFlags.HideAndDontSave)
@@ -1475,14 +1478,14 @@ namespace UnityEngine.InputSystem
                 m_Runtime.onUpdate = null;
                 m_Runtime.onBeforeUpdate = null;
                 m_Runtime.onDeviceDiscovered = null;
-                m_Runtime.onFocusChanged = null;
+                m_Runtime.onPlayerFocusChanged = null;
                 m_Runtime.onShouldRunUpdate = null;
             }
 
             m_Runtime = runtime;
             m_Runtime.onUpdate = OnUpdate;
             m_Runtime.onDeviceDiscovered = OnNativeDeviceDiscovered;
-            m_Runtime.onFocusChanged = OnFocusChanged;
+            m_Runtime.onPlayerFocusChanged = OnFocusChanged;
             m_Runtime.onShouldRunUpdate = ShouldRunUpdate;
             m_Runtime.pollingFrequency = pollingFrequency;
 
@@ -1520,6 +1523,31 @@ namespace UnityEngine.InputSystem
                 InputStateBuffers.SwitchTo(m_StateBuffers, InputUpdateType.Dynamic);
                 InputStateBuffers.s_DefaultStateBuffer = m_StateBuffers.defaultStateBuffer;
                 InputStateBuffers.s_NoiseMaskBuffer = m_StateBuffers.noiseMaskBuffer;
+            }
+        }
+
+        internal void UninstallGlobals()
+        {
+            if (ReferenceEquals(InputControlLayout.s_Layouts.baseLayoutTable, m_Layouts.baseLayoutTable))
+                InputControlLayout.s_Layouts = new InputControlLayout.Collection();
+            if (ReferenceEquals(InputProcessor.s_Processors.table, m_Processors.table))
+                InputProcessor.s_Processors = new TypeTable();
+            if (ReferenceEquals(InputInteraction.s_Interactions.table, m_Interactions.table))
+                InputInteraction.s_Interactions = new TypeTable();
+            if (ReferenceEquals(InputBindingComposite.s_Composites.table, m_Composites.table))
+                InputBindingComposite.s_Composites = new TypeTable();
+
+            // Detach from runtime.
+            if (m_Runtime != null)
+            {
+                m_Runtime.onUpdate = null;
+                m_Runtime.onDeviceDiscovered = null;
+                m_Runtime.onBeforeUpdate = null;
+                m_Runtime.onPlayerFocusChanged = null;
+                m_Runtime.onShouldRunUpdate = null;
+
+                if (ReferenceEquals(InputRuntime.s_Instance, m_Runtime))
+                    InputRuntime.s_Instance = null;
             }
         }
 
@@ -1768,14 +1796,9 @@ namespace UnityEngine.InputSystem
             InputStateBuffers.s_DefaultStateBuffer = newBuffers.defaultStateBuffer;
             InputStateBuffers.s_NoiseMaskBuffer = newBuffers.noiseMaskBuffer;
 
-            // Make sure that even if we didn't have an update yet, we already have buffers active. This is
-            // especially important if only dynamic updates are enabled. If we don't switch to the dynamic buffers
-            // here, the first fixed update will run without any buffers active.
-            if (m_Settings.updateMode == InputSettings.UpdateMode.ProcessEventsManually)
-                InputStateBuffers.SwitchTo(m_StateBuffers, InputUpdateType.Manual);
-            else
-                InputStateBuffers.SwitchTo(m_StateBuffers,
-                    InputUpdate.s_LastUpdateType != 0 ? InputUpdate.s_LastUpdateType : InputUpdateType.Dynamic);
+            // Switch to buffers.
+            InputStateBuffers.SwitchTo(m_StateBuffers,
+                InputUpdate.s_LastUpdateType != InputUpdateType.None ? InputUpdate.s_LastUpdateType : defaultUpdateType);
 
             ////TODO: need to update state change monitors
         }
@@ -1818,22 +1841,17 @@ namespace UnityEngine.InputSystem
             // Copy default state to all front and back buffers.
             var stateBlock = device.m_StateBlock;
             var deviceIndex = device.m_DeviceIndex;
-            if (m_StateBuffers.m_DynamicUpdateBuffers.valid)
+            if (m_StateBuffers.m_PlayerStateBuffers.valid)
             {
-                stateBlock.CopyToFrom(m_StateBuffers.m_DynamicUpdateBuffers.GetFrontBuffer(deviceIndex), defaultStateBuffer);
-                stateBlock.CopyToFrom(m_StateBuffers.m_DynamicUpdateBuffers.GetBackBuffer(deviceIndex), defaultStateBuffer);
-            }
-            if (m_StateBuffers.m_FixedUpdateBuffers.valid)
-            {
-                stateBlock.CopyToFrom(m_StateBuffers.m_FixedUpdateBuffers.GetFrontBuffer(deviceIndex), defaultStateBuffer);
-                stateBlock.CopyToFrom(m_StateBuffers.m_FixedUpdateBuffers.GetBackBuffer(deviceIndex), defaultStateBuffer);
+                stateBlock.CopyToFrom(m_StateBuffers.m_PlayerStateBuffers.GetFrontBuffer(deviceIndex), defaultStateBuffer);
+                stateBlock.CopyToFrom(m_StateBuffers.m_PlayerStateBuffers.GetBackBuffer(deviceIndex), defaultStateBuffer);
             }
 
             #if UNITY_EDITOR
-            if (m_StateBuffers.m_EditorUpdateBuffers.valid)
+            if (m_StateBuffers.m_EditorStateBuffers.valid)
             {
-                stateBlock.CopyToFrom(m_StateBuffers.m_EditorUpdateBuffers.GetFrontBuffer(deviceIndex), defaultStateBuffer);
-                stateBlock.CopyToFrom(m_StateBuffers.m_EditorUpdateBuffers.GetBackBuffer(deviceIndex), defaultStateBuffer);
+                stateBlock.CopyToFrom(m_StateBuffers.m_EditorStateBuffers.GetFrontBuffer(deviceIndex), defaultStateBuffer);
+                stateBlock.CopyToFrom(m_StateBuffers.m_EditorStateBuffers.GetBackBuffer(deviceIndex), defaultStateBuffer);
             }
             #endif
         }
@@ -1994,8 +2012,6 @@ namespace UnityEngine.InputSystem
             if (m_HaveDevicesWithStateCallbackReceivers && updateType != InputUpdateType.BeforeRender) ////REVIEW: before-render handling is probably wrong
             {
                 var stateBuffers = m_StateBuffers.GetDoubleBuffersFor(updateType);
-                var isDynamicOrFixedUpdate =
-                    updateType == InputUpdateType.Dynamic || updateType == InputUpdateType.Fixed;
 
                 ////REVIEW: should we rather allocate a temp buffer on a per-device basis? the current code makes one
                 ////        temp allocation equal to the combined state of all devices in the system; even with touch in the
@@ -2015,29 +2031,6 @@ namespace UnityEngine.InputSystem
                         var device = m_Devices[i];
                         if ((device.m_DeviceFlags & InputDevice.DeviceFlags.HasStateCallbacks) != InputDevice.DeviceFlags.HasStateCallbacks)
                             continue;
-
-                        // Depending on update ordering, we are writing events into *upcoming* updates inside of
-                        // OnUpdate(). E.g. we may receive an event in fixed update and write it concurrently into
-                        // the fixed and dynamic update buffer for the device.
-                        //
-                        // This means that we have to be extra careful here not to overwrite state which has already
-                        // been updated with events. To check for this, we simply determine whether the device's update
-                        // count for the current update type already corresponds to the count of the upcoming update.
-                        //
-                        // NOTE: This is only relevant for non-editor updates.
-                        if (isDynamicOrFixedUpdate)
-                        {
-                            if (updateType == InputUpdateType.Dynamic)
-                            {
-                                if (device.m_CurrentDynamicUpdateCount == InputUpdate.s_DynamicUpdateCount + 1)
-                                    continue; // Device already received state for upcoming dynamic update.
-                            }
-                            else if (updateType == InputUpdateType.Fixed)
-                            {
-                                if (device.m_CurrentFixedUpdateCount == InputUpdate.s_FixedUpdateCount + 1)
-                                    continue; // Device already received state for upcoming fixed update.
-                            }
-                        }
 
                         var deviceStateOffset = device.m_StateBlock.byteOffset;
                         var deviceStateSize = device.m_StateBlock.alignedSizeInBytes;
@@ -2093,23 +2086,21 @@ namespace UnityEngine.InputSystem
                 // so we always preserve this if set.
                 newUpdateMask |= InputUpdateType.BeforeRender;
             }
+            if (m_Settings.updateMode == InputSettings.s_OldUnsupportedFixedAndDynamicUpdateSetting)
+                m_Settings.updateMode = InputSettings.UpdateMode.ProcessEventsInDynamicUpdate;
             switch (m_Settings.updateMode)
             {
-                case InputSettings.UpdateMode.ProcessEventsInBothFixedAndDynamicUpdate:
-                    newUpdateMask |= InputUpdateType.Fixed;
+                case InputSettings.UpdateMode.ProcessEventsInDynamicUpdate:
                     newUpdateMask |= InputUpdateType.Dynamic;
                     break;
-                case InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly:
-                    newUpdateMask |= InputUpdateType.Dynamic;
-                    break;
-                case InputSettings.UpdateMode.ProcessEventsInFixedUpdateOnly:
+                case InputSettings.UpdateMode.ProcessEventsInFixedUpdate:
                     newUpdateMask |= InputUpdateType.Fixed;
                     break;
                 case InputSettings.UpdateMode.ProcessEventsManually:
                     newUpdateMask |= InputUpdateType.Manual;
                     break;
                 default:
-                    throw new NotImplementedException("Input update mode: " + m_Settings.updateMode);
+                    throw new NotSupportedException("Invalid input update mode: " + m_Settings.updateMode);
             }
 
             #if UNITY_EDITOR
@@ -2236,7 +2227,6 @@ namespace UnityEngine.InputSystem
             // Restore devices before checking update mask. See InputSystem.RunInitialUpdate().
             RestoreDevicesAfterDomainReloadIfNecessary();
 
-            ////FIXME: this shouldn't happen; looks like are sometimes getting before-update calls from native when we shouldn't
             if ((updateType & m_UpdateMask) == 0)
             {
                 Profiler.EndSample();
@@ -2269,13 +2259,9 @@ namespace UnityEngine.InputSystem
             InputStateBuffers.SwitchTo(m_StateBuffers, updateType);
 
             var isBeforeRenderUpdate = false;
-            if (updateType == InputUpdateType.Dynamic)
+            if (updateType == InputUpdateType.Dynamic || updateType == InputUpdateType.Manual || updateType == InputUpdateType.Fixed)
             {
-                ++InputUpdate.s_DynamicUpdateCount;
-            }
-            else if (updateType == InputUpdateType.Fixed)
-            {
-                ++InputUpdate.s_FixedUpdateCount;
+                ++InputUpdate.s_UpdateStepCount;
             }
             else if (updateType == InputUpdateType.BeforeRender)
             {
@@ -2359,8 +2345,8 @@ namespace UnityEngine.InputSystem
                     continue;
                 }
 
-                if (currentEventReadPtr->time <= currentTime)
-                    totalEventLag += currentTime - currentEventReadPtr->time;
+                if (currentEventReadPtr->internalTime <= currentTime)
+                    totalEventLag += currentTime - currentEventReadPtr->internalTime;
 
                 // Give listeners a shot at the event.
                 var listenerCount = m_EventListeners.length;
@@ -2423,7 +2409,6 @@ namespace UnityEngine.InputSystem
                         uint receivedStateSize;
                         byte* ptrToReceivedState;
                         FourCC receivedStateFormat;
-                        var needToCopyFromBackBuffer = false;
 
                         // Grab state data from event and decide where to copy to and how much to copy.
                         if (currentEventType == StateEvent.Type)
@@ -2532,8 +2517,6 @@ namespace UnityEngine.InputSystem
                                 (byte*)deviceBuffer + stateBlockOfDevice.byteOffset,
                                 sizeOfStateToCopy, offsetInDeviceStateToCopyTo);
 
-                        var deviceStateOffset = device.m_StateBlock.byteOffset + offsetInDeviceStateToCopyTo;
-
                         // If noise filtering on .current is turned on and the device may have noise,
                         // determine if the event carries signal or not.
                         var makeDeviceCurrent = true;
@@ -2552,105 +2535,22 @@ namespace UnityEngine.InputSystem
                         }
 
                         // Buffer flip.
-                        if (FlipBuffersForDeviceIfNecessary(device, updateType))
-                        {
-                            // In case of a delta state event we need to carry forward all state we're
-                            // not updating. Instead of optimizing the copy here, we're just bringing the
-                            // entire state forward.
-                            //
-                            // Also, if we received a mismatching state format that the device chose to
-                            // incorporate using OnReceiveStateWithDifferentFormat, we're potentially performing
-                            // a partial state update, so bring the current state forward like for delta
-                            // state events.
-                            if (currentEventType == DeltaStateEvent.Type || receivedStateFormat != stateBlockOfDevice.format)
-                                needToCopyFromBackBuffer = true;
-                        }
+                        var flipped = FlipBuffersForDeviceIfNecessary(device, updateType);
 
-                        // Now write the state.
-                        #if UNITY_EDITOR
-                        if (!gameIsPlayingAndHasFocus)
-                        {
-                            var frontBuffer = m_StateBuffers.m_EditorUpdateBuffers.GetFrontBuffer(deviceIndex);
-                            Debug.Assert(frontBuffer != null);
+			            // Now write the state.
+			            #if UNITY_EDITOR
+			            if (updateType == InputUpdateType.Editor)
+			            {
+			                WriteStateChange(m_StateBuffers.m_EditorStateBuffers, deviceIndex, ref stateBlockOfDevice, offsetInDeviceStateToCopyTo,
+			                    ptrToReceivedState, sizeOfStateToCopy, flipped);
+			            }
+			            else
+			            #endif
+			            {
+			                WriteStateChange(m_StateBuffers.m_PlayerStateBuffers, deviceIndex, ref stateBlockOfDevice,
+			                    offsetInDeviceStateToCopyTo, ptrToReceivedState, sizeOfStateToCopy, flipped);
+			            }
 
-                            if (needToCopyFromBackBuffer)
-                            {
-                                var backBuffer = m_StateBuffers.m_EditorUpdateBuffers.GetBackBuffer(deviceIndex);
-                                Debug.Assert(backBuffer != null);
-
-                                UnsafeUtility.MemCpy(
-                                    (byte*)frontBuffer + (int)stateBlockOfDevice.byteOffset,
-                                    (byte*)backBuffer + (int)stateBlockOfDevice.byteOffset,
-                                    stateBlockSizeOfDevice);
-                            }
-
-                            UnsafeUtility.MemCpy((byte*)frontBuffer + (int)deviceStateOffset, ptrToReceivedState, sizeOfStateToCopy);
-                        }
-                        else
-                        #endif
-                        if (updateType == InputUpdateType.Manual)
-                        {
-                            var frontBuffer = m_StateBuffers.m_ManualUpdateBuffers.GetFrontBuffer(deviceIndex);
-                            Debug.Assert(frontBuffer != null);
-
-                            if (needToCopyFromBackBuffer)
-                            {
-                                var backBuffer = m_StateBuffers.m_ManualUpdateBuffers.GetBackBuffer(deviceIndex);
-                                Debug.Assert(backBuffer != null);
-
-                                UnsafeUtility.MemCpy(
-                                    (byte*)frontBuffer + (int)stateBlockOfDevice.byteOffset,
-                                    (byte*)backBuffer + (int)stateBlockOfDevice.byteOffset,
-                                    stateBlockSizeOfDevice);
-                            }
-
-                            UnsafeUtility.MemCpy((byte*)frontBuffer + (int)deviceStateOffset, ptrToReceivedState, sizeOfStateToCopy);
-                        }
-                        else
-                        {
-                            // For dynamic and fixed updates, we have to write into the front buffer
-                            // of both updates as a state change event comes in only once and we have
-                            // to reflect the most current state in both update types.
-                            //
-                            // If one or the other update is disabled, however, we will perform a single
-                            // memcpy here.
-                            if (m_StateBuffers.m_DynamicUpdateBuffers.valid)
-                            {
-                                var frontBuffer = m_StateBuffers.m_DynamicUpdateBuffers.GetFrontBuffer(deviceIndex);
-                                Debug.Assert(frontBuffer != null);
-
-                                if (needToCopyFromBackBuffer)
-                                {
-                                    var backBuffer = m_StateBuffers.m_DynamicUpdateBuffers.GetBackBuffer(deviceIndex);
-                                    Debug.Assert(backBuffer != null);
-
-                                    UnsafeUtility.MemCpy(
-                                        (byte*)frontBuffer + (int)stateBlockOfDevice.byteOffset,
-                                        (byte*)backBuffer + (int)stateBlockOfDevice.byteOffset,
-                                        stateBlockSizeOfDevice);
-                                }
-
-                                UnsafeUtility.MemCpy((byte*)frontBuffer + (int)deviceStateOffset, ptrToReceivedState, sizeOfStateToCopy);
-                            }
-                            if (m_StateBuffers.m_FixedUpdateBuffers.valid)
-                            {
-                                var frontBuffer = m_StateBuffers.m_FixedUpdateBuffers.GetFrontBuffer(deviceIndex);
-                                Debug.Assert(frontBuffer != null);
-
-                                if (needToCopyFromBackBuffer)
-                                {
-                                    var backBuffer = m_StateBuffers.m_FixedUpdateBuffers.GetBackBuffer(deviceIndex);
-                                    Debug.Assert(backBuffer != null);
-
-                                    UnsafeUtility.MemCpy(
-                                        (byte*)frontBuffer + (int)stateBlockOfDevice.byteOffset,
-                                        (byte*)backBuffer + (int)stateBlockOfDevice.byteOffset,
-                                        stateBlockSizeOfDevice);
-                                }
-
-                                UnsafeUtility.MemCpy((byte*)frontBuffer + (int)deviceStateOffset, ptrToReceivedState, sizeOfStateToCopy);
-                            }
-                        }
 
                         if (device.m_LastUpdateTimeInternal <= currentEventTimeInternal)
                             device.m_LastUpdateTimeInternal = currentEventTimeInternal;
@@ -2772,46 +2672,6 @@ namespace UnityEngine.InputSystem
         {
             for (var i = 0; i < m_AfterUpdateListeners.length; ++i)
                 m_AfterUpdateListeners[i](updateType);
-        }
-
-        /// <summary>
-        /// Switch the current set of state buffers (<see cref="InputStateBuffers"/>) to the
-        /// ones that are tracked by input actions.
-        /// </summary>
-        /// <remarks>
-        /// If both fixed and dynamic updates are enabled, we use the buffers dictated by <see cref="InputSettings.actionUpdateMode"/>.
-        /// Otherwise we use fixed, dynamic, or manual update buffers depending on <see cref="InputSettings.updateMode"/>.
-        /// </remarks>
-        private void SwitchToBuffersForActions()
-        {
-            InputUpdateType updateType;
-            switch (m_Settings.updateMode)
-            {
-                case InputSettings.UpdateMode.ProcessEventsInBothFixedAndDynamicUpdate:
-                    if (m_Settings.actionUpdateMode == InputSettings.ActionUpdateMode.UpdateActionsInFixedUpdate)
-                        updateType = InputUpdateType.Fixed;
-                    else
-                        updateType = InputUpdateType.Dynamic;
-                    break;
-
-                case InputSettings.UpdateMode.ProcessEventsInDynamicUpdateOnly:
-                    updateType = InputUpdateType.Dynamic;
-                    break;
-
-                case InputSettings.UpdateMode.ProcessEventsInFixedUpdateOnly:
-                    updateType = InputUpdateType.Fixed;
-                    break;
-
-                case InputSettings.UpdateMode.ProcessEventsManually:
-                    updateType = InputUpdateType.Manual;
-                    break;
-
-                default:
-                    throw new NotSupportedException(
-                        $"Unrecognized update mode '{m_Settings.updateMode}'; don't know which buffers to use for actions");
-            }
-
-            InputStateBuffers.SwitchTo(m_StateBuffers, updateType);
         }
 
         // NOTE: 'newState' can be a subset of the full state stored at 'oldState'. In this case,
@@ -2966,8 +2826,6 @@ namespace UnityEngine.InputSystem
             if (timeoutCount == 0)
                 return;
 
-            SwitchToBuffersForActions();
-
             // Go through the list and both trigger expired timers and remove any irrelevant
             // ones by compacting the array.
             // NOTE: We do not actually release any memory we may have allocated.
@@ -3003,6 +2861,35 @@ namespace UnityEngine.InputSystem
             m_StateChangeMonitorTimeouts.SetLength(remainingTimeoutCount);
         }
 
+        private static unsafe void WriteStateChange(InputStateBuffers.DoubleBuffers buffers, int deviceIndex,
+            ref InputStateBlock deviceStateBlock, uint stateOffsetInDevice, void* statePtr, uint stateSizeInBytes, bool flippedBuffers)
+        {
+            var frontBuffer = buffers.GetFrontBuffer(deviceIndex);
+            Debug.Assert(frontBuffer != null);
+
+            // If we're updating less than the full state, we need to preserve the parts we are not updating.
+            // Instead of trying to optimize here and only copy what we really need, we just go and copy the
+            // entire state of the device over.
+            //
+            // NOTE: This copying must only happen once, right after a buffer flip. Otherwise we may copy old,
+            //       stale input state from the back buffer over state that has already been updated with newer
+            //       data.
+            var deviceStateSize = deviceStateBlock.alignedSizeInBytes;
+            if (flippedBuffers && deviceStateSize != stateSizeInBytes)
+            {
+                var backBuffer = buffers.GetBackBuffer(deviceIndex);
+                Debug.Assert(backBuffer != null);
+
+                UnsafeUtility.MemCpy(
+                    (byte*)frontBuffer + deviceStateBlock.byteOffset,
+                    (byte*)backBuffer + deviceStateBlock.byteOffset,
+                    deviceStateSize);
+            }
+
+            UnsafeUtility.MemCpy((byte*)frontBuffer + deviceStateBlock.byteOffset + stateOffsetInDevice, statePtr,
+                stateSizeInBytes);
+        }
+
         // Flip front and back buffer for device, if necessary. May flip buffers for more than just
         // the given update type.
         // Returns true if there was a buffer flip.
@@ -3017,6 +2904,7 @@ namespace UnityEngine.InputSystem
             }
 
 #if UNITY_EDITOR
+            ////REVIEW: should this use the editor update ticks as quasi-frame-boundaries?
             // Updates go to the editor only if the game isn't playing or does not have focus.
             // Otherwise we fall through to the logic that flips for the *next* dynamic and
             // fixed updates.
@@ -3025,61 +2913,20 @@ namespace UnityEngine.InputSystem
                 // The editor doesn't really have a concept of frame-to-frame operation the
                 // same way the player does. So we simply flip buffers on a device whenever
                 // a new state event for it comes in.
-                m_StateBuffers.m_EditorUpdateBuffers.SwapBuffers(device.m_DeviceIndex);
+                m_StateBuffers.m_EditorStateBuffers.SwapBuffers(device.m_DeviceIndex);
                 return true;
             }
 #endif
 
-            var flipped = false;
-
-            // If it is *NOT* a fixed update, we need to flip for the *next* coming fixed
-            // update if we haven't already.
-            if (updateType != InputUpdateType.Fixed &&
-                device.m_CurrentFixedUpdateCount != InputUpdate.s_FixedUpdateCount + 1)
+            // Flip buffers if we haven't already for this frame.
+            if (device.m_CurrentUpdateStepCount != InputUpdate.s_UpdateStepCount)
             {
-                m_StateBuffers.m_FixedUpdateBuffers.SwapBuffers(device.m_DeviceIndex);
-                device.m_CurrentFixedUpdateCount = InputUpdate.s_FixedUpdateCount + 1;
-                flipped = true;
+                m_StateBuffers.m_PlayerStateBuffers.SwapBuffers(device.m_DeviceIndex);
+                device.m_CurrentUpdateStepCount = InputUpdate.s_UpdateStepCount;
+                return true;
             }
 
-            // If it is *NOT* a dynamic update, we need to flip for the *next* coming
-            // dynamic update if we haven't already.
-            if (updateType != InputUpdateType.Dynamic &&
-                device.m_CurrentDynamicUpdateCount != InputUpdate.s_DynamicUpdateCount + 1)
-            {
-                m_StateBuffers.m_DynamicUpdateBuffers.SwapBuffers(device.m_DeviceIndex);
-                device.m_CurrentDynamicUpdateCount = InputUpdate.s_DynamicUpdateCount + 1;
-                flipped = true;
-            }
-
-            // If it *is* a fixed update and we haven't flipped for the current update
-            // yet, do it.
-            if (updateType == InputUpdateType.Fixed &&
-                device.m_CurrentFixedUpdateCount != InputUpdate.s_FixedUpdateCount)
-            {
-                m_StateBuffers.m_FixedUpdateBuffers.SwapBuffers(device.m_DeviceIndex);
-                device.m_CurrentFixedUpdateCount = InputUpdate.s_FixedUpdateCount;
-                flipped = true;
-            }
-
-            // If it *is* a dynamic update and we haven't flipped for the current update
-            // yet, do it.
-            if (updateType == InputUpdateType.Dynamic &&
-                device.m_CurrentDynamicUpdateCount != InputUpdate.s_DynamicUpdateCount)
-            {
-                m_StateBuffers.m_DynamicUpdateBuffers.SwapBuffers(device.m_DeviceIndex);
-                device.m_CurrentDynamicUpdateCount = InputUpdate.s_DynamicUpdateCount;
-                flipped = true;
-            }
-
-            // In manual mode, we always flip. There are no frame boundaries.
-            if (updateType == InputUpdateType.Manual)
-            {
-                m_StateBuffers.m_ManualUpdateBuffers.SwapBuffers(device.m_DeviceIndex);
-                flipped = true;
-            }
-
-            return flipped;
+            return false;
         }
 
         // Domain reload survival logic. Also used for pushing and popping input system

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2537,19 +2537,19 @@ namespace UnityEngine.InputSystem
                         // Buffer flip.
                         var flipped = FlipBuffersForDeviceIfNecessary(device, updateType);
 
-			            // Now write the state.
-			            #if UNITY_EDITOR
-			            if (updateType == InputUpdateType.Editor)
-			            {
-			                WriteStateChange(m_StateBuffers.m_EditorStateBuffers, deviceIndex, ref stateBlockOfDevice, offsetInDeviceStateToCopyTo,
-			                    ptrToReceivedState, sizeOfStateToCopy, flipped);
-			            }
-			            else
-			            #endif
-			            {
-			                WriteStateChange(m_StateBuffers.m_PlayerStateBuffers, deviceIndex, ref stateBlockOfDevice,
-			                    offsetInDeviceStateToCopyTo, ptrToReceivedState, sizeOfStateToCopy, flipped);
-			            }
+                        // Now write the state.
+                        #if UNITY_EDITOR
+                        if (updateType == InputUpdateType.Editor)
+                        {
+                            WriteStateChange(m_StateBuffers.m_EditorStateBuffers, deviceIndex, ref stateBlockOfDevice, offsetInDeviceStateToCopyTo,
+                                ptrToReceivedState, sizeOfStateToCopy, flipped);
+                        }
+                        else
+                        #endif
+                        {
+                            WriteStateChange(m_StateBuffers.m_PlayerStateBuffers, deviceIndex, ref stateBlockOfDevice,
+                                offsetInDeviceStateToCopyTo, ptrToReceivedState, sizeOfStateToCopy, flipped);
+                        }
 
 
                         if (device.m_LastUpdateTimeInternal <= currentEventTimeInternal)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -51,31 +51,6 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        public ActionUpdateMode actionUpdateMode
-        {
-            get
-            {
-                // Certain update modes force certain action update modes.
-                switch (updateMode)
-                {
-                    case UpdateMode.ProcessEventsInDynamicUpdateOnly:
-                        return ActionUpdateMode.UpdateActionsInDynamicUpdate;
-
-                    case UpdateMode.ProcessEventsInFixedUpdateOnly:
-                        return ActionUpdateMode.UpdateActionsInFixedUpdate;
-                }
-
-                return m_ActionUpdateMode;
-            }
-            set
-            {
-                if (m_ActionUpdateMode == value)
-                    return;
-                m_ActionUpdateMode = value;
-                OnChange();
-            }
-        }
-
         /// <summary>
         /// If enabled, any given input event will only be processed for any given fixed or dynamic
         /// update if it has been generated before or within the time slice allotted to the update.
@@ -271,10 +246,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] private string[] m_SupportedDevices;
         [Tooltip("Determine when Unity processes events. By default, accumulated input events are flushed out before each fixed update and "
             + "before each dynamic update. This setting can be used to restrict event processing to only where the application needs it.")]
-        [SerializeField] private UpdateMode m_UpdateMode;
-        [Tooltip("Determine when input actions are triggered. This is only relevant if both fixed and dynamic updates are enabled. By default, "
-            + "actions are triggered right before fixed updates.")]
-        [SerializeField] private ActionUpdateMode m_ActionUpdateMode;
+        [SerializeField] private UpdateMode m_UpdateMode = UpdateMode.ProcessEventsInDynamicUpdate;
 
         [Tooltip("Whether events should be distributed across updates according to their timestamps. This is most relevant when fixed "
             + "updates are enabled. If enabled, the system will compute a real-time time span corresponding to each update and will process only "
@@ -291,28 +263,21 @@ namespace UnityEngine.InputSystem
         //[SerializeField] private float m_DefaultMultiTapMaximumDelay = 0.75f;
         [SerializeField] private float m_DefaultHoldTime = 0.4f;
 
-        #if UNITY_EDITOR
-        [SerializeField] private bool m_LockInputToGameView;
-        #endif
-
         internal void OnChange()
         {
             if (InputSystem.settings == this)
                 InputSystem.s_Manager.ApplySettings();
         }
 
+        internal const int s_OldUnsupportedFixedAndDynamicUpdateSetting = 0;
+
         /// <summary>
         /// How the input system should update.
         /// </summary>
         /// <remarks>
         /// By default, the input system will run event processing as part of the player loop. In the default configuration,
-        /// the processing will happens once before every fixed update (<see cref="FixedUpdate"/>) and once
-        /// before every dynamic update (<see cref="Update"/>), i.e. <see cref="ProcessEventsInBothFixedAndDynamicUpdate"/>
+        /// the processing will happens once before every every dynamic update (<see cref="Update"/>), i.e. <see cref="ProcessEventsInDynamicUpdate"/>
         /// is the default behavior.
-        ///
-        /// Note that as dynamic and fixed update represent different timelines, input state (<see cref="InputStateBlock"/>)
-        /// is stored separately for them. This means that if both dynamic and fixed updates are enabled, twice the memory
-        /// is consumed as compared to enabling only one of the updates.
         ///
         /// There are two types of updates not governed by UpdateMode. One is <see cref="InputUpdateType.Editor"/> which
         /// will always be enabled in the editor and govern input updates for <see cref="UnityEditor.EditorWindow"/>s in
@@ -324,37 +289,31 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="InputSystem.Update()"/>
         /// <seealso cref="InputUpdateType"/>
-        /// <seealso cref="FixedUpdate"/>
-        /// <seealso cref="Update"/>
+        /// <seealso cref="MonoBehaviour.FixedUpdate"/>
+        /// <seealso cref="MonoBehaviour.Update"/>
         public enum UpdateMode
         {
-            /// <summary>
-            /// Automatically run updates both right before <see cref="FixedUpdate"/> and right before
-            /// <see cref="Update"/>.
-            /// </summary>
-            /// <seealso cref="FixedUpdate"/>
-            /// <seealso cref="Update"/>
-            ProcessEventsInBothFixedAndDynamicUpdate,
+            // Removed: ProcessEventsInBothFixedAndDynamicUpdate=0
 
             /// <summary>
-            /// Automatically run updates only right before <see cref="Update"/>.
+            /// Automatically run input updates right before every <see cref="MonoBehaviour.Update"/>.
             /// </summary>
             /// <remarks>
             /// In this mode, no processing happens specifically for fixed updates. Querying input state in
-            /// <see cref="FixedUpdate"/> will result in errors being logged in the editor and in
+            /// <see cref="MonoBehaviour.FixedUpdate"/> will result in errors being logged in the editor and in
             /// development builds. In release player builds, the value of the dynamic update state is returned.
             /// </remarks>
-            ProcessEventsInDynamicUpdateOnly,
+            ProcessEventsInDynamicUpdate = 1,
 
             /// <summary>
-            /// Automatically run updates only right before <see cref="FixedUpdate"/>.
+            /// Automatically input run updates right before every <see cref="MonoBehaviour.FixedUpdate"/>.
             /// </summary>
             /// <remarks>
             /// In this mode, no processing happens specifically for dynamic updates. Querying input state in
-            /// <see cref="Update"/> will result in errors being logged in the editor and in
+            /// <see cref="MonoBehaviour.Update"/> will result in errors being logged in the editor and in
             /// development builds. In release player builds, the value of the fixed update state is returned.
             /// </remarks>
-            ProcessEventsInFixedUpdateOnly,
+            ProcessEventsInFixedUpdate,
 
             /// <summary>
             /// Do not run updates automatically. In this mode, <see cref="InputSystem.Update()"/> must be called
@@ -367,12 +326,6 @@ namespace UnityEngine.InputSystem
             /// accumulating or some input getting lost.
             /// </remarks>
             ProcessEventsManually,
-        }
-
-        public enum ActionUpdateMode
-        {
-            UpdateActionsInFixedUpdate,
-            UpdateActionsInDynamicUpdate,
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1214,6 +1214,9 @@ namespace UnityEngine.InputSystem
 
         public static void Update(InputUpdateType updateType)
         {
+            if (updateType != InputUpdateType.None && (s_Manager.updateMask & updateType) == 0)
+                throw new InvalidOperationException(
+                    $"'{updateType}' updates are not enabled; InputSystem.settings.updateMode is set to '{settings.updateMode}'");
             s_Manager.Update(updateType);
         }
 
@@ -1677,6 +1680,7 @@ namespace UnityEngine.InputSystem
 
         private static void OnProjectChange()
         {
+            ////TODO: use dirty count to find whether settings have actually changed
             // May have added, removed, moved, or renamed settings asset. Force a refresh
             // of the UI.
             InputSettingsProvider.ForceReload();
@@ -1801,6 +1805,8 @@ namespace UnityEngine.InputSystem
             {
                 foreach (var device in s_Manager.devices)
                     device.NotifyRemoved();
+
+                s_Manager.UninstallGlobals();
             }
 
             // Create temporary settings. In the tests, this is all we need. But outside of tests,

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -34,6 +34,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         Fixed = 1 << 1,
 
+        ////REVIEW: Axe this update type from the public API?
         /// <summary>
         /// Input update that happens right before rendering.
         /// </summary>
@@ -61,14 +62,14 @@ namespace UnityEngine.InputSystem
         ////TODO
         Manual = 1 << 4,
 
+        ////REVIEW: kill?
         Default = Dynamic | Fixed | Editor,
     }
 
     internal static class InputUpdate
     {
         public static InputUpdateType s_LastUpdateType;
-        public static uint s_DynamicUpdateCount;
-        public static uint s_FixedUpdateCount;
+        public static uint s_UpdateStepCount;
         public static uint s_LastUpdateRetainedEventBytes;
         public static uint s_LastUpdateRetainedEventCount;
 
@@ -76,8 +77,7 @@ namespace UnityEngine.InputSystem
         public struct SerializedState
         {
             public InputUpdateType lastUpdateType;
-            public uint dynamicUpdateCount;
-            public uint fixedUpdateCount;
+            public uint updateStepCount;
             public uint lastUpdateRetainedEventBytes;
             public uint lastUpdateRetainedEventCount;
         }
@@ -87,8 +87,7 @@ namespace UnityEngine.InputSystem
             return new SerializedState
             {
                 lastUpdateType = s_LastUpdateType,
-                dynamicUpdateCount = s_DynamicUpdateCount,
-                fixedUpdateCount = s_FixedUpdateCount,
+                updateStepCount = s_UpdateStepCount,
                 lastUpdateRetainedEventBytes = s_LastUpdateRetainedEventBytes,
                 lastUpdateRetainedEventCount = s_LastUpdateRetainedEventCount,
             };
@@ -97,8 +96,7 @@ namespace UnityEngine.InputSystem
         public static void Restore(SerializedState state)
         {
             s_LastUpdateType = state.lastUpdateType;
-            s_DynamicUpdateCount = state.dynamicUpdateCount;
-            s_FixedUpdateCount = state.fixedUpdateCount;
+            s_UpdateStepCount = state.updateStepCount;
             s_LastUpdateRetainedEventBytes = state.lastUpdateRetainedEventBytes;
             s_LastUpdateRetainedEventCount = state.lastUpdateRetainedEventCount;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -19,7 +19,7 @@ namespace UnityEngine.InputSystem.LowLevel
     /// </summary>
     internal class NativeInputRuntime : IInputRuntime
     {
-        public static NativeInputRuntime instance = new NativeInputRuntime();
+        public static readonly NativeInputRuntime instance = new NativeInputRuntime();
 
         public int AllocateDeviceId()
         {
@@ -65,9 +65,7 @@ namespace UnityEngine.InputSystem.LowLevel
                         }
                         catch (Exception e)
                         {
-                            Debug.LogError(string.Format(
-                                "{0} during event processing of {1} update; resetting event buffer",
-                                e.GetType().Name, updateType));
+                            Debug.LogError($"{e.GetType().Name} during event processing of {updateType} update; resetting event buffer");
                             Debug.LogException(e);
                             buffer.Reset();
                         }
@@ -154,18 +152,16 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public Action<bool> onFocusChanged
+        public Action<bool> onPlayerFocusChanged
         {
             get => m_FocusChangedMethod;
             set
             {
                 if (value == null)
-                #if UNITY_2019_1_OR_NEWER
                     Application.focusChanged -= OnFocusChanged;
                 else if (m_FocusChangedMethod == null)
                     Application.focusChanged += OnFocusChanged;
-                #endif
-                    m_FocusChangedMethod = value;
+                m_FocusChangedMethod = value;
             }
         }
 
@@ -181,6 +177,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public double currentTime => NativeInputSystem.currentTime;
 
+        ////REVIEW: this applies the offset, currentTime doesn't
         public double currentTimeForFixedUpdate => Time.fixedUnscaledTime + currentTimeOffsetToRealtimeSinceStartup;
 
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
@@ -203,10 +200,6 @@ namespace UnityEngine.InputSystem.LowLevel
         }
 
         public ScreenOrientation screenOrientation => Screen.orientation;
-
-        public Vector2 screenSize => new Vector2(Screen.width, Screen.height);
-
-        public int frameCount => Time.frameCount;
 
         public bool isInBatchMode => Application.isBatchMode;
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -140,7 +140,7 @@ namespace UnityEngine.InputSystem.LowLevel
         // Allocates all buffers to serve the given updates and comes up with a spot
         // for the state block of each device. Returns the new state blocks for the
         // devices (it will *NOT* install them on the devices).
-        public uint[] AllocateAll(InputUpdateType updateMask, InputDevice[] devices, int deviceCount)
+        public uint[] AllocateAll(InputDevice[] devices, int deviceCount)
         {
             uint[] newDeviceOffsets = null;
             sizePerBuffer = ComputeSizeOfSingleBufferAndOffsetForEachDevice(devices, deviceCount, ref newDeviceOffsets);

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -22,51 +22,11 @@ namespace UnityEngine.InputSystem.LowLevel
         // Edit mode and play mode each get their own double buffering. Updates to them
         // are tied to focus and only one mode will actually receive state events while the
         // other mode is dormant. In the player, we only get play mode buffers, of course.
-        //
-        // For edit mode, we only need a single set of front and back buffers.
-        //
-        // For play mode, things are complicated by the fact that we can have several
-        // update slices (dynamic, fixed, before-render) in a single frame. Each such
-        // update type has its own point in time it considers the "previous" point in time.
-        // So, in the worst case where multiple update types are enabled concurrently,
-        // we have to keep multiple separate buffers for play mode.
-        //
-        // If, however, only a single update type is enabled (e.g. either fixed or dynamic),
-        // we operate the same way as edit mode with only one front and one back buffer.
-        //
-        // Buffer swapping happens differently than it does for graphics as we have to
-        // carry forward the current state of a device. In a scheme where you simply swap
-        // the meaning of front and back buffer every frame, every swap brings back the
-        // state from two frames ago. In graphics, this isn't a problem as you are expected
-        // to either clear or render over the entire frame. For us, it'd be okay as well
-        // if we could guarantee that every device gets a state event every frame -- which,
-        // however, we can't guarantee.
-        //
-        // We solve this by making buffer swapping *per device* rather than global. Only
-        // when a device actually receives a state event will we swap the front and back
-        // buffer for it. This means that what is the "current" buffer to one device may
-        // be the "previous" buffer to another. This avoids having to do any copying of
-        // state between the buffers.
-        //
-        // In play mode, when we do have multiple types of updates enabled at the same time,
-        // some additional rules apply.
-        //
-        // Before render updates never get their own state buffers. If enabled, they will
-        // process into the state buffers of the fixed and/or dynamic updates (depending
-        // on whether only one or both are enabled).
-        //
-        // Fixed and dynamic each get their own buffers. We specifically want to *NOT*
-        // optimize for this case as doing input processing from game scripts in both
-        // updates is a bad setup -- a game should decide where it wants to process input
-        // and then disable the update type that it does not need. This will put the
-        // game in a simple double buffering configuration.
-
 
         ////TODO: need to clear the current buffers when switching between edit and play mode
         ////      (i.e. if you click an editor window while in play mode, the play mode
         ////      device states will all go back to default)
         ////      actually, if we really reset on mode change, can't we just keep a single set buffers?
-
 
         public uint sizePerBuffer;
         public uint totalSize;
@@ -133,32 +93,24 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        internal DoubleBuffers m_DynamicUpdateBuffers;
-        internal DoubleBuffers m_FixedUpdateBuffers;
-        internal DoubleBuffers m_ManualUpdateBuffers;
+        internal DoubleBuffers m_PlayerStateBuffers;
 
 #if UNITY_EDITOR
-        internal DoubleBuffers m_EditorUpdateBuffers;
+        internal DoubleBuffers m_EditorStateBuffers;
 #endif
 
         public DoubleBuffers GetDoubleBuffersFor(InputUpdateType updateType)
         {
             switch (updateType)
             {
-                case InputUpdateType.Dynamic:
-                    return m_DynamicUpdateBuffers;
-                case InputUpdateType.Fixed:
-                    return m_FixedUpdateBuffers;
                 case InputUpdateType.BeforeRender:
-                    if (m_DynamicUpdateBuffers.valid)
-                        return m_DynamicUpdateBuffers;
-                    else
-                        return m_FixedUpdateBuffers;
+                case InputUpdateType.Fixed:
+                case InputUpdateType.Dynamic:
                 case InputUpdateType.Manual:
-                    return m_ManualUpdateBuffers;
+                    return m_PlayerStateBuffers;
 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
-                    return m_EditorUpdateBuffers;
+                    return m_EditorStateBuffers;
 #endif
             }
 
@@ -194,38 +146,22 @@ namespace UnityEngine.InputSystem.LowLevel
             sizePerBuffer = ComputeSizeOfSingleBufferAndOffsetForEachDevice(devices, deviceCount, ref newDeviceOffsets);
             if (sizePerBuffer == 0)
                 return null;
-            sizePerBuffer = NumberHelpers.AlignToMultiple(sizePerBuffer, 4);
-
-            var isDynamicUpdateEnabled = (updateMask & InputUpdateType.Dynamic) != 0;
-            var isFixedUpdateEnabled = (updateMask & InputUpdateType.Fixed) != 0;
-            var isManualUpdateEnabled = (updateMask & InputUpdateType.Manual) != 0;
+            sizePerBuffer = sizePerBuffer.AlignToMultipleOf(4);
 
             // Determine how much memory we need.
             var mappingTableSizePerBuffer = (uint)(deviceCount * sizeof(void*) * 2);
 
-            if (isDynamicUpdateEnabled)
-            {
-                totalSize += sizePerBuffer * 2;
-                totalSize += mappingTableSizePerBuffer;
-            }
-            if (isFixedUpdateEnabled)
-            {
-                totalSize += sizePerBuffer * 2;
-                totalSize += mappingTableSizePerBuffer;
-            }
-            if (isManualUpdateEnabled)
-            {
-                totalSize += sizePerBuffer * 2;
-                totalSize += mappingTableSizePerBuffer;
-            }
-            // Before render doesn't have its own buffers.
+            totalSize = 0;
+
+            totalSize += sizePerBuffer * 2;
+            totalSize += mappingTableSizePerBuffer;
 
             #if UNITY_EDITOR
             totalSize += sizePerBuffer * 2;
             totalSize += mappingTableSizePerBuffer;
             #endif
 
-            // Plus 2 more buffers (1 for default states, and one for noise filters).
+            // Plus 2 more buffers (1 for default states, and one for noise masks).
             totalSize += sizePerBuffer * 2;
 
             // Allocate.
@@ -234,27 +170,12 @@ namespace UnityEngine.InputSystem.LowLevel
 
             // Set up device to buffer mappings.
             var ptr = (byte*)m_AllBuffers;
-            if (isDynamicUpdateEnabled)
-            {
-                m_DynamicUpdateBuffers =
-                    SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer,
-                        mappingTableSizePerBuffer);
-            }
-            if (isFixedUpdateEnabled)
-            {
-                m_FixedUpdateBuffers =
-                    SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer,
-                        mappingTableSizePerBuffer);
-            }
-            if (isManualUpdateEnabled)
-            {
-                m_ManualUpdateBuffers =
-                    SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer,
-                        mappingTableSizePerBuffer);
-            }
+            m_PlayerStateBuffers =
+                SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer,
+                    mappingTableSizePerBuffer);
 
             #if UNITY_EDITOR
-            m_EditorUpdateBuffers =
+            m_EditorStateBuffers =
                 SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer, mappingTableSizePerBuffer);
             #endif
 
@@ -293,11 +214,10 @@ namespace UnityEngine.InputSystem.LowLevel
                 m_AllBuffers = null;
             }
 
-            m_DynamicUpdateBuffers = new DoubleBuffers();
-            m_FixedUpdateBuffers = new DoubleBuffers();
+            m_PlayerStateBuffers = new DoubleBuffers();
 
 #if UNITY_EDITOR
-            m_EditorUpdateBuffers = new DoubleBuffers();
+            m_EditorStateBuffers = new DoubleBuffers();
 #endif
 
             s_CurrentBuffers = new DoubleBuffers();
@@ -327,13 +247,11 @@ namespace UnityEngine.InputSystem.LowLevel
             // and the new set of buffers.
             if (oldBuffers.totalSize > 0)
             {
-                MigrateDoubleBuffer(m_DynamicUpdateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_DynamicUpdateBuffers,
-                    oldDeviceIndices);
-                MigrateDoubleBuffer(m_FixedUpdateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_FixedUpdateBuffers,
+                MigrateDoubleBuffer(m_PlayerStateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_PlayerStateBuffers,
                     oldDeviceIndices);
 
 #if UNITY_EDITOR
-                MigrateDoubleBuffer(m_EditorUpdateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_EditorUpdateBuffers,
+                MigrateDoubleBuffer(m_EditorStateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_EditorStateBuffers,
                     oldDeviceIndices);
 #endif
 
@@ -442,7 +360,7 @@ namespace UnityEngine.InputSystem.LowLevel
             for (var i = 0; i < deviceCount; ++i)
             {
                 var sizeOfDevice = devices[i].m_StateBlock.alignedSizeInBytes;
-                sizeOfDevice = NumberHelpers.AlignToMultiple(sizeOfDevice, 4);
+                sizeOfDevice = sizeOfDevice.AlignToMultipleOf(4);
                 if (sizeOfDevice == 0) // Shouldn't happen as we don't allow empty layouts but make sure we catch this if something slips through.
                     throw new ArgumentException($"Device '{devices[i]}' has a zero-size state buffer", nameof(devices));
                 result[i] = sizeInBytes;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
@@ -4,7 +4,7 @@ namespace UnityEngine.InputSystem.Utilities
 {
     internal static class NumberHelpers
     {
-        public static int AlignToMultiple(int number, int alignment)
+        public static int AlignToMultipleOf(this int number, int alignment)
         {
             var remainder = number % alignment;
             if (remainder == 0)
@@ -13,7 +13,7 @@ namespace UnityEngine.InputSystem.Utilities
             return number + alignment - remainder;
         }
 
-        public static uint AlignToMultiple(uint number, uint alignment)
+        public static uint AlignToMultipleOf(this uint number, uint alignment)
         {
             var remainder = number % alignment;
             if (remainder == 0)

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestRuntime.cs
@@ -68,34 +68,24 @@ namespace UnityEngine.InputSystem
 
                     onUpdate(type, ref buffer);
 
-                    #if UNITY_2019_1_OR_NEWER
                     m_EventCount = buffer.eventCount;
                     m_EventWritePosition = (int)buffer.sizeInBytes;
                     if (NativeArrayUnsafeUtility.GetUnsafeBufferPointerWithoutChecks(buffer.data) !=
                         NativeArrayUnsafeUtility.GetUnsafeBufferPointerWithoutChecks(m_EventBuffer))
                         m_EventBuffer = buffer.data;
-                    #else
-                    if (type != InputUpdateType.BeforeRender)
-                    {
-                        m_EventCount = 0;
-                        m_EventWritePosition = 0;
-                    }
-                    #endif
                 }
                 else
                 {
                     m_EventCount = 0;
                     m_EventWritePosition = 0;
                 }
-
-                ++frameCount;
             }
         }
 
         public unsafe void QueueEvent(InputEvent* eventPtr)
         {
             var eventSize = eventPtr->sizeInBytes;
-            var alignedEventSize = NumberHelpers.AlignToMultiple(eventSize, 4);
+            var alignedEventSize = eventSize.AlignToMultipleOf(4);
 
             lock (m_Lock)
             {
@@ -203,19 +193,19 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        public void InvokeFocusChanged(bool newFocusState)
+        public void InvokePlayerFocusChanged(bool newFocusState)
         {
-            onFocusChanged?.Invoke(newFocusState);
+            onPlayerFocusChanged?.Invoke(newFocusState);
         }
 
-        public void FocusLost()
+        public void PlayerFocusLost()
         {
-            InvokeFocusChanged(false);
+            InvokePlayerFocusChanged(false);
         }
 
-        public void FocusGained()
+        public void PlayerFocusGained()
         {
-            InvokeFocusChanged(true);
+            InvokePlayerFocusChanged(true);
         }
 
         public int ReportNewInputDevice(string deviceDescriptor, int deviceId = InputDevice.InvalidDeviceId)
@@ -323,18 +313,14 @@ namespace UnityEngine.InputSystem
         public Func<InputUpdateType, bool> onShouldRunUpdate { get; set; }
         public Action<int, string> onDeviceDiscovered { get; set; }
         public Action onShutdown { get; set; }
-        public Action<bool> onFocusChanged { get; set; }
+        public Action<bool> onPlayerFocusChanged { get; set; }
         public float pollingFrequency { get; set; }
         public double currentTime { get; set; }
         public double currentTimeForFixedUpdate { get; set; }
-        public bool shouldRunInBackground { get; set; }
-        public int frameCount { get; set; }
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;
 
         public ScreenOrientation screenOrientation { set; get; } = ScreenOrientation.Portrait;
-
-        public Vector2 screenSize { set; get; } = new Vector2(Screen.width, Screen.height);
 
         public List<PairedUser> userAccountPairings
         {


### PR DESCRIPTION
- Removes `InputSettings.ProcessEventsInBothFixedAndDynamicUpdate`.
- Removes `InputSettings.actionUpdateMode` which is no longer needed as the ambiguity only arises in combination with processing input in both fixed and dynamic update.
- Defaults to processing input in dynamic updates (like old input system).