### PR TITLE
FIX: Bindings not getting sync'd when renaming/deleting control schemes.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -2243,7 +2243,7 @@ partial class CoreTests
         map2.AddAction("action3", binding: "<Gamepad>/leftTrigger");
 
         asset.AddControlScheme("scheme1").WithBindingGroup("group1").WithRequiredDevice("<Gamepad>");
-        asset.AddControlScheme("scheme2").BasedOn("scheme1").WithBindingGroup("group2")
+        asset.AddControlScheme("scheme2").WithBindingGroup("group2")
             .WithOptionalDevice("<Keyboard>").WithRequiredDevice("<Mouse>").OrWithRequiredDevice("<Pen>");
 
         var json = asset.ToJson();
@@ -2279,8 +2279,6 @@ partial class CoreTests
         Assert.That(asset.controlSchemes[1].name, Is.EqualTo("scheme2"));
         Assert.That(asset.controlSchemes[0].bindingGroup, Is.EqualTo("group1"));
         Assert.That(asset.controlSchemes[1].bindingGroup, Is.EqualTo("group2"));
-        Assert.That(asset.controlSchemes[0].baseScheme, Is.Null);
-        Assert.That(asset.controlSchemes[1].baseScheme, Is.EqualTo("scheme1"));
         Assert.That(asset.controlSchemes[0].deviceRequirements, Has.Count.EqualTo(1));
         Assert.That(asset.controlSchemes[1].deviceRequirements, Has.Count.EqualTo(3));
         Assert.That(asset.controlSchemes[0].deviceRequirements[0].controlPath, Is.EqualTo("<Gamepad>"));

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,7 +10,12 @@ however, it has to be formatted properly to pass verification tests.
 ## [0.9.5-preview] - 2099-1-1
 
 ### Fixed
+
 #### Actions
+
+- When deleting a control scheme, bindings are now updated. A dialog is presented that allows choosing between deleting the bindings or just unassigning them from the control scheme.
+- When renaming a control scheme, bindings are now updated. Previously the old name was in place on bindings.
+- Control scheme names can no longer be set to empty strings.
 
 ### Changed
 
@@ -21,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - When switching devices/controls on actions, the system will no longer subsequently force an initial state check on __all__ actions. Instead, every time an action's bindings get re-resolved, the system will simply cancel all on-going actions and then re-enable them the same way it would happen by manually calling `InputAction.Enable`.
+- Removed non-functional `InputControlScheme.baseScheme` API and `basedOn` serialized property. This was never fully implemented.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -571,19 +571,6 @@ namespace UnityEngine.InputSystem
                 m_ControlScheme = controlScheme;
             }
 
-            public ControlSchemeSyntax BasedOn(string baseControlScheme)
-            {
-                if (string.IsNullOrEmpty(baseControlScheme))
-                    throw new ArgumentNullException(nameof(baseControlScheme));
-
-                if (m_Asset == null)
-                    m_ControlScheme.m_BaseSchemeName = baseControlScheme;
-                else
-                    m_Asset.m_ControlSchemes[m_ControlSchemeIndex].m_BaseSchemeName = baseControlScheme;
-
-                return this;
-            }
-
             public ControlSchemeSyntax WithBindingGroup(string bindingGroup)
             {
                 if (string.IsNullOrEmpty(bindingGroup))

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputControlScheme.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputControlScheme.cs
@@ -8,9 +8,6 @@ using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: allow associating control schemes with platforms, too?
 
-////REVIEW: move `baseScheme` entirely into JSON data only such that we resolve it during loading?
-////        (and thus support it only input assets only)
-
 namespace UnityEngine.InputSystem
 {
     /// <summary>
@@ -34,19 +31,6 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="InputActionAsset.AddControlScheme"/>
         public string name => m_Name;
-
-        ////REVIEW: is this actually functional? if not, kill
-        //problem: how do you do any subtractive operation? should we care?
-        //problem: this won't allow resolving things on just an InputControlScheme itself; needs context
-        /// <summary>
-        /// Name of control scheme that this scheme is based on.
-        /// </summary>
-        /// <remarks>
-        /// When the control scheme is enabled, all bindings from the base control
-        /// scheme will also be enabled. At the same time, bindings act as overrides on
-        /// bindings coming through from the base scheme.
-        /// </remarks>
-        public string baseScheme => m_BaseSchemeName;
 
         /// <summary>
         /// Binding group that is associated with the control scheme.
@@ -74,20 +58,26 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         public ReadOnlyArray<DeviceRequirement> deviceRequirements => new ReadOnlyArray<DeviceRequirement>(m_DeviceRequirements);
 
-        public InputControlScheme(string name, string basedOn = null, IEnumerable<DeviceRequirement> devices = null)
+        public InputControlScheme(string name, IEnumerable<DeviceRequirement> devices = null)
+            : this()
         {
-            m_Name = name;
-            m_BaseSchemeName = string.Empty;
-            m_BindingGroup = name; // Defaults to name.
-            m_BaseSchemeName = basedOn;
-            m_DeviceRequirements = null;
+            SetNameAndBindingGroup(name);
 
+            m_DeviceRequirements = null;
             if (devices != null)
             {
                 m_DeviceRequirements = devices.ToArray();
                 if (m_DeviceRequirements.Length == 0)
                     m_DeviceRequirements = null;
             }
+        }
+
+        internal void SetNameAndBindingGroup(string name)
+        {
+            m_Name = name;
+            bindingGroup = name.Contains(InputBinding.Separator)
+                ? name.Replace(InputBinding.kSeparatorString, "")
+                : name;
         }
 
         public static InputControlScheme? FindControlSchemeForDevice<TList>(InputDevice device, TList schemes)
@@ -288,7 +278,6 @@ namespace UnityEngine.InputSystem
         public bool Equals(InputControlScheme other)
         {
             if (!(string.Equals(m_Name, other.m_Name, StringComparison.InvariantCultureIgnoreCase) &&
-                  string.Equals(m_BaseSchemeName, other.m_BaseSchemeName, StringComparison.InvariantCultureIgnoreCase) &&
                   string.Equals(m_BindingGroup, other.m_BindingGroup, StringComparison.InvariantCultureIgnoreCase)))
                 return false;
 
@@ -332,7 +321,6 @@ namespace UnityEngine.InputSystem
             unchecked
             {
                 var hashCode = (m_Name != null ? m_Name.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (m_BaseSchemeName != null ? m_BaseSchemeName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (m_BindingGroup != null ? m_BindingGroup.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (m_DeviceRequirements != null ? m_DeviceRequirements.GetHashCode() : 0);
                 return hashCode;
@@ -376,7 +364,6 @@ namespace UnityEngine.InputSystem
         }
 
         [SerializeField] internal string m_Name;
-        [SerializeField] internal string m_BaseSchemeName;
         [SerializeField] internal string m_BindingGroup;
         [SerializeField] internal DeviceRequirement[] m_DeviceRequirements;
 
@@ -770,8 +757,6 @@ namespace UnityEngine.InputSystem
         internal struct SchemeJson
         {
             public string name;
-            ////TODO: nuke 'basedOn'
-            public string basedOn;
             public string bindingGroup;
             public DeviceJson[] devices;
 
@@ -817,7 +802,6 @@ namespace UnityEngine.InputSystem
                 return new InputControlScheme
                 {
                     m_Name = string.IsNullOrEmpty(name) ? null : name,
-                    m_BaseSchemeName = string.IsNullOrEmpty(basedOn) ? null : basedOn,
                     m_BindingGroup = string.IsNullOrEmpty(bindingGroup) ? null : bindingGroup,
                     m_DeviceRequirements = deviceRequirements,
                 };
@@ -837,7 +821,6 @@ namespace UnityEngine.InputSystem
                 return new SchemeJson
                 {
                     name = scheme.m_Name,
-                    basedOn = scheme.m_BaseSchemeName,
                     bindingGroup = scheme.m_BindingGroup,
                     devices = devices,
                 };

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -21,7 +21,7 @@ namespace UnityEngine.InputSystem.Editor
         public static FourCC k_GroupsChanged => new FourCC("GRPS");
         public static FourCC k_PathChanged => new FourCC("PATH");
         public static FourCC k_CompositeTypeChanged => new FourCC("COMP");
-        public static FourCC k_CompositePartAssignmentChanged = new FourCC("PART");
+        public static FourCC k_CompositePartAssignmentChanged => new FourCC("PART");
 
         public InputBindingPropertiesView(
             SerializedProperty bindingProperty,
@@ -36,7 +36,8 @@ namespace UnityEngine.InputSystem.Editor
             m_BindingProperty = bindingProperty;
             m_GroupsProperty = bindingProperty.FindPropertyRelative("m_Groups");
             m_PathProperty = bindingProperty.FindPropertyRelative("m_Path");
-            m_BindingGroups = m_GroupsProperty.stringValue.Split(InputBinding.Separator).ToList();
+            m_BindingGroups = m_GroupsProperty.stringValue
+                .Split(new[] {InputBinding.Separator}, StringSplitOptions.RemoveEmptyEntries).ToList();
             m_ExpectedControlLayout = expectedControlLayout;
             m_ControlSchemes = controlSchemes;
 
@@ -253,9 +254,6 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnBindingGroupsChanged()
         {
-            ////FIXME: changing the binding group of a GLOBAL binding when a control scheme is selected does not cause the binding to disappear from the control scheme immediately
-            ////       (same goes for the other way round)
-
             m_GroupsProperty.stringValue = string.Join(InputBinding.kSeparatorString, m_BindingGroups.ToArray());
             m_GroupsProperty.serializedObject.ApplyModifiedProperties();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -560,6 +560,67 @@ namespace UnityEngine.InputSystem.Editor
 
             return bindingProperty;
         }
+
+        public static void ReplaceBindingGroup(SerializedObject asset, string oldBindingGroup, string newBindingGroup, bool deleteOrphanedBindings = false)
+        {
+            var mapArrayProperty = asset.FindProperty("m_ActionMaps");
+            var mapCount = mapArrayProperty.arraySize;
+
+            for (var k = 0; k < mapCount; ++k)
+            {
+                var actionMapProperty = mapArrayProperty.GetArrayElementAtIndex(k);
+                var bindingsArrayProperty = actionMapProperty.FindPropertyRelative("m_Bindings");
+                var bindingsCount = bindingsArrayProperty.arraySize;
+
+                for (var i = 0; i < bindingsCount; ++i)
+                {
+                    var bindingProperty = bindingsArrayProperty.GetArrayElementAtIndex(i);
+                    var groupsProperty = bindingProperty.FindPropertyRelative("m_Groups");
+                    var groups = groupsProperty.stringValue;
+
+                    // Ignore bindings not belonging to any control scheme.
+                    if (string.IsNullOrEmpty(groups))
+                        continue;
+
+                    var groupsArray = groups.Split(InputBinding.Separator);
+                    var numGroups = groupsArray.LengthSafe();
+                    var didRename = false;
+                    for (var n = 0; n < numGroups; ++n)
+                    {
+                        if (string.Compare(groupsArray[n], oldBindingGroup, StringComparison.InvariantCultureIgnoreCase) != 0)
+                            continue;
+                        if (string.IsNullOrEmpty(newBindingGroup))
+                        {
+                            ArrayHelpers.EraseAt(ref groupsArray, n);
+                            --n;
+                            --numGroups;
+                        }
+                        else
+                            groupsArray[n] = newBindingGroup;
+                        didRename = true;
+                    }
+                    if (!didRename)
+                        continue;
+
+                    if (groupsArray != null)
+                        groupsProperty.stringValue = string.Join(InputBinding.kSeparatorString, groupsArray);
+                    else
+                    {
+                        if (deleteOrphanedBindings)
+                        {
+                            // Binding no long belongs to any binding group. Delete it.
+                            bindingsArrayProperty.DeleteArrayElementAtIndex(i);
+                            --i;
+                            --bindingsCount;
+                        }
+                        else
+                        {
+                            groupsProperty.stringValue = string.Empty;
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
@@ -141,7 +141,7 @@ namespace UnityEngine.InputSystem.Utilities
             return -1;
         }
 
-        public static int IndexOf<TValue>(TValue[] array, Predicate<TValue> predicate)
+        public static int IndexOf<TValue>(this TValue[] array, Predicate<TValue> predicate)
         {
             if (array == null)
                 return -1;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -231,15 +231,15 @@ namespace UnityEngine.InputSystem.Utilities
         public static int ReadIntFromMultipleBits(void* ptr, uint bitOffset, uint bitCount)
         {
             if (ptr == null)
-                throw new ArgumentNullException("ptr");
+                throw new ArgumentNullException(nameof(ptr));
             if (bitCount >= sizeof(int) * 8)
-                throw new ArgumentException("Trying to read more than 32 bits as int", "bitCount");
+                throw new ArgumentException("Trying to read more than 32 bits as int", nameof(bitCount));
 
-            //Shift the pointer up on larger bitmasks and retry
+            // Shift the pointer up on larger bitmasks and retry.
             if (bitOffset > 32)
             {
-                int newBitOffset = (int)bitOffset % 32;
-                int intOffset = ((int)bitOffset - newBitOffset) / 32;
+                var newBitOffset = (int)bitOffset % 32;
+                var intOffset = ((int)bitOffset - newBitOffset) / 32;
                 ptr = (byte*)ptr + (intOffset * 4);
                 bitOffset = (uint)newBitOffset;
             }
@@ -277,9 +277,9 @@ namespace UnityEngine.InputSystem.Utilities
         public static void WriteIntFromMultipleBits(void* ptr, uint bitOffset, uint bitCount, int value)
         {
             if (ptr == null)
-                throw new ArgumentNullException("ptr");
+                throw new ArgumentNullException(nameof(ptr));
             if (bitCount >= sizeof(int) * 8)
-                throw new ArgumentException("Trying to write more than 32 bits as int", "bitCount");
+                throw new ArgumentException("Trying to write more than 32 bits as int", nameof(bitCount));
 
             // Bits out of byte.
             if (bitOffset + bitCount <= 8)
@@ -317,13 +317,13 @@ namespace UnityEngine.InputSystem.Utilities
         public static void SetBitsInBuffer(void* buffer, int byteOffset, int bitOffset, int sizeInBits, bool value)
         {
             if (buffer == null)
-                throw new ArgumentException("A buffer must be provided to apply the bitmask on", "buffer");
+                throw new ArgumentException("A buffer must be provided to apply the bitmask on", nameof(buffer));
             if (sizeInBits < 0)
-                throw new ArgumentException("Negative sizeInBits", "sizeInBits");
+                throw new ArgumentException("Negative sizeInBits", nameof(sizeInBits));
             if (bitOffset < 0)
-                throw new ArgumentException("Negative bitOffset", "bitOffset");
+                throw new ArgumentException("Negative bitOffset", nameof(bitOffset));
             if (byteOffset < 0)
-                throw new ArgumentException("Negative byteOffset", "byteOffset");
+                throw new ArgumentException("Negative byteOffset", nameof(byteOffset));
 
             // If we're offset by more than a byte, adjust our pointers.
             if (bitOffset >= 8)


### PR DESCRIPTION
Deleting and renaming control schemes didn't update bindings so old binding groups were left lying around.

Also, the editor allowed you to add control schemes with empty names.

There's one more problem I didn't yet find a good solution for. ATM you can add bindings to control schemes that use devices not required by the control scheme. In most cases, that won't work correctly when used. We should probably check in `InputBindingPropertiesView` *both* when toggling the control scheme mask as well as when setting a binding whether there's a mismatch with the control scheme and if so, pop up a dialog to allow the user to choose a solution.

There's one unrelated change in here. I removed code for `basedOn` from `InputControlScheme` as the feature was never functional.