### PR TITLE
FIX: Composite bindings with the default interaction will now correct…

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4823,7 +4823,7 @@ partial class CoreTests
         InputSystem.RegisterInteraction<LogInteraction>();
 
         var action = new InputAction();
-        action.AddCompositeBinding("Dpad")
+        action.AddCompositeBinding("Dpad(normalize=0)")
             .With("Up", "<Keyboard>/w")
             .With("Down", "<Keyboard>/s")
             .With("Left", "<Keyboard>/a")
@@ -4857,11 +4857,19 @@ partial class CoreTests
         Assert.That(value, Is.EqualTo(Vector2.left));
         performedControl = null;
 
-        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.W));
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A, Key.W));
         InputSystem.Update();
 
         Assert.That(canceledControl, Is.Null);
         Assert.That(performedControl, Is.EqualTo(keyboard.wKey));
+        Assert.That(value, Is.EqualTo(Vector2.up + Vector2.left));
+        performedControl = null;
+
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.W));
+        InputSystem.Update();
+
+        Assert.That(canceledControl, Is.Null);
+        Assert.That(performedControl, Is.EqualTo(keyboard.aKey));
         Assert.That(value, Is.EqualTo(Vector2.up));
         performedControl = null;
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed actions not updating their set of controls when the usages of a device are changed.
+- Composite bindings with the default interaction will now correctly cancel when the composite is released, even if there are multiple composite bindings on the action.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1169,8 +1169,12 @@ namespace UnityEngine.InputSystem
             // NOTE: We may be looking at a control here that points in a completely direction, for example, even
             //       though it has the same magnitude. However, we require a control to *higher* absolute actuation
             //       before we let it drive the action.
-            if (Mathf.Approximately(trigger.magnitude, actionState->magnitude) && triggerControlIndex != actionStateControlIndex)
+            if (Mathf.Approximately(trigger.magnitude, actionState->magnitude))
             {
+                // However, if we have changed the control to a different control on the same composite, we *should* let
+                // it drive the action - this is like a direction change on the same control.
+                if (bindingStates[trigger.bindingIndex].isPartOfComposite && triggerControlIndex == actionStateControlIndex)
+                    return false;
                 if (trigger.magnitude > 0 && triggerControlIndex != actionState->controlIndex)
                     actionState->hasMultipleConcurrentActuations = true;
                 return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1041,6 +1041,13 @@ namespace UnityEngine.InputSystem
                 return false;
             }
 
+            var actionStateControlIndex = actionState->controlIndex;
+            if (bindingStates[actionState->bindingIndex].isPartOfComposite)
+            {
+                var compositeBindingIndex = bindingStates[actionState->bindingIndex].compositeOrCompositeBindingIndex;
+                actionStateControlIndex = bindingStates[compositeBindingIndex].controlStartIndex;
+            }
+
             // If the control is actuated *less* then the current level of actuation we
             // recorded for the action *and* the control that changed is the one that is currently
             // driving the action, we have to check whether there is another actuation
@@ -1049,7 +1056,7 @@ namespace UnityEngine.InputSystem
             {
                 // If we're not currently driving the action, it's simple. Doesn't matter that we lowered
                 // actuation as we didn't have the highest actuation anyway.
-                if (triggerControlIndex != actionState->controlIndex)
+                if (triggerControlIndex != actionStateControlIndex)
                 {
                     Profiler.EndSample();
                     ////REVIEW: should we *count* actuations instead? (problem is that then we have to reliably determine when a control
@@ -1162,7 +1169,7 @@ namespace UnityEngine.InputSystem
             // NOTE: We may be looking at a control here that points in a completely direction, for example, even
             //       though it has the same magnitude. However, we require a control to *higher* absolute actuation
             //       before we let it drive the action.
-            if (Mathf.Approximately(trigger.magnitude, actionState->magnitude))
+            if (Mathf.Approximately(trigger.magnitude, actionState->magnitude) && triggerControlIndex != actionStateControlIndex)
             {
                 if (trigger.magnitude > 0 && triggerControlIndex != actionState->controlIndex)
                     actionState->hasMultipleConcurrentActuations = true;


### PR DESCRIPTION
…ly cancel when the composite is released, even if there are multiple composite bindings on the action.

Previously, the conflict resolution would ignore the change in such a case. Fixes https://fogbugz.unity3d.com/f/cases/1170923/