### PR TITLE
Fix Keyboard indexer being unable to index the last key

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
@@ -1865,16 +1865,16 @@ namespace UnityEngine.InputSystem
         /// <param name="key">Key code of key control to return.</param>
         /// <exception cref="ArgumentOutOfRangeException">The given <see cref="key"/> is not valid.</exception>
         /// <remarks>
-        /// This is equivalent to <c>allKeys[(int)key]</c>.
+        /// This is equivalent to <c>allKeys[(int)key - 1]</c>.
         /// </remarks>
         public KeyControl this[Key key]
         {
             get
             {
-                var index = (int)key;
-                if (index <= 0 || index >= m_Keys.Length)
+                var index = (int)key - 1;
+                if (index < 0 || index >= m_Keys.Length)
                     throw new ArgumentOutOfRangeException(nameof(key));
-                return m_Keys[(int)key - 1];
+                return m_Keys[index];
             }
         }
 


### PR DESCRIPTION
The m_Keys array is shifted left by 1 in comparison to enum, and the indexer incorrectly checks for a number one too small for the range. 
This fix makes it possible to do keyboard[Key.OEM5] without having to use Keyboard.allKeys. Also, the documentation was incorrectly stating how to index the allKeys array.