### PR TITLE
NEW: Add two composites for defining buttons with modifiers.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -5058,6 +5058,121 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_CanCreateButtonWithOneModifierComposite()
+    {
+        // Using gamepad so we can use the triggers and make sure
+        // that the composite preserves the full button value instead
+        // of just going 0 and 1.
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction(type: InputActionType.Button);
+        action.AddCompositeBinding("ButtonWithOneModifier")
+            .With("Modifier", "<Gamepad>/leftTrigger")
+            .With("Modifier", "<Gamepad>/dpad/up")
+            .With("Button", "<Gamepad>/rightTrigger");
+
+        action.Enable();
+
+        using (var trace = new InputActionTrace(action))
+        {
+            Set(gamepad.leftTrigger, 0.5f);
+            Assert.That(trace, Is.Empty);
+
+            Set(gamepad.rightTrigger, 0.75f);
+            Assert.That(trace,
+                Started(action, value: 0.75f, control: gamepad.rightTrigger)
+                    .AndThen(Performed(action, value: 0.75f, control: gamepad.rightTrigger)));
+
+            trace.Clear();
+
+            Set(gamepad.leftTrigger, 0);
+            Assert.That(trace,
+                Canceled(action, value: 0f, control: gamepad.leftTrigger));
+
+            trace.Clear();
+
+            Press(gamepad.dpad.up);
+            Assert.That(trace,
+                Started(action, value: 0.75f, control: gamepad.dpad.up)
+                    .AndThen(Performed(action, value: 0.75f, control: gamepad.dpad.up)));
+
+            trace.Clear();
+
+            Set(gamepad.rightTrigger, 0);
+            Assert.That(trace,
+                Canceled(action, value: 0f, control: gamepad.rightTrigger));
+
+            trace.Clear();
+
+            Release(gamepad.dpad.up);
+            Set(gamepad.rightTrigger, 0.456f);
+
+            Assert.That(trace, Is.Empty);
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanCreateButtonWithTwoModifiersComposite()
+    {
+        // Using gamepad so we can use the triggers and make sure
+        // that the composite preserves the full button value instead
+        // of just going 0 and 1.
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction(type: InputActionType.Button);
+        action.AddCompositeBinding("ButtonWithTwoModifiers")
+            .With("Modifier1", "<Gamepad>/leftTrigger")
+            .With("Modifier1", "<Gamepad>/dpad/up")
+            .With("Modifier2", "<Gamepad>/rightTrigger")
+            .With("Modifier2", "<Gamepad>/dpad/down")
+            .With("Button", "<Gamepad>/leftStick/up");
+
+        action.Enable();
+
+        using (var trace = new InputActionTrace(action))
+        {
+            Set(gamepad.leftTrigger, 0.345f);
+            Assert.That(trace, Is.Empty);
+
+            Set(gamepad.rightTrigger, 0.456f);
+            Assert.That(trace, Is.Empty);
+
+            Set(gamepad.leftStick, new Vector2(0, 0.75f));
+            Assert.That(trace,
+                Started(action,
+                    value: 0.75f,
+                    control: gamepad.leftStick.up)
+                    .AndThen(Performed(action,
+                    value: 0.75f,
+                    control: gamepad.leftStick.up)));
+
+            trace.Clear();
+
+            Press(gamepad.dpad.up);
+            Set(gamepad.leftTrigger, 0);
+
+            // Bit counter-intuitive but the composite yields a value every time
+            // one of the constituents change.
+            Assert.That(trace,
+                Performed(action,
+                    value: 0.75f,
+                    control: gamepad.dpad.up)
+                    .AndThen(Performed(action,
+                    value: 0.75f,
+                    control: gamepad.leftTrigger)));
+
+            trace.Clear();
+
+            Set(gamepad.rightTrigger, 0);
+
+            Assert.That(trace,
+                Canceled(action, value: 0f, control: gamepad.rightTrigger));
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_CanSerializeAndDeserializeActionMapsWithCompositeBindings()
     {
         var map = new InputActionMap(name: "test");

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -5060,6 +5060,8 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_CanCreateButtonWithOneModifierComposite()
     {
+        InputSystem.settings.defaultButtonPressPoint = 0.1f;
+
         // Using gamepad so we can use the triggers and make sure
         // that the composite preserves the full button value instead
         // of just going 0 and 1.
@@ -5115,6 +5117,8 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_CanCreateButtonWithTwoModifiersComposite()
     {
+        InputSystem.settings.defaultButtonPressPoint = 0.1f;
+
         // Using gamepad so we can use the triggers and make sure
         // that the composite preserves the full button value instead
         // of just going 0 and 1.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,9 @@ however, it has to be formatted properly to pass verification tests.
 ### Changed
 ### Added
 
+- Two new composite bindings have been added.
+  * `ButtonWithOneModifier` can be used to represent shortcut-like bindings such as "CTRL+1".
+  * `ButtonWithTwoModifiers` can be used to represent shortcut-like bindings such as "CTRL+SHIFT+1".
 
 ## [0.9.2-preview] - 2019-8-9
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,11 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 ### Actions
+
 ### Changed
+
+- When adding a composite, only ones compatible with the value type of the current action are shown. This will, for example, no longer display a `2D Vector` composite as an option on a floating-point button action.
+
 ### Added
 
 - Two new composite bindings have been added.

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -119,6 +119,8 @@ In addition, you can set the following parameters on a 2D vector composite:
 
 A composite that requires another button to be held when pressing the button that triggers the action. This is useful, for example, to represent keyboard shortcuts such as "CTRL+1" but is not restricted to keyboard controls, i.e. the buttons can be on any device and may be toggle buttons or full-range buttons like the gamepad triggers.
 
+The result is a `float`.
+
 ```CSharp
 myAction.AddCompositeBinding("ButtonWithOneModifier")
     .With("Button", "<Keyboard>/1")
@@ -139,8 +141,10 @@ The Button With One Modifier composite does not have parameters.
 
 A composite that requires two other buttons to be held when pressing the button that triggers the action. This is useful, for example, to represent keyboard shortcuts such as "CTRL+SHIFT+1" but is not restricted to keyboard controls, i.e. the buttons can be on any device and may be toggle buttons or full-range buttons like the gamepad triggers.
 
+The result is a `float`.
+
 ```CSharp
-myAction.AddCompositeBinding("ButtonWithTwoMOdifiers")
+myAction.AddCompositeBinding("ButtonWithTwoModifiers")
     .With("Button", "<Keyboard>/1")
     .With("Modifier1", "<Keyboard>/leftCtrl")
     .With("Modifier1", "<Keyboard>/rightCtrl")

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -137,7 +137,7 @@ The Button With One Modifier composite does not have parameters.
 
 ### Button With Two Modifiers
 
-A composite that requires two other buttons to be held when pressing the button that triggers the action. This is useful, for example, to represent keyboard shortcuts such as "CTRL+SHIFT+1" but is not restricted to keyboard controls, but is not restricted to keyboard controls, i.e. the buttons can be on any device and may be toggle buttons or full-range buttons like the gamepad triggers.
+A composite that requires two other buttons to be held when pressing the button that triggers the action. This is useful, for example, to represent keyboard shortcuts such as "CTRL+SHIFT+1" but is not restricted to keyboard controls, i.e. the buttons can be on any device and may be toggle buttons or full-range buttons like the gamepad triggers.
 
 ```CSharp
 myAction.AddCompositeBinding("ButtonWithTwoMOdifiers")

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -90,6 +90,8 @@ If controls from both the `positive` and the `negative` side are actuated, then 
 
 A composite representing a 4-way button setup akin to the d-pad on gamepads with each button representing a cardinal direction. The result is a `Vector2`.
 
+This composite is most useful for representing controls such as WASD.
+
 ```CSharp
 myAction.AddCompositeBinding("2DVector") // Or "Dpad"
     .With("Up", "<Keyboard>/w")
@@ -113,6 +115,49 @@ In addition, you can set the following parameters on a 2D vector composite:
 |---------|-----------|
 |`normalize`|Whether the resulting vector should be normalized or not. If this is disabled, then, for example, pressing both `up` and `right` will yield a vector `(1,1)` which has a length greater than one. This can be undesirable in situations where the vector's magnitude matterse. E.g. when scaling running speed by the length of the input vector.<br><br>This is true by default.|
 
+### Button With One Modifier
+
+A composite that requires another button to be held when pressing the button that triggers the action. This is useful, for example, to represent keyboard shortcuts such as "CTRL+1" but is not restricted to keyboard controls, i.e. the buttons can be on any device and may be toggle buttons or full-range buttons like the gamepad triggers.
+
+```CSharp
+myAction.AddCompositeBinding("ButtonWithOneModifier")
+    .With("Button", "<Keyboard>/1")
+    .With("Modifier", "<Keyboard>/leftCtrl")
+    .With("Modifier", "<Keyboard>/rightCtrl");
+```
+
+The Button With One Modifier composite has two part bindings.
+
+|Part|Type|Description|
+|----|----|-----------|
+|`modifier`|`Button`|Modifier that has to be held for `button` to come through. If any of the buttons bound to the `modifier` part is pressed, the composite will assume the value of the `button` binding. If none of the buttons bound to the `modifier` part is pressed, the composite has a zero value.|
+|`button`|`Button`|The button whose value the composite will assume while `modifier` is pressed.|
+
+The Button With One Modifier composite does not have parameters.
+
+### Button With Two Modifiers
+
+A composite that requires two other buttons to be held when pressing the button that triggers the action. This is useful, for example, to represent keyboard shortcuts such as "CTRL+SHIFT+1" but is not restricted to keyboard controls, but is not restricted to keyboard controls, i.e. the buttons can be on any device and may be toggle buttons or full-range buttons like the gamepad triggers.
+
+```CSharp
+myAction.AddCompositeBinding("ButtonWithTwoMOdifiers")
+    .With("Button", "<Keyboard>/1")
+    .With("Modifier1", "<Keyboard>/leftCtrl")
+    .With("Modifier1", "<Keyboard>/rightCtrl")
+    .With("Modifier2", "<Keyboard>/leftShift")
+    .With("Modifier2", "<Keyboard>/rightShift");
+```
+
+The Button With Two Modifiers composite has three part bindings.
+
+|Part|Type|Description|
+|----|----|-----------|
+|`modifier1`|`Button`|First modifier that has to be held for `button` to come through. If none of the buttons bound to the `modifier1` part is pressed, the composite has a zero value.|
+|`modifier2`|`Button`|Second modifier that has to be held for `button` to come through. If none of the buttons bound to the `modifier2` part is pressed, the composite has a zero value.|
+|`button`|`Button`|The button whose value the composite will assume while both `modifier1` and `modifier2` are pressed.|
+
+The Button With Two Modifiers composite does not have parameters.
+
 ### Writing Custom Composites
 
 New types of composites can be defined and registered with the API. They are treated the same as predefined types &mdash; which are internally defined and registered the same way.
@@ -124,6 +169,9 @@ To define a new type of composite, create a class based on `InputBindingComposit
 // values of type TValue.
 // NOTE: It is possible to define a composite that returns different kinds of values
 //       but doing so requires deriving directly from InputBindingComposite.
+#if UNITY_EDITOR
+[InitializeOnLoad] // Automatically register in editor.
+#endif
 public class CustomComposite : InputBindingComposite<float>
 {
     // Each part binding is represented as a field of type int and annotated with
@@ -160,16 +208,25 @@ public class CustomComposite : InputBindingComposite<float>
     {
         // Compute normalized [0..1] magnitude value for current actuation level.
     }
+
+    static CustomComposite()
+    {
+        // Can give custom name or use default (type name with "Composite" clipped off).
+        // Same composite can be registered multiple times with different names to introduce
+        // aliases.
+        //
+        // NOTE: Registering from the static constructor using InitializeOnLoad and
+        //       RuntimeInitializeOnLoad is only one way. You can register the
+        //       composite from wherever it works best for you. Note, however, that
+        //       the registration has to take place before the composite is first used
+        //       in a binding. Also, for the composite to show in the editor, it has
+        //       to be registered from code that runs in edit mode.
+        InputSystem.RegisterBindingComposite<CustomComposite>();
+    }
+
+    [RuntimeInitializeOnLoad]
+    static void Init() {} // Trigger static constructor.
 }
-```
-
-To register the composite, call `InputSystem.RegisterBindingComposite<TComposite>()`. This is best done during from `InitializeOnLoad`/`RuntimeInitializeOnLoad` code.
-
-```CSharp
-// Can give custom name or use default (type name with "Composite" clipped off).
-// Same composite can be registered multiple times with different names to introduce
-// aliases.
-InputSystem.RegisterBindingComposite<CustomComposite>();
 ```
 
 The composite should now show up in the editor UI when adding a binding and it can now be used in scripts.
@@ -218,7 +275,7 @@ This behavior can be overridden by restricting `InputActionAssets` or individual
 
 ## Disambiguation
 
-TODO
+## Initial State Check
 
 ## Runtime Rebinding
 

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -216,7 +216,7 @@ public class CustomComposite : InputBindingComposite<float>
         // aliases.
         //
         // NOTE: Registering from the static constructor using InitializeOnLoad and
-        //       RuntimeInitializeOnLoad is only one way. You can register the
+        //       RuntimeInitializeOnLoadMethod is only one way. You can register the
         //       composite from wherever it works best for you. Note, however, that
         //       the registration has to take place before the composite is first used
         //       in a binding. Also, for the composite to show in the editor, it has
@@ -224,7 +224,7 @@ public class CustomComposite : InputBindingComposite<float>
         InputSystem.RegisterBindingComposite<CustomComposite>();
     }
 
-    [RuntimeInitializeOnLoad]
+    [RuntimeInitializeOnLoadMethod]
     static void Init() {} // Trigger static constructor.
 }
 ```

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithOneModifier.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithOneModifier.cs
@@ -1,0 +1,94 @@
+using UnityEngine.InputSystem.Layouts;
+
+namespace UnityEngine.InputSystem.Composites
+{
+    /// <summary>
+    /// A button with an additional modifier. The button only triggers when
+    /// the modifier is pressed.
+    /// </summary>
+    /// <remarks>
+    /// This composite can be used to require another button to be held while
+    /// pressing the button that triggers the action. This is most commonly used
+    /// on keyboards to require one of the modifier keys (shift, ctrl, or alt)
+    /// to be held in combination with another key, e.g. "CTRL+1".
+    ///
+    /// <example>
+    /// <code>
+    /// // Create a button action that triggers when CTRL+1
+    /// // is pressed on the keyboard.
+    /// var action = new InputAction(type: InputActionType.Button);
+    /// action.AddCompositeBinding("ButtonWithOneModifier")
+    ///     .With("Modifier", "&lt;Keyboard&gt;/leftCtrl")
+    ///     .With("Modifier", "&lt;Keyboard&gt;/rightControl")
+    ///     .With("Button", "&lt;Keyboard&gt;/1")
+    /// </code>
+    /// </example>
+    ///
+    /// Note that this is not restricted to the keyboard and will preserve
+    /// the full value of the button.
+    ///
+    /// <example>
+    /// <code>
+    /// // Create a button action that requires the A button on the
+    /// // gamepad to be held and will then trigger from the gamepad's
+    /// // left trigger button.
+    /// var action = new InputAction(type: InputActionType.Button);
+    /// action.AddCompositeBinding("ButtonWithOneModifier")
+    ///     .With("Modifier", "&lt;Gamepad&gt;/buttonSouth")
+    ///     .With("Button", "&lt;Gamepad&gt;/leftTrigger");
+    /// </code>
+    /// </example>
+    /// </remarks>
+    /// <seealso cref="ButtonWithTwoModifiers"/>
+    public class ButtonWithOneModifier : InputBindingComposite<float>
+    {
+        /// <summary>
+        /// Binding for the button that acts as a modifier, e.g. <c>&lt;Keyboard/leftCtrl</c>.
+        /// </summary>
+        /// <value>Part index to use with <see cref="InputBindingCompositeContext.ReadValue{T}(int)"/>.</value>
+        /// <remarks>
+        /// This property is automatically assigned by the input system.
+        /// </remarks>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once UnassignedField.Global
+        [InputControl(layout = "Button")] public int modifier;
+
+        /// <summary>
+        /// Binding for the button that is gated by the modifier. The composite will assume the value
+        /// of this button while the modifier is pressed.
+        /// </summary>
+        /// <value>Part index to use with <see cref="InputBindingCompositeContext.ReadValue{T}(int)"/>.</value>
+        /// <remarks>
+        /// This property is automatically assigned by the input system.
+        /// </remarks>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once UnassignedField.Global
+        [InputControl(layout = "Button")] public int button;
+
+        /// <summary>
+        /// Return the value of the <see cref="button"/> part if <see cref="modifier"/> is pressed. Otherwise
+        /// return 0.
+        /// </summary>
+        /// <param name="context">Evaluation context passed in from the input system.</param>
+        /// <returns>The current value of the composite.</returns>
+        public override float ReadValue(ref InputBindingCompositeContext context)
+        {
+            if (context.ReadValueAsButton(modifier))
+                return context.ReadValue<float>(button);
+
+            return default;
+        }
+
+        /// <summary>
+        /// Same as <see cref="ReadValue"/> in this case.
+        /// </summary>
+        /// <param name="context">Evaluation context passed in from the input system.</param>
+        /// <returns>A >0 value if the composite is currently actuated.</returns>
+        public override float EvaluateMagnitude(ref InputBindingCompositeContext context)
+        {
+            return ReadValue(ref context);
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithOneModifier.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithOneModifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 15164829aab964eedaee6bac785c2c05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithTwoModifiers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithTwoModifiers.cs
@@ -1,0 +1,109 @@
+using UnityEngine.InputSystem.Layouts;
+
+namespace UnityEngine.InputSystem.Composites
+{
+    /// <summary>
+    /// A button with two additional modifiers. The button only triggers when
+    /// the both modifiers are pressed.
+    /// </summary>
+    /// <remarks>
+    /// This composite can be used to require two other buttons to be held while
+    /// pressing the button that triggers the action. This is most commonly used
+    /// on keyboards to require two of the modifier keys (shift, ctrl, or alt)
+    /// to be held in combination with another key, e.g. "CTRL+SHIFT+1".
+    ///
+    /// <example>
+    /// <code>
+    /// // Create a button action that triggers when CTRL+SHIFT+1
+    /// // is pressed on the keyboard.
+    /// var action = new InputAction(type: InputActionType.Button);
+    /// action.AddCompositeBinding("ButtonWithTwoModifiers")
+    ///     .With("Modifier1", "&lt;Keyboard&gt;/leftCtrl")
+    ///     .With("Modifier1", "&lt;Keyboard&gt;/rightControl")
+    ///     .With("Modifier2", "&lt;Keyboard&gt;/leftShift")
+    ///     .With("Modifier2", "&lt;Keyboard&gt;/rightShift")
+    ///     .With("Button", "&lt;Keyboard&gt;/1")
+    /// </code>
+    /// </example>
+    ///
+    /// Note that this is not restricted to the keyboard and will preserve
+    /// the full value of the button.
+    ///
+    /// <example>
+    /// <code>
+    /// // Create a button action that requires the A and X button on the
+    /// // gamepad to be held and will then trigger from the gamepad's
+    /// // left trigger button.
+    /// var action = new InputAction(type: InputActionType.Button);
+    /// action.AddCompositeBinding("ButtonWithTwoModifiers")
+    ///     .With("Modifier1", "&lt;Gamepad&gt;/buttonSouth")
+    ///     .With("Modifier2", "&lt;Gamepad&gt;/buttonWest")
+    ///     .With("Button", "&lt;Gamepad&gt;/leftTrigger");
+    /// </code>
+    /// </example>
+    /// </remarks>
+    /// <seealso cref="ButtonWithOneModifier"/>
+    public class ButtonWithTwoModifiers : InputBindingComposite<float>
+    {
+        /// <summary>
+        /// Binding for the first button that acts as a modifier, e.g. <c>&lt;Keyboard/leftCtrl</c>.
+        /// </summary>
+        /// <value>Part index to use with <see cref="InputBindingCompositeContext.ReadValue{T}(int)"/>.</value>
+        /// <remarks>
+        /// This property is automatically assigned by the input system.
+        /// </remarks>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once UnassignedField.Global
+        [InputControl(layout = "Button")] public int modifier1;
+
+        /// <summary>
+        /// Binding for the second button that acts as a modifier, e.g. <c>&lt;Keyboard/leftCtrl</c>.
+        /// </summary>
+        /// <value>Part index to use with <see cref="InputBindingCompositeContext.ReadValue{T}(int)"/>.</value>
+        /// <remarks>
+        /// This property is automatically assigned by the input system.
+        /// </remarks>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once UnassignedField.Global
+        [InputControl(layout = "Button")] public int modifier2;
+
+        /// <summary>
+        /// Binding for the button that is gated by the <see cref="modifier1"/> and <see cref="modifier2"/>.
+        /// The composite will assume the value of this button while both of the modifiers are pressed.
+        /// </summary>
+        /// <value>Part index to use with <see cref="InputBindingCompositeContext.ReadValue{T}(int)"/>.</value>
+        /// <remarks>
+        /// This property is automatically assigned by the input system.
+        /// </remarks>
+        // ReSharper disable once MemberCanBePrivate.Global
+        // ReSharper disable once FieldCanBeMadeReadOnly.Global
+        // ReSharper disable once UnassignedField.Global
+        [InputControl(layout = "Button")] public int button;
+
+        /// <summary>
+        /// Return the value of the <see cref="button"/> part while both <see cref="modifier1"/> and <see cref="modifier2"/>
+        /// are pressed. Otherwise return 0.
+        /// </summary>
+        /// <param name="context">Evaluation context passed in from the input system.</param>
+        /// <returns>The current value of the composite.</returns>
+        public override float ReadValue(ref InputBindingCompositeContext context)
+        {
+            if (context.ReadValueAsButton(modifier1) && context.ReadValueAsButton(modifier2))
+                return context.ReadValue<float>(button);
+
+            return default;
+        }
+
+        /// <summary>
+        /// Same as <see cref="ReadValue"/> in this case.
+        /// </summary>
+        /// <param name="context">Evaluation context passed in from the input system.</param>
+        /// <returns>A >0 value if the composite is currently actuated.</returns>
+        public override float EvaluateMagnitude(ref InputBindingCompositeContext context)
+        {
+            return ReadValue(ref context);
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithTwoModifiers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithTwoModifiers.cs
@@ -4,7 +4,7 @@ namespace UnityEngine.InputSystem.Composites
 {
     /// <summary>
     /// A button with two additional modifiers. The button only triggers when
-    /// the both modifiers are pressed.
+    /// both modifiers are pressed.
     /// </summary>
     /// <remarks>
     /// This composite can be used to require two other buttons to be held while
@@ -19,7 +19,7 @@ namespace UnityEngine.InputSystem.Composites
     /// var action = new InputAction(type: InputActionType.Button);
     /// action.AddCompositeBinding("ButtonWithTwoModifiers")
     ///     .With("Modifier1", "&lt;Keyboard&gt;/leftCtrl")
-    ///     .With("Modifier1", "&lt;Keyboard&gt;/rightControl")
+    ///     .With("Modifier1", "&lt;Keyboard&gt;/rightCtrl")
     ///     .With("Modifier2", "&lt;Keyboard&gt;/leftShift")
     ///     .With("Modifier2", "&lt;Keyboard&gt;/rightShift")
     ///     .With("Button", "&lt;Keyboard&gt;/1")

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithTwoModifiers.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/ButtonWithTwoModifiers.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62dcc18c42c2246bdaed7fe210b77118
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingComposite.cs
@@ -19,6 +19,7 @@ namespace UnityEngine.InputSystem
     /// <summary>
     /// A binding that synthesizes a value from from several component bindings.
     /// </summary>
+    ////TODO: clarify whether this can have state or not
     public abstract class InputBindingComposite
     {
         public abstract Type valueType { get; }
@@ -32,6 +33,18 @@ namespace UnityEngine.InputSystem
         }
 
         internal static TypeTable s_Composites;
+
+        internal static Type GetValueType(string composite)
+        {
+            if (string.IsNullOrEmpty(composite))
+                throw new ArgumentNullException(nameof(composite));
+
+            var compositeType = s_Composites.LookupTypeRegistration(composite);
+            if (compositeType == null)
+                return null;
+
+            return TypeHelpers.GetGenericTypeArgumentFromHierarchy(compositeType, typeof(InputBindingComposite<>), 0);
+        }
 
         /// <summary>
         /// Return the name of the control layout that is expected for the given part (e.g. "Up") on the given

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -1709,6 +1709,22 @@ namespace UnityEngine.InputSystem.Layouts
                 return result;
             }
 
+            // Return true if the given control layout has a value type whose values
+            // can be assigned to variables of type valueType.
+            public bool ValueTypeIsAssignableFrom(InternedString layoutName, Type valueType)
+            {
+                var controlType = GetControlTypeForLayout(layoutName);
+                if (controlType == null)
+                    return false;
+
+                var valueTypOfControl =
+                    TypeHelpers.GetGenericTypeArgumentFromHierarchy(controlType, typeof(InputControl<>), 0);
+                if (valueTypOfControl == null)
+                    return false;
+
+                return valueType.IsAssignableFrom(valueTypOfControl);
+            }
+
             public bool IsBasedOn(InternedString parentLayout, InternedString childLayout)
             {
                 var layout = childLayout;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -886,9 +886,21 @@ namespace UnityEngine.InputSystem.Editor
                 });
 
             // Add one entry for each registered type of composite binding.
+            var expectedControlLayout = new InternedString(actionItem?.expectedControlLayout);
             foreach (var compositeName in InputBindingComposite.s_Composites.internedNames.Where(x =>
                 !InputBindingComposite.s_Composites.aliases.Contains(x)).OrderBy(x => x))
             {
+                // If the action is expected a specific control layout, check
+                // whether the value type use by the composite matches that of
+                // the layout.
+                if (!expectedControlLayout.IsEmpty())
+                {
+                    var valueType = InputBindingComposite.GetValueType(compositeName);
+                    if (valueType != null &&
+                        !InputControlLayout.s_Layouts.ValueTypeIsAssignableFrom(expectedControlLayout, valueType))
+                        continue;
+                }
+
                 var niceName = ObjectNames.NicifyVariableName(compositeName);
                 menu.AddItem(new GUIContent($"Add {niceName} Composite"), false,
                     () =>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -154,6 +154,15 @@ namespace UnityEngine.InputSystem.Editor
             foreach (var composite in InputBindingComposite.s_Composites.internedNames.Where(x =>
                 !InputBindingComposite.s_Composites.aliases.Contains(x)).OrderBy(x => x))
             {
+                if (!string.IsNullOrEmpty(m_ExpectedControlLayout))
+                {
+                    var valueType = InputBindingComposite.GetValueType(composite);
+                    if (valueType != null &&
+                        !InputControlLayout.s_Layouts.ValueTypeIsAssignableFrom(
+                            new InternedString(m_ExpectedControlLayout), valueType))
+                        continue;
+                }
+
                 if (InputBindingComposite.s_Composites.LookupTypeRegistration(composite) == compositeType)
                     selectedCompositeIndex = currentIndex;
                 var name = ObjectNames.NicifyVariableName(composite);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine.InputSystem.Editor.Lists;
+using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: when we start with a blank tree view state, we should initialize the control picker to select the control currently

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
@@ -114,7 +114,7 @@ namespace UnityEngine.InputSystem.Editor
             Debug.Assert(typeof(InputControl).IsAssignableFrom(type),
                 "Layout's associated type should be derived from InputControl");
 
-            return TypeHelpers.GetGenericTypeArgumentFromHierarchy(type, typeof(InputControl<>), 0);
+            return layout.GetValueType();
         }
 
         public static IEnumerable<InputDeviceMatcher> GetDeviceMatchers(string layoutName)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1520,6 +1520,8 @@ namespace UnityEngine.InputSystem
             composites.AddTypeRegistration("2DVector", typeof(Vector2Composite));
             composites.AddTypeRegistration("Axis", typeof(AxisComposite));// Alias for pre-0.2 name.
             composites.AddTypeRegistration("Dpad", typeof(Vector2Composite));// Alias for pre-0.2 name.
+            composites.AddTypeRegistration("ButtonWithOneModifier", typeof(ButtonWithOneModifier));
+            composites.AddTypeRegistration("ButtonWithTwoModifiers", typeof(ButtonWithTwoModifiers));
         }
 
         internal void InstallRuntime(IInputRuntime runtime)


### PR DESCRIPTION
The question/request for a way to set up things such as "CTRL+1" has come up so often and is so easy to add on our side as two composites that I thought what the heck, we may as well just add that.

Also contains a slight tweak to the action editor to filter out composites that aren't applicable to a given action. Cleans up the "Add Binding" menu to hide options that don't make sense anyway.

PS: First PR where I add both full scripting API docs *and* coverage in the manual. So proud of myself.