### PR TITLE
FIX: Compile errors when using C# reserved identifiers in assets.

### DIFF
--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 
-public class SimpleControls : IInputActionCollection, IDisposable
+public class @SimpleControls: IInputActionCollection, IDisposable
 {
     private InputActionAsset asset;
-    public SimpleControls()
+    public @SimpleControls()
     {
         asset = InputActionAsset.FromJson(@"{
     ""name"": ""SimpleControls"",
@@ -207,8 +207,8 @@ public class SimpleControls : IInputActionCollection, IDisposable
     private readonly InputAction m_gameplay_look;
     public struct GameplayActions
     {
-        private SimpleControls m_Wrapper;
-        public GameplayActions(SimpleControls wrapper) { m_Wrapper = wrapper; }
+        private @SimpleControls m_Wrapper;
+        public GameplayActions(@SimpleControls wrapper) { m_Wrapper = wrapper; }
         public InputAction @fire => m_Wrapper.m_gameplay_fire;
         public InputAction @move => m_Wrapper.m_gameplay_move;
         public InputAction @look => m_Wrapper.m_gameplay_look;
@@ -221,28 +221,28 @@ public class SimpleControls : IInputActionCollection, IDisposable
         {
             if (m_Wrapper.m_GameplayActionsCallbackInterface != null)
             {
-                fire.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
-                fire.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
-                fire.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
-                move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
-                look.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
-                look.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
-                look.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
+                @fire.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
+                @fire.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
+                @fire.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnFire;
+                @move.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                @move.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                @move.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnMove;
+                @look.started -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
+                @look.performed -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
+                @look.canceled -= m_Wrapper.m_GameplayActionsCallbackInterface.OnLook;
             }
             m_Wrapper.m_GameplayActionsCallbackInterface = instance;
             if (instance != null)
             {
-                fire.started += instance.OnFire;
-                fire.performed += instance.OnFire;
-                fire.canceled += instance.OnFire;
-                move.started += instance.OnMove;
-                move.performed += instance.OnMove;
-                move.canceled += instance.OnMove;
-                look.started += instance.OnLook;
-                look.performed += instance.OnLook;
-                look.canceled += instance.OnLook;
+                @fire.started += instance.OnFire;
+                @fire.performed += instance.OnFire;
+                @fire.canceled += instance.OnFire;
+                @move.started += instance.OnMove;
+                @move.performed += instance.OnMove;
+                @move.canceled += instance.OnMove;
+                @look.started += instance.OnLook;
+                @look.performed += instance.OnLook;
+                @look.canceled += instance.OnLook;
             }
         }
     }

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -1756,6 +1756,8 @@ partial class CoreTests
         map1.AddAction("action2", binding: "/gamepad/rightStick");
         var map2 = new InputActionMap("set2");
         map2.AddAction("action1", binding: "/gamepad/buttonSouth");
+        // Add an action that has a C# reserved keyword name.
+        map2.AddAction("return");
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
         asset.AddActionMap(map1);
         asset.AddActionMap(map2);

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -1749,6 +1749,7 @@ partial class CoreTests
     [TestCase("MyControls (2)", "MyNamespace", "", "MyNamespace.MyControls2")]
     [TestCase("MyControls (2)", "MyNamespace", "MyClassName", "MyNamespace.MyClassName")]
     [TestCase("MyControls", "", "MyClassName", "MyClassName")]
+    [TestCase("interface", "", "class", "class")] // Make sure we can deal with C# reserved keywords.
     public void Editor_CanGenerateCodeWrapperForInputAsset(string assetName, string namespaceName, string className, string typeName)
     {
         var map1 = new InputActionMap("set1");

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed missing keyboard bindings in `DefaultInputActions.inputactions` for navigation in UI.
+- Fixed using C# reserved names in .inputactions assets leading to compile errors in generated C# classes (case 1189861).
 
 ## [1.0.0-preview.1] - 2019-10-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -82,13 +82,13 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Begin class.
-            writer.WriteLine($"public class {options.className} : IInputActionCollection, IDisposable");
+            writer.WriteLine($"public class @{options.className} : IInputActionCollection, IDisposable");
             writer.BeginBlock();
 
             writer.WriteLine($"private InputActionAsset asset;");
 
             // Default constructor.
-            writer.WriteLine($"public {options.className}()");
+            writer.WriteLine($"public @{options.className}()");
             writer.BeginBlock();
             writer.WriteLine($"asset = InputActionAsset.FromJson(@\"{asset.ToJson().Replace("\"", "\"\"")}\");");
 
@@ -186,8 +186,8 @@ namespace UnityEngine.InputSystem.Editor
                 writer.BeginBlock();
 
                 // Constructor.
-                writer.WriteLine($"private {options.className} m_Wrapper;");
-                writer.WriteLine($"public {mapTypeName}({options.className} wrapper) {{ m_Wrapper = wrapper; }}");
+                writer.WriteLine($"private @{options.className} m_Wrapper;");
+                writer.WriteLine($"public {mapTypeName}(@{options.className} wrapper) {{ m_Wrapper = wrapper; }}");
 
                 // Getter for each action.
                 foreach (var action in map.actions)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -223,9 +223,9 @@ namespace UnityEngine.InputSystem.Editor
                     var actionName = CSharpCodeHelpers.MakeIdentifier(action.name);
                     var actionTypeName = CSharpCodeHelpers.MakeTypeName(action.name);
 
-                    writer.WriteLine($"{actionName}.started -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
-                    writer.WriteLine($"{actionName}.performed -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
-                    writer.WriteLine($"{actionName}.canceled -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
+                    writer.WriteLine($"@{actionName}.started -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
+                    writer.WriteLine($"@{actionName}.performed -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
+                    writer.WriteLine($"@{actionName}.canceled -= m_Wrapper.m_{mapTypeName}CallbackInterface.On{actionTypeName};");
                 }
                 writer.EndBlock();
 
@@ -238,9 +238,9 @@ namespace UnityEngine.InputSystem.Editor
                     var actionName = CSharpCodeHelpers.MakeIdentifier(action.name);
                     var actionTypeName = CSharpCodeHelpers.MakeTypeName(action.name);
 
-                    writer.WriteLine($"{actionName}.started += instance.On{actionTypeName};");
-                    writer.WriteLine($"{actionName}.performed += instance.On{actionTypeName};");
-                    writer.WriteLine($"{actionName}.canceled += instance.On{actionTypeName};");
+                    writer.WriteLine($"@{actionName}.started += instance.On{actionTypeName};");
+                    writer.WriteLine($"@{actionName}.performed += instance.On{actionTypeName};");
+                    writer.WriteLine($"@{actionName}.canceled += instance.On{actionTypeName};");
                 }
                 writer.EndBlock();
                 writer.EndBlock();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -22,7 +22,7 @@ namespace UnityEngine.InputSystem.Editor
     [ScriptedImporter(kVersion, InputActionAsset.Extension)]
     internal class InputActionImporter : ScriptedImporter
     {
-        private const int kVersion = 7;
+        private const int kVersion = 8;
 
         private const string kActionIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/InputAction.png";
         private const string kAssetIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/InputActionAsset.png";

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/CSharpCodeHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/CSharpCodeHelpers.cs
@@ -40,10 +40,11 @@ namespace UnityEngine.InputSystem.Utilities
             return name.Split('.').All(IsProperIdentifier);
         }
 
+        ////TODO: this one should add the @escape automatically so no other code has to worry
         public static string MakeIdentifier(string name, string suffix = "")
         {
             if (string.IsNullOrEmpty(name))
-                throw new ArgumentNullException("name");
+                throw new ArgumentNullException(nameof(name));
 
             if (char.IsDigit(name[0]))
                 name = "_" + name;


### PR DESCRIPTION
Fixes https://fogbugz.unity3d.com/f/cases/1189861/ https://issuetracker.unity3d.com/product/unity/issues/guid/1189861/.