### PR TITLE
FIX: Fixed incorrect default state for axes on some controllers.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 -Will now close Input Action Asset Editor windows from previous sessions when the corresponding action was deleted.
+- Fixed incorrect default state for axes on some controllers.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -209,6 +209,16 @@ namespace UnityEngine.InputSystem.Controls
             m_StateBlock.format = InputStateBlock.FormatFloat;
         }
 
+        protected override void FinishSetup()
+        {
+            base.FinishSetup();
+
+            // if we don't have any default state, and we are using normalizeZero, then the default value
+            // should not be zero. Generate it from normalizeZero.
+            if (!hasDefaultState && normalize && Mathf.Abs(normalizeZero) > Mathf.Epsilon)
+                m_DefaultState = stateBlock.FloatToPrimitiveValue(normalizeZero);
+        }
+
         /// <inheritdoc />
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -522,6 +522,18 @@ namespace UnityEngine.InputSystem.LowLevel
                     return (int)(value * maxValue);
                 }
             }
+            else if (format == FormatInt)
+            {
+                Debug.Assert(sizeInBits == 32, "SHRT state must have sizeInBits=16");
+                Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
+                return (int)(value * 2147483647.0f);
+            }
+            else if (format == FormatUInt)
+            {
+                Debug.Assert(sizeInBits == 32, "SHRT state must have sizeInBits=16");
+                Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
+                return (uint)(value * 4294967295.0f);
+            }
             else if (format == FormatShort)
             {
                 Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -502,6 +502,62 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
+        internal PrimitiveValue FloatToPrimitiveValue(float value)
+        {
+            if (format == FormatFloat)
+            {
+                Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
+                Debug.Assert(bitOffset == 0, "FLT state must be byte-aligned");
+                return value;
+            }
+            else if (format == FormatBit)
+            {
+                if (sizeInBits == 1)
+                {
+                    return value >= 0.5f;
+                }
+                else
+                {
+                    var maxValue = (1 << (int)sizeInBits) - 1;
+                    return (int)(value * maxValue);
+                }
+            }
+            else if (format == FormatShort)
+            {
+                Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
+                Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
+                return (short)(value * 32768.0f);
+            }
+            else if (format == FormatUShort)
+            {
+                Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
+                Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
+                return (ushort)(value * 65535.0f);
+            }
+            else if (format == FormatByte)
+            {
+                Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
+                Debug.Assert(bitOffset == 0, "BYTE state must be byte-aligned");
+                return (byte)(value * 255.0f);
+            }
+            else if (format == FormatSByte)
+            {
+                Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
+                Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
+                return (sbyte)(value * 128.0f);
+            }
+            else if (format == FormatDouble)
+            {
+                Debug.Assert(sizeInBits == 64, "DBL state must have sizeInBits=64");
+                Debug.Assert(bitOffset == 0, "DBL state must be byte-aligned");
+                return value;
+            }
+            else
+            {
+                throw new Exception($"State format '{format}' is not supported as floating-point format");
+            }
+        }
+
         ////REVIEW: This is some bad code duplication here between Read/WriteFloat&Double but given that there's no
         ////        way to use a type argument here, not sure how to get rid of it.
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -524,14 +524,14 @@ namespace UnityEngine.InputSystem.LowLevel
             }
             else if (format == FormatInt)
             {
-                Debug.Assert(sizeInBits == 32, "SHRT state must have sizeInBits=16");
-                Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
+                Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=32");
+                Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
                 return (int)(value * 2147483647.0f);
             }
             else if (format == FormatUInt)
             {
-                Debug.Assert(sizeInBits == 32, "SHRT state must have sizeInBits=16");
-                Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
+                Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=32");
+                Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
                 return (uint)(value * 4294967295.0f);
             }
             else if (format == FormatShort)


### PR DESCRIPTION
When a control does not have an explicit defaultState argument to the InputControl attribute, the default state is considered to be 0. But for axis controls which are normalized to return values from -1..1, and which are represented by an unsigned integer on the device, 0 is not the correct default value for the input state. This meant that the axis would be considered to be at it's default value when at -1. This is common for gamepad access, and would result in canceled callbacks being sent when moving the axis towards -1. 

Now, in combination with my previous fix here: https://github.com/Unity-Technologies/InputSystem/pull/828/files#diff-a82dc3439d6b317a87e69ff2cdc0bc0a , which would always return 0 values for canceled interactions, this would mean that moving a gamepad stick all the way to the left would generate a value of 0, which completely broke the Input System.

This PR automatically generates default values for axes when no default is explicitly set and when normalizeZero is used, which fixes the problem. This is the best fix I could think of - I also considered adding default values everywhere (but that would have been much work, and easy to get wrong or miss a place), or to ignore any controls without explicit default values for `CheckStateIsAtDefault`, but that would skip optimizations and possibly change behavior).