### PR TITLE
FIX: GC heap garbage from event processing and when replugging native device.

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -258,6 +258,7 @@ class APIVerificationTests
             type.FullName == typeof(UnityEngine.InputSystem.Android.AndroidRelativeHumidity).FullName ||
             type.FullName == typeof(UnityEngine.InputSystem.Android.AndroidRotationVector).FullName ||
             type.FullName == typeof(UnityEngine.InputSystem.Android.AndroidStepCounter).FullName ||
+            type.FullName == typeof(UnityEngine.InputSystem.Switch.INPadRumble).FullName ||
             ////REVIEW: why are the ones in the .Editor namespace being filtered out by the docs generator?
             type.FullName == typeof(UnityEngine.InputSystem.Editor.InputActionCodeGenerator).FullName ||
             type.FullName == typeof(UnityEngine.InputSystem.Editor.InputControlPathEditor).FullName ||

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -289,7 +289,7 @@ partial class CoreTests
     // the action pretends for the control to *just* have changed to the state it already has.
     [Test]
     [Category("Actions")]
-    public void Actions_ValueActionsPerformInitialStateCheckWhenEnabled()
+    public void Actions_ValueActionsReactToCurrentStateOfControlWhenEnabled()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
 

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -12,6 +12,7 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.DualShock;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.Profiling;
 using UnityEngine.TestTools;
 using UnityEngine.TestTools.Utils;
 using Gyroscope = UnityEngine.InputSystem.Gyroscope;
@@ -3286,7 +3287,22 @@ partial class CoreTests
 
     [Test]
     [Category("Devices")]
-    public void Devices_RemovingDeviceCleansUpUpdateCallback()
+    public void Devices_RemovingDevice_UpdatesInternalDevicesIndices()
+    {
+        var device1 = InputSystem.AddDevice<Gamepad>();
+        var device2 = InputSystem.AddDevice<Mouse>();
+        var device3 = InputSystem.AddDevice<Keyboard>();
+
+        InputSystem.RemoveDevice(device2);
+
+        Assert.That(device1.m_DeviceIndex, Is.EqualTo(0));
+        Assert.That(device2.m_DeviceIndex, Is.EqualTo(InputDevice.kInvalidDeviceIndex));
+        Assert.That(device3.m_DeviceIndex, Is.EqualTo(1));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_RemovingDevice_CleansUpUpdateCallback()
     {
         var device = InputSystem.AddDevice<CustomDeviceWithUpdate>();
         InputSystem.RemoveDevice(device);
@@ -3296,10 +3312,13 @@ partial class CoreTests
         Assert.That(device.onUpdateCallCount, Is.Zero);
     }
 
+    // Sadly, while this one is a respectable effort on InputManager's part, in practice it is limited in usefulness
+    // by the fact that when native sends us the descriptor string, that very string will lead to a GC allocation and
+    // thus already cause garbage (albeit a very small amount). At least InputManager isn't adding any to it, though.
     [Test]
     [Category("Devices")]
-    [Ignore("TODO")]
-    public void TODO_Devices_RemovingAndReaddingDevice_DoesNotAllocateMemory()
+    [Retry(2)] // Warm up JIT
+    public void Devices_RemovingAndReaddingDevice_DoesNotAllocateMemory()
     {
         var description =
             new InputDeviceDescription
@@ -3312,16 +3331,39 @@ partial class CoreTests
         var deviceId = runtime.ReportNewInputDevice(description);
         InputSystem.Update();
 
+        // We allow the system to allocate memory the first time the removal happens. In particular,
+        // the array we use to hold removed devices we only allocate the first time we need to put
+        // something in it so we need one run to warm up the system. However, even the first re-adding
+        // should not allocate.
+        var removeEvent1 = DeviceRemoveEvent.Create(deviceId);
+        InputSystem.QueueEvent(ref removeEvent1);
+        InputSystem.Update();
+
+        // Avoid GC hit from string allocation.
+        var kProfilerRegion = "Devices_RemovingAndReaddingDevice_DoesNotAllocateMemory";
+
+        // We don't want a GC hit from the InputDescription->JSON conversion we get from the test runtime.
+        // Doesn't happen when a native backend reports a device.
+        var descriptionJson = description.ToJson();
+
         Assert.That(() =>
         {
+            Profiler.BeginSample(kProfilerRegion);
+
+            // "Plug" it back in.
+            deviceId = runtime.ReportNewInputDevice(descriptionJson);
+            InputSystem.Update();
+
             // "Unplug" device.
-            var removeEvent = DeviceRemoveEvent.Create(deviceId, 0.123);
-            InputSystem.QueueEvent(ref removeEvent);
+            var removeEvent2 = DeviceRemoveEvent.Create(deviceId);
+            InputSystem.QueueEvent(ref removeEvent2);
             InputSystem.Update();
 
             // "Plug" it back in.
-            runtime.ReportNewInputDevice(description);
+            runtime.ReportNewInputDevice(descriptionJson);
             InputSystem.Update();
+
+            Profiler.EndSample();
         }, Is.Not.AllocatingGCMemory());
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -112,7 +112,7 @@ partial class CoreTests
     public void Events_QueuingAndProcessingStateEvent_DoesNotAllocateMemory()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
-        
+
         // Warm up JIT and get rid of GC noise from initial input system update.
         InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = Vector2.one });
         InputSystem.Update();

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -109,10 +109,13 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    [Retry(2)] // Warm up JIT and get rid of noise from first input update
     public void Events_QueuingAndProcessingStateEvent_DoesNotAllocateMemory()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
+        
+        // Warm up JIT and get rid of GC noise from initial input system update.
+        InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = Vector2.one });
+        InputSystem.Update();
 
         // Make sure we don't get an allocation from the string literal.
         var kProfilerRegion = "Events_ProcessingStateEvent_DoesNotAllocateMemory";

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -11,6 +11,7 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.Profiling;
 using UnityEngine.TestTools.Constraints;
 using UnityEngine.TestTools.Utils;
 using Is = UnityEngine.TestTools.Constraints.Is;
@@ -108,19 +109,21 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    [Ignore("TODO")]
-    public void TODO_Events_ProcessingStateEvent_DoesNotAllocateMemory()
+    [Retry(2)] // Warm up JIT and get rid of noise from first input update
+    public void Events_QueuingAndProcessingStateEvent_DoesNotAllocateMemory()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
-        ////REVIEW: We do some analytics stuff on the first update that allocates. Probably there's
-        ////        a better way to handle this.
-        InputSystem.Update();
+        // Make sure we don't get an allocation from the string literal.
+        var kProfilerRegion = "Events_ProcessingStateEvent_DoesNotAllocateMemory";
 
-        InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = Vector2.one });
-
-        ////FIXME: seeing odd allocations that seem be triggered by the noise filtering stuff
-        Assert.That(() => InputSystem.Update(), Is.Not.AllocatingGCMemory());
+        Assert.That(() =>
+        {
+            Profiler.BeginSample(kProfilerRegion);
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = Vector2.one });
+            InputSystem.Update();
+            Profiler.EndSample();
+        }, Is.Not.AllocatingGCMemory());
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Utilities/JsonParserTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/JsonParserTests.cs
@@ -1,0 +1,184 @@
+#if UNITY_EDITOR
+using System;
+using NUnit.Framework;
+using UnityEngine.Profiling;
+using UnityEngine.InputSystem.Utilities;
+using UnityEngine.TestTools.Constraints;
+using Is = NUnit.Framework.Is;
+
+// JsonParser implements Yet Another JSON Parser. So that's sad. The one redeeming quality and sole reason
+// for its existence is that it can avoid a bunch of GC heap allocations for strings, arrays, and dictionaries
+// by navigating the JSON string directly. Means we can compare individual values to JSON data we receive
+// from the native backend without having to actually pipe the JSON data through JsonUtility.
+
+internal class JsonParserTests
+{
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanCompareJsonStringProperty()
+    {
+        const string json = @"
+            {
+                ""first"" : true,
+                ""second"" : [ 1, 2, 3.00 ],
+                ""third"" : ""test"",
+                ""fourth"" : ""ot\""her""
+            }
+        ";
+
+        var parser = new JsonParser(json);
+        Assert.That(parser.NavigateToProperty("third"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo("test"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo("foo"), Is.False);
+        parser.Reset();
+        Assert.That(parser.NavigateToProperty("fourth"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo("ot\"her"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo("other"), Is.False);
+    }
+
+    [Test]
+    [Category("Utilities")]
+    [Retry(2)] // Warm up JIT.
+    public void Utilities_CanCompareJsonStringProperty_WithoutAllocatingGCMemory()
+    {
+        var json = @"
+            {
+                ""first"" : true,
+                ""second"" : [ 1, 2, 3.00 ],
+                ""third"" : ""test"",
+                ""fourth"" : ""other""
+            }
+        ";
+
+        var kProfileRegion = "Utilities_CanCompareJsonStringProperty_WithoutAllocatingGCMemory";
+        var kThird = "third";
+        var kTest = "test";
+
+        Assert.That(() =>
+        {
+            Profiler.BeginSample(kProfileRegion);
+            var parser = new JsonParser(json);
+            parser.NavigateToProperty(kThird);
+            parser.CurrentPropertyHasValueEqualTo(kTest);
+            Profiler.EndSample();
+        }, ConstraintExtensions.AllocatingGCMemory(Is.Not));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    [Retry(2)] // Warm up JIT
+    public void Utilities_CanCompareJsonStringProperty_WithoutAllocatingGCMemory_EvenIfStringContainsEscapeSequences()
+    {
+        var json = @"
+            {
+                ""first"" : true,
+                ""second"" : [ 1, 2, 3.00 ],
+                ""third"" : ""te\""st"",
+                ""fourth"" : ""other""
+            }
+        ";
+
+        var kProfileRegion = "Utilities_CanCompareJsonStringProperty_WithoutAllocatingGCMemory";
+        var kThird = "third";
+        var kTest = "te\"st";
+
+        Assert.That(() =>
+        {
+            Profiler.BeginSample(kProfileRegion);
+            var parser = new JsonParser(json);
+            parser.NavigateToProperty(kThird);
+            parser.CurrentPropertyHasValueEqualTo(kTest);
+            Profiler.EndSample();
+        }, ConstraintExtensions.AllocatingGCMemory(Is.Not));
+    }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanCompareJsonNumberProperty()
+    {
+        const string json = @"
+            {
+                ""first"" : true,
+                ""second"" : [ 1, 2, 3.00 ],
+                ""third"" : 123,
+                ""fourth"" : 234.567
+            }
+        ";
+
+        var parser = new JsonParser(json);
+        Assert.That(parser.NavigateToProperty("third"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(123), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(234), Is.False);
+        parser.Reset();
+        Assert.That(parser.NavigateToProperty("fourth"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(234.567), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(345.678), Is.False);
+    }
+
+    private enum TestEnum
+    {
+        AA,
+        BB,
+        CC,
+    }
+
+    // To JsonParser, enum string literals, integer values, and boxed Enum values are all interchangeable.
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_CanCompareJsonEnumProperty()
+    {
+        const string json = @"
+            {
+                ""first"" : true,
+                ""second"" : [ 1, 2, 3.00 ],
+                ""third"" : 1,
+                ""fourth"" : ""CC""
+            }
+        ";
+
+        var parser = new JsonParser(json);
+        Assert.That(parser.NavigateToProperty("third"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(TestEnum.BB), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(TestEnum.CC), Is.False);
+        parser.Reset();
+        Assert.That(parser.NavigateToProperty("fourth"), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(TestEnum.CC), Is.True);
+        Assert.That(parser.CurrentPropertyHasValueEqualTo(TestEnum.BB), Is.False);
+    }
+
+    [Test]
+    [Category("Utilities")]
+    [Retry(2)] // Warm up JIT
+    [Ignore(".NET Enum APIs allocate garbage")]
+    public void TODO_Utilities_CanCompareJsonEnumProperty_WithoutAllocatingGCMemory()
+    {
+        var json = @"
+            {
+                ""first"" : true,
+                ""second"" : [ 1, 2, 3.00 ],
+                ""third"" : 1,
+                ""fourth"" : ""BB""
+            }
+        ";
+
+        var kProfileRegion = "Utilities_CanCompareJsonEnumProperty_WithoutAllocatingGCMemory";
+        var kThird = "third";
+        var kFourth = "fourth";
+        var kTest = (Enum)TestEnum.BB;
+
+        Assert.That(() =>
+        {
+            Profiler.BeginSample(kProfileRegion);
+            var parser = new JsonParser(json);
+            parser.NavigateToProperty(kThird);
+            parser.CurrentPropertyHasValueEqualTo(kTest);
+
+            parser.Reset();
+            parser.NavigateToProperty(kFourth);
+            parser.CurrentPropertyHasValueEqualTo(kTest);
+
+            Profiler.EndSample();
+        }, ConstraintExtensions.AllocatingGCMemory(Is.Not));
+    }
+}
+#endif // UNITY_EDITOR

--- a/Assets/Tests/InputSystem/Utilities/JsonParserTests.cs.meta
+++ b/Assets/Tests/InputSystem/Utilities/JsonParserTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 23936e98e17f45d88e1afab8c86eb24a
+timeCreated: 1563281228

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
-## [0.3.1-preview] - 2020-1-1
+## [0.9-preview] - 2020-1-1
 
 ### Fixed
 
@@ -23,7 +23,9 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed duplicate devices showing in the "Supported Devices" popup when using a search filter.
 - Fixed an error when adding new bindings in the Input Actions editor window when a filter was applied.
 - Fixed scroll wheel handling in `InputSystemUIInputModule` not being smooth.
-- Fixed inconsistent ifdefs in NPad.cs for the swtich pro controller.
+- Fixed compile errors from Switch Pro controller code on Linux.
+- Fixed GC heap garbage being caused by triggered by event processing.
+  * This meant that every processing of input would trigger garbage being allocated on the managed heap. The culprit was a peculiarity in the C# compiler which caused a struct in `InputEventPtr.IsA` to be allocated on the heap.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
-## [0.9-preview] - 2020-1-1
+## [0.9.0-preview] - 2020-1-1
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
-## [0.9.0-preview] - 2020-1-1
+## [0.3.1-preview] - 2020-1-1
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,11 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [0.9.1-preview] - 2099-1-1
 
+### Fixed
+
+- Fixed GC heap garbage being caused by triggered by event processing.
+  * This meant that every processing of input would trigger garbage being allocated on the managed heap. The culprit was a peculiarity in the C# compiler which caused a struct in `InputEventPtr.IsA` to be allocated on the heap.
+
 ## [0.9.0-preview] - 2019-7-18
 
 ### Fixed
@@ -26,8 +31,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an error when adding new bindings in the Input Actions editor window when a filter was applied.
 - Fixed scroll wheel handling in `InputSystemUIInputModule` not being smooth.
 - Fixed compile errors from Switch Pro controller code on Linux.
-- Fixed GC heap garbage being caused by triggered by event processing.
-  * This meant that every processing of input would trigger garbage being allocated on the managed heap. The culprit was a peculiarity in the C# compiler which caused a struct in `InputEventPtr.IsA` to be allocated on the heap.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.InputSystem.Interactions
         /// be considered pressed.
         /// </summary>
         /// <remarks>
-        /// If this is less than or equal to 0 (the default), <see cref="InputSettings.defaultButtonPressPoint"/> is used.
+        /// If this is less than or equal to 0 (the default), <see cref="InputSettings.defaultButtonPressPoint"/> is used instead.
         /// </remarks>
         /// <seealso cref="InputControl.EvaluateMagnitude()"/>
         public float pressPoint;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -7,7 +7,8 @@ namespace UnityEngine.InputSystem.Interactions
 {
     /// <summary>
     /// Interaction that requires multiple taps (press and release within <see cref="tapTime"/>) spaced no more
-    /// than <see cref="tapDelay"/> seconds apart.
+    /// than <see cref="tapDelay"/> seconds apart. This equates to a chain of <see cref="TapInteraction"/> with
+    /// a maximum delay between each tap.
     /// </summary>
     /// <remarks>
     /// The interaction goes into <see cref="InputActionPhase.Started"/> on the first press and then will not
@@ -45,12 +46,21 @@ namespace UnityEngine.InputSystem.Interactions
         [Tooltip("How many taps need to be performed in succession. Two means double-tap, three means triple-tap, and so on.")]
         public int tapCount = 2;
 
+        /// <summary>
+        /// Magnitude threshold that must be crossed by an actuated control for the control to
+        /// be considered pressed.
+        /// </summary>
+        /// <remarks>
+        /// If this is less than or equal to 0 (the default), <see cref="InputSettings.defaultButtonPressPoint"/> is used instead.
+        /// </remarks>
+        /// <seealso cref="InputControl.EvaluateMagnitude()"/>
         public float pressPoint;
 
         private float tapTimeOrDefault => tapTime > 0.0 ? tapTime : InputSystem.settings.defaultTapTime;
         internal float tapDelayOrDefault => tapDelay > 0.0 ? tapDelay : tapTimeOrDefault * 2;
         private float pressPointOrDefault => pressPoint > 0 ? pressPoint : InputSystem.settings.defaultButtonPressPoint;
 
+        /// <inheritdoc />
         public void Process(ref InputInteractionContext context)
         {
             if (context.timerHasExpired)
@@ -115,6 +125,7 @@ namespace UnityEngine.InputSystem.Interactions
             }
         }
 
+        /// <inheritdoc />
         public void Reset()
         {
             m_CurrentTapPhase = TapPhase.None;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -3,18 +3,27 @@ using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 #endif
 
+////REVIEW: shouldn't it use Canceled for release on PressAndRelease instead of triggering Performed again?
+
 namespace UnityEngine.InputSystem.Interactions
 {
     /// <summary>
-    /// Performs the action when a control is actuated past the button press point and then does not perform
-    /// again until the button is first released and then pressed again.
+    /// Performs the action at specific points in a button press-and-release sequence according top <see cref="behavior"/>.
     /// </summary>
     /// <remarks>
-    /// The exact trigger behavior can be determined via <see cref="behavior"/>.
+    /// By default, uses <see cref="PressBehavior.PressOnly"/> which performs the action as soon as the control crosses the
+    /// button press threshold defined by <see cref="pressPoint"/>. The action then will not trigger again until the control
+    /// is first released.
     ///
-    /// Note that this interaction is not restricted to controls of type <c>float</c>. Actuation is measured
-    /// through magnitudes (<see cref="InputControl.EvaluateMagnitude()"/> and will thus work with any control
-    /// that can return a magnitude of actuation.
+    /// Can be set to instead trigger on release (i.e. when the control goes back below the button press threshold) using
+    /// <see cref="PressBehavior.ReleaseOnly"/> or can be set to trigger on both press and release using <see cref="PressBehavior.PressAndRelease"/>).
+    ///
+    /// Note that using an explicit press interaction is only necessary if the goal is to either customize the press behavior
+    /// of a button or when binding to controls that are not buttons as such (the press interaction compares magnitudes to
+    /// <see cref="pressPoint"/> and thus any type of control that can deliver a magnitude can act as a button). The default
+    /// behavior available out of the box when binding <see cref="InputActionType.Button"/> type actions to button-type controls
+    /// (<see cref="UnityEngine.InputSystem.Controls.ButtonControl"/>) corresponds to using a press modifier with <see cref="behavior"/>
+    /// set to <see cref="PressBehavior.PressOnly"/> and <see cref="pressPoint"/> left at default.
     /// </remarks>
     public class PressInteraction : IInputInteraction
     {
@@ -34,11 +43,10 @@ namespace UnityEngine.InputSystem.Interactions
         /// <remarks>
         /// By default (PressOnly), the action is performed on press.
         /// With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is
-        /// performed on press and canceled on release.
+        /// performed on press and on release.
         /// </remarks>
         [Tooltip("Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
-            + "With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is performed on press and "
-            + "canceled on release.")]
+            + "With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is performed on press and release.")]
         public PressBehavior behavior;
 
         private float pressPointOrDefault => pressPoint > 0 ? pressPoint : InputSystem.settings.defaultButtonPressPoint;
@@ -115,18 +123,30 @@ namespace UnityEngine.InputSystem.Interactions
         /// <summary>
         /// Perform the action when the button is pressed.
         /// </summary>
+        /// <remarks>
+        /// Triggers <see cref="InputAction.performed"/> when a control crosses the button press threshold.
+        /// </remarks>
         // ReSharper disable once UnusedMember.Global
         PressOnly = 0,
 
         /// <summary>
         /// Perform the action when the button is released.
         /// </summary>
+        /// <remarks>
+        /// Triggers <see cref="InputAction.started"/> when a control crosses the button press threshold and
+        /// <see cref="InputAction.performed"/> when the control goes back below the button press threshold.
+        /// </remarks>
         // ReSharper disable once UnusedMember.Global
         ReleaseOnly = 1,
 
         /// <summary>
-        /// Perform the action when the button is pressed and cancel the action when the button is released.
+        /// Perform the action when the button is pressed and when the button is released.
         /// </summary>
+        /// <remarks>
+        /// Triggers <see cref="InputAction.performed"/> when a control crosses the button press threshold
+        /// and triggers <see cref="InputAction.performed"/> again when it goes back below the button press
+        /// threshold.
+        /// </remarks>
         // ReSharper disable once UnusedMember.Global
         PressAndRelease = 2,
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AnyKeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AnyKeyControl.cs
@@ -1,3 +1,4 @@
+using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 
 namespace UnityEngine.InputSystem.Controls
@@ -7,6 +8,7 @@ namespace UnityEngine.InputSystem.Controls
     /// for whether there's any non-zero bytes. If there are, the control
     /// returns 1.0; otherwise it returns 0.0.
     /// </summary>
+    [InputControlLayout(hideInUI = true)]
     public class AnyKeyControl : ButtonControl
     {
         ////TODO: wasPressedThisFrame and wasReleasedThisFrame

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -15,7 +15,7 @@ using UnityEngine.InputSystem.Utilities;
 namespace UnityEngine.InputSystem
 {
     /// <summary>
-    /// Functions to working with control path specs (like "/gamepad/*stick").
+    /// Functions for working with control path specs (like "/gamepad/*stick").
     /// </summary>
     /// <remarks>
     /// The thinking here is somewhat similar to System.IO.Path, i.e. have a range

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -304,34 +304,22 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Same as <see cref="buttonSouth"/>.
         /// </summary>
-        public ButtonControl aButton
-        {
-            get { return buttonSouth; }
-        }
+        public ButtonControl aButton => buttonSouth;
 
         /// <summary>
         /// Same as <see cref="buttonEast"/>.
         /// </summary>
-        public ButtonControl bButton
-        {
-            get { return buttonEast; }
-        }
+        public ButtonControl bButton => buttonEast;
 
         /// <summary>
         /// Same as <see cref="buttonWest"/>
         /// </summary>
-        public ButtonControl xButton
-        {
-            get { return buttonWest; }
-        }
+        public ButtonControl xButton => buttonWest;
 
         /// <summary>
         /// Same as <see cref="buttonNorth"/>.
         /// </summary>
-        public ButtonControl yButton
-        {
-            get { return buttonNorth; }
-        }
+        public ButtonControl yButton => buttonNorth;
 
         ////REVIEW: what about having 'axes' and 'buttons' read-only arrays like Joysticks and allowing to index that?
         public ButtonControl this[GamepadButton button]
@@ -424,10 +412,11 @@ namespace UnityEngine.InputSystem
                 current = null;
 
             // Remove from `all`.
-            var wasFound = ArrayHelpers.Erase(ref s_Gamepads, this);
-            Debug.Assert(wasFound, $"Gamepad {this} seems to not have been added but is being removed");
-            if (wasFound)
-                --s_GamepadCount;
+            var index = ArrayHelpers.IndexOfReference(s_Gamepads, this, s_GamepadCount);
+            if (index != -1)
+                ArrayHelpers.EraseAtWithCapacity(s_Gamepads, ref s_GamepadCount, index);
+            else
+                Debug.Assert(false, $"Gamepad {this} seems to not have been added but is being removed"); // Put in else to not allocate on normal path.
         }
 
         public virtual void PauseHaptics()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -416,7 +416,11 @@ namespace UnityEngine.InputSystem
             if (index != -1)
                 ArrayHelpers.EraseAtWithCapacity(s_Gamepads, ref s_GamepadCount, index);
             else
-                Debug.Assert(false, $"Gamepad {this} seems to not have been added but is being removed"); // Put in else to not allocate on normal path.
+            {
+                Debug.Assert(false,
+                    string.Format("Gamepad {0} seems to not have been added but is being removed (gamepad list: {1})",
+                        this, string.Join(", ", all))); // Put in else to not allocate on normal path.
+            }
         }
 
         public virtual void PauseHaptics()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine.InputSystem.Utilities;
 
 ////TODO: add a 'devicePath' property that platforms can use to relay their internal device locators
 ////      (but do *not* take it into account when comparing descriptions for disconnected devices)
@@ -226,6 +227,21 @@ namespace UnityEngine.InputSystem.Layouts
                 version = data.version,
                 capabilities = data.capabilities
             };
+        }
+
+        internal static bool ComparePropertyToDeviceDescriptor(string propertyName, string propertyValue, string deviceDescriptor)
+        {
+            // We use JsonParser instead of JsonUtility.Parse in order to not allocate GC memory here.
+
+            var json = new JsonParser(deviceDescriptor);
+            if (!json.NavigateToProperty(propertyName))
+            {
+                if (string.IsNullOrEmpty(propertyValue))
+                    return true;
+                return false;
+            }
+
+            return json.CurrentPropertyHasValueEqualTo(propertyValue);
         }
 
         [SerializeField] private string m_InterfaceName;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -70,7 +70,8 @@ namespace UnityEngine.InputSystem.Layouts
             // If it's a string, check whether it's a regex.
             if (supportRegex && value is string str)
             {
-                var mayBeRegex = !str.All(ch => char.IsLetterOrDigit(ch) || char.IsWhiteSpace(ch));
+	            var mayBeRegex = !str.All(ch => char.IsLetterOrDigit(ch) || char.IsWhiteSpace(ch)) &&
+	                             !double.TryParse(str, out var _); // Avoid '.' in floats forcing the value to be a regex.
                 if (mayBeRegex)
                     value = new Regex(str, RegexOptions.IgnoreCase);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -70,8 +70,8 @@ namespace UnityEngine.InputSystem.Layouts
             // If it's a string, check whether it's a regex.
             if (supportRegex && value is string str)
             {
-	            var mayBeRegex = !str.All(ch => char.IsLetterOrDigit(ch) || char.IsWhiteSpace(ch)) &&
-	                             !double.TryParse(str, out var _); // Avoid '.' in floats forcing the value to be a regex.
+                var mayBeRegex = !str.All(ch => char.IsLetterOrDigit(ch) || char.IsWhiteSpace(ch)) &&
+                    !double.TryParse(str, out var _);              // Avoid '.' in floats forcing the value to be a regex.
                 if (mayBeRegex)
                     value = new Regex(str, RegexOptions.IgnoreCase);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -143,7 +143,7 @@ namespace UnityEngine.InputSystem.Layouts
 
                     var graph = new JsonParser(deviceDescription.capabilities);
                     if (!graph.NavigateToProperty(key.ToString()) ||
-                        !graph.CurrentPropertyHasValueEqualTo(pattern))
+                        !graph.CurrentPropertyHasValueEqualTo(new JsonParser.JsonValue { type = JsonParser.JsonValueType.Any, anyValue = pattern}))
                         return 0;
                 }
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -4,6 +4,8 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 
+////TODO: option to allow to constrain mouse input to the screen area (i.e. no input once mouse leaves player window)
+
 namespace UnityEngine.InputSystem.LowLevel
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -14,6 +14,8 @@ using UnityEngine.InputSystem.Utilities;
 
 ////TODO: remove remoting of layout information
 
+////REVIEW: it seems that the various XXXMsg struct should be public; AWTM doesn't seem like working with the message interface is practical
+
 ////REVIEW: the namespacing mechanism for layouts which changes base layouts means that layouts can't be played
 ////        around with on the editor side but will only be changed once they're updated in the player
 
@@ -73,7 +75,7 @@ namespace UnityEngine.InputSystem
 
         public bool sending
         {
-            get { return (m_Flags & Flags.Sending) == Flags.Sending; }
+            get => (m_Flags & Flags.Sending) == Flags.Sending;
             private set
             {
                 if (value)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/SerializedPropertyHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/SerializedPropertyHelpers.cs
@@ -272,7 +272,7 @@ namespace UnityEngine.InputSystem.Editor
                     parser.ParseStringValue(out var propertyName);
                     parser.ParseToken(':');
 
-                    var childProperty = property.FindPropertyRelative(propertyName);
+                    var childProperty = property.FindPropertyRelative(propertyName.ToString());
                     if (childProperty == null)
                         throw new ArgumentException($"Cannot find property '{propertyName}' in {property}", nameof(property));
 
@@ -287,21 +287,21 @@ namespace UnityEngine.InputSystem.Editor
                     case SerializedPropertyType.Float:
                     {
                         parser.ParseNumber(out var num);
-                        property.floatValue = Convert.ToSingle(num);
+                        property.floatValue = (float)num.ToDouble();
                         break;
                     }
 
                     case SerializedPropertyType.String:
                     {
                         parser.ParseStringValue(out var str);
-                        property.stringValue = str;
+                        property.stringValue = str.ToString();
                         break;
                     }
 
                     case SerializedPropertyType.Boolean:
                     {
                         parser.ParseBooleanValue(out var b);
-                        property.boolValue = b;
+                        property.boolValue = b.ToBoolean();
                         break;
                     }
 
@@ -309,7 +309,7 @@ namespace UnityEngine.InputSystem.Editor
                     case SerializedPropertyType.Integer:
                     {
                         parser.ParseNumber(out var num);
-                        property.intValue = Convert.ToInt32(num);
+                        property.intValue = (int)num.ToInteger();
                         break;
                     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
@@ -151,8 +151,10 @@ namespace UnityEngine.InputSystem.LowLevel
             if (m_EventPtr == null)
                 return false;
 
-            var otherEventTypeCode = new TOtherEvent().typeStatic;
-            return m_EventPtr->type == otherEventTypeCode;
+            // NOTE: Important to say `default` instead of `new TOtherEvent()` here. The latter will result in a call to
+            //       `Activator.CreateInstance` on Mono and thus allocate GC memory.
+            TOtherEvent otherEvent = default;
+            return m_EventPtr->type == otherEvent.typeStatic;
         }
 
         // NOTE: It is your responsibility to know *if* there actually another event following this one in memory.

--- a/Packages/com.unity.inputsystem/InputSystem/Events/StateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/StateEvent.cs
@@ -52,10 +52,7 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC typeStatic
-        {
-            get { return Type; }
-        }
+        public FourCC typeStatic => Type;
 
         public static int GetEventSizeWithPayload<TState>()
             where TState : struct

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1085,26 +1085,24 @@ namespace UnityEngine.InputSystem
             var deviceIndex = device.m_DeviceIndex;
             var deviceId = device.id;
             ArrayHelpers.EraseAtWithCapacity(m_Devices, ref m_DevicesCount, deviceIndex);
-            device.m_DeviceIndex = InputDevice.kInvalidDeviceIndex;
             m_DevicesById.Remove(deviceId);
 
             if (m_Devices != null)
             {
-                var oldDeviceIndices = new int[m_DevicesCount];
-                for (var i = 0; i < m_DevicesCount; ++i)
-                {
-                    oldDeviceIndices[i] = m_Devices[i].m_DeviceIndex;
-                    m_Devices[i].m_DeviceIndex = i;
-                }
-
                 // Remove from state buffers.
-                ReallocateStateBuffers(oldDeviceIndices);
+                ReallocateStateBuffers();
             }
             else
             {
                 // No more devices. Kill state buffers.
                 m_StateBuffers.FreeAll();
             }
+
+            // Update device indices. Do this after reallocating state buffers as that call requires
+            // the old indices to still be in place.
+            for (var i = deviceIndex + 1; i < m_DevicesCount; ++i)
+                --m_Devices[i].m_DeviceIndex; // Indices have shifted down by one.
+            device.m_DeviceIndex = InputDevice.kInvalidDeviceIndex;
 
             // Update list of available devices.
             for (var i = 0; i < m_AvailableDeviceCount; ++i)
@@ -1120,7 +1118,7 @@ namespace UnityEngine.InputSystem
             }
 
             // Unbake offset into global state buffers.
-            device.BakeOffsetIntoStateBlockRecursive((uint)(-device.m_StateBlock.byteOffset));
+            device.BakeOffsetIntoStateBlockRecursive((uint)-device.m_StateBlock.byteOffset);
 
             // Force enabled actions to remove controls from the device.
             // We've already set the device index to be invalid so we any attempts
@@ -1578,7 +1576,6 @@ namespace UnityEngine.InputSystem
 
         // Used by EditorInputControlLayoutCache to determine whether its state is outdated.
         internal int m_LayoutRegistrationVersion;
-        internal int m_DeviceSetupVersion;////TODO
         private float m_PollingFrequency;
 
         internal InputControlLayout.Collection m_Layouts;
@@ -1767,16 +1764,16 @@ namespace UnityEngine.InputSystem
         // (Re)allocates state buffers and assigns each device that's been added
         // a segment of the buffer. Preserves the current state of devices.
         // NOTE: Installs the buffers globally.
-        private unsafe void ReallocateStateBuffers(int[] oldDeviceIndices = null)
+        private unsafe void ReallocateStateBuffers()
         {
             var oldBuffers = m_StateBuffers;
 
             // Allocate new buffers.
             var newBuffers = new InputStateBuffers();
-            var newStateBlockOffsets = newBuffers.AllocateAll(m_Devices, m_DevicesCount);
+            newBuffers.AllocateAll(m_Devices, m_DevicesCount);
 
             // Migrate state.
-            newBuffers.MigrateAll(m_Devices, m_DevicesCount, newStateBlockOffsets, oldBuffers, oldDeviceIndices);
+            newBuffers.MigrateAll(m_Devices, m_DevicesCount, oldBuffers);
 
             // Install the new buffers.
             oldBuffers.FreeAll();
@@ -1885,8 +1882,13 @@ namespace UnityEngine.InputSystem
             // had before a domain reload.
             RestoreDevicesAfterDomainReloadIfNecessary();
 
-            // Parse description.
-            var description = InputDeviceDescription.FromJson(deviceDescriptor);
+            // See if we have a disconnected device we can revive.
+            // NOTE: We do this all the way up here as the first thing before we even parse the JSON descriptor so
+            //       if we do have a device we can revive, we can do so without allocating any GC memory.
+            var device = TryMatchDisconnectedDevice(deviceDescriptor);
+
+            // Parse description, if need be.
+            var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
 
             // Add it.
             var markAsRemoved = false;
@@ -1896,7 +1898,7 @@ namespace UnityEngine.InputSystem
                 // we should support.
                 if (m_Settings.supportedDevices.Count > 0)
                 {
-                    var layout = TryFindMatchingControlLayout(ref description, deviceId);
+                    var layout = device != null ? device.m_Layout : TryFindMatchingControlLayout(ref description, deviceId);
                     if (!IsDeviceLayoutMarkedAsSupportedInSettings(layout))
                     {
                         // Not supported. Ignore device. Still will get added to m_AvailableDevices
@@ -1905,18 +1907,6 @@ namespace UnityEngine.InputSystem
                         // and create the device.
                         markAsRemoved = true;
                         return;
-                    }
-                }
-
-                // See if we have a disconnected device we can revive.
-                InputDevice device = null;
-                for (var i = 0; i < m_DisconnectedDevicesCount; ++i)
-                {
-                    if (m_DisconnectedDevices[i].description == description)
-                    {
-                        device = m_DisconnectedDevices[i];
-                        ArrayHelpers.EraseAtWithCapacity(m_DisconnectedDevices, ref m_DisconnectedDevicesCount, i);
-                        break;
                     }
                 }
 
@@ -1961,6 +1951,38 @@ namespace UnityEngine.InputSystem
                         isRemoved = markAsRemoved,
                     });
             }
+        }
+
+        private InputDevice TryMatchDisconnectedDevice(string deviceDescriptor)
+        {
+            for (var i = 0; i < m_DisconnectedDevicesCount; ++i)
+            {
+                var device = m_DisconnectedDevices[i];
+                var description = device.description;
+
+                // We don't parse the full description but rather go property by property in order to not
+                // allocate GC memory if we can avoid it.
+
+                if (!string.IsNullOrEmpty(description.interfaceName) &&
+                    !InputDeviceDescription.ComparePropertyToDeviceDescriptor("interface", description.interfaceName, deviceDescriptor))
+                    continue;
+                if (!string.IsNullOrEmpty(description.product) &&
+                    !InputDeviceDescription.ComparePropertyToDeviceDescriptor("product", description.product, deviceDescriptor))
+                    continue;
+                if (!string.IsNullOrEmpty(description.manufacturer) &&
+                    !InputDeviceDescription.ComparePropertyToDeviceDescriptor("manufacturer", description.manufacturer, deviceDescriptor))
+                    continue;
+                if (!string.IsNullOrEmpty(description.deviceClass) &&
+                    !InputDeviceDescription.ComparePropertyToDeviceDescriptor("type", description.deviceClass, deviceDescriptor))
+                    continue;
+
+                // We ignore capabilities here.
+
+                ArrayHelpers.EraseAtWithCapacity(m_DisconnectedDevices, ref m_DisconnectedDevicesCount, i);
+                return device;
+            }
+
+            return null;
         }
 
         private void InstallBeforeUpdateHookIfNecessary()
@@ -2905,7 +2927,6 @@ namespace UnityEngine.InputSystem
         internal struct SerializedState
         {
             public int layoutRegistrationVersion;
-            public int deviceSetupVersion;
             public float pollingFrequency;
             public DeviceState[] devices;
             public AvailableDevice[] availableDevices;
@@ -2950,7 +2971,6 @@ namespace UnityEngine.InputSystem
             return new SerializedState
             {
                 layoutRegistrationVersion = m_LayoutRegistrationVersion,
-                deviceSetupVersion = m_DeviceSetupVersion,
                 pollingFrequency = m_PollingFrequency,
                 devices = deviceArray,
                 availableDevices = m_AvailableDevices?.Take(m_AvailableDeviceCount).ToArray(),
@@ -2971,7 +2991,6 @@ namespace UnityEngine.InputSystem
         {
             m_StateBuffers = state.buffers;
             m_LayoutRegistrationVersion = state.layoutRegistrationVersion + 1;
-            m_DeviceSetupVersion = state.deviceSetupVersion + 1;
             updateMask = state.updateMask;
             m_Metrics = state.metrics;
             m_PollingFrequency = state.pollingFrequency;

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1100,7 +1100,7 @@ namespace UnityEngine.InputSystem
 
             // Update device indices. Do this after reallocating state buffers as that call requires
             // the old indices to still be in place.
-            for (var i = deviceIndex + 1; i < m_DevicesCount; ++i)
+            for (var i = deviceIndex; i < m_DevicesCount; ++i)
                 --m_Devices[i].m_DeviceIndex; // Indices have shifted down by one.
             device.m_DeviceIndex = InputDevice.kInvalidDeviceIndex;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1219,6 +1219,7 @@ namespace UnityEngine.InputSystem
             return numFound;
         }
 
+        ////TODO: this should reset the device to its default state
         public void EnableOrDisableDevice(InputDevice device, bool enable)
         {
             if (device == null)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1316,8 +1316,9 @@ namespace UnityEngine.InputSystem
         /// system level. In the input system, the current keyboard layout can be queried via <see cref="Keyboard.keyboardLayout"/>.
         /// When the layout changes at the system level, the input backend sends a configuration change event
         /// to signal that the configuration of the keyboard has changed and that cached data may be outdated.
-        /// In response,
-        ///
+        /// In response, <see cref="Keyboard"/> will flush out cached information such as the name of the keyboard
+        /// layout and display names (<see cref="InputControl.displayName"/>) of individual keys which causes them
+        /// to be fetched again from the backend the next time they are accessed.
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="device"/> has not been added
@@ -1340,14 +1341,23 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Queue a text input event on the given device.
+        /// Queue a <see cref="TextEvent"/> on the given device.
         /// </summary>
         /// <param name="device">Device to queue the event on.</param>
         /// <param name="character">Text character to input through the event.</param>
         /// <param name="time">Optional event time stamp. If not supplied, the current time will be used.</param>
+        /// <remarks>
+        /// Text input is sent to devices character by character. This allows sending strings of arbitrary
+        /// length without necessary incurring GC overhead.
+        ///
+        /// For the event to have any effect on <paramref name="device"/>, the device must
+        /// implement <see cref="ITextInputReceiver"/>. It will see <see cref="ITextInputReceiver.OnTextInput"/>
+        /// being called when the event is processed.
+        /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="device"/> is a device that has not been
         /// added to the system.</exception>
+        /// <seealso cref="Keyboard.onTextInput"/>
         public static void QueueTextEvent(InputDevice device, char character, double time = -1)
         {
             if (device == null)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1170,7 +1170,7 @@ namespace UnityEngine.InputSystem
         /// // using statement automatically disposes the memory once we have queued the event.
         /// using (StateEvent.From(Mouse.current, out var eventPtr))
         /// {
-        /// 	// Use controls on mouse to write values into event.
+        ///     // Use controls on mouse to write values into event.
         ///     Mouse.current.position.WriteValueIntoEvent(new Vector(123, 234), eventPtr);
         ///
         ///     // Queue event.
@@ -1241,7 +1241,7 @@ namespace UnityEngine.InputSystem
             public const int kMaxSize = 512;
             public fixed byte data[kMaxSize - 1]; // DeltaStateEvent already adds one.
         }
-        
+
         /// <summary>
         /// Queue a <see cref="DeltaStateEvent"/> to update part of the input state of the given device.
         /// </summary>
@@ -1310,14 +1310,14 @@ namespace UnityEngine.InputSystem
         /// <param name="time">Timestamp for the event. If not supplied, the current time will be used.</param>
         /// <remarks>
         /// All state of an input device that is not input or output state is considered its "configuration".
-        /// 
+        ///
         /// A simple example is keyboard layouts. A <see cref="Keyboard"/> will typically have an associated
         /// keyboard layout that dictates the function of each key and which can be changed by the user at the
         /// system level. In the input system, the current keyboard layout can be queried via <see cref="Keyboard.keyboardLayout"/>.
         /// When the layout changes at the system level, the input backend sends a configuration change event
         /// to signal that the configuration of the keyboard has changed and that cached data may be outdated.
-        /// In response, 
-        /// 
+        /// In response,
+        ///
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="device"/> has not been added
@@ -1562,7 +1562,7 @@ namespace UnityEngine.InputSystem
         {
             RegisterInteraction(typeof(T), name);
         }
-        
+
         ////REVIEW: can we move the getters and listers somewhere else? maybe `interactions` and `processors` properties and such?
 
         public static Type TryGetInteraction(string name)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -65,6 +65,7 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Event that is signalled when the layout setup in the system changes.
         /// </summary>
+        /// <seealso cref="InputControlLayout"/>
         public static event Action<string, InputControlLayoutChange> onLayoutChange
         {
             add => s_Manager.onLayoutChange += value;
@@ -85,7 +86,7 @@ namespace UnityEngine.InputSystem
         public static void RegisterLayout(Type type, string name = null, InputDeviceMatcher? matches = null)
         {
             if (type == null)
-                throw new System.ArgumentNullException(nameof(type));
+                throw new ArgumentNullException(nameof(type));
 
             if (string.IsNullOrEmpty(name))
                 name = type.Name;
@@ -221,7 +222,7 @@ namespace UnityEngine.InputSystem
         ///     public InputControlLayout Build()
         ///     {
         ///         var builder = new InputControlLayout.Builder()
-        ///             .WithType<MyDevice>();
+        ///             .WithType&lt;MyDevice&gt;();
         ///         builder.AddControl("button1").WithLayout("Button");
         ///         return builder.Build();
         ///     }
@@ -443,7 +444,7 @@ namespace UnityEngine.InputSystem
         ///
         /// The value returned by this property should not be held on to. When the device
         /// setup in the system changes, any value previously returned by this property
-        /// becomes invalid. Query the property directly whenever you need it.
+        /// may become invalid. Query the property directly whenever you need it.
         /// </remarks>
         public static ReadOnlyArray<InputDevice> devices => s_Manager.devices;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -1,6 +1,8 @@
 using System;
 using UnityEngine.InputSystem.Layouts;
 
+////REVIEW: can we make this internal?
+
 ////TODO: ManualThreaded
 
 namespace UnityEngine.InputSystem

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/INPadRumble.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/INPadRumble.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR || UNITY_SWITCH || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_WSA
 using UnityEngine.InputSystem.Haptics;
 
 namespace UnityEngine.InputSystem.Switch
@@ -23,3 +24,4 @@ namespace UnityEngine.InputSystem.Switch
         void SetMotorSpeedRight(float lowAmplitude, float lowFrequency, float highAmplitude, float highFrequency);
     }
 }
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupport.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_SWITCH || UNITY_STANDALONE || UNITY_WSA
+#if UNITY_EDITOR || UNITY_SWITCH || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_WSA
 using UnityEngine.InputSystem.Layouts;
 
 namespace UnityEngine.InputSystem.Switch
@@ -32,4 +32,4 @@ namespace UnityEngine.InputSystem.Switch
         }
     }
 }
-#endif // UNITY_EDITOR || UNITY_SWITCH
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -1,7 +1,5 @@
 using System;
 using Unity.Collections.LowLevel.Unsafe;
-using UnityEngine.InputSystem;
-using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: allow to restrict state change monitors to specific updates?

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -170,12 +170,12 @@ namespace UnityEngine.InputSystem.LowLevel
             // Set up device to buffer mappings.
             var ptr = (byte*)m_AllBuffers;
             m_PlayerStateBuffers =
-                SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer,
+                SetUpDeviceToBufferMappings(deviceCount, ref ptr, sizePerBuffer,
                     mappingTableSizePerBuffer);
 
             #if UNITY_EDITOR
             m_EditorStateBuffers =
-                SetUpDeviceToBufferMappings(devices, deviceCount, ref ptr, sizePerBuffer, mappingTableSizePerBuffer);
+                SetUpDeviceToBufferMappings(deviceCount, ref ptr, sizePerBuffer, mappingTableSizePerBuffer);
             #endif
 
             // Default state and noise filter buffers go last.
@@ -183,7 +183,7 @@ namespace UnityEngine.InputSystem.LowLevel
             noiseMaskBuffer = ptr + sizePerBuffer;
         }
 
-        private static DoubleBuffers SetUpDeviceToBufferMappings(InputDevice[] devices, int deviceCount, ref byte* bufferPtr, uint sizePerBuffer, uint mappingTableSizePerBuffer)
+        private static DoubleBuffers SetUpDeviceToBufferMappings(int deviceCount, ref byte* bufferPtr, uint sizePerBuffer, uint mappingTableSizePerBuffer)
         {
             var front = bufferPtr;
             var back = bufferPtr + sizePerBuffer;
@@ -194,8 +194,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
             for (var i = 0; i < deviceCount; ++i)
             {
-                var deviceIndex = devices[i].m_DeviceIndex;
-
+                var deviceIndex = i;
                 buffers.SetFrontBuffer(deviceIndex, front);
                 buffers.SetBackBuffer(deviceIndex, back);
             }
@@ -279,6 +278,8 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (delta != 0)
                         device.BakeOffsetIntoStateBlockRecursive(delta);
                 }
+
+                Debug.Assert(device.m_StateBlock.byteOffset == newOffset, "Device state offset not set correctly");
 
                 newOffset = NextDeviceOffset(newOffset, device);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -140,12 +140,11 @@ namespace UnityEngine.InputSystem.LowLevel
         // Allocates all buffers to serve the given updates and comes up with a spot
         // for the state block of each device. Returns the new state blocks for the
         // devices (it will *NOT* install them on the devices).
-        public uint[] AllocateAll(InputDevice[] devices, int deviceCount)
+        public void AllocateAll(InputDevice[] devices, int deviceCount)
         {
-            uint[] newDeviceOffsets = null;
-            sizePerBuffer = ComputeSizeOfSingleBufferAndOffsetForEachDevice(devices, deviceCount, ref newDeviceOffsets);
+            sizePerBuffer = ComputeSizeOfSingleStateBuffer(devices, deviceCount);
             if (sizePerBuffer == 0)
-                return null;
+                return;
             sizePerBuffer = sizePerBuffer.AlignToMultipleOf(4);
 
             // Determine how much memory we need.
@@ -182,8 +181,6 @@ namespace UnityEngine.InputSystem.LowLevel
             // Default state and noise filter buffers go last.
             defaultStateBuffer = ptr;
             noiseMaskBuffer = ptr + sizePerBuffer;
-
-            return newDeviceOffsets;
         }
 
         private static DoubleBuffers SetUpDeviceToBufferMappings(InputDevice[] devices, int deviceCount, ref byte* bufferPtr, uint sizePerBuffer, uint mappingTableSizePerBuffer)
@@ -239,49 +236,55 @@ namespace UnityEngine.InputSystem.LowLevel
         // Migrate state data for all devices from a previous set of buffers to the current set of buffers.
         // Copies all state from their old locations to their new locations and bakes the new offsets into
         // the control hierarchies of the given devices.
-        // NOTE: oldDeviceIndices is only required if devices have been removed; otherwise it can be null.
-        public void MigrateAll(InputDevice[] devices, int deviceCount, uint[] newStateBlockOffsets, InputStateBuffers oldBuffers, int[] oldDeviceIndices)
+        // NOTE: When having oldBuffers, this method only works properly if the only alteration compared to the
+        //       new buffers is that either devices have been removed or devices have been added. Cannot be
+        //       a mix of the two. Also, new devices MUST be added to the end and cannot be inserted in the middle.
+        // NOTE: Also, state formats MUST not change from before. A device that has changed its format must
+        //       be treated as a newly device that didn't exist before.
+        public void MigrateAll(InputDevice[] devices, int deviceCount, InputStateBuffers oldBuffers)
         {
             // If we have old data, perform migration.
-            // Note that the enabled update types don't need to match between the old set of buffers
-            // and the new set of buffers.
             if (oldBuffers.totalSize > 0)
             {
-                MigrateDoubleBuffer(m_PlayerStateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_PlayerStateBuffers,
-                    oldDeviceIndices);
+                MigrateDoubleBuffer(m_PlayerStateBuffers, devices, deviceCount, oldBuffers.m_PlayerStateBuffers);
 
 #if UNITY_EDITOR
-                MigrateDoubleBuffer(m_EditorStateBuffers, devices, deviceCount, newStateBlockOffsets, oldBuffers.m_EditorStateBuffers,
-                    oldDeviceIndices);
+                MigrateDoubleBuffer(m_EditorStateBuffers, devices, deviceCount, oldBuffers.m_EditorStateBuffers);
 #endif
 
-                MigrateSingleBuffer(defaultStateBuffer, devices, deviceCount, newStateBlockOffsets, oldBuffers.defaultStateBuffer);
-                MigrateSingleBuffer(noiseMaskBuffer, devices, deviceCount, newStateBlockOffsets, oldBuffers.noiseMaskBuffer);
+                MigrateSingleBuffer(defaultStateBuffer, devices, deviceCount, oldBuffers.defaultStateBuffer);
+                MigrateSingleBuffer(noiseMaskBuffer, devices, deviceCount, oldBuffers.noiseMaskBuffer);
             }
 
-            // Assign state blocks.
+            // Assign state blocks. This is where devices will receive their updates state offsets. Up
+            // until now we've left any previous m_StateBlocks alone.
+            var newOffset = 0u;
             for (var i = 0; i < deviceCount; ++i)
             {
-                var newOffset = newStateBlockOffsets[i];
                 var device = devices[i];
                 var oldOffset = device.m_StateBlock.byteOffset;
 
                 if (oldOffset == InputStateBlock.InvalidOffset)
                 {
+                    // Device is new and has no offset yet baked into it.
                     device.m_StateBlock.byteOffset = 0;
                     if (newOffset != 0)
                         device.BakeOffsetIntoStateBlockRecursive(newOffset);
                 }
                 else
                 {
+                    // Device is not new and still has its old offset baked into it. We could first unbake the old offset
+                    // and then bake the new one but instead just bake a relative offset.
                     var delta = newOffset - oldOffset;
                     if (delta != 0)
                         device.BakeOffsetIntoStateBlockRecursive(delta);
                 }
+
+                newOffset = NextDeviceOffset(newOffset, device);
             }
         }
 
-        private static void MigrateDoubleBuffer(DoubleBuffers newBuffer, InputDevice[] devices, int deviceCount, uint[] newStateBlockOffsets, DoubleBuffers oldBuffer, int[] oldDeviceIndices)
+        private static void MigrateDoubleBuffer(DoubleBuffers newBuffer, InputDevice[] devices, int deviceCount, DoubleBuffers oldBuffer)
         {
             // Nothing to migrate if we no longer keep a buffer of the corresponding type.
             if (!newBuffer.valid)
@@ -291,84 +294,80 @@ namespace UnityEngine.InputSystem.LowLevel
             if (!oldBuffer.valid)
                 return;
 
-            ////TOOD: if we assume linear layouts of devices in 'devices' and assume that new devices are only added
-            ////      at the end and only single devices can be removed, we can copy state buffers much more efficiently
-            ////      in bulk rather than device-by-device
-
             // Migrate every device that has allocated state blocks.
-            var newDeviceCount = deviceCount;
-            var oldDeviceCount = oldDeviceIndices?.Length ?? newDeviceCount;
-            for (var i = 0; i < newDeviceCount && i < oldDeviceCount; ++i)
+            var newStateBlockOffset = 0u;
+            for (var i = 0; i < deviceCount; ++i)
             {
                 var device = devices[i];
-                Debug.Assert(device.m_DeviceIndex == i);
 
-                // Skip device if it's a newly added device.
+                // Stop as soon as we're hitting a new device. Newly added devices *must* be *appended* to the
+                // array as otherwise our computing of offsets into the old buffer may be wrong.
+                // NOTE: This also means that device indices of
                 if (device.m_StateBlock.byteOffset == InputStateBlock.InvalidOffset)
-                    continue;
+                {
+                    #if DEVELOPMENT_BUILD || UNITY_EDITOR
+                    for (var n = i + 1; n < deviceCount; ++n)
+                        Debug.Assert(devices[n].m_StateBlock.byteOffset == InputStateBlock.InvalidOffset,
+                            "New devices must be appended to the array; found an old device coming in the array after a newly added device");
+                    #endif
+                    break;
+                }
 
-                ////FIXME: this is not protecting against devices that have changed their formats between domain reloads
-
-                var oldDeviceIndex = oldDeviceIndices ? [i] ?? i;
+                var oldDeviceIndex = device.m_DeviceIndex;
                 var newDeviceIndex = i;
                 var numBytes = device.m_StateBlock.alignedSizeInBytes;
 
-                var oldFrontPtr = (byte*)oldBuffer.GetFrontBuffer(oldDeviceIndex) + (int)device.m_StateBlock.byteOffset;
+                var oldFrontPtr = (byte*)oldBuffer.GetFrontBuffer(oldDeviceIndex) + (int)device.m_StateBlock.byteOffset; // m_StateBlock still refers to oldBuffer.
                 var oldBackPtr = (byte*)oldBuffer.GetBackBuffer(oldDeviceIndex) + (int)device.m_StateBlock.byteOffset;
 
-                var newFrontPtr = (byte*)newBuffer.GetFrontBuffer(newDeviceIndex) + (int)newStateBlockOffsets[i];
-                var newBackPtr = (byte*)newBuffer.GetBackBuffer(newDeviceIndex) + (int)newStateBlockOffsets[i];
+                var newFrontPtr = (byte*)newBuffer.GetFrontBuffer(newDeviceIndex) + (int)newStateBlockOffset;
+                var newBackPtr = (byte*)newBuffer.GetBackBuffer(newDeviceIndex) + (int)newStateBlockOffset;
 
                 // Copy state.
                 UnsafeUtility.MemCpy(newFrontPtr, oldFrontPtr, numBytes);
                 UnsafeUtility.MemCpy(newBackPtr, oldBackPtr, numBytes);
+
+                newStateBlockOffset = NextDeviceOffset(newStateBlockOffset, device);
             }
         }
 
-        private static void MigrateSingleBuffer(void* newBuffer, InputDevice[] devices, int deviceCount, uint[] newStateBlockOffsets, void* oldBuffer)
+        private static void MigrateSingleBuffer(void* newBuffer, InputDevice[] devices, int deviceCount, void* oldBuffer)
         {
             // Migrate every device that has allocated state blocks.
             var newDeviceCount = deviceCount;
+            var newStateBlockOffset = 0u;
             for (var i = 0; i < newDeviceCount; ++i)
             {
                 var device = devices[i];
-                Debug.Assert(device.m_DeviceIndex == i);
 
-                // Skip device if it's a newly added device.
+                // Stop if we've reached newly added devices.
                 if (device.m_StateBlock.byteOffset == InputStateBlock.InvalidOffset)
-                    continue;
+                    break;
 
                 var numBytes = device.m_StateBlock.alignedSizeInBytes;
                 var oldStatePtr = (byte*)oldBuffer + (int)device.m_StateBlock.byteOffset;
-                var newStatePtr = (byte*)newBuffer + (int)newStateBlockOffsets[i];
+                var newStatePtr = (byte*)newBuffer + (int)newStateBlockOffset;
 
                 UnsafeUtility.MemCpy(newStatePtr, oldStatePtr, numBytes);
+
+                newStateBlockOffset = NextDeviceOffset(newStateBlockOffset, device);
             }
         }
 
-        // Compute the total size of we need for a single state buffer to encompass
-        // all devices we have and also linearly assign offsets to all the devices
-        // within such a buffer.
-        private static uint ComputeSizeOfSingleBufferAndOffsetForEachDevice(InputDevice[] devices, int deviceCount, ref uint[] offsets)
+        private static uint ComputeSizeOfSingleStateBuffer(InputDevice[] devices, int deviceCount)
         {
-            if (devices == null)
-                return 0;
-
-            var result = new uint[deviceCount];
             var sizeInBytes = 0u;
-
             for (var i = 0; i < deviceCount; ++i)
-            {
-                var sizeOfDevice = devices[i].m_StateBlock.alignedSizeInBytes;
-                sizeOfDevice = sizeOfDevice.AlignToMultipleOf(4);
-                if (sizeOfDevice == 0) // Shouldn't happen as we don't allow empty layouts but make sure we catch this if something slips through.
-                    throw new ArgumentException($"Device '{devices[i]}' has a zero-size state buffer", nameof(devices));
-                result[i] = sizeInBytes;
-                sizeInBytes += sizeOfDevice;
-            }
-
-            offsets = result;
+                sizeInBytes = NextDeviceOffset(sizeInBytes, devices[i]);
             return sizeInBytes;
+        }
+
+        private static uint NextDeviceOffset(uint currentOffset, InputDevice device)
+        {
+            var sizeOfDevice = device.m_StateBlock.alignedSizeInBytes;
+            if (sizeOfDevice == 0) // Shouldn't happen as we don't allow empty layouts but make sure we catch this if something slips through.
+                throw new ArgumentException($"Device '{device}' has a zero-size state buffer", nameof(device));
+            return currentOffset + sizeOfDevice.AlignToMultipleOf(4);
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using UnityEngine.UI;
 
 namespace UnityEngine.InputSystem.Utilities
 {
@@ -23,6 +26,14 @@ namespace UnityEngine.InputSystem.Utilities
 
             m_Text = json;
             m_Length = json.Length;
+        }
+
+        public void Reset()
+        {
+            m_Position = 0;
+            m_CurrentPropertyIsArray = false;
+            m_MatchAnyElementInArray = false;
+            m_DryRun = false;
         }
 
         public override string ToString()
@@ -137,13 +148,8 @@ namespace UnityEngine.InputSystem.Utilities
         /// </summary>
         /// <param name="expectedValue"></param>
         /// <returns></returns>
-        public bool CurrentPropertyHasValueEqualTo(object expectedValue)
+        public bool CurrentPropertyHasValueEqualTo(JsonValue expectedValue)
         {
-            if (expectedValue == null)
-                throw new ArgumentNullException(nameof(expectedValue));
-
-            ////TODO: prevent boxing on numbers and bools
-
             // Grab property value.
             var savedPosition = m_Position;
             m_DryRun = false;
@@ -156,61 +162,18 @@ namespace UnityEngine.InputSystem.Utilities
 
             // Match given value.
             var isMatch = false;
-            if (propertyValue is List<object> array && m_MatchAnyElementInArray)
+            if (propertyValue.type == JsonValueType.Array && m_MatchAnyElementInArray)
             {
+                var array = propertyValue.arrayValue;
                 for (var i = 0; !isMatch && i < array.Count; ++i)
-                    isMatch = MatchValue(array[i], expectedValue);
+                    isMatch = array[i] == expectedValue;
             }
             else
             {
-                isMatch = MatchValue(propertyValue, expectedValue);
+                isMatch = propertyValue == expectedValue;
             }
 
             return isMatch;
-        }
-
-        private static bool MatchValue(object propertyValue, object expectedValue)
-        {
-            if (expectedValue is Regex regex)
-                return regex.IsMatch(propertyValue.ToString());
-
-            var str = expectedValue as string;
-            if (str != null)
-            {
-                // Special case float comparison to take precision into account.
-                if (propertyValue is float value)
-                {
-                    if (float.TryParse(str, out var f))
-                        return Mathf.Approximately(f, value);
-                    return false;
-                }
-
-                // This path should work for ints and bools, too.
-                return string.Compare(str, propertyValue.ToString(), StringComparison.InvariantCultureIgnoreCase) == 0;
-            }
-
-            if (expectedValue is Enum enumValue)
-            {
-                if (propertyValue is int)
-                    return (int)propertyValue == Convert.ToInt32(enumValue);
-                if (propertyValue is string stringValue)
-                    return string.Compare(str, stringValue,
-                        StringComparison.InvariantCultureIgnoreCase) == 0;
-            }
-            else
-            {
-                if (expectedValue is float && propertyValue is float)
-                {
-                    var expectedNum = Convert.ToSingle(expectedValue);
-                    var actualNum = Convert.ToSingle(propertyValue);
-
-                    return Mathf.Approximately(expectedNum, actualNum);
-                }
-
-                return propertyValue.Equals(expectedValue);
-            }
-
-            return false;
         }
 
         public bool ParseToken(char token)
@@ -230,13 +193,12 @@ namespace UnityEngine.InputSystem.Utilities
 
         public bool ParseValue()
         {
-            object result;
-            return ParseValue(out result);
+            return ParseValue(out var result);
         }
 
-        public bool ParseValue(out object result)
+        public bool ParseValue(out JsonValue result)
         {
-            result = null;
+            result = default;
 
             SkipWhitespace();
             if (m_Position == m_Length)
@@ -246,18 +208,12 @@ namespace UnityEngine.InputSystem.Utilities
             switch (ch)
             {
                 case '"':
-                    if (ParseStringValue(out var stringResult))
-                    {
-                        result = stringResult;
+                    if (ParseStringValue(out result))
                         return true;
-                    }
                     break;
                 case '[':
-                    if (ParseArrayValue(out var arrayResult))
-                    {
-                        result = arrayResult;
+                    if (ParseArrayValue(out result))
                         return true;
-                    }
                     break;
                 case '{':
                     if (ParseObjectValue(out result))
@@ -265,11 +221,8 @@ namespace UnityEngine.InputSystem.Utilities
                     break;
                 case 't':
                 case 'f':
-                    if (ParseBooleanValue(out var boolValue))
-                    {
-                        result = boolValue;
+                    if (ParseBooleanValue(out result))
                         return true;
-                    }
                     break;
                 case 'n':
                     if (ParseNullValue(out result))
@@ -284,45 +237,47 @@ namespace UnityEngine.InputSystem.Utilities
             return false;
         }
 
-        public bool ParseStringValue(out string result)
+        public bool ParseStringValue(out JsonValue result)
         {
-            result = null;
-            if (!m_DryRun)
-            {
-                if (m_StringBuilder == null)
-                    m_StringBuilder = new StringBuilder();
-                m_StringBuilder.Length = 0;
-            }
+            result = default;
 
             SkipWhitespace();
             if (m_Position == m_Length || m_Text[m_Position] != '"')
                 return false;
             ++m_Position;
 
+            var startIndex = m_Position;
+            var hasEscapes = false;
+
             while (m_Position < m_Length)
             {
                 var ch = m_Text[m_Position];
                 if (ch == '\\')
-                    throw new NotImplementedException("Escape sequences");
-                if (ch == '"')
                 {
                     ++m_Position;
-                    if (!m_DryRun)
-                        result = m_StringBuilder.ToString();
+                    if (m_Position == m_Length)
+                        break;
+                    hasEscapes = true;
+                }
+                else if (ch == '"')
+                {
+                    ++m_Position;
+                    result = new JsonString
+                    {
+                        text = new Substring(m_Text, startIndex, m_Position - startIndex - 1),
+                        hasEscapes = hasEscapes
+                    };
                     return true;
                 }
                 ++m_Position;
-
-                if (!m_DryRun)
-                    m_StringBuilder.Append(ch);
             }
 
             return false;
         }
 
-        public bool ParseArrayValue(out List<object> result)
+        public bool ParseArrayValue(out JsonValue result)
         {
-            result = null;
+            result = default;
 
             SkipWhitespace();
             if (m_Position == m_Length || m_Text[m_Position] != '[')
@@ -334,13 +289,14 @@ namespace UnityEngine.InputSystem.Utilities
             if (m_Text[m_Position] == ']')
             {
                 // Empty array.
+                result = new JsonValue { type = JsonValueType.Array };
                 ++m_Position;
                 return true;
             }
 
-            List<object> values = null;
+            List<JsonValue> values = null;
             if (!m_DryRun)
-                values = new List<object>();
+                values = new List<JsonValue>();
 
             while (m_Position < m_Length)
             {
@@ -366,29 +322,28 @@ namespace UnityEngine.InputSystem.Utilities
             return false;
         }
 
-        public bool ParseObjectValue(out object result)
+        public bool ParseObjectValue(out JsonValue result)
         {
-            result = null;
+            result = default;
 
             if (!ParseToken('{'))
                 return false;
             if (m_Position < m_Length && m_Text[m_Position] == '}')
             {
+                result = new JsonValue { type = JsonValueType.Object };
                 ++m_Position;
                 return true;
             }
 
             while (m_Position < m_Length)
             {
-                string propertyName;
-                if (!ParseStringValue(out propertyName))
+                if (!ParseStringValue(out var propertyName))
                     return false;
 
                 if (!SkipToValue())
                     return false;
 
-                object propertyValue;
-                if (!ParseValue(out propertyValue))
+                if (!ParseValue(out var propertyValue))
                     return false;
 
                 if (!m_DryRun)
@@ -407,9 +362,9 @@ namespace UnityEngine.InputSystem.Utilities
             return false;
         }
 
-        public bool ParseNumber(out object result)
+        public bool ParseNumber(out JsonValue result)
         {
-            result = null;
+            result = default;
 
             SkipWhitespace();
             if (m_Position == m_Length)
@@ -417,7 +372,7 @@ namespace UnityEngine.InputSystem.Utilities
 
             var negative = false;
             var haveFractionalPart = false;
-            var integralPart = 0;
+            var integralPart = 0L;
             var fractionalPart = 0.0;
             var fractionalDivisor = 10.0;
 
@@ -485,10 +440,8 @@ namespace UnityEngine.InputSystem.Utilities
             return true;
         }
 
-        public bool ParseBooleanValue(out bool result)
+        public bool ParseBooleanValue(out JsonValue result)
         {
-            result = false;
-
             SkipWhitespace();
             if (SkipString("true"))
             {
@@ -502,12 +455,13 @@ namespace UnityEngine.InputSystem.Utilities
                 return true;
             }
 
+            result = default;
             return false;
         }
 
-        public bool ParseNullValue(out object result)
+        public bool ParseNullValue(out JsonValue result)
         {
-            result = null;
+            result = default;
             return SkipString("null");
         }
 
@@ -551,6 +505,328 @@ namespace UnityEngine.InputSystem.Utilities
         private bool m_CurrentPropertyIsArray;
         private bool m_MatchAnyElementInArray;
         private bool m_DryRun;
-        private StringBuilder m_StringBuilder;
+
+        public enum JsonValueType
+        {
+            None,
+            Bool,
+            Real,
+            Integer,
+            String,
+            Array,
+            Object,
+            Any,
+        }
+
+        public struct JsonString : IEquatable<JsonString>
+        {
+            public Substring text;
+            public bool hasEscapes;
+
+            public override string ToString()
+            {
+                if (!hasEscapes)
+                    return text.ToString();
+
+                var builder = new StringBuilder();
+                var length = text.length;
+                for (var i = 0; i < length; ++i)
+                {
+                    var ch = text[i];
+                    if (ch == '\\')
+                    {
+                        ++i;
+                        if (i == length)
+                            break;
+                        ch = text[i];
+                    }
+                    builder.Append(ch);
+                }
+                return builder.ToString();
+            }
+
+            public bool Equals(JsonString other)
+            {
+                if (hasEscapes == other.hasEscapes)
+                    return text == other.text;
+
+                var thisLength = text.length;
+                var otherLength = other.text.length;
+
+                int thisIndex = 0, otherIndex = 0;
+                for (; thisIndex < thisLength && otherIndex < otherLength; ++thisIndex, ++otherIndex)
+                {
+                    var thisChar = text[thisIndex];
+                    var otherChar = other.text[otherIndex];
+
+                    if (thisChar == '\\')
+                    {
+                        ++thisIndex;
+                        if (thisIndex == thisLength)
+                            return false;
+                        thisChar = text[thisIndex];
+                    }
+
+                    if (otherChar == '\\')
+                    {
+                        ++otherIndex;
+                        if (otherIndex == otherLength)
+                            return false;
+                        otherChar = other.text[otherIndex];
+                    }
+
+                    if (thisChar != otherChar)
+                        return false;
+                }
+
+                return thisIndex == thisLength && otherIndex == otherLength;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is JsonString other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return (text.GetHashCode() * 397) ^ hasEscapes.GetHashCode();
+                }
+            }
+
+            public static bool operator==(JsonString left, JsonString right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator!=(JsonString left, JsonString right)
+            {
+                return !left.Equals(right);
+            }
+
+            public static implicit operator JsonString(string str)
+            {
+                return new JsonString { text = str };
+            }
+        }
+
+        public struct JsonValue : IEquatable<JsonValue>
+        {
+            public JsonValueType type;
+            public bool boolValue;
+            public double realValue;
+            public long integerValue;
+            public JsonString stringValue;
+            public List<JsonValue> arrayValue; // Allocates.
+            public Dictionary<string, JsonValue> objectValue; // Allocates.
+            public object anyValue;
+
+            public bool ToBoolean()
+            {
+                switch (type)
+                {
+                    case JsonValueType.Bool: return boolValue;
+                    case JsonValueType.Integer: return integerValue != 0;
+                    case JsonValueType.Real: return NumberHelpers.Approximately(0, realValue);
+                    case JsonValueType.String: return Convert.ToBoolean(ToString());
+                }
+                return default;
+            }
+
+            public long ToInteger()
+            {
+                switch (type)
+                {
+                    case JsonValueType.Bool: return boolValue ? 1 : 0;
+                    case JsonValueType.Integer: return integerValue;
+                    case JsonValueType.Real: return (long)realValue;
+                    case JsonValueType.String: return Convert.ToInt64(ToString());
+                }
+                return default;
+            }
+
+            public double ToDouble()
+            {
+                switch (type)
+                {
+                    case JsonValueType.Bool: return boolValue ? 1 : 0;
+                    case JsonValueType.Integer: return integerValue;
+                    case JsonValueType.Real: return realValue;
+                    case JsonValueType.String: return Convert.ToSingle(ToString());
+                }
+                return default;
+            }
+
+            public override string ToString()
+            {
+                switch (type)
+                {
+                    case JsonValueType.None: return "null";
+                    case JsonValueType.Bool: return boolValue.ToString();
+                    case JsonValueType.Integer: return integerValue.ToString(CultureInfo.InvariantCulture);
+                    case JsonValueType.Real: return realValue.ToString(CultureInfo.InvariantCulture);
+                    case JsonValueType.String: return stringValue.ToString();
+                    case JsonValueType.Array:
+                        if (arrayValue == null)
+                            return "[]";
+                        return $"[{string.Join(",", arrayValue.Select(x => x.ToString()))}]";
+                    case JsonValueType.Object:
+                        if (objectValue == null)
+                            return "{}";
+                        var elements = objectValue.Select(pair => $"\"{pair.Key}\" : \"{pair.Value}\"");
+                        return $"{{{string.Join(",", elements)}}}";
+                    case JsonValueType.Any: return anyValue.ToString();
+                }
+                return base.ToString();
+            }
+
+            public static implicit operator JsonValue(bool val)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.Bool,
+                    boolValue = val
+                };
+            }
+
+            public static implicit operator JsonValue(long val)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.Integer,
+                    integerValue = val
+                };
+            }
+
+            public static implicit operator JsonValue(double val)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.Real,
+                    realValue = val
+                };
+            }
+
+            public static implicit operator JsonValue(string str)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.String,
+                    stringValue = new JsonString { text = str }
+                };
+            }
+
+            public static implicit operator JsonValue(JsonString str)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.String,
+                    stringValue = str
+                };
+            }
+
+            public static implicit operator JsonValue(List<JsonValue> array)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.Array,
+                    arrayValue = array
+                };
+            }
+
+            public static implicit operator JsonValue(Dictionary<string, JsonValue> obj)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.Object,
+                    objectValue = obj
+                };
+            }
+
+            public static implicit operator JsonValue(Enum val)
+            {
+                return new JsonValue
+                {
+                    type = JsonValueType.Any,
+                    anyValue = val
+                };
+            }
+
+            public bool Equals(JsonValue other)
+            {
+                // Default comparisons.
+                if (type == other.type)
+                {
+                    switch (type)
+                    {
+                        case JsonValueType.None: return true;
+                        case JsonValueType.Bool: return boolValue == other.boolValue;
+                        case JsonValueType.Integer: return integerValue == other.integerValue;
+                        case JsonValueType.Real: return NumberHelpers.Approximately(realValue, other.realValue);
+                        case JsonValueType.String: return stringValue == other.stringValue;
+                        case JsonValueType.Object: throw new NotImplementedException();
+                        case JsonValueType.Array: throw new NotImplementedException();
+                        case JsonValueType.Any: return anyValue.Equals(other.anyValue);
+                    }
+                    return false;
+                }
+
+                // Special-case comparisons.
+                if (other.anyValue is Regex otherRegex)
+                    return otherRegex.IsMatch(ToString());
+                if (anyValue is Regex thisRegex)
+                    return thisRegex.IsMatch(other.ToString());
+                // NOTE: The enum-based comparisons allocate both on the Convert.ToInt64() and Enum.GetName() path. I've found
+                //       no way to do either comparison in a way that does not allocate.
+                if (other.anyValue is Enum otherEnum)
+                {
+                    if (type == JsonValueType.Integer)
+                        return Convert.ToInt64(otherEnum) == integerValue;
+                    if (type == JsonValueType.String)
+                        return stringValue == Enum.GetName(otherEnum.GetType(), other.anyValue);
+                }
+                if (anyValue is Enum thisEnum)
+                {
+                    if (other.type == JsonValueType.Integer)
+                        return Convert.ToInt64(thisEnum) == other.integerValue;
+                    if (type == JsonValueType.String)
+                        return other.stringValue == Enum.GetName(thisEnum.GetType(), anyValue);
+                }
+
+                return false;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is JsonValue other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = (int)type;
+                    hashCode = (hashCode * 397) ^ boolValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ realValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ integerValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ stringValue.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (arrayValue != null ? arrayValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (objectValue != null ? objectValue.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (anyValue != null ? anyValue.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
+
+            public static bool operator==(JsonValue left, JsonValue right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator!=(JsonValue left, JsonValue right)
+            {
+                return !left.Equals(right);
+            }
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -545,8 +545,8 @@ namespace UnityEngine.InputSystem.Utilities
 
             public bool Equals(JsonString other)
             {
-	            if (hasEscapes == other.hasEscapes)
-		            return Substring.Compare(text, other.text, StringComparison.InvariantCultureIgnoreCase) == 0;
+                if (hasEscapes == other.hasEscapes)
+                    return Substring.Compare(text, other.text, StringComparison.InvariantCultureIgnoreCase) == 0;
 
                 var thisLength = text.length;
                 var otherLength = other.text.length;
@@ -772,48 +772,48 @@ namespace UnityEngine.InputSystem.Utilities
 
                 // anyValue-based comparisons.
                 if (anyValue != null)
-	                return Equals(anyValue, other);
+                    return Equals(anyValue, other);
                 if (other.anyValue != null)
-	                return Equals(other.anyValue, this);
+                    return Equals(other.anyValue, this);
 
                 return false;
             }
 
             private static bool Equals(object obj, JsonValue value)
             {
-	            if (obj == null)
-		            return false;
-	            
+                if (obj == null)
+                    return false;
+
                 if (obj is Regex regex)
                     return regex.IsMatch(value.ToString());
                 if (obj is string str)
                 {
-	                switch (value.type)
-	                {
-		                case JsonValueType.String: return value.stringValue == str;
-		                case JsonValueType.Integer: return long.TryParse(str, out var si) && si == value.integerValue;
-		                case JsonValueType.Real:
-			                return double.TryParse(str, out var sf) && NumberHelpers.Approximately(sf, value.realValue);
-		                case JsonValueType.Bool:
-			                if (value.boolValue)
-				                return str == "True" || str == "true" || str == "1";
-			                return str == "False" || str == "false" || str == "0";
-	                }
+                    switch (value.type)
+                    {
+                        case JsonValueType.String: return value.stringValue == str;
+                        case JsonValueType.Integer: return long.TryParse(str, out var si) && si == value.integerValue;
+                        case JsonValueType.Real:
+                            return double.TryParse(str, out var sf) && NumberHelpers.Approximately(sf, value.realValue);
+                        case JsonValueType.Bool:
+                            if (value.boolValue)
+                                return str == "True" || str == "true" || str == "1";
+                            return str == "False" || str == "false" || str == "0";
+                    }
                 }
                 if (obj is float f)
                 {
-                     if (value.type == JsonValueType.Real)
+                    if (value.type == JsonValueType.Real)
                         return NumberHelpers.Approximately(f, value.realValue);
-                     if (value.type == JsonValueType.String)
-                         return float.TryParse(value.ToString(), out var otherF) && Mathf.Approximately(f, otherF);
+                    if (value.type == JsonValueType.String)
+                        return float.TryParse(value.ToString(), out var otherF) && Mathf.Approximately(f, otherF);
                 }
                 if (obj is double d)
                 {
-                     if (value.type == JsonValueType.Real)
+                    if (value.type == JsonValueType.Real)
                         return NumberHelpers.Approximately(d, value.realValue);
-                     if (value.type == JsonValueType.String)
-                         return double.TryParse(value.ToString(), out var otherD) &&
-                                NumberHelpers.Approximately(d, otherD);
+                    if (value.type == JsonValueType.String)
+                        return double.TryParse(value.ToString(), out var otherD) &&
+                            NumberHelpers.Approximately(d, otherD);
                 }
                 if (obj is int i)
                 {
@@ -831,16 +831,16 @@ namespace UnityEngine.InputSystem.Utilities
                 }
                 if (obj is bool b)
                 {
-                     if (value.type == JsonValueType.Bool)
+                    if (value.type == JsonValueType.Bool)
                         return b == value.boolValue;
-                     if (value.type == JsonValueType.String)
-                     {
-                         if (b)
-                             return value.stringValue == "true" || value.stringValue == "True" ||
-                                    value.stringValue == "1";
-                         return value.stringValue == "false" || value.stringValue == "False" ||
-                                value.stringValue == "0";
-                     }
+                    if (value.type == JsonValueType.String)
+                    {
+                        if (b)
+                            return value.stringValue == "true" || value.stringValue == "True" ||
+                                value.stringValue == "1";
+                        return value.stringValue == "false" || value.stringValue == "False" ||
+                            value.stringValue == "0";
+                    }
                 }
                 // NOTE: The enum-based comparisons allocate both on the Convert.ToInt64() and Enum.GetName() path. I've found
                 //       no way to do either comparison in a way that does not allocate.


### PR DESCRIPTION
Fixes
- GC heap garbage on every processing of a `StateEvent` or `DeltaStateEvent`.
- GC heap garbage from `InputManager` when unplugging a native device and then plugging it back in.

Note that the latter fix is only a half win. The native backend will send us a `String` containing a device descriptor. Allocating that string still allocates garbage.

Also has some script ref doc changes in the PR. Doesn't seem worth bothering to put them into separate PRs.