### PR TITLE
FIX: Missing custom editors for stick and axis deadzone processors.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed missing keyboard bindings in `DefaultInputActions.inputactions` for navigation in UI.
+- Fixed missing custom editors for `AxisDeadzoneProcessor` and `StickDeadzoneProcessor` that link `min` and `max` values to input settings.
 
 ## [1.0.0-preview.1] - 2019-10-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -1,6 +1,12 @@
+using UnityEngine.Scripting;
+
+#if UNITY_EDITOR
+using UnityEngine.InputSystem.Editor;
+#endif
+
 namespace UnityEngine.InputSystem.Processors
 {
-    [Scripting.Preserve]
+    [Preserve]
     internal class AxisDeadzoneProcessor : InputProcessor<float>
     {
         public float min;
@@ -23,4 +29,32 @@ namespace UnityEngine.InputSystem.Processors
             return Mathf.Sign(value) * ((absValue - min) / (max - min));
         }
     }
+
+    #if UNITY_EDITOR
+    internal class AxisDeadzoneProcessorEditor : InputParameterEditor<AxisDeadzoneProcessor>
+    {
+        protected override void OnEnable()
+        {
+            m_MinSetting.Initialize("Min",
+                "Value below which input values will be clamped. After clamping, values will be renormalized to [0..1] between min and max.",
+                "Default Deadzone Min",
+                () => target.min, v => target.min = v,
+                () => InputSystem.settings.defaultDeadzoneMin);
+            m_MaxSetting.Initialize("Max",
+                "Value above which input values will be clamped. After clamping, values will be renormalized to [0..1] between min and max.",
+                "Default Deadzone Max",
+                () => target.max, v => target.max = v,
+                () => InputSystem.settings.defaultDeadzoneMax);
+        }
+
+        public override void OnGUI()
+        {
+            m_MinSetting.OnGUI();
+            m_MaxSetting.OnGUI();
+        }
+
+        private CustomOrDefaultSetting m_MinSetting;
+        private CustomOrDefaultSetting m_MaxSetting;
+    }
+    #endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -1,3 +1,9 @@
+using UnityEngine.Scripting;
+
+#if UNITY_EDITOR
+using UnityEngine.InputSystem.Editor;
+#endif
+
 ////REVIEW: rename to RadialDeadzone
 
 ////TODO: add different deadzone shapes and/or option to min/max X and Y separately
@@ -8,7 +14,7 @@ namespace UnityEngine.InputSystem.Processors
     /// Processes a Vector2 to apply deadzoning according to the magnitude of the vector (rather
     /// than just clamping individual axes). Normalizes to the min/max range.
     /// </summary>
-    [Scripting.Preserve]
+    [Preserve]
     public class StickDeadzoneProcessor : InputProcessor<Vector2>
     {
         /// <summary>
@@ -49,4 +55,32 @@ namespace UnityEngine.InputSystem.Processors
             return Mathf.Sign(value) * ((absValue - min) / (max - min));
         }
     }
+
+    #if UNITY_EDITOR
+    internal class StickDeadzoneProcessorEditor : InputParameterEditor<StickDeadzoneProcessor>
+    {
+        protected override void OnEnable()
+        {
+            m_MinSetting.Initialize("Min",
+                "Vector length  below which input values will be clamped. After clamping, vector lengths will be renormalized to [0..1] between min and max.",
+                "Default Deadzone Min",
+                () => target.min, v => target.min = v,
+                () => InputSystem.settings.defaultDeadzoneMin);
+            m_MaxSetting.Initialize("Max",
+                "Vector length above which input values will be clamped. After clamping, vector lengths will be renormalized to [0..1] between min and max.",
+                "Default Deadzone Max",
+                () => target.max, v => target.max = v,
+                () => InputSystem.settings.defaultDeadzoneMax);
+        }
+
+        public override void OnGUI()
+        {
+            m_MinSetting.OnGUI();
+            m_MaxSetting.OnGUI();
+        }
+
+        private CustomOrDefaultSetting m_MinSetting;
+        private CustomOrDefaultSetting m_MaxSetting;
+    }
+    #endif
 }


### PR DESCRIPTION
https://forum.unity.com/threads/default-deadzone-settings-are-forgotten.760667/

While using input settings, both processors were indeed missing custom editors that linked the settings to the respective defaults.