### PR TITLE
FIX: Deactivated input bindings leading to initialization errors (case 1187377, 1189867).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4389,6 +4389,54 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    [TestCase("", "<Gamepad>/buttonSouth", "<Gamepad>/buttonWest", "<Gamepad>/buttonEast")]
+    [TestCase("<Gamepad>/buttonNorth", "", "<Gamepad>/buttonWest", "<Gamepad>/buttonEast")]
+    [TestCase("<Gamepad>/buttonNorth", "<Gamepad>/buttonSouth", "", "<Gamepad>/buttonEast")]
+    [TestCase("<Gamepad>/buttonNorth", "<Gamepad>/buttonSouth", "<Gamepad>/buttonWest", "")]
+    public void Actions_CanHaveCompositesWithPartsThatAreNotBound(string up, string down, string left, string right)
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction();
+        action.AddCompositeBinding("2DVector")
+            .With("Up", up)
+            .With("Down", down)
+            .With("Left", left)
+            .With("Right", right);
+
+        action.Enable();
+
+        if (!string.IsNullOrEmpty(up))
+        {
+            Press(gamepad.buttonNorth);
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.up).Using(Vector2EqualityComparer.Instance));
+            Release(gamepad.buttonNorth);
+        }
+
+        if (!string.IsNullOrEmpty(down))
+        {
+            Press(gamepad.buttonSouth);
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.down).Using(Vector2EqualityComparer.Instance));
+            Release(gamepad.buttonSouth);
+        }
+
+        if (!string.IsNullOrEmpty(left))
+        {
+            Press(gamepad.buttonWest);
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.left).Using(Vector2EqualityComparer.Instance));
+            Release(gamepad.buttonWest);
+        }
+
+        if (!string.IsNullOrEmpty(right))
+        {
+            Press(gamepad.buttonEast);
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
+            Release(gamepad.buttonEast);
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
     [Ignore("TODO")]
     public void TODO_Actions_CompositesWithMissingBindings_ThrowExceptions()
     {

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -145,6 +145,61 @@ internal class PlayerInputTests : InputTestFixture
 
     [Test]
     [Category("PlayerInput")]
+    public void PlayerInput_CanHaveActionWithNoBindingsInOneControlScheme()
+    {
+        const string kActions = @"
+            {
+                ""maps"" : [
+                    {
+                        ""name"" : ""gameplay"",
+                        ""actions"" : [
+                            { ""name"" : ""Fire"", ""type"" : ""button"" }
+                        ],
+                        ""bindings"" : [
+                            { ""path"" : ""<Gamepad>/buttonSouth"", ""action"" : ""fire"", ""groups"" : ""Gamepad"" }
+                        ]
+                    }
+                ],
+                ""controlSchemes"" : [
+                    {
+                        ""name"" : ""Gamepad"",
+                        ""bindingGroup"" : ""Gamepad"",
+                        ""devices"" : [
+                            { ""devicePath"" : ""<Gamepad>"" }
+                        ]
+                    },
+                    {
+                        ""name"" : ""Keyboard&Mouse"",
+                        ""bindingGroup"" : ""Keyboard&Mouse"",
+                        ""devices"" : [
+                            { ""devicePath"" : ""<Keyboard>"" },
+                            { ""devicePath"" : ""<Mouse>"" }
+                        ]
+                    }
+                ]
+            }
+        ";
+        var prefab = new GameObject();
+        prefab.SetActive(false);
+        prefab.AddComponent<PlayerInput>();
+        prefab.GetComponent<PlayerInput>().actions = InputActionAsset.FromJson(kActions);
+        prefab.GetComponent<PlayerInput>().defaultActionMap = "gameplay";
+        prefab.AddComponent<MessageListener>();
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        var instance = PlayerInput.Instantiate(prefab, pairWithDevices: new InputDevice[] { keyboard, mouse });
+        var listener = instance.GetComponent<MessageListener>();
+
+        Press(gamepad.buttonSouth);
+
+        Assert.That(listener.messages, Is.EquivalentTo(new[] {new Message("OnFire", 1f)}));
+    }
+
+    [Test]
+    [Category("PlayerInput")]
     public void PlayerInput_CanBeUsedWithoutControlSchemes()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,8 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed missing keyboard bindings in `DefaultInputActions.inputactions` for navigation in UI.
+- Fixed actions ending up being disabled if switching to a control scheme that has no binding for the action (case 1187377).
+- Fixed part of composite not being bound leading to subsequent part bindings not being functional (case 1189867).
 
 ## [1.0.0-preview.1] - 2019-10-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -462,7 +462,7 @@ namespace UnityEngine.InputSystem
 
             // Put all actions into waiting state.
             var mapIndex = map.m_MapIndexInState;
-            Debug.Assert(mapIndex >= 0 && mapIndex < totalMapCount);
+            Debug.Assert(mapIndex >= 0 && mapIndex < totalMapCount, "Map index on InputActionMap is out of range");
             var actionCount = mapIndices[mapIndex].actionCount;
             var actionStartIndex = mapIndices[mapIndex].actionStartIndex;
             for (var i = 0; i < actionCount; ++i)
@@ -489,7 +489,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(maps.Contains(map), "Map must be contained in state");
 
             var mapIndex = map.m_MapIndexInState;
-            Debug.Assert(mapIndex >= 0 && mapIndex < totalMapCount);
+            Debug.Assert(mapIndex >= 0 && mapIndex < totalMapCount, "Map index on InputActionMap is out of range");
 
             // Install state monitors for all controls.
             var controlCount = mapIndices[mapIndex].controlCount;
@@ -1762,13 +1762,13 @@ namespace UnityEngine.InputSystem
                 var compositeBindingIndex = bindingStates[bindingIndex].compositeOrCompositeBindingIndex;
                 var compositeIndex = bindingStates[compositeBindingIndex].compositeOrCompositeBindingIndex;
                 var compositeObject = composites[compositeIndex];
-                Debug.Assert(compositeObject != null);
+                Debug.Assert(compositeObject != null, "Composite object on composite state is null");
 
                 return compositeObject.valueSizeInBytes;
             }
 
             var control = controls[controlIndex];
-            Debug.Assert(control != null);
+            Debug.Assert(control != null, "Control at given index is null");
             return control.valueSizeInBytes;
         }
 
@@ -1895,7 +1895,7 @@ namespace UnityEngine.InputSystem
             if (!ignoreComposites && bindingStates[bindingIndex].isPartOfComposite)
             {
                 var compositeBindingIndex = bindingStates[bindingIndex].compositeOrCompositeBindingIndex;
-                Debug.Assert(compositeBindingIndex >= 0 && compositeBindingIndex < totalBindingCount);
+                Debug.Assert(compositeBindingIndex >= 0 && compositeBindingIndex < totalBindingCount, "Composite binding index is out of range");
                 var compositeIndex = bindingStates[compositeBindingIndex].compositeOrCompositeBindingIndex;
                 var compositeObject = composites[compositeIndex];
                 Debug.Assert(compositeObject != null, "Composite object is null");
@@ -2105,7 +2105,7 @@ namespace UnityEngine.InputSystem
                 get => m_TriggerControlIndex;
                 set
                 {
-                    Debug.Assert(value >= 0 && value <= ushort.MaxValue);
+                    Debug.Assert(value >= 0 && value <= ushort.MaxValue, "Trigger control index is out of range");
                     if (value < 0 || value > ushort.MaxValue)
                         throw new NotSupportedException("Cannot have more than ushort.MaxValue controls in a single InputActionState");
                     m_TriggerControlIndex = (ushort)value;
@@ -2191,7 +2191,7 @@ namespace UnityEngine.InputSystem
                 get => m_ControlStartIndex;
                 set
                 {
-                    Debug.Assert(value != kInvalidIndex);
+                    Debug.Assert(value != kInvalidIndex, "Control state index is invalid");
                     if (value >= ushort.MaxValue)
                         throw new NotSupportedException("Total control count in state cannot exceed byte.MaxValue=" + ushort.MaxValue);
                     m_ControlStartIndex = (ushort)value;
@@ -2319,7 +2319,7 @@ namespace UnityEngine.InputSystem
                 get => m_MapIndex;
                 set
                 {
-                    Debug.Assert(value != kInvalidIndex);
+                    Debug.Assert(value != kInvalidIndex, "Map index is invalid");
                     if (value >= byte.MaxValue)
                         throw new NotSupportedException("Map count cannot exceed byte.MaxValue=" + byte.MaxValue);
                     m_MapIndex = (byte)value;
@@ -3165,7 +3165,7 @@ namespace UnityEngine.InputSystem
                 for (var n = 0; n < mapCount; ++n)
                 {
                     maps[n].Disable();
-                    Debug.Assert(!maps[n].enabled);
+                    Debug.Assert(!maps[n].enabled, "Map is still enabled after calling Disable");
                 }
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -73,7 +73,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         public void StartWithArraysFrom(InputActionState state)
         {
-            Debug.Assert(state != null);
+            Debug.Assert(state != null, "Received null state");
 
             maps = state.maps;
             interactions = state.interactions;
@@ -113,7 +113,7 @@ namespace UnityEngine.InputSystem
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1809:AvoidExcessiveLocals", Justification = "TODO: Refactor later.")]
         public unsafe void AddActionMap(InputActionMap map)
         {
-            Debug.Assert(map != null);
+            Debug.Assert(map != null, "Received null map");
 
             var actionsInThisMap = map.m_Actions;
             var bindingsInThisMap = map.m_Bindings;
@@ -174,29 +174,20 @@ namespace UnityEngine.InputSystem
                     {
                         ////TODO: if it's a composite, check if any of the children matches our binding masks (if any) and skip composite if none do
 
-                        // Set binding state to defaults.
-                        bindingState->mapIndex = totalMapCount;
-                        bindingState->compositeOrCompositeBindingIndex = InputActionState.kInvalidIndex;
-                        bindingState->actionIndex = InputActionState.kInvalidIndex;
+                        var firstControlIndex = 0; // numControls dictates whether this is a valid index or not.
+                        var firstInteractionIndex = InputActionState.kInvalidIndex;
+                        var firstProcessorIndex = InputActionState.kInvalidIndex;
+                        var actionIndexForBinding = InputActionState.kInvalidIndex;
+                        var partIndex = InputActionState.kInvalidIndex;
+
+                        var numControls = 0;
+                        var numInteractions = 0;
+                        var numProcessors = 0;
 
                         // Make sure that if it's part of a composite, we are actually part of a composite.
                         if (isPartOfComposite && currentCompositeBindingIndex == InputActionState.kInvalidIndex)
                             throw new InvalidOperationException(
                                 $"Binding '{unresolvedBinding}' is marked as being part of a composite but the preceding binding is not a composite");
-
-                        // Skip binding if it is disabled (path is empty string).
-                        var path = unresolvedBinding.effectivePath;
-                        if (string.IsNullOrEmpty(path))
-                            continue;
-
-                        // Skip binding if it doesn't match with our binding mask (might be empty).
-                        if (!isComposite && bindingMask != null && !bindingMask.Value.Matches(ref unresolvedBinding))
-                            continue;
-
-                        // Skip binding if it doesn't match the binding mask on the map (might be empty).
-                        if (!isComposite && bindingMaskOnThisMap != null &&
-                            !bindingMaskOnThisMap.Value.Matches(ref unresolvedBinding))
-                            continue;
 
                         // Try to find action.
                         //
@@ -227,132 +218,140 @@ namespace UnityEngine.InputSystem
                             action = currentCompositeAction;
                         }
 
-                        // Skip binding if it doesn't match the binding mask on the action (might be empty).
-                        if (!isComposite && action?.m_BindingMask != null &&
-                            !action.m_BindingMask.Value.Matches(ref unresolvedBinding))
-                            continue;
+                        // Determine if the binding is disabled.
+                        // Disabled if path is empty.
+                        var path = unresolvedBinding.effectivePath;
+                        var bindingIsDisabled = string.IsNullOrEmpty(path);
 
-                        // Instantiate processors.
-                        var firstProcessorIndex = InputActionState.kInvalidIndex;
-                        var numProcessors = 0;
-                        var processorString = unresolvedBinding.effectiveProcessors;
-                        if (!string.IsNullOrEmpty(processorString))
+                        // Also, disabled if binding doesn't match with our binding mask (might be empty).
+                        bindingIsDisabled |= !isComposite && bindingMask != null && !bindingMask.Value.Matches(ref unresolvedBinding);
+
+                        // Also, disabled if binding doesn't match the binding mask on the map (might be empty).
+                        bindingIsDisabled |= !isComposite && bindingMaskOnThisMap != null &&
+                            !bindingMaskOnThisMap.Value.Matches(ref unresolvedBinding);
+
+                        // Finally, also disabled if binding doesn't match the binding mask on the action (might be empty).
+                        bindingIsDisabled |= !isComposite && action?.m_BindingMask != null &&
+                            !action.m_BindingMask.Value.Matches(ref unresolvedBinding);
+
+                        // If the binding isn't disabled, resolve its controls, processors, and interactions.
+                        if (!bindingIsDisabled)
                         {
-                            // Add processors from binding.
-                            firstProcessorIndex = ResolveProcessors(processorString);
-                            if (firstProcessorIndex != InputActionState.kInvalidIndex)
-                                numProcessors = totalProcessorCount - firstProcessorIndex;
-                        }
-                        if (action != null && !string.IsNullOrEmpty(action.m_Processors))
-                        {
-                            // Add processors from action.
-                            var index = ResolveProcessors(action.m_Processors);
-                            if (index != InputActionState.kInvalidIndex)
+                            // Instantiate processors.
+                            var processorString = unresolvedBinding.effectiveProcessors;
+                            if (!string.IsNullOrEmpty(processorString))
                             {
-                                if (firstProcessorIndex == InputActionState.kInvalidIndex)
-                                    firstProcessorIndex = index;
-                                numProcessors += totalProcessorCount - index;
+                                // Add processors from binding.
+                                firstProcessorIndex = ResolveProcessors(processorString);
+                                if (firstProcessorIndex != InputActionState.kInvalidIndex)
+                                    numProcessors = totalProcessorCount - firstProcessorIndex;
                             }
-                        }
-
-                        // Instantiate interactions.
-                        var firstInteractionIndex = InputActionState.kInvalidIndex;
-                        var numInteractions = 0;
-                        var interactionString = unresolvedBinding.effectiveInteractions;
-                        if (!string.IsNullOrEmpty(interactionString))
-                        {
-                            // Add interactions from binding.
-                            firstInteractionIndex = ResolveInteractions(interactionString);
-                            if (firstInteractionIndex != InputActionState.kInvalidIndex)
-                                numInteractions = totalInteractionCount - firstInteractionIndex;
-                        }
-                        if (action != null && !string.IsNullOrEmpty(action.m_Interactions))
-                        {
-                            // Add interactions from action.
-                            var index = ResolveInteractions(action.m_Interactions);
-                            if (index != InputActionState.kInvalidIndex)
+                            if (action != null && !string.IsNullOrEmpty(action.m_Processors))
                             {
-                                if (firstInteractionIndex == InputActionState.kInvalidIndex)
-                                    firstInteractionIndex = index;
-                                numInteractions += totalInteractionCount - index;
+                                // Add processors from action.
+                                var index = ResolveProcessors(action.m_Processors);
+                                if (index != InputActionState.kInvalidIndex)
+                                {
+                                    if (firstProcessorIndex == InputActionState.kInvalidIndex)
+                                        firstProcessorIndex = index;
+                                    numProcessors += totalProcessorCount - index;
+                                }
                             }
-                        }
 
-                        // If it's the start of a composite chain, create the composite.
-                        if (isComposite)
-                        {
-                            var actionIndexForComposite = actionIndexInMap != InputActionState.kInvalidIndex
-                                ? actionStartIndex + actionIndexInMap
-                                : InputActionState.kInvalidIndex;
-
-                            // Instantiate. For composites, the path is the name of the composite.
-                            var composite = InstantiateBindingComposite(unresolvedBinding.path);
-                            currentCompositeIndex =
-                                ArrayHelpers.AppendWithCapacity(ref composites, ref totalCompositeCount, composite);
-                            currentCompositeBindingIndex = bindingIndex;
-                            currentCompositeAction = action;
-                            currentCompositeActionIndexInMap = actionIndexInMap;
-
-                            *bindingState = new InputActionState.BindingState
+                            // Instantiate interactions.
+                            var interactionString = unresolvedBinding.effectiveInteractions;
+                            if (!string.IsNullOrEmpty(interactionString))
                             {
-                                actionIndex = actionIndexForComposite,
-                                compositeOrCompositeBindingIndex = currentCompositeIndex,
-                                processorStartIndex = firstProcessorIndex,
-                                processorCount = numProcessors,
-                                interactionCount = numInteractions,
-                                interactionStartIndex = firstInteractionIndex,
-                                mapIndex = totalMapCount,
-                                isComposite = true,
-                                // Record where the controls for parts of the composite start.
-                                controlStartIndex = memory.controlCount + resolvedControls.Count,
-                            };
-
-                            // The composite binding entry itself does not resolve to any controls.
-                            // It creates a composite binding object which is then populated from
-                            // subsequent bindings.
-                            continue;
-                        }
-
-                        // If we've reached the end of a composite chain, finish
-                        // off the current composite.
-                        if (!isPartOfComposite && currentCompositeBindingIndex != InputActionState.kInvalidIndex)
-                        {
-                            currentCompositePartCount = 0;
-                            currentCompositeBindingIndex = InputActionState.kInvalidIndex;
-                            currentCompositeIndex = InputActionState.kInvalidIndex;
-                            currentCompositeAction = null;
-                            currentCompositeActionIndexInMap = InputActionState.kInvalidIndex;
-                        }
-
-                        // Look up controls.
-                        //
-                        // NOTE: We continuously add controls here to `resolvedControls`. Once we've completed our
-                        //       pass over the bindings in the map, `resolvedControls` will have all the controls for
-                        //       the current map.
-                        var firstControlIndex = memory.controlCount + resolvedControls.Count;
-                        var numControls = 0;
-                        if (devicesForThisMap != null)
-                        {
-                            // Search in devices for only this map.
-                            var list = devicesForThisMap.Value;
-                            for (var i = 0; i < list.Count; ++i)
-                            {
-                                var device = list[i];
-                                if (!device.added)
-                                    continue; // Skip devices that have been removed.
-                                numControls += InputControlPath.TryFindControls(device, path, 0, ref resolvedControls);
+                                // Add interactions from binding.
+                                firstInteractionIndex = ResolveInteractions(interactionString);
+                                if (firstInteractionIndex != InputActionState.kInvalidIndex)
+                                    numInteractions = totalInteractionCount - firstInteractionIndex;
                             }
-                        }
-                        else
-                        {
-                            // Search globally.
-                            numControls = InputSystem.FindControls(path, ref resolvedControls);
+                            if (action != null && !string.IsNullOrEmpty(action.m_Interactions))
+                            {
+                                // Add interactions from action.
+                                var index = ResolveInteractions(action.m_Interactions);
+                                if (index != InputActionState.kInvalidIndex)
+                                {
+                                    if (firstInteractionIndex == InputActionState.kInvalidIndex)
+                                        firstInteractionIndex = index;
+                                    numInteractions += totalInteractionCount - index;
+                                }
+                            }
+
+                            // If it's the start of a composite chain, create the composite.
+                            if (isComposite)
+                            {
+                                var actionIndexForComposite = actionIndexInMap != InputActionState.kInvalidIndex
+                                    ? actionStartIndex + actionIndexInMap
+                                    : InputActionState.kInvalidIndex;
+
+                                // Instantiate. For composites, the path is the name of the composite.
+                                var composite = InstantiateBindingComposite(unresolvedBinding.path);
+                                currentCompositeIndex =
+                                    ArrayHelpers.AppendWithCapacity(ref composites, ref totalCompositeCount, composite);
+                                currentCompositeBindingIndex = bindingIndex;
+                                currentCompositeAction = action;
+                                currentCompositeActionIndexInMap = actionIndexInMap;
+
+                                *bindingState = new InputActionState.BindingState
+                                {
+                                    actionIndex = actionIndexForComposite,
+                                    compositeOrCompositeBindingIndex = currentCompositeIndex,
+                                    processorStartIndex = firstProcessorIndex,
+                                    processorCount = numProcessors,
+                                    interactionCount = numInteractions,
+                                    interactionStartIndex = firstInteractionIndex,
+                                    mapIndex = totalMapCount,
+                                    isComposite = true,
+                                    // Record where the controls for parts of the composite start.
+                                    controlStartIndex = memory.controlCount + resolvedControls.Count,
+                                };
+
+                                // The composite binding entry itself does not resolve to any controls.
+                                // It creates a composite binding object which is then populated from
+                                // subsequent bindings.
+                                continue;
+                            }
+
+                            // If we've reached the end of a composite chain, finish
+                            // off the current composite.
+                            if (!isPartOfComposite && currentCompositeBindingIndex != InputActionState.kInvalidIndex)
+                            {
+                                currentCompositePartCount = 0;
+                                currentCompositeBindingIndex = InputActionState.kInvalidIndex;
+                                currentCompositeIndex = InputActionState.kInvalidIndex;
+                                currentCompositeAction = null;
+                                currentCompositeActionIndexInMap = InputActionState.kInvalidIndex;
+                            }
+
+                            // Look up controls.
+                            //
+                            // NOTE: We continuously add controls here to `resolvedControls`. Once we've completed our
+                            //       pass over the bindings in the map, `resolvedControls` will have all the controls for
+                            //       the current map.
+                            firstControlIndex = memory.controlCount + resolvedControls.Count;
+                            if (devicesForThisMap != null)
+                            {
+                                // Search in devices for only this map.
+                                var list = devicesForThisMap.Value;
+                                for (var i = 0; i < list.Count; ++i)
+                                {
+                                    var device = list[i];
+                                    if (!device.added)
+                                        continue; // Skip devices that have been removed.
+                                    numControls += InputControlPath.TryFindControls(device, path, 0, ref resolvedControls);
+                                }
+                            }
+                            else
+                            {
+                                // Search globally.
+                                numControls = InputSystem.FindControls(path, ref resolvedControls);
+                            }
                         }
 
                         // If the binding is part of a composite, pass the resolved controls
                         // on to the composite.
-                        var partIndex = InputActionState.kInvalidIndex;
-                        var actionIndexForBinding = InputActionState.kInvalidIndex;
                         if (isPartOfComposite && currentCompositeBindingIndex != InputActionState.kInvalidIndex && numControls > 0)
                         {
                             // Make sure the binding is named. The name determines what in the composite
@@ -376,7 +375,7 @@ namespace UnityEngine.InputSystem
                             actionIndexForBinding = actionStartIndex + actionIndexInMap;
                         }
 
-                        // Add entry for resolved binding.
+                        // Store resolved binding.
                         *bindingState = new InputActionState.BindingState
                         {
                             controlStartIndex = firstControlIndex,

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -474,7 +474,7 @@ namespace UnityEngine.InputSystem.Editor
             var selectedDefaultActionMap = !string.IsNullOrEmpty(playerInput.defaultActionMap)
                 ? asset.FindActionMap(playerInput.defaultActionMap)
                 : null;
-            m_SelectedDefaultActionMap = 0;
+            m_SelectedDefaultActionMap = asset.actionMaps.Count > 0 ? 1 : 0;
             var actionMaps = asset.actionMaps;
             m_ActionMapOptions = new GUIContent[actionMaps.Count + 1];
             m_ActionMapOptions[0] = new GUIContent(EditorGUIUtility.TrTextContent("<None>"));


### PR DESCRIPTION
Fixes 
- https://fogbugz.unity3d.com/f/cases/1187377/, https://issuetracker.unity3d.com/issues/input-system-composite-bindings-are-not-responsive-when-one-of-their-path-is-set-to-an-empty-string-or-null
- https://fogbugz.unity3d.com/f/cases/1189867/, https://issuetracker.unity3d.com/issues/input-system-action-with-no-bindings-in-one-scheme-remains-disabled-in-other-schemes