### PR TITLE
FIX: Actions unexpectedly triggering when switching devices.

### DIFF
--- a/Assets/Demo/DemoGame.cs
+++ b/Assets/Demo/DemoGame.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.UI;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
@@ -311,7 +312,7 @@ public class DemoGame : MonoBehaviour
     /// switch from one or the other. In that case, while we will stay on the Gamepad control scheme,
     /// we will still unassign the previously used gamepad from the player and assign the newly used one.
     /// </remarks>
-    private void OnUnpairedInputDeviceUsed(InputControl control)
+    private void OnUnpairedInputDeviceUsed(InputControl control, InputEventPtr eventPtr)
     {
         // We should only listen for unpaired device activity when we're either in the lobby
         // or in single-player mode. In a multi-player game, we turn it off and simply ignore whatever

--- a/Assets/Tests/InputSystem/Plugins/UserTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UserTests.cs
@@ -768,7 +768,7 @@ internal class UserTests : InputTestFixture
 
         var receivedControls = new List<InputControl>();
         InputUser.onUnpairedDeviceUsed +=
-            control => { receivedControls.Add(control); };
+            (control, eventPtr) => { receivedControls.Add(control); };
 
         var mouse = InputSystem.AddDevice<Mouse>();
 
@@ -798,7 +798,7 @@ internal class UserTests : InputTestFixture
 
         var receivedControls = new List<InputControl>();
         InputUser.onUnpairedDeviceUsed +=
-            control => { receivedControls.Add(control); };
+            (control, eventPtr) => { receivedControls.Add(control); };
 
         InputSystem.RegisterLayout(gamepadWithNoisyGyro);
         var gamepad = (Gamepad)InputSystem.AddDevice("GamepadWithNoisyGyro");
@@ -863,7 +863,7 @@ internal class UserTests : InputTestFixture
 
         var receivedControls = new List<InputControl>();
         InputUser.onUnpairedDeviceUsed +=
-            control =>
+            (control, eventPtr) =>
         {
             InputUser.PerformPairingWithDevice(control.device);
             receivedControls.Add(control);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,7 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - `InputUser.onUnpairedDeviceUsed` now receives a 2nd argument which is the event that triggered the callback.
   * Also, the callback is now triggered __BEFORE__ the given event is processed rather than after the event has already been written to the device. This allows updating the pairing state of the system before input is processed.
   * In practice, this means that, for example, if the user switches from keyboard&mouse to gamepad, the initial input that triggered the switch will get picked up right away.
-  
+
 #### Actions
 
 - When switching devices/controls on actions, the system will no longer subsequently force an initial state check on __all__ actions. Instead, every time an action's bindings get re-resolved, the system will simply cancel all on-going actions and then re-enable them the same way it would happen by manually calling `InputAction.Enable`.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,8 +10,18 @@ however, it has to be formatted properly to pass verification tests.
 ## [0.9.4-preview] - 2099-1-1
 
 ### Fixed
-### Actions
+#### Actions
+
 ### Changed
+
+- `InputUser.onUnpairedDeviceUsed` now receives a 2nd argument which is the event that triggered the callback.
+  * Also, the callback is now triggered __BEFORE__ the given event is processed rather than after the event has already been written to the device. This allows updating the pairing state of the system before input is processed.
+  * In practice, this means that, for example, if the user switches from keyboard&mouse to gamepad, the initial input that triggered the switch will get picked up right away.
+  
+#### Actions
+
+- When switching devices/controls on actions, the system will no longer subsequently force an initial state check on __all__ actions. Instead, every time an action's bindings get re-resolved, the system will simply cancel all on-going actions and then re-enable them the same way it would happen by manually calling `InputAction.Enable`.
+
 ### Added
 
 ## [0.9.3-preview] - 2019-8-15

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -110,10 +110,10 @@ namespace UnityEngine.InputSystem
         public InteractionState* interactionStates => memory.interactionStates;
         public int* controlIndexToBindingIndex => memory.controlIndexToBindingIndex;
 
-        private Action m_OnBeforeUpdateDelegate;
-        private Action m_OnAfterUpdateDelegate;
         private bool m_OnBeforeUpdateHooked;
         private bool m_OnAfterUpdateHooked;
+        private Action m_OnBeforeUpdateDelegate;
+        private Action m_OnAfterUpdateDelegate;
 
         /// <summary>
         /// Initialize execution state with given resolved binding information.
@@ -212,7 +212,7 @@ namespace UnityEngine.InputSystem
         /// <param name="device">Any input device.</param>
         /// <returns>True if any of the maps in the state has the device in its <see cref="InputActionMap.devices"/>
         /// list or if any of the device's controls are contained in <see cref="controls"/>.</returns>
-        public bool IsUsingDevice(InputDevice device)
+        private bool IsUsingDevice(InputDevice device)
         {
             Debug.Assert(device != null, "Device is null");
 
@@ -246,7 +246,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <param name="device"></param>
         /// <returns></returns>
-        public bool CanUseDevice(InputDevice device)
+        private bool CanUseDevice(InputDevice device)
         {
             Debug.Assert(device != null, "Device is null");
 
@@ -363,11 +363,8 @@ namespace UnityEngine.InputSystem
                 }
 
                 // Enable all controls on the binding.
-                // NOTE: We force an initial state check on actions here regardless of whether the action has
-                //       it enabled or not. The reason is that we use this path to temporarily disable actions
-                //       and re-enabling them should have the actions resume where they left off (where applicable).
-                EnableControls(actionState->mapIndex, bindingState->controlStartIndex, bindingState->controlCount,
-                    forceStateCheck: true);
+                EnableControls(actionState->mapIndex, bindingState->controlStartIndex,
+                    bindingState->controlCount);
             }
 
             // Make sure we get an initial state check.
@@ -655,7 +652,7 @@ namespace UnityEngine.InputSystem
 
         ////REVIEW: can we have a method on InputManager doing this in bulk?
 
-        private void EnableControls(int mapIndex, int controlStartIndex, int numControls, bool forceStateCheck = false)
+        private void EnableControls(int mapIndex, int controlStartIndex, int numControls)
         {
             Debug.Assert(controls != null, "State must have controls");
             Debug.Assert(controlStartIndex >= 0 && (controlStartIndex < totalControlCount || numControls == 0),
@@ -669,7 +666,7 @@ namespace UnityEngine.InputSystem
                 var bindingIndex = controlIndexToBindingIndex[controlIndex];
                 var mapControlAndBindingIndex = ToCombinedMapAndControlAndBindingIndex(mapIndex, controlIndex, bindingIndex);
 
-                if (forceStateCheck || bindingStates[bindingIndex].wantsInitialStateCheck)
+                if (bindingStates[bindingIndex].wantsInitialStateCheck)
                     bindingStates[bindingIndex].initialStateCheckPending = true;
                 manager.AddStateChangeMonitor(controls[controlIndex], this, mapControlAndBindingIndex);
             }
@@ -849,6 +846,13 @@ namespace UnityEngine.InputSystem
                 startTime = time,
                 passThrough = actionIndex != kInvalidIndex && actionStates[actionIndex].passThrough,
             };
+
+            // If we have pending initial state checks that will run in the next update,
+            // force-reset the flag on the control that just triggered. This ensures that we're
+            // not triggering an action twice from the same state change in case the initial state
+            // check happens later (see Actions_ValueActionsEnabledInOnEvent_DoNotReactToCurrentStateOfControlTwice).
+            if (m_OnBeforeUpdateHooked)
+                bindingStatePtr->initialStateCheckPending = false;
 
             // If the binding is part of a composite, check for interactions on the composite
             // itself and give them a first shot at processing the value change.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -135,6 +135,7 @@ namespace UnityEngine.InputSystem.HID
                 */
             }
 
+            ////REVIEW: these layout names are impossible to bind to; come up with a better way
             ////TODO: match HID layouts by vendor and product ID
             ////REVIEW: this probably works fine for most products out there but I'm not sure it works reliably for all cases
             // Come up with a unique template name. HIDs are required to have product and vendor IDs.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/InputValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/InputValue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 ////TODO: ToString()
 
@@ -14,6 +15,7 @@ namespace UnityEngine.InputSystem
     /// the receiver from having to know about action callback specifics.
     /// </remarks>
     /// <seealso cref="InputAction"/>
+    [DebuggerDisplay("Value = {Get()}")]
     public class InputValue
     {
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
+using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.UI;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
@@ -640,7 +641,7 @@ namespace UnityEngine.InputSystem
         internal static int s_AllActivePlayersCount;
         internal static PlayerInput[] s_AllActivePlayers;
         internal static Action<InputUser, InputUserChange, InputDevice> s_UserChangeDelegate;
-        internal static Action<InputControl> s_UnpairedDeviceUsedDelegate;
+        internal static Action<InputControl, InputEventPtr> s_UnpairedDeviceUsedDelegate;
         internal static bool s_OnUnpairedDeviceHooked;
 
         // The following information is used when the next PlayerInput component is enabled.
@@ -662,11 +663,11 @@ namespace UnityEngine.InputSystem
             for (var i = 0; i < s_AllActivePlayersCount; ++i)
                 if (s_AllActivePlayers[i].m_Actions == m_Actions && s_AllActivePlayers[i] != this)
                 {
-                    InputActionAsset oldActions = m_Actions;
+                    var oldActions = m_Actions;
                     m_Actions = Instantiate(m_Actions);
-                    for (int actionMap = 0; actionMap < oldActions.actionMaps.Count; actionMap++)
+                    for (var actionMap = 0; actionMap < oldActions.actionMaps.Count; actionMap++)
                     {
-                        for (int binding = 0; binding < oldActions.actionMaps[actionMap].bindings.Count; binding++)
+                        for (var binding = 0; binding < oldActions.actionMaps[actionMap].bindings.Count; binding++)
                             m_Actions.actionMaps[actionMap].ApplyBindingOverride(binding, oldActions.actionMaps[actionMap].bindings[binding]);
                     }
 
@@ -1212,7 +1213,7 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        private static void OnUnpairedDeviceUsed(InputControl control)
+        private static void OnUnpairedDeviceUsed(InputControl control, InputEventPtr eventPtr)
         {
             // We only support automatic control scheme switching in single player mode.
             // OnEnable() should automatically unhook us.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -1,6 +1,7 @@
 using System;
 using UnityEngine.Events;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.UI;
@@ -396,7 +397,7 @@ namespace UnityEngine.InputSystem
         [NonSerialized] private bool m_JoinActionDelegateHooked;
         [NonSerialized] private bool m_UnpairedDeviceUsedDelegateHooked;
         [NonSerialized] private Action<InputAction.CallbackContext> m_JoinActionDelegate;
-        [NonSerialized] private Action<InputControl> m_UnpairedDeviceUsedDelegate;
+        [NonSerialized] private Action<InputControl, InputEventPtr> m_UnpairedDeviceUsedDelegate;
         [NonSerialized] private InlinedArray<Action<PlayerInput>> m_PlayerJoinedCallbacks;
         [NonSerialized] private InlinedArray<Action<PlayerInput>> m_PlayerLeftCallbacks;
 
@@ -436,7 +437,7 @@ namespace UnityEngine.InputSystem
             return true;
         }
 
-        private void OnUnpairedDeviceUsed(InputControl control)
+        private void OnUnpairedDeviceUsed(InputControl control, InputEventPtr eventPtr)
         {
             if (!m_AllowJoining)
                 return;

--- a/countsloc.sh
+++ b/countsloc.sh
@@ -2,5 +2,5 @@
 echo "----- System ------"
 wc `find Packages/com.unity.inputsystem/InputSystem -name "*.cs"`
 echo "----- Tests -------"
-wc `find Packages/com.unity.inputsystem/Tests -name "*.cs"`
+wc `find Packages/com.unity.inputsystem/Tests -name "*.cs"` `find Assets/Tests -name "*.cs"`
 


### PR DESCRIPTION
According to my tests, along with some changes that already went into 0.9.3, this seems to make PlayerInput control scheme switching work as expected in combination with hotplugging.

Key changes:

- Moved InputUser.onUnpairedDeviceUsed up inside of input system updates to now happen *before* we process the given input. I.e. we go from an after-the-fact "hey, an unpaired device was used" notification to a before-the-fact one.
- Removed forced initial state checks on *all* actions when we re-resolve controls on actions (e.g. after a device was plugged in). This was simply an ill-advised thing to do in the first place.