### PR TITLE
FIX: InputAction.bindings not getting refreshed after ApplyBindingOverride (#829).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -2115,7 +2115,7 @@ partial class CoreTests
         map.AddAction(name: "action1", expectedControlLayout: "Button", binding: "/gamepad/leftStick")
             .AddBinding("/gamepad/rightStick")
             .WithGroup("group")
-            .WithProcessor("deadzone");
+            .WithProcessor("stickDeadzone");
         map.AddAction(name: "action2", binding: "/gamepad/buttonSouth", interactions: "tap,slowTap(duration=0.1)");
 
         var json = map.ToJson();
@@ -2136,7 +2136,7 @@ partial class CoreTests
         Assert.That(maps[0].actions[0].bindings[0].groups, Is.Null);
         Assert.That(maps[0].actions[0].bindings[1].groups, Is.EqualTo("group"));
         Assert.That(maps[0].actions[0].bindings[0].processors, Is.Null);
-        Assert.That(maps[0].actions[0].bindings[1].processors, Is.EqualTo("deadzone"));
+        Assert.That(maps[0].actions[0].bindings[1].processors, Is.EqualTo("stickDeadzone"));
         Assert.That(maps[0].actions[0].bindings[0].interactions, Is.Null);
         Assert.That(maps[0].actions[0].bindings[1].interactions, Is.Null);
         Assert.That(maps[0].actions[1].bindings[0].groups, Is.Null);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Setting timeouts from `IInputInteraction.Process` not working as expected when processing happened in response to previous timeout expiring (#714).
 - Pending timeouts on a device not being removed when device was removed.
+- Applying binding overrides (interactively or through `ApplyBindingOverride`) will now correctly flush cached data on `InputAction.bindings`.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -244,6 +244,10 @@ namespace UnityEngine.InputSystem
         ////TODO: add support for turning binding array into displayable info
         ////      (allow to constrain by sets of devices set on action set)
 
+        ////FIXME: ATM accessing this property causes bindings to be resolved. This should not
+        ////       happen. The problem is that in InputActionMap.SetUpPerActionCachedBindingData
+        ////       we set up *both* the control and the binding array. This means that the code
+        ////       requires the list of controls to be up-to-date.
         /// <summary>
         /// The list of bindings associated with the action.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -262,15 +262,7 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// May allocate memory each time the control setup changes on the action.
         /// </remarks>
-        public ReadOnlyArray<InputControl> controls
-        {
-            get
-            {
-                var map = GetOrCreateActionMap();
-                map.ResolveBindingsIfNecessary();
-                return map.GetControlsForSingleAction(this);
-            }
-        }
+        public ReadOnlyArray<InputControl> controls => GetOrCreateActionMap().GetControlsForSingleAction(this);
 
         /// <summary>
         /// The current phase of the action.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -532,6 +532,9 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         private unsafe void SetUpPerActionCachedBindingData()
         {
+            // Make sure our binding resolution data is up to date.
+            ResolveBindingsIfNecessary();
+
             // Handle case where we don't have any bindings.
             if (m_Bindings == null)
                 return;
@@ -726,6 +729,10 @@ namespace UnityEngine.InputSystem
             // enable actions.
             if (m_EnabledActionsCount == 0)
             {
+                // Make sure that if actions query their bindings or controls, we
+                // force a call to ResolveBindings().
+                ClearPerActionCachedBindingData();
+
                 m_NeedToResolveBindings = true;
                 return false;
             }
@@ -863,9 +870,6 @@ namespace UnityEngine.InputSystem
                 {
                     var map = actionMaps[i];
                     map.m_NeedToResolveBindings = false;
-
-                    ////TODO: determine whether we really need to wipe this; keep them if nothing has changed
-                    map.m_ControlsForEachAction = null;
 
                     if (map.m_SingletonAction != null)
                         InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged, map.m_SingletonAction);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -504,12 +504,9 @@ namespace UnityEngine.InputSystem
 
         internal ReadOnlyArray<InputControl> GetControlsForSingleAction(InputAction action)
         {
-            Debug.Assert(m_State != null);
-            Debug.Assert(m_MapIndexInState != InputActionState.kInvalidIndex);
-            Debug.Assert(m_Actions != null);
-            Debug.Assert(action != null);
-            Debug.Assert(action.m_ActionMap == this);
-            Debug.Assert(!action.isSingletonAction || m_SingletonAction == action);
+            Debug.Assert(action != null, "Action cannot be null");
+            Debug.Assert(action.m_ActionMap == this, "Action must be in action map");
+            Debug.Assert(!action.isSingletonAction || m_SingletonAction == action, "Action is not a singleton action");
 
             if (m_ControlsForEachAction == null)
                 SetUpPerActionCachedBindingData();
@@ -532,6 +529,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         private unsafe void SetUpPerActionCachedBindingData()
         {
+            ////FIXME: Ideally we shouldn't do this here; see comment on InputAction.bindings
             // Make sure our binding resolution data is up to date.
             ResolveBindingsIfNecessary();
 
@@ -870,6 +868,8 @@ namespace UnityEngine.InputSystem
                 {
                     var map = actionMaps[i];
                     map.m_NeedToResolveBindings = false;
+
+                    map.ClearPerActionCachedBindingData();
 
                     if (map.m_SingletonAction != null)
                         InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged, map.m_SingletonAction);


### PR DESCRIPTION
Actually ended up finding a more fundamental mistake in how `SetUpPerActionCachedBindingData` works. Left a `////FIXME` comment and made it work such that that it at least fixes the original problem.

Something to revisit after 1.0.