### PR TITLE
CHANGE: Generated action wrappers now won't `Destroy` the generated A…

### DIFF
--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -1,11 +1,12 @@
 // GENERATED AUTOMATICALLY FROM 'Assets/Samples/SimpleDemo/SimpleControls.inputactions'
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 
-public class SimpleControls : IInputActionCollection
+public class SimpleControls : IInputActionCollection, IDisposable
 {
     private InputActionAsset asset;
     public SimpleControls()
@@ -154,7 +155,7 @@ public class SimpleControls : IInputActionCollection
         m_gameplay_look = m_gameplay.FindAction("look", throwIfNotFound: true);
     }
 
-    ~SimpleControls()
+    public void Dispose()
     {
         UnityEngine.Object.Destroy(asset);
     }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview1] - 2999-9-20
+
+### Changed
+
+- Generated action wrappers now won't `Destroy` the generated Asset in a finalizer, but instead implement `IDisposable`.
+
 ## [1.0.0-preview] - 2019-9-20
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -66,6 +66,7 @@ namespace UnityEngine.InputSystem.Editor
                 writer.WriteLine($"// GENERATED AUTOMATICALLY FROM '{options.sourceAssetPath}'\n");
 
             // Usings.
+            writer.WriteLine("using System;");
             writer.WriteLine("using System.Collections;");
             writer.WriteLine("using System.Collections.Generic;");
             writer.WriteLine("using UnityEngine.InputSystem;");
@@ -81,7 +82,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Begin class.
-            writer.WriteLine($"public class {options.className} : IInputActionCollection");
+            writer.WriteLine($"public class {options.className} : IInputActionCollection, IDisposable");
             writer.BeginBlock();
 
             writer.WriteLine($"private InputActionAsset asset;");
@@ -108,7 +109,7 @@ namespace UnityEngine.InputSystem.Editor
             writer.EndBlock();
             writer.WriteLine();
 
-            writer.WriteLine($"~{options.className}()");
+            writer.WriteLine("public void Dispose()");
             writer.BeginBlock();
             writer.WriteLine("UnityEngine.Object.Destroy(asset);");
             writer.EndBlock();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -22,7 +22,7 @@ namespace UnityEngine.InputSystem.Editor
     [ScriptedImporter(kVersion, InputActionAsset.Extension)]
     internal class InputActionImporter : ScriptedImporter
     {
-        private const int kVersion = 6;
+        private const int kVersion = 7;
 
         private const string kActionIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/InputAction.png";
         private const string kAssetIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/InputActionAsset.png";

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "1.0.0-preview",
+	"version": "1.0.0-preview1",
 	"unity": "2019.1",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
…sset in a finalizer, but instead implement `IDisposable`.

Fixes https://fogbugz.unity3d.com/f/cases/1178792/