### PR TITLE
FIX: Compile issue on linux standalone

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - DualShock 3 on macOS:
   * Fixed actions bound to the dpad control performing correctly.
   * Fixed non-present touchpad button control being triggered incorrectly.
+- Fixed compile issues with switch classes on standalone Linux.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2202,7 +2202,9 @@ namespace UnityEngine.InputSystem
             #endif
 
             #if UNITY_EDITOR || UNITY_SWITCH || UNITY_STANDALONE || UNITY_WSA
+                #if !UNITY_STANDALONE_LINUX
             Switch.SwitchSupport.Initialize();
+                #endif
             #endif
 
             #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_ANDROID || UNITY_IOS || UNITY_WSA

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2201,10 +2201,8 @@ namespace UnityEngine.InputSystem
             WebGL.WebGLSupport.Initialize();
             #endif
 
-            #if UNITY_EDITOR || UNITY_SWITCH || UNITY_STANDALONE || UNITY_WSA
-                #if !UNITY_STANDALONE_LINUX
+            #if UNITY_EDITOR || UNITY_SWITCH || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA
             Switch.SwitchSupport.Initialize();
-                #endif
             #endif
 
             #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_ANDROID || UNITY_IOS || UNITY_WSA


### PR DESCRIPTION
Can't build linux standalone player with Switch module in InputSystem.cs.  

NOTE: The format tool did that funky indenting.