### PR TITLE
FIX: Multiple minor UI glitches.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,11 +7,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview2] - 2019-?-??
+
+### Fixed
+
+- Selecting a layout in the input debugger no longer selects its first child item, too.
+
+#### Action
+
+- The text on the "Listen" button is no longer clipped off on 2019.3.
+- Controls bound to actions through composites no longer as duplicates in the input debugger.
+
 ## [1.0.0-preview] - 2019-9-20
 
 ### Fixed
 
--Will now close Input Action Asset Editor windows from previous sessions when the corresponding action was deleted.
+- Will now close Input Action Asset Editor windows from previous sessions when the corresponding action was deleted.
 - Fixed an issue where Stick Controls could not be created in Players built with medium or high code stripping level enabled.
 - Fixed incorrect default state for axes on some controllers.
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,7 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed a bug where multiple composite bindings for the same controls but on different action maps would throw exceptions.
 - The text on the "Listen" button is no longer clipped off on 2019.3.
-- Controls bound to actions through composites no longer as duplicates in the input debugger.
+- Controls bound to actions through composites no longer show up as duplicates in the input debugger.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -511,12 +511,12 @@ namespace UnityEngine.InputSystem.Editor
                     // When picking controls, have a "Listen" button that allows listening for input.
                     if (m_Owner.m_Mode == InputControlPicker.Mode.PickControl)
                     {
-                        using (new EditorGUILayout.VerticalScope(GUILayout.MaxWidth(42)))
+                        using (new EditorGUILayout.VerticalScope(GUILayout.MaxWidth(50)))
                         {
                             GUILayout.Space(4);
                             var isListeningOld = m_Owner.isListening;
                             var isListeningNew = GUILayout.Toggle(isListeningOld, "Listen",
-                                EditorStyles.miniButton, GUILayout.MaxWidth(45));
+                                EditorStyles.miniButton, GUILayout.MaxWidth(50));
 
                             if (isListeningOld != isListeningNew)
                             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -695,7 +695,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     parent = parent,
                     depth = parent.depth + 1,
-                    id = ++id,
+                    id = id++,
                     displayName = layout.displayName ?? layout.name,
                     layoutName = layout.name,
                 };
@@ -879,6 +879,8 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     ref var bindingState = ref state.bindingStates[i];
                     if (bindingState.actionIndex != actionIndex)
+                        continue;
+                    if (bindingState.isComposite)
                         continue;
 
                     var binding = state.GetBinding(i);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -4,6 +4,7 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.XInput.LowLevel;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.Scripting;
 
 namespace UnityEngine.InputSystem.XInput.LowLevel
 {
@@ -169,10 +170,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [FieldOffset(14)]
         public uint buttons;
 
-        public FourCC format
-        {
-            get { return kFormat; }
-        }
+        public FourCC format => kFormat;
 
         public XInputControllerWirelessOSXState WithButton(Button button)
         {
@@ -197,8 +195,6 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 }
 namespace UnityEngine.InputSystem.XInput
 {
-    [InputControlLayout(stateType = typeof(XInputControllerOSXState), hideInUI = true)]
-    [Scripting.Preserve]
     /// <summary>
     /// A wired Xbox Gamepad connected to a macOS computer.
     /// </summary>
@@ -207,12 +203,12 @@ namespace UnityEngine.InputSystem.XInput
     /// These controllers don't work on a mac out of the box, but require a driver like https://github.com/360Controller/
     /// to work.
     /// </remarks>
+    [InputControlLayout(displayName = "Xbox Controller", stateType = typeof(XInputControllerOSXState), hideInUI = true)]
+    [Preserve]
     public class XboxGamepadMacOS : XInputController
     {
     }
 
-    [InputControlLayout(stateType = typeof(XInputControllerWirelessOSXState), hideInUI = true)]
-    [Scripting.Preserve]
     /// <summary>
     /// A wireless Xbox One Gamepad connected to a macOS computer.
     /// </summary>
@@ -222,6 +218,8 @@ namespace UnityEngine.InputSystem.XInput
     /// with a proprietary Xbox wireless protocol, and cannot be used on a Mac.
     /// Unlike wired controllers, bluetooth-cabable Xbox One controllers do not need a custom driver to work on macOS.
     /// </remarks>
+    [InputControlLayout(displayName = "Wireless Xbox Controller", stateType = typeof(XInputControllerWirelessOSXState), hideInUI = true)]
+    [Preserve]
     public class XboxOneGampadMacOSWireless : XInputController
     {
     }


### PR DESCRIPTION
- Fixes "Listen" button not being wide enough for its text on 2019.3.
- Fixes multiple items in the "Layouts" branch of the input debugger receiving the same ID.
- Fixes composites leading to duplicate mentions of controls in the input debugger.