### PR TITLE
FIX: Correctly implemented `IsPointerOverGameObject` method for `Inpu…

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -163,6 +163,7 @@ internal class UITests : InputTestFixture
         // Reset initial selection
         leftChildReceiver.Reset();
 
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.False);
         // Move mouse over left child.
         InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(100, 100) });
         InputSystem.Update();
@@ -172,6 +173,7 @@ internal class UITests : InputTestFixture
         Assert.That(leftChildReceiver.events[0].type, Is.EqualTo(EventType.Enter));
         leftChildReceiver.Reset();
         Assert.That(rightChildReceiver.events, Is.Empty);
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.True);
 
         // Check basic down/up
         InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(100, 100), buttons = 1 << (int)MouseButton.Left });
@@ -248,6 +250,7 @@ internal class UITests : InputTestFixture
         Assert.That(rightChildReceiver.events, Has.Count.EqualTo(1));
         Assert.That(rightChildReceiver.events[0].type, Is.EqualTo(EventType.Scroll));
         rightChildReceiver.Reset();
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.True);
     }
 
     unsafe void SetTouchState(TouchscreenState state, int index, TouchState touch)
@@ -311,6 +314,11 @@ internal class UITests : InputTestFixture
         leftChildReceiver.Reset();
         Assert.That(rightChildReceiver.events, Is.Empty);
 
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.False);
+        Assert.That(eventSystem.IsPointerOverGameObject(1), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(2), Is.False);
+        Assert.That(eventSystem.IsPointerOverGameObject(3), Is.False);
+
         InputSystem.QueueDeltaStateEvent(touchScreen.touches[0], new TouchState()
         {
             touchId = 1,
@@ -343,6 +351,11 @@ internal class UITests : InputTestFixture
         Assert.That(rightChildReceiver.events[0].type, Is.EqualTo(EventType.Enter));
         rightChildReceiver.Reset();
         Assert.That(leftChildReceiver.events, Is.Empty);
+
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.False);
+        Assert.That(eventSystem.IsPointerOverGameObject(1), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(2), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(3), Is.False);
 
         InputSystem.QueueDeltaStateEvent(touchScreen.touches[1], new TouchState()
         {
@@ -392,6 +405,11 @@ internal class UITests : InputTestFixture
         leftChildReceiver.Reset();
         Assert.That(rightChildReceiver.events, Is.Empty);
 
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.False);
+        Assert.That(eventSystem.IsPointerOverGameObject(1), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(2), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(3), Is.False);
+
         // release right button
         // NOTE: The UI behavior is a bit funky here, as it cannot properly handle selection state for multiple
         // objects. As a result, only releasing the left button will receive a click in this setup.
@@ -420,6 +438,11 @@ internal class UITests : InputTestFixture
         Assert.That((rightChildReceiver.events[0].data as PointerEventData).button, Is.EqualTo(PointerEventData.InputButton.Left));
         rightChildReceiver.Reset();
         Assert.That(leftChildReceiver.events, Is.Empty);
+
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.False);
+        Assert.That(eventSystem.IsPointerOverGameObject(1), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(2), Is.True);
+        Assert.That(eventSystem.IsPointerOverGameObject(3), Is.False);
     }
 
     [UnityTest]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview1] - 2999-1-1
+
+### Fixed
+
+- Correctly implemented `IsPointerOverGameObject` method for `InputSystemUIInputModule`.
+
 ## [1.0.0-preview] - 2019-9-20
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -34,6 +34,16 @@ namespace UnityEngine.InputSystem.UI
             eventSystem.SetSelectedGameObject(toSelect, GetBaseEventData());
         }
 
+        public override bool IsPointerOverGameObject(int pointerId)
+        {
+            foreach (var state in mouseStates)
+            {
+                if (state.touchId == pointerId)
+                    return state.pointerTarget != null;
+            }
+            return false;
+        }
+
         private RaycastResult PerformRaycast(PointerEventData eventData)
         {
             if (eventData == null)
@@ -705,7 +715,7 @@ namespace UnityEngine.InputSystem.UI
         int GetMouseDeviceIndexForCallbackContext(InputAction.CallbackContext context)
         {
             Debug.Assert(context.action.type == InputActionType.PassThrough, $"Pointer actions should be pass-through actions, so the UI can properly distinguish multiple pointing devices/fingers. Please set the action type of '{context.action.name}' to 'Pass-Through'.");
-            var touchId = 0;
+            var touchId = PointerInputModule.kMouseLeftId;
             if (context.control.parent is TouchControl)
                 touchId = ((TouchControl)context.control.parent).touchId.ReadValue();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MouseModel.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MouseModel.cs
@@ -354,6 +354,8 @@ namespace UnityEngine.InputSystem.UI
         private MouseButtonModel m_RightButton;
         private MouseButtonModel m_MiddleButton;
 
+        internal GameObject pointerTarget => m_InternalData.pointerTarget;
+
         private InternalData m_InternalData;
     }
 }


### PR DESCRIPTION
…tSystemUIInputModule`.

Raised in https://forum.unity.com/threads/is-there-a-replacement-for-eventsystem-ispointerovergameobject.740462/