### PR TITLE
Fix samples

### DIFF
--- a/Assets/Samples/TanksDemo/TanksDemo.asset
+++ b/Assets/Samples/TanksDemo/TanksDemo.asset
@@ -13,3 +13,5 @@ MonoBehaviour:
   m_Name: TanksDemo
   m_EditorClassIdentifier: 
   url: https://github.com/Unity-Technologies/InputSystem/releases/download/%VERSION%/TanksDemo-%VERSION%.unitypackage
+  packageDeps:
+  - com.unity.inputsystem

--- a/Assets/Samples/TouchSamples/TouchSamples.asset
+++ b/Assets/Samples/TouchSamples/TouchSamples.asset
@@ -10,6 +10,9 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9858d4c8055fd45539a2e86388f7c5ba, type: 3}
-  m_Name: TanksDemo
+  m_Name: TouchSamples
   m_EditorClassIdentifier: 
-  url: https://github.com/Unity-Technologies/InputSystem/releases/download/%VERSION%/TanksDemo-%VERSION%.unitypackage
+  url: https://github.com/Unity-Technologies/InputSystem/releases/download/%VERSION%/TouchSamples-%VERSION%.unitypackage
+  packageDeps:
+  - com.unity.inputsystem
+  - com.unity.cinemachine

--- a/ExternalSampleProjects/TanksDemo/Assets/Scenes/ButtonRemapScreen.unity
+++ b/ExternalSampleProjects/TanksDemo/Assets/Scenes/ButtonRemapScreen.unity
@@ -168,7 +168,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2189698}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -206,7 +206,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2189698}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -289,7 +289,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 17009752}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -304,7 +304,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 17009752}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -385,7 +385,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 93996318}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -423,7 +423,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 93996318}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -508,7 +508,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 314339490}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -553,7 +553,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 314339490}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -648,7 +648,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 469867317}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -671,7 +671,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 469867317}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -872,7 +872,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 589531837}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -887,7 +887,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 589531837}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -967,7 +967,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 636639085}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -982,7 +982,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 636639085}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1062,7 +1062,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 749014066}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1077,7 +1077,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 749014066}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1157,7 +1157,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 758330975}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1172,7 +1172,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 758330975}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1252,7 +1252,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 934252313}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1275,7 +1275,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 934252313}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1347,7 +1347,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 951764315}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1362,7 +1362,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 951764315}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1422,7 +1422,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1272049765}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Script: {fileID: 1997211142, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_RepeatDelay: 0.5
@@ -1460,7 +1460,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1272049765}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}
@@ -1528,7 +1528,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1440245651}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1573,7 +1573,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1440245651}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1649,7 +1649,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1457698465}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1664,7 +1664,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1457698465}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1746,7 +1746,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1655994320}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -1791,7 +1791,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1655994320}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1888,7 +1888,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1811647188}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1903,7 +1903,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1811647188}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -1983,7 +1983,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1888623799}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -1998,7 +1998,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1888623799}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -2080,7 +2080,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1893932649}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -2125,7 +2125,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1893932649}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -2201,7 +2201,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1954812116}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -2218,7 +2218,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1954812116}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 0
@@ -2330,7 +2330,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1967465514}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -2345,7 +2345,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1967465514}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -2518,7 +2518,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2119408676}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Script: {fileID: 1392445389, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Navigation:
@@ -2563,7 +2563,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2119408676}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}

--- a/ExternalSampleProjects/TanksDemo/Assets/Scenes/NewInput.unity
+++ b/ExternalSampleProjects/TanksDemo/Assets/Scenes/NewInput.unity
@@ -168,7 +168,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 102963699}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
@@ -210,7 +210,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 102963699}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_EffectColor: {r: 0.44705883, g: 0.2784314, b: 0.15686275, a: 0.49019608}
@@ -274,7 +274,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 575313008}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Script: {fileID: 1301386320, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
@@ -291,7 +291,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 575313008}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Script: {fileID: 1980459831, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_UiScaleMode: 0
@@ -453,7 +453,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1282556331}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Script: {fileID: 1997211142, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_RepeatDelay: 0.5
@@ -491,7 +491,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1282556331}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Script: {fileID: -619905303, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_FirstSelected: {fileID: 0}

--- a/ExternalSampleProjects/TanksDemo/Assets/Scripts/TanksDemo.asmdef
+++ b/ExternalSampleProjects/TanksDemo/Assets/Scripts/TanksDemo.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "TanksDemo",
+    "references": [
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
+}

--- a/ExternalSampleProjects/TanksDemo/Assets/Scripts/TanksDemo.asmdef.meta
+++ b/ExternalSampleProjects/TanksDemo/Assets/Scripts/TanksDemo.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 077c2f479adfd4235945ff14eeaeda57
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using UnityEditor.PackageManager.Requests;
 #if UNITY_EDITOR
 using UnityEngine;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
@@ -1,23 +1,100 @@
+
+using System.Linq;
+using UnityEditor.PackageManager.Requests;
 #if UNITY_EDITOR
 using UnityEngine;
 using UnityEditor;
 using UnityEngine.InputSystem;
+using UnityEditor.PackageManager;
+using UnityEditor.PackageManager.Requests;
 
 internal class DownloadableSample : ScriptableObject
 {
     public string url;
+    public string[] packageDeps;
 }
 
 [CustomEditor(typeof(DownloadableSample))]
 internal class DownloadableSampleInspector : Editor
 {
+    private ListRequest list;
+    private AddRequest add;
+    
+    public void OnEnable()
+    {
+        list = Client.List();
+    }
+
+    bool HasPackage(string id)
+    {
+        if (id.Contains('@'))
+            return list.Result.Any(x => x.packageId == id);
+        else
+            return list.Result.Any(x => x.packageId.Split('@')[0] == id);
+    }
+    
     public override void OnInspectorGUI()
     {
+        GUILayout.Label("Downloadable Sample", EditorStyles.boldLabel);
+
+        var sample = (DownloadableSample)target;
         EditorGUILayout.HelpBox($"The {target.name} sample is stored outside of the input system package, because it contains custom project settings and is too big to be distributed as part of the sample. Instead, you can download it as a .unitypackage file which you can import into the project. Click the button below to download this sample", MessageType.Info);
         if (GUILayout.Button("Download Sample"))
         {
-            var url = ((DownloadableSample)target).url.Replace("%VERSION%", InputSystem.version.ToString());
+            var url = sample.url.Replace("%VERSION%", InputSystem.version.ToString());
             Application.OpenURL(url);
+        }
+
+        GUILayout.Space(10);
+        
+        GUILayout.Label("Package Dependencies", EditorStyles.boldLabel);
+
+        // We are adding a new package, wait for the operation to finish and then relist.
+        if (add != null)
+        {
+            if (add.IsCompleted)
+            {
+                add = null;
+                list = Client.List();
+            }
+        }
+        
+        if (add != null || !list.IsCompleted)
+            // Keep refreshing while we are waiting for Packman to resolve our request.
+            Repaint();
+        else
+        {
+            if (!sample.packageDeps.All(x => HasPackage(x)))
+                EditorGUILayout.HelpBox($"The {target.name} sample requires the following packages to be installed in your project.", MessageType.Warning);
+        }
+
+        
+        foreach (var req in sample.packageDeps)
+        {
+            Rect rect = EditorGUILayout.GetControlRect(true, 20);
+
+            GUI.Label(rect, new GUIContent(req), EditorStyles.label);
+            rect.width -= 160;
+            rect.x += 160;
+            if (add != null || !list.IsCompleted)
+            {
+                using (new EditorGUI.DisabledScope(true))
+                {
+                    GUI.Label(rect, "checking…", EditorStyles.label);
+                }
+            }
+            else if (HasPackage(req))
+            {
+                GUI.Label(rect, $"OK \u2713", EditorStyles.boldLabel);
+            }
+            else
+            {
+                GUI.Label(rect, "Missing \u2717", EditorStyles.label);
+                rect.x += rect.width - 80;
+                rect.width = 80;
+                if (GUI.Button(rect, "Add"))
+                    add = Client.Add(req);
+            }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
@@ -1,4 +1,3 @@
-
 using System.Linq;
 using UnityEditor.PackageManager.Requests;
 #if UNITY_EDITOR
@@ -19,7 +18,7 @@ internal class DownloadableSampleInspector : Editor
 {
     private ListRequest list;
     private AddRequest add;
-    
+
     public void OnEnable()
     {
         list = Client.List();
@@ -32,7 +31,7 @@ internal class DownloadableSampleInspector : Editor
         else
             return list.Result.Any(x => x.packageId.Split('@')[0] == id);
     }
-    
+
     public override void OnInspectorGUI()
     {
         GUILayout.Label("Downloadable Sample", EditorStyles.boldLabel);
@@ -46,7 +45,7 @@ internal class DownloadableSampleInspector : Editor
         }
 
         GUILayout.Space(10);
-        
+
         GUILayout.Label("Package Dependencies", EditorStyles.boldLabel);
 
         // We are adding a new package, wait for the operation to finish and then relist.
@@ -58,7 +57,7 @@ internal class DownloadableSampleInspector : Editor
                 list = Client.List();
             }
         }
-        
+
         if (add != null || !list.IsCompleted)
             // Keep refreshing while we are waiting for Packman to resolve our request.
             Repaint();
@@ -68,7 +67,7 @@ internal class DownloadableSampleInspector : Editor
                 EditorGUILayout.HelpBox($"The {target.name} sample requires the following packages to be installed in your project.", MessageType.Warning);
         }
 
-        
+
         foreach (var req in sample.packageDeps)
         {
             Rect rect = EditorGUILayout.GetControlRect(true, 20);


### PR DESCRIPTION
-Fix URL for TouchSamples
-Make sample place holders check package requirements, and offer to install missing packages
-Fix uGUI GUIDs in TanksDemo to work with 19.1 again
-Add asmdef file to TanksDemo to make sure the unsafe code compiles. Adding the flag to PlayerSettings apparently does not work well, as it does not automatically trigger a recompile when imported after the scripts.