### PR TITLE
FIX: Remove unnecessary package promotion tests

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -6,49 +6,6 @@ test_platforms:
     image: package-ci/win10:stable
     flavor: b1.large
 ---
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-promotion_test_{{ platform.name }}_{{ editor.version }}:
-  name : Promotion Test {{ editor.version }} on {{ platform.name }}
-  agent:
-    type: {{ platform.type }}
-    image: {{ platform.image }}
-    flavor: {{ platform.flavor}}
-  variables:
-    UPMCI_PROMOTION: 1
-  commands:
-    - mv ./Assets/Samples ./Packages/com.unity.inputsystem
-    - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
-    - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }}
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-{% endfor %}
-{% endfor %}
-
-promotion_test_trigger:
-  name: Promotion Tests Trigger
-  agent:
-    type: Unity::VM
-    image: package-ci/win10:stable
-    flavor: b1.large
-  artifacts:
-    logs:
-      paths:
-        - "upm-ci~/test-results/**/*"
-    packages:
-      paths:
-        - "upm-ci~/packages/**/*"
-  dependencies:
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-    - .yamato/promotion.yml#promotion_test_{{platform.name}}_{{editor.version}}
-{% endfor %}
-{% endfor %}
-
 promote:
   name: Promote to Production
   agent:
@@ -71,9 +28,3 @@ promote:
     artifacts:
       paths:
         - "upm-ci~/packages/*.tgz"
-  dependencies:
-{% for editor in test_editors %}
-{% for platform in test_platforms %}
-    - .yamato/promotion.yml#promotion_test_{{ platform.name }}_{{ editor.version }}
-{% endfor %}
-{% endfor %}


### PR DESCRIPTION
We could never auto publish to production due to tests that were running verified package tests on our preview package.  Removed this section so that we can auto publish.