### PR TITLE
FIX: Samples not being included in package.

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -17,6 +17,8 @@ promotion_test_{{ platform.name }}_{{ editor.version }}:
   variables:
     UPMCI_PROMOTION: 1
   commands:
+    - mv ./Assets/Samples ./Packages/com.unity.inputsystem
+    - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }}
   artifacts:
@@ -57,6 +59,8 @@ promote:
   variables:
     UPMCI_PROMOTION: 1
   commands:
+    - mv ./Assets/Samples ./Packages/com.unity.inputsystem
+    - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package promote --package-path ./Packages/com.unity.inputsystem/

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,6 +68,8 @@ publish:
     image: package-ci/win10:stable
     flavor: b1.large
   commands:
+    - mv ./Assets/Samples ./Packages/com.unity.inputsystem
+    - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package publish --package-path ./Packages/com.unity.inputsystem/


### PR DESCRIPTION
Samples were included in the packages we tested but not in the package we test but not in the package we push. Was considering removing them entirely from the "Build and Test" step but not sure whether there's something in package validation that makes it good to also have it in that step. Guess the package we test should be identical to the package we push.