### PR TITLE
FIX: PlayerInput.Instantiate not handling control schemes correctly.

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -535,7 +535,7 @@ internal class PlayerInputTests : InputTestFixture
     // schemes.
     [Test]
     [Category("PlayerInput")]
-    public void PlayerInput_CanSetUpSlitKeyboardPlay()
+    public void PlayerInput_CanSetUpSplitKeyboardPlay()
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();
 

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -11,6 +11,20 @@ using UnityEngine.InputSystem.Processors;
 using Object = UnityEngine.Object;
 using Gyroscope = UnityEngine.InputSystem.Gyroscope;
 
+//what if we want to join by button but NOT directly process the input? is the previous behavior actually better?
+//problem is that the control scheme switch may still trigger an initial state check on all actions
+//should there be a "sort-of-handled" kind of flag which puts the event on the device but does not trigger actions?
+
+//why is InputSystem.Update() triggering an initial state check on the "fire" button action?
+//should the unpaired device activity check in InputUser be moved to *before* state is incorporated into the device
+//   (the current setup doesn't seem to make it possible to immediately react to the state change via actions)
+
+//TODO:
+// - fix playerinput hotplugging
+// - add message for control scheme switches
+// - add message for device changes
+// - add ability to intercept playerinputmanager player instantiation
+
 /// <summary>
 /// Tests for <see cref="PlayerInput"/> and <see cref="PlayerInputManager"/>.
 /// </summary>
@@ -529,6 +543,91 @@ internal class PlayerInputTests : InputTestFixture
         Assert.That(playerInput.user.controlScheme, Is.Not.Null);
         Assert.That(playerInput.user.controlScheme.Value.name, Is.EqualTo("Gamepad"));
         Assert.That(listener.messages, Is.EquivalentTo(new[] {new Message("OnFire", 1f)}));
+    }
+
+    // Test setup where two players both use the keyboard but with two different control
+    // schemes.
+    [Test]
+    [Category("PlayerInput")]
+    public void PlayerInput_CanSetUpSlitKeyboardPlay()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        // We add a gamepad device and scheme just to add noise and make sure
+        // this isn't throwing the thing off the rails.
+        InputSystem.AddDevice<Gamepad>();
+
+        const string kActions = @"
+        {
+            ""maps"" : [
+                {
+                    ""name"" : ""gameplay"",
+                    ""actions"" : [
+                        { ""name"" : ""fire"", ""type"" : ""button"" }
+                    ],
+                    ""bindings"" : [
+                        { ""path"" : ""<Gamepad>/buttonSouth"", ""action"" : ""fire"", ""groups"" : ""Gamepad"" },
+                        { ""path"" : ""<Keyboard>/leftCtrl"", ""action"" : ""fire"", ""groups"" : ""KeyboardWASD"" },
+                        { ""path"" : ""<Keyboard>/rightCtrl"", ""action"" : ""fire"", ""groups"" : ""KeyboardArrows"" }
+                    ]
+                }
+            ],
+            ""controlSchemes"" : [
+                {
+                    ""name"" : ""Gamepad"",
+                    ""bindingGroup"" : ""Gamepad"",
+                    ""devices"" : [
+                        { ""devicePath"" : ""<Gamepad>"" }
+                    ]
+                },
+                {
+                    ""name"" : ""Keyboard WASD"",
+                    ""bindingGroup"" : ""KeyboardWASD"",
+                    ""devices"" : [
+                        { ""devicePath"" : ""<Keyboard>"" }
+                    ]
+                },
+                {
+                    ""name"" : ""Keyboard Arrows"",
+                    ""bindingGroup"" : ""KeyboardArrows"",
+                    ""devices"" : [
+                        { ""devicePath"" : ""<Keyboard>"" }
+                    ]
+                }
+            ]
+        }";
+
+        var prefab = new GameObject();
+        prefab.SetActive(false);
+        prefab.AddComponent<MessageListener>();
+        prefab.AddComponent<PlayerInput>();
+        prefab.GetComponent<PlayerInput>().actions = InputActionAsset.FromJson(kActions);
+        prefab.GetComponent<PlayerInput>().defaultActionMap = "gameplay";
+
+        var player1 = PlayerInput.Instantiate(prefab, controlScheme: "Keyboard WASD", pairWithDevice: keyboard);
+        var player2 = PlayerInput.Instantiate(prefab, controlScheme: "Keyboard Arrows", pairWithDevice: keyboard);
+
+        Assert.That(player1.devices, Is.EquivalentTo(new[] { keyboard }));
+        Assert.That(player2.devices, Is.EquivalentTo(new[] { keyboard }));
+        Assert.That(player1.controlScheme, Is.EqualTo("Keyboard WASD"));
+        Assert.That(player2.controlScheme, Is.EqualTo("Keyboard Arrows"));
+        Assert.That(player1.actions["fire"].controls, Is.EquivalentTo(new[] { keyboard.leftCtrlKey }));
+        Assert.That(player2.actions["fire"].controls, Is.EquivalentTo(new[] { keyboard.rightCtrlKey }));
+
+        Press(keyboard.leftCtrlKey);
+
+        Assert.That(player1.GetComponent<MessageListener>().messages,
+            Is.EquivalentTo(new[] {new Message { name = "OnFire", value = 1f }}));
+        Assert.That(player2.GetComponent<MessageListener>().messages, Is.Empty);
+
+        Release(keyboard.leftCtrlKey);
+        player1.GetComponent<MessageListener>().messages.Clear();
+
+        Press(keyboard.rightCtrlKey);
+
+        Assert.That(player1.GetComponent<MessageListener>().messages, Is.Empty);
+        Assert.That(player2.GetComponent<MessageListener>().messages,
+            Is.EquivalentTo(new[] {new Message { name = "OnFire", value = 1f }}));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -11,20 +11,6 @@ using UnityEngine.InputSystem.Processors;
 using Object = UnityEngine.Object;
 using Gyroscope = UnityEngine.InputSystem.Gyroscope;
 
-//what if we want to join by button but NOT directly process the input? is the previous behavior actually better?
-//problem is that the control scheme switch may still trigger an initial state check on all actions
-//should there be a "sort-of-handled" kind of flag which puts the event on the device but does not trigger actions?
-
-//why is InputSystem.Update() triggering an initial state check on the "fire" button action?
-//should the unpaired device activity check in InputUser be moved to *before* state is incorporated into the device
-//   (the current setup doesn't seem to make it possible to immediately react to the state change via actions)
-
-//TODO:
-// - fix playerinput hotplugging
-// - add message for control scheme switches
-// - add message for device changes
-// - add ability to intercept playerinputmanager player instantiation
-
 /// <summary>
 /// Tests for <see cref="PlayerInput"/> and <see cref="PlayerInputManager"/>.
 /// </summary>

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,7 +10,12 @@ however, it has to be formatted properly to pass verification tests.
 ## [0.9.4-preview] - 2099-1-1
 
 ### Fixed
-### Actions
+
+#### Actions
+
+- `PlayerInput.Instantiate` now correctly sets up a given control scheme, if specified.
+  * When passing a `controlScheme:` argument, the result used to be a correctly assigned control scheme at the `InputUser` level but no restrictions being actually applied to the bindings, i.e. every single binding was active regardless of the specified control scheme.
+
 ### Changed
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -459,7 +459,7 @@ namespace UnityEngine.InputSystem.Users
             {
                 actions.devices = pairedDevices;
                 if (s_AllUserData[userIndex].controlScheme != null)
-                    ActivateControlScheme(s_AllUserData[userIndex].controlScheme.Value);
+                    ActivateControlSchemeInternal(userIndex, s_AllUserData[userIndex].controlScheme.Value);
             }
         }
 
@@ -498,34 +498,40 @@ namespace UnityEngine.InputSystem.Users
         public ControlSchemeChangeSyntax ActivateControlScheme(InputControlScheme scheme)
         {
             var userIndex = index; // Throws if user is invalid.
-            var isEmpty = scheme == default;
 
-            if (s_AllUserData[userIndex].controlScheme != scheme || (isEmpty && s_AllUserData[userIndex].controlScheme != null))
+            if (s_AllUserData[userIndex].controlScheme != scheme ||
+                (scheme == default && s_AllUserData[userIndex].controlScheme != null))
             {
-                if (isEmpty)
-                    s_AllUserData[userIndex].controlScheme = null;
-                else
-                    s_AllUserData[userIndex].controlScheme = scheme;
-
-                if (s_AllUserData[userIndex].actions != null)
-                {
-                    if (isEmpty)
-                    {
-                        s_AllUserData[userIndex].actions.bindingMask = null;
-                        s_AllUserData[userIndex].controlSchemeMatch.Dispose();
-                        s_AllUserData[userIndex].controlSchemeMatch = new InputControlScheme.MatchResult();
-                    }
-                    else
-                    {
-                        s_AllUserData[userIndex].actions.bindingMask = new InputBinding {groups = scheme.bindingGroup};
-                        UpdateControlSchemeMatch(userIndex);
-                    }
-                }
-
+                ActivateControlSchemeInternal(userIndex, scheme);
                 Notify(userIndex, InputUserChange.ControlSchemeChanged, null);
             }
 
             return new ControlSchemeChangeSyntax {m_UserIndex = userIndex};
+        }
+
+        private void ActivateControlSchemeInternal(int userIndex, InputControlScheme scheme)
+        {
+            var isEmpty = scheme == default;
+
+            if (isEmpty)
+                s_AllUserData[userIndex].controlScheme = null;
+            else
+                s_AllUserData[userIndex].controlScheme = scheme;
+
+            if (s_AllUserData[userIndex].actions != null)
+            {
+                if (isEmpty)
+                {
+                    s_AllUserData[userIndex].actions.bindingMask = null;
+                    s_AllUserData[userIndex].controlSchemeMatch.Dispose();
+                    s_AllUserData[userIndex].controlSchemeMatch = new InputControlScheme.MatchResult();
+                }
+                else
+                {
+                    s_AllUserData[userIndex].actions.bindingMask = new InputBinding {groups = scheme.bindingGroup};
+                    UpdateControlSchemeMatch(userIndex);
+                }
+            }
         }
 
         public void PauseHaptics()


### PR DESCRIPTION
User report: https://forum.unity.com/threads/playerinput-instantiate-ignores-controller-schemes-for-multiplayer-with-players-on-same-device.730868/

The following used to result in two players with both having all keyboard bindings from all control schemes active rather than one using "KeyboardWASD" only and the other using "KeyboardArrows" only. Was a problem in `InputUser` where the order in which actions were set on a user WRT when its control scheme was set ended up mattering when it shouldn't.

```
PlayerInput.Instantiate(player, controlScheme: "Keyboard WASD", pairWithDevice: Keyboard.current);
PlayerInput.Instantiate(player, controlScheme: "Keyboard Arrows", pairWithDevice: Keyboard.current);
```