### PR TITLE
CHANGE: Make ToHumanReadableString() respect display names.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -996,11 +996,20 @@ partial class CoreTests
     public void Controls_CanTurnControlPathIntoHumanReadableText()
     {
         Assert.That(InputControlPath.ToHumanReadableString("*/{PrimaryAction}"), Is.EqualTo("PrimaryAction [Any]"));
-        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/leftStick"), Is.EqualTo("leftStick [Gamepad]"));
-        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/leftStick/x"), Is.EqualTo("leftStick/x [Gamepad]"));
+        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/leftStick"), Is.EqualTo("Left Stick [Gamepad]"));
+        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/leftStick/x"), Is.EqualTo("Left Stick/X [Gamepad]"));
         Assert.That(InputControlPath.ToHumanReadableString("<XRController>{LeftHand}/position"), Is.EqualTo("position [LeftHand XRController]"));
         Assert.That(InputControlPath.ToHumanReadableString("*/leftStick"), Is.EqualTo("leftStick [Any]"));
         Assert.That(InputControlPath.ToHumanReadableString("*/{PrimaryMotion}/x"), Is.EqualTo("PrimaryMotion/x [Any]"));
+        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/buttonSouth"), Is.EqualTo("Button South [Gamepad]"));
+        Assert.That(InputControlPath.ToHumanReadableString("<XInputController>/buttonSouth"), Is.EqualTo("A [Xbox Controller]"));
+
+        Assert.That(
+            InputControlPath.ToHumanReadableString("<Gamepad>/buttonSouth",
+                InputControlPath.HumanReadableStringOptions.OmitDevice), Is.EqualTo("Button South"));
+        Assert.That(
+            InputControlPath.ToHumanReadableString("*/{PrimaryAction}",
+                InputControlPath.HumanReadableStringOptions.OmitDevice), Is.EqualTo("PrimaryAction"));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,11 +15,16 @@ however, it has to be formatted properly to pass verification tests.
 
 #### Actions
 
+- Binding paths now show the same way in the action editor UI as they do in the control picker.
+  * For example, where before a binding to `<XInputController>/buttonSouth` was shown as `rightShoulder [XInputController]`, the same binding will now show as `A [Xbox Controller]`.
+
 ### Changed
 
 - `InputUser.onUnpairedDeviceUsed` now receives a 2nd argument which is the event that triggered the callback.
   * Also, the callback is now triggered __BEFORE__ the given event is processed rather than after the event has already been written to the device. This allows updating the pairing state of the system before input is processed.
   * In practice, this means that, for example, if the user switches from keyboard&mouse to gamepad, the initial input that triggered the switch will get picked up right away.
+- `InputControlPath.ToHumanReadableString` now takes display names from registered `InputControlLayout` instances into account.
+  * This means that the method can now be used to generate strings to display in rebinding UIs.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -147,7 +147,7 @@ namespace UnityEngine.InputSystem
         ///
         /// The method uses display names (see <see cref="InputControlAttribute.displayName"/>,
         /// <see cref="InputControlLayoutAttribute.displayName"/>, and <see cref="InputControlLayout.ControlItem.displayName"/>)
-        /// where possible. For example, if a "&lt;XInputController&gt;/buttonSouth" will be returned as
+        /// where possible. For example, "&lt;XInputController&gt;/buttonSouth" will be returned as
         /// "A [Xbox Controller]" as the display name of <see cref="XInput.XInputController"/> is "XBox Controller"
         /// and the display name of its "buttonSouth" control is "A".
         ///
@@ -1059,7 +1059,7 @@ namespace UnityEngine.InputSystem
                 if (!name.isEmpty && !isWildcard)
                 {
                     // If we have a layout from a preceding path component, try to find
-                    // the control by name on the layout. If we find it, use it's display
+                    // the control by name on the layout. If we find it, use its display
                     // name rather than the name referenced in the binding.
                     string nameString = null;
                     if (!string.IsNullOrEmpty(parentLayoutName))
@@ -1076,7 +1076,7 @@ namespace UnityEngine.InputSystem
                                 if (!string.IsNullOrEmpty(control.Value.displayName))
                                     nameString = control.Value.displayName;
 
-                                // If we don't have an explicit <layout> part in the component, take
+                                // If we don't have an explicit <layout> part in the component,
                                 // remember the name of the layout referenced by the control name so
                                 // that path components further down the line can keep looking up their
                                 // display names.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -114,11 +114,59 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
+        /// Options for customizing the behavior of <see cref="ToHumanReadableString"/>.
+        /// </summary>
+        [Flags]
+        public enum HumanReadableStringOptions
+        {
+            /// <summary>
+            /// The default behavior.
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// Do not mention the device of the control. For example, instead of "A [Gamepad]",
+            /// return just "A".
+            /// </summary>
+            OmitDevice = 1 << 1,
+        }
+
+        ////TODO: factor out the part that looks up an InputControlLayout.ControlItem from a given path
+        ////      and make that available as a stand-alone API
+        ////TODO: add option to customize path separation character
+        /// <summary>
         /// Create a human readable string from the given control path.
         /// </summary>
         /// <param name="path">A control path such as "&lt;XRController>{LeftHand}/position".</param>
-        /// <returns>A string such as "leftStick/x [Gamepad]".</returns>
-        public static string ToHumanReadableString(string path)
+        /// <param name="options">Customize the resulting string.</param>
+        /// <returns>A string such as "Left Stick/X [Gamepad]".</returns>
+        /// <remarks>
+        /// This function is most useful for turning binding paths (see <see cref="InputBinding.path"/>)
+        /// into strings that can be displayed in UIs (such as rebinding screens). It is used by
+        /// the Unity editor itself to display binding paths in the UI.
+        ///
+        /// The method uses display names (see <see cref="InputControlAttribute.displayName"/>,
+        /// <see cref="InputControlLayoutAttribute.displayName"/>, and <see cref="InputControlLayout.ControlItem.displayName"/>)
+        /// where possible. For example, if a "&lt;XInputController&gt;/buttonSouth" will be returned as
+        /// "A [Xbox Controller]" as the display name of <see cref="XInput.XInputController"/> is "XBox Controller"
+        /// and the display name of its "buttonSouth" control is "A".
+        ///
+        /// Note that these lookups depend on the currently registered control layouts (see <see
+        /// cref="InputControlLayout"/>) and different strings may thus be returned for the same control
+        /// path depending on the layouts registered with the system.
+        ///
+        /// <example>
+        /// <code>
+        /// InputControlPath.ToHumanReadableString("*/{PrimaryAction"); // -> "PrimaryAction [Any]"
+        /// InputControlPath.ToHumanReadableString("&lt;Gamepad&gt;/buttonSouth"); // -> "Button South [Gamepad]"
+        /// InputControlPath.ToHumanReadableString("&lt;XInputController&gt;/buttonSouth"); // -> "A [Xbox Controller]"
+        /// InputControlPath.ToHumanReadableString("&lt;Gamepad&gt;/leftStick/x"); // -> "Left Stick/X [Gamepad]"
+        /// </code>
+        /// </example>
+        /// </remarks>
+        /// <seealso cref="InputBinding.path"/>
+        public static string ToHumanReadableString(string path,
+            HumanReadableStringOptions options = HumanReadableStringOptions.None)
         {
             if (string.IsNullOrEmpty(path))
                 return string.Empty;
@@ -126,38 +174,45 @@ namespace UnityEngine.InputSystem
             var buffer = new StringBuilder();
             var parser = new PathParser(path);
 
-            ////REVIEW: ideally, we'd use display names of controls rather than the control paths directly from the path
-
-            // First level is taken to be device.
-            if (parser.MoveToNextComponent())
+            // For display names of controls and devices, we need to look at InputControlLayouts.
+            // If none is in place here, we establish a temporary layout cache while we go through
+            // the path. If one is in place already, we reuse what's already there.
+            using (InputControlLayout.CacheRef())
             {
-                var device = parser.current.ToHumanReadableString();
-
-                // Any additional levels (if present) are taken to form a control path on the device.
-                var isFirstControlLevel = true;
-                while (parser.MoveToNextComponent())
+                // First level is taken to be device.
+                if (parser.MoveToNextComponent())
                 {
-                    if (!isFirstControlLevel)
-                        buffer.Append('/');
+                    // Keep track of which control layout we're on (if any) as we're crawling
+                    // down the path.
+                    var device = parser.current.ToHumanReadableString(null, out var currentLayoutName);
 
-                    buffer.Append(parser.current.ToHumanReadableString());
-                    isFirstControlLevel = false;
+                    // Any additional levels (if present) are taken to form a control path on the device.
+                    var isFirstControlLevel = true;
+                    while (parser.MoveToNextComponent())
+                    {
+                        if (!isFirstControlLevel)
+                            buffer.Append('/');
+
+                        buffer.Append(parser.current.ToHumanReadableString(
+                            currentLayoutName, out currentLayoutName));
+                        isFirstControlLevel = false;
+                    }
+
+                    if ((options & HumanReadableStringOptions.OmitDevice) == 0 && !string.IsNullOrEmpty(device))
+                    {
+                        buffer.Append(" [");
+                        buffer.Append(device);
+                        buffer.Append(']');
+                    }
                 }
 
-                if (!string.IsNullOrEmpty(device))
-                {
-                    buffer.Append(" [");
-                    buffer.Append(device);
-                    buffer.Append(']');
-                }
+                // If we didn't manage to figure out a display name, default to displaying
+                // the path as is.
+                if (buffer.Length == 0)
+                    return path;
+
+                return buffer.ToString();
             }
-
-            // If we didn't manage to figure out a display name, default to displaying
-            // the path as is.
-            if (buffer.Length == 0)
-                return path;
-
-            return buffer.ToString();
         }
 
         public static string[] TryGetDeviceUsages(string path)
@@ -171,7 +226,7 @@ namespace UnityEngine.InputSystem
 
             if (parser.current.usages != null && parser.current.usages.Length > 0)
             {
-                return Array.ConvertAll<Substring, string>(parser.current.usages, i => { return i.ToString(); });
+                return Array.ConvertAll(parser.current.usages, i => { return i.ToString(); });
             }
 
             return null;
@@ -219,11 +274,6 @@ namespace UnityEngine.InputSystem
         ////TODO: return Substring and use path parser; should get rid of allocations
 
         // From the given control path, try to determine the control layout being used.
-        //
-        // NOTE: This function will only use information available in the path itself or
-        //       in layouts referenced by the path. It will not look at actual devices
-        //       in the system. This is to make the behavior predictable and not dependent
-        //       on whether you currently have the right device connected or not.
         // NOTE: Allocates!
         public static string TryGetControlLayout(string path)
         {
@@ -956,8 +1006,10 @@ namespace UnityEngine.InputSystem
             public bool isWildcard => name == Wildcard;
             public bool isDoubleWildcard => name == DoubleWildcard;
 
-            public string ToHumanReadableString()
+            public string ToHumanReadableString(string parentLayoutName, out string referencedLayoutName)
             {
+                referencedLayoutName = null;
+
                 var result = string.Empty;
                 if (isWildcard)
                     result += "Any";
@@ -987,18 +1039,60 @@ namespace UnityEngine.InputSystem
 
                 if (!layout.isEmpty)
                 {
-                    if (!string.IsNullOrEmpty(result))
-                        result += ' ' + ToHumanReadableString(layout);
+                    referencedLayoutName = layout.ToString();
+
+                    // Where possible, use the displayName of the given layout rather than
+                    // just the internal layout name.
+                    string layoutString;
+                    var referencedLayout = InputControlLayout.cache.FindOrLoadLayout(referencedLayoutName);
+                    if (referencedLayout != null && !string.IsNullOrEmpty(referencedLayout.m_DisplayName))
+                        layoutString = referencedLayout.m_DisplayName;
                     else
-                        result += ToHumanReadableString(layout);
+                        layoutString = ToHumanReadableString(layout);
+
+                    if (!string.IsNullOrEmpty(result))
+                        result += ' ' + layoutString;
+                    else
+                        result += layoutString;
                 }
 
                 if (!name.isEmpty && !isWildcard)
                 {
+                    // If we have a layout from a preceding path component, try to find
+                    // the control by name on the layout. If we find it, use it's display
+                    // name rather than the name referenced in the binding.
+                    string nameString = null;
+                    if (!string.IsNullOrEmpty(parentLayoutName))
+                    {
+                        // NOTE: This produces a fully merged layout. We should thus pick up display names
+                        //       from base layouts automatically wherever applicable.
+                        var parentLayout = InputControlLayout.cache.FindOrLoadLayout(new InternedString(parentLayoutName));
+                        if (parentLayout != null)
+                        {
+                            var controlName = new InternedString(name.ToString());
+                            var control = parentLayout.FindControl(controlName);
+                            if (control != null)
+                            {
+                                if (!string.IsNullOrEmpty(control.Value.displayName))
+                                    nameString = control.Value.displayName;
+
+                                // If we don't have an explicit <layout> part in the component, take
+                                // remember the name of the layout referenced by the control name so
+                                // that path components further down the line can keep looking up their
+                                // display names.
+                                if (string.IsNullOrEmpty(referencedLayoutName))
+                                    referencedLayoutName = control.Value.layout;
+                            }
+                        }
+                    }
+
+                    if (nameString == null)
+                        nameString = ToHumanReadableString(name);
+
                     if (!string.IsNullOrEmpty(result))
-                        result += ' ' + ToHumanReadableString(name);
+                        result += ' ' + nameString;
                     else
-                        result += ToHumanReadableString(name);
+                        result += nameString;
                 }
 
                 if (!displayName.isEmpty)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
@@ -10,6 +10,7 @@ namespace UnityEngine.InputSystem.Editor
         protected string m_ControlPath;
         protected string m_Device;
         protected string m_Usage;
+        protected bool m_Searchable;
 
         public string controlPath => m_ControlPath;
 
@@ -26,7 +27,23 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
-        public override string searchableName => m_SearchableName ?? string.Empty;
+        public override string searchableName
+        {
+            get
+            {
+                // ToHumanReadableString is expensive, especially given that we build the whole tree
+                // every time the control picker comes up. Build searchable names only on demand
+                // to save some time.
+                if (m_SearchableName == null)
+                {
+                    if (m_Searchable)
+                        m_SearchableName = InputControlPath.ToHumanReadableString(controlPathWithDevice);
+                    else
+                        m_SearchableName = string.Empty;
+                }
+                return m_SearchableName;
+            }
+        }
 
         protected InputControlDropdownItem(string name)
             : base(name) {}
@@ -54,7 +71,7 @@ namespace UnityEngine.InputSystem.Editor
             m_Device = "*";
             m_ControlPath = usage;
             id = controlPathWithDevice.GetHashCode();
-            m_SearchableName = InputControlPath.ToHumanReadableString(controlPathWithDevice);
+            m_Searchable = true;
         }
     }
 
@@ -68,8 +85,7 @@ namespace UnityEngine.InputSystem.Editor
             if (usage != null)
                 name += " (" + usage + ")";
             id = name.GetHashCode();
-            if (searchable)
-                m_SearchableName = InputControlPath.ToHumanReadableString(controlPathWithDevice);
+            m_Searchable = searchable;
         }
     }
 
@@ -80,6 +96,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             m_Device = device;
             m_Usage = usage;
+            m_Searchable = searchable;
 
             if (parent != null)
                 m_ControlPath = $"{parent.controlPath}/{controlName}";
@@ -90,9 +107,6 @@ namespace UnityEngine.InputSystem.Editor
 
             id = controlPathWithDevice.GetHashCode();
             indent = parent?.indent + 1 ?? 0;
-
-            if (searchable)
-                m_SearchableName = InputControlPath.ToHumanReadableString(controlPathWithDevice);
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
@@ -29,7 +29,7 @@ namespace UnityEngine.InputSystem.Editor
             get
             {
                 Refresh();
-                return s_Cache.table.Values;
+                return InputControlLayout.cache.table.Values;
             }
         }
 
@@ -51,7 +51,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Refresh();
                 foreach (var name in s_ControlLayouts)
-                    yield return s_Cache.FindOrLoadLayout(name.ToString());
+                    yield return InputControlLayout.cache.FindOrLoadLayout(name.ToString());
             }
         }
 
@@ -61,7 +61,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Refresh();
                 foreach (var name in s_DeviceLayouts)
-                    yield return s_Cache.FindOrLoadLayout(name.ToString());
+                    yield return InputControlLayout.cache.FindOrLoadLayout(name.ToString());
             }
         }
 
@@ -71,22 +71,8 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Refresh();
                 foreach (var name in s_ProductLayouts)
-                    yield return s_Cache.FindOrLoadLayout(name.ToString());
+                    yield return InputControlLayout.cache.FindOrLoadLayout(name.ToString());
             }
-        }
-
-        /// <summary>
-        /// Event that is triggered whenever the layout setup in the system changes.
-        /// </summary>
-        public static event Action onRefresh
-        {
-            add
-            {
-                if (s_RefreshListeners == null)
-                    s_RefreshListeners = new List<Action>();
-                s_RefreshListeners.Add(value);
-            }
-            remove => s_RefreshListeners?.Remove(value);
         }
 
         public static InputControlLayout TryGetLayout(string layoutName)
@@ -95,7 +81,7 @@ namespace UnityEngine.InputSystem.Editor
                 throw new ArgumentException("Layout name cannot be null or empty", nameof(layoutName));
 
             Refresh();
-            return s_Cache.FindOrLoadLayout(layoutName);
+            return InputControlLayout.cache.FindOrLoadLayout(layoutName);
         }
 
         public static Type GetValueType(string layoutName)
@@ -205,7 +191,7 @@ namespace UnityEngine.InputSystem.Editor
         internal static void Clear()
         {
             s_LayoutRegistrationVersion = 0;
-            s_Cache.table?.Clear();
+            s_LayoutCacheRef.Dispose();
             s_Usages.Clear();
             s_ControlLayouts.Clear();
             s_DeviceLayouts.Clear();
@@ -223,6 +209,15 @@ namespace UnityEngine.InputSystem.Editor
 
             Clear();
 
+            if (!s_LayoutCacheRef.valid)
+            {
+                // In the editor, we keep a permanent reference on the global layout
+                // cache. Means that in th editor, we always have all layouts loaded in full
+                // at all times whereas in the player, we load layouts only while we need
+                // them and then release them again.
+                s_LayoutCacheRef = InputControlLayout.CacheRef();
+            }
+
             var layoutNames = new List<string>();
             manager.ListControlLayouts(layoutNames);
 
@@ -239,7 +234,7 @@ namespace UnityEngine.InputSystem.Editor
             // Load and store all layouts.
             foreach (var layoutName in layoutNames)
             {
-                var layout = s_Cache.FindOrLoadLayout(layoutName);
+                var layout = InputControlLayout.cache.FindOrLoadLayout(layoutName);
                 ScanLayout(layout);
 
                 if (layout.isControlLayout)
@@ -254,7 +249,7 @@ namespace UnityEngine.InputSystem.Editor
             // a layout that has one over to the product list.
             foreach (var name in s_DeviceLayouts)
             {
-                var layout = s_Cache.FindOrLoadLayout(name);
+                var layout = InputControlLayout.cache.FindOrLoadLayout(name);
 
                 if (layout.m_BaseLayouts.length > 1)
                     throw new NotImplementedException();
@@ -268,7 +263,7 @@ namespace UnityEngine.InputSystem.Editor
                         break;
                     }
 
-                    var baseLayout = s_Cache.FindOrLoadLayout(baseLayoutName);
+                    var baseLayout = InputControlLayout.cache.FindOrLoadLayout(baseLayoutName);
                     if (baseLayout.m_BaseLayouts.length > 1)
                         throw new NotImplementedException();
                     baseLayoutName = baseLayout.baseLayouts.FirstOrDefault();
@@ -279,15 +274,10 @@ namespace UnityEngine.InputSystem.Editor
             s_DeviceLayouts.ExceptWith(s_ProductLayouts);
 
             s_LayoutRegistrationVersion = manager.m_LayoutRegistrationVersion;
-
-            if (s_RefreshListeners != null)
-                foreach (var listener in s_RefreshListeners)
-                    listener();
         }
 
         private static int s_LayoutRegistrationVersion;
-        private static InputControlLayout.Cache s_Cache;
-        private static List<Action> s_RefreshListeners;
+        private static InputControlLayout.CacheRefInstance s_LayoutCacheRef;
 
         private static readonly HashSet<InternedString> s_ControlLayouts = new HashSet<InternedString>();
         private static readonly HashSet<InternedString> s_DeviceLayouts = new HashSet<InternedString>();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
@@ -212,7 +212,7 @@ namespace UnityEngine.InputSystem.Editor
             if (!s_LayoutCacheRef.valid)
             {
                 // In the editor, we keep a permanent reference on the global layout
-                // cache. Means that in th editor, we always have all layouts loaded in full
+                // cache. Means that in the editor, we always have all layouts loaded in full
                 // at all times whereas in the player, we load layouts only while we need
                 // them and then release them again.
                 s_LayoutCacheRef = InputControlLayout.CacheRef();

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -429,6 +429,11 @@ namespace UnityEngine.InputSystem
         {
             ++m_LayoutRegistrationVersion;
 
+            // Force-clear layout cache. Don't clear reference count so that
+            // the cache gets cleared out properly when released in case someone
+            // is using it ATM.
+            InputControlLayout.s_CacheInstance = default;
+
             // For layouts that aren't overrides, add the name of the base
             // layout to the lookup table.
             if (!isOverride && baseLayouts.length > 0)
@@ -1589,6 +1594,10 @@ namespace UnityEngine.InputSystem
                 InputInteraction.s_Interactions = new TypeTable();
             if (ReferenceEquals(InputBindingComposite.s_Composites.table, m_Composites.table))
                 InputBindingComposite.s_Composites = new TypeTable();
+
+            // Clear layout cache.
+            InputControlLayout.s_CacheInstance = default;
+            InputControlLayout.s_CacheInstanceRef = 0;
 
             // Detach from runtime.
             if (m_Runtime != null)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputController.cs
@@ -20,6 +20,17 @@ namespace UnityEngine.InputSystem.XInput
     [InputControlLayout(displayName = "Xbox Controller")]
     public class XInputController : Gamepad
     {
+        // Change the display names for the buttons to conform to Xbox conventions.
+        [InputControl(name = "buttonSouth", displayName = "A")]
+        [InputControl(name = "buttonEast", displayName = "B")]
+        [InputControl(name = "buttonWest", displayName = "X")]
+        [InputControl(name = "buttonNorth", displayName = "Y")]
+        [InputControl(name = "leftShoulder", displayName = "Left Bumper")]
+        [InputControl(name = "rightShoulder", displayName = "Right Bumper")]
+        // This follows Xbox One conventions; on Xbox 360, this is start=start and select=back.
+        [InputControl(name = "start", displayName = "Menu")]
+        [InputControl(name = "select", displayName = "View")]
+
         public ButtonControl menu { get; private set; }
         public ButtonControl view { get; private set; }
 


### PR DESCRIPTION
This PR attempts to solve two issues in one change.

1. The first is that the "Path" property on bindings in the UI displays differently than the paths selected in the control picker, which has been confusing for people. The picker was switched over to using display names at some point but doing the same for the path display was left as a `TODO`.
2. The second is that users want to themselves display paths to the player in their rebinding UIs. With the current APIs that left them with either using `InputControlPath.ToHumanReadableString` which was *NOT* using display names and thus produced ugly strings or implementing their own conversion routines which required a good deal of understanding of how paths and the layout system works.

What this PR changes is that `InputControlPath.ToHumanReadableString` now actually goes to the InputControlLayout database to translate, where possible, path components from internal names to external display names. So, where `<XInputController>/buttonSouth` used to come out as `buttonSouth [XInputController]`, it now comes out as `A [Xbox Controller]`.

Also, I've added an option to omit the device so you can translate `<XInputController>/buttonSouth` to just "A", for example.

As part of this, I've changed the system to no longer just use local InputControlLayout caches. Constructing layouts is expensive and should not be done over and over. Instead, there is now *one* global cache which is always initialized in the editor (if input system UIs are used) and initialized for certain code regions in the player and then released.

Note that `ToHumanReadableString` is now much more costly than before. Initially, this made the control picker come up noticeably slower than before (my timings showed something like 50-60ms on average before and 90-100ms on average after my change) as it was called for *every* possible control in the system. However, since in the picker `ToHumanReadableString` is only used for searchable names, I mitigated this by making searchable names be constructed lazily. Which now actually makes the picker come up *faster* than before the change and the initial hit when starting the search has proven to not be too bad (basically we're moving around 30-40ms of work to when you start the first search).

![image](https://user-images.githubusercontent.com/3418347/63583750-e3905300-c59b-11e9-974d-d9e16babf4ab.png)

![image](https://user-images.githubusercontent.com/3418347/63583755-e68b4380-c59b-11e9-9b6b-fae745cb59d5.png)
