### PR TITLE
FIX: Compile error when installing Visualizers sample.

### DIFF
--- a/Assets/Samples/Visualizers/Unity.InputSystem.Visualizers.asmdef
+++ b/Assets/Samples/Visualizers/Unity.InputSystem.Visualizers.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "InputSystem.Samples.Visualizers",
+    "references": [
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/Assets/Samples/Visualizers/Unity.InputSystem.Visualizers.asmdef.meta
+++ b/Assets/Samples/Visualizers/Unity.InputSystem.Visualizers.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 728e24aed463f43edbdc096fef896432
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Installing the visualizers sample leads to a compile error from unsafe code. This fixes it by adding an .asmdef file that enables unsafe code for the sample.