### PR TITLE
FIX: Fixed control scheme popup window in input action asset editor w…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Exceptions in scenes of `Visualizers` sample if respective device was not present on system (e.g. in `PenVisualizer` if no pen was present in system).
+- Fixed control scheme popup window in input action asset editor window showing in the correct screen position on windows.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
@@ -49,7 +49,13 @@ namespace UnityEngine.InputSystem.Editor
 
             if (GUI.Button(buttonRect, buttonGUI, EditorStyles.toolbarPopup))
             {
-                buttonRect = new Rect(EditorGUIUtility.GUIToScreenPoint(new Vector2(buttonRect.x, buttonRect.y)), Vector2.zero);
+                // PopupWindow.Show already takes the current OnGUI EditorWindow context into account for window coordinates.
+                // However, on macOS, menu commands are performed asynchronously, so we don't have a current OnGUI context.
+                // So in that case, we need to translate the rect to screen coordinates. Don't do that on windows, as we will
+                // overcompensate otherwise.
+                if (Application.platform == RuntimePlatform.OSXEditor)
+                    buttonRect = new Rect(EditorGUIUtility.GUIToScreenPoint(new Vector2(buttonRect.x, buttonRect.y)), Vector2.zero);
+
                 var menu = new GenericMenu();
 
                 // Add entries to select control scheme, if we have some.


### PR DESCRIPTION
…indow showing in the correct screen position on windows.

Fixes https://fogbugz.unity3d.com/f/cases/1165490/