### PR TITLE
NEW: Add 'Copy Device Description' to context menu in debugger.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,7 +12,11 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 ### Actions
 ### Changed
+
 ### Added
+
+- Can right-click devices in Input Debugger (also those under "Unsupported") and select "Copy Device Description" to copy the internal `InputDeviceDescription` of the device in JSON format to the system clipboard.
+  * This information is helpful for us to debug problems related to specific devices.
 
 ## [0.9.3-preview] - 2019-8-15
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -330,6 +330,7 @@ namespace UnityEngine.InputSystem.Editor
             public static GUIContent addDevicesNotSupportedByProjectContent = new GUIContent("Add Devices Not Listed in 'Supported Devices'");
             public static GUIContent diagnosticsModeContent = new GUIContent("Enable Event Diagnostics");
             public static GUIContent openDebugView = new GUIContent("Open Device Debug View");
+            public static GUIContent copyDeviceDescription = new GUIContent("Copy Device Description");
             public static GUIContent removeDevice = new GUIContent("Remove Device");
             public static GUIContent enableDevice = new GUIContent("Enable Device");
             public static GUIContent disableDevice = new GUIContent("Disable Device");
@@ -369,11 +370,21 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     var menu = new GenericMenu();
                     menu.AddItem(Contents.openDebugView, false, () => InputDeviceDebuggerWindow.CreateOrShowExisting(deviceItem.device));
+                    menu.AddItem(Contents.copyDeviceDescription, false,
+                        () => EditorGUIUtility.systemCopyBuffer = deviceItem.device.description.ToJson());
                     menu.AddItem(Contents.removeDevice, false, () => InputSystem.RemoveDevice(deviceItem.device));
                     if (deviceItem.device.enabled)
                         menu.AddItem(Contents.disableDevice, false, () => InputSystem.DisableDevice(deviceItem.device));
                     else
                         menu.AddItem(Contents.enableDevice, false, () => InputSystem.EnableDevice(deviceItem.device));
+                    menu.ShowAsContext();
+                }
+
+                if (item is UnsupportedDeviceItem unsupportedDeviceItem)
+                {
+                    var menu = new GenericMenu();
+                    menu.AddItem(Contents.copyDeviceDescription, false,
+                        () => EditorGUIUtility.systemCopyBuffer = unsupportedDeviceItem.description.ToJson());
                     menu.ShowAsContext();
                 }
             }
@@ -464,8 +475,18 @@ namespace UnityEngine.InputSystem.Editor
                     var parent = haveRemotes ? localDevicesNode : devicesItem;
                     var unsupportedDevicesNode = AddChild(parent, $"Unsupported ({m_UnsupportedDevices.Count})", ref id);
                     foreach (var device in m_UnsupportedDevices)
-                        AddChild(unsupportedDevicesNode, device.ToString(), ref id);
-                    unsupportedDevicesNode.children.Sort((a, b) => string.Compare(a.displayName, b.displayName));
+                    {
+                        var item = new UnsupportedDeviceItem
+                        {
+                            id = id++,
+                            depth = unsupportedDevicesNode.depth + 1,
+                            displayName = device.ToString(),
+                            description = device
+                        };
+                        unsupportedDevicesNode.AddChild(item);
+                    }
+                    unsupportedDevicesNode.children.Sort((a, b) =>
+                        string.Compare(a.displayName, b.displayName, StringComparison.InvariantCulture));
                 }
 
                 var disconnectedDevices = InputSystem.disconnectedDevices;
@@ -475,7 +496,8 @@ namespace UnityEngine.InputSystem.Editor
                     var disconnectedDevicesNode = AddChild(parent, $"Disconnected ({disconnectedDevices.Count})", ref id);
                     foreach (var device in disconnectedDevices)
                         AddChild(disconnectedDevicesNode, device.ToString(), ref id);
-                    disconnectedDevicesNode.children.Sort((a, b) => string.Compare(a.displayName, b.displayName));
+                    disconnectedDevicesNode.children.Sort((a, b) =>
+                        string.Compare(a.displayName, b.displayName, StringComparison.InvariantCulture));
                 }
 
                 // Layouts.
@@ -851,6 +873,11 @@ namespace UnityEngine.InputSystem.Editor
             private class DeviceItem : TreeViewItem
             {
                 public InputDevice device;
+            }
+
+            private class UnsupportedDeviceItem : TreeViewItem
+            {
+                public InputDeviceDescription description;
             }
 
             private class ConfigurationItem : TreeViewItem


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3418347/63350009-e5200800-c35c-11e9-931f-57419da817f2.png)

For debugging problems that users have with specific devices, it has proven an obstacle to not be able to easily obtain the full `InputDeviceDescription` (includes the entire HID descriptor) of a device. This PR adds a "Copy Device Description" command that copies the description to the system clipboard so the user can easily paste it anywhere.