### PR TITLE
Trigger samples publish as dependency of promotion

### DIFF
--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -4,6 +4,8 @@ promote:
     type: Unity::VM::osx
     image: buildfarm/mac:stable
     flavor: m1.mac
+  dependencies:
+    - .yamato/publish-samples.yml   
   variables:
     UPMCI_PROMOTION: 1
   commands:


### PR DESCRIPTION
Since merging the publish samples script and the promote packages script did not work well (as one wants to run on windows and the other on a mac) - @douglas-piconi had to revert the change - I figured it would be much easier to just make the promote package script depend on the publish samples script. Then both can run on the agents they want to run on.