### PR TITLE
Fix exceptions being thrown in input tester scene when old input is d…

### DIFF
--- a/Assets/Samples/InputDeviceTester/Scripts/EventsystemPicker.cs
+++ b/Assets/Samples/InputDeviceTester/Scripts/EventsystemPicker.cs
@@ -17,6 +17,9 @@ public class EventsystemPicker : MonoBehaviour
     void Start()
     {
         m_toggles = GetComponent<ToggleGroup>().ActiveToggles();
+        m_oldSystem.enabled = false;
+        m_newSystem.enabled = true;
+
         foreach (Toggle toggle in m_toggles)
         {
             toggle.onValueChanged.AddListener(delegate {

--- a/Assets/Samples/InputDeviceTester/Scripts/Input/ControllerDiagramOldInput.cs
+++ b/Assets/Samples/InputDeviceTester/Scripts/Input/ControllerDiagramOldInput.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public class ControllerDiagramOldInput : GamepadOldInput
 {
+#if ENABLE_LEGACY_INPUT_MANAGER
     // Update is called once per frame
     void Update()
     {
@@ -57,4 +58,6 @@ public class ControllerDiagramOldInput : GamepadOldInput
         color.a = 1f;
         return color;
     }
+
+#endif
 }

--- a/Assets/Samples/InputDeviceTester/Scripts/Input/DualShockOldInput.cs
+++ b/Assets/Samples/InputDeviceTester/Scripts/Input/DualShockOldInput.cs
@@ -18,6 +18,7 @@ public class DualShockOldInput : GamepadOldInput
     private List<DualShockTrigger> m_dualShockTriggers = new List<DualShockTrigger>();
     private readonly Color m_stickButtonColor = new Color(0.4f, 0.4f, 0.55f, 1f);    // The default color for Stick when it is NOT pressed.
 
+#if ENABLE_LEGACY_INPUT_MANAGER
     // Start is called before the first frame update
     void Start()
     {
@@ -145,6 +146,8 @@ public class DualShockOldInput : GamepadOldInput
             }
         }
     }
+
+#endif
 }
 
 // This is for DualShock controller triggers on Windows and OSX

--- a/Assets/Samples/InputDeviceTester/Scripts/Input/GamepadOldInput.cs
+++ b/Assets/Samples/InputDeviceTester/Scripts/Input/GamepadOldInput.cs
@@ -25,6 +25,7 @@ public class GamepadOldInput : MonoBehaviour
     protected List<AnalogStick> analog_sticks = new List<AnalogStick>();
     protected List<AnalogButton> analog_buttons = new List<AnalogButton>();
 
+#if ENABLE_LEGACY_INPUT_MANAGER
     protected void UpdateAllButtons()
     {
         foreach (KeyCode kcode in Enum.GetValues(typeof(KeyCode)))
@@ -141,6 +142,8 @@ public class GamepadOldInput : MonoBehaviour
     {
         m_MessageWindow.text += "<color=blue>" + msg + "</color>\n";
     }
+
+#endif
 }
 
 [Serializable]

--- a/Assets/Samples/InputDeviceTester/Scripts/Input/KeyboardMouseOldInput.cs
+++ b/Assets/Samples/InputDeviceTester/Scripts/Input/KeyboardMouseOldInput.cs
@@ -14,6 +14,7 @@ public class KeyboardMouseOldInput : MonoBehaviour
     public Text m_keyboardInfoText;
     public Text m_mouseInfoText;
 
+#if ENABLE_LEGACY_INPUT_MANAGER
     void Update()
     {
         // Keyboard input or mouse button is pressed
@@ -150,4 +151,6 @@ public class KeyboardMouseOldInput : MonoBehaviour
     {
         m_MessageWindow.text += "<color=blue>" + msg + "</color>\n";
     }
+
+#endif
 }

--- a/Assets/Samples/InputDeviceTester/Scripts/Input/XboxOldInput.cs
+++ b/Assets/Samples/InputDeviceTester/Scripts/Input/XboxOldInput.cs
@@ -18,6 +18,7 @@ public class XboxOldInput : GamepadOldInput
     private List<XboxTrigger> xbox_triggers = new List<XboxTrigger>();
     private readonly Color m_stickButtonColor = new Color(0.4f, 0.4f, 0.55f, 1f);    // The default color for Stick when it is NOT pressed.
 
+#if ENABLE_LEGACY_INPUT_MANAGER
     // Use this for initialization
     void Start()
     {
@@ -143,6 +144,8 @@ public class XboxOldInput : GamepadOldInput
             }
         }
     }
+
+#endif
 }
 
 // This is for xbox controller triggers on MacOS ONLY


### PR DESCRIPTION
…isabled

Currently, the InputDeviceTester sample will throw exceptions in 19.3 and higher when you only have the new input system enabled, as it also shows the input from the old system for comparison. This PR fixes that by using the new ENABLE_LEGACY_INPUT_MANAGER define.

(This will make old input visualization not work in 19.1, because I'm not backporting the define all the way there. I think that's ok).