### PR TITLE
FIX: Properties of actions embedded into components not being editable.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,7 @@ however, it has to be formatted properly to pass verification tests.
 - It is now possible to use an empty binding path with a non empty override path.
 - It is now possible to use set an empty override path to disable a binding.
 - It is not possible to query the effectively used path of a binding using `effectivePath`.
+- Actions embedded into MonoBehaviour components can now have their properties edited in the inspector. Previously there was no way to get to the properties in this workflow. There is a gear icon now on the action that will open the action properties.
 
 ### Changed
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -1099,7 +1099,16 @@ namespace UnityEngine.InputSystem.Editor
                             AddNewActionMap();
                         }
                     }
+
+                    buttonRect.x -= buttonRect.width + EditorGUIUtility.standardVerticalSpacing;
                 }
+            }
+
+            // Draw action properties button.
+            if (drawActionPropertiesButton && rootItem is ActionTreeItem item)
+            {
+                if (GUI.Button(buttonRect, s_ActionPropertiesIcon, GUIStyle.none))
+                    onDoubleClick?.Invoke(item);
             }
         }
 
@@ -1251,6 +1260,7 @@ namespace UnityEngine.InputSystem.Editor
         public bool drawHeader { get; set; }
         public bool drawPlusButton { get; set; }
         public bool drawMinusButton { get; set; }
+        public bool drawActionPropertiesButton { get; set; }
         public float foldoutOffset { get; set; }
 
         public Action<SerializedProperty> onHandleAddNewAction { get; set; }
@@ -1309,6 +1319,7 @@ namespace UnityEngine.InputSystem.Editor
         private static readonly GUIContent s_PlusActionIcon = EditorGUIUtility.TrIconContent("Toolbar Plus", "Add Action");
         private static readonly GUIContent s_PlusActionMapIcon = EditorGUIUtility.TrIconContent("Toolbar Plus", "Add Action Map");
         private static readonly GUIContent s_DeleteSectionIcon = EditorGUIUtility.TrIconContent("Toolbar Minus", "Delete Selection");
+        private static readonly GUIContent s_ActionPropertiesIcon = EditorGUIUtility.TrIconContent("Settings", "Action Properties");
 
         private static readonly GUIContent s_CutLabel = EditorGUIUtility.TrTextContent("Cut");
         private static readonly GUIContent s_CopyLabel = EditorGUIUtility.TrTextContent("Copy");

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -48,7 +48,8 @@ namespace UnityEngine.InputSystem.Editor
                     title = property.displayName,
                     // With the tree in the inspector, the foldouts are drawn too far to the left. I don't
                     // really know where this is coming from. This works around it by adding an arbitrary offset...
-                    foldoutOffset = 14
+                    foldoutOffset = 14,
+                    drawActionPropertiesButton = true
                 };
                 m_TreeView.Reload();
             }


### PR DESCRIPTION
If you did this

```
public MyBehavior : MonoBehaviour
{
    public InputAction action;
}
```

there did not use to be a way to edit the properties of that action in the editor. Now you get

![image](https://user-images.githubusercontent.com/3418347/62773734-3863a200-baa3-11e9-9699-77eb25316a01.png)