### PR TITLE
FIX: Custom devices lost on domain reload (case 1192379).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -141,13 +141,31 @@ partial class CoreTests
         var device = InputSystem.AddDevice<Gamepad>();
         InputSystem.SetDeviceUsage(device, CommonUsages.LeftHand);
 
-        InputSystem.SaveAndReset();
-        InputSystem.Restore();
+        SimulateDomainReload();
 
-        var newDevice = InputSystem.devices.First(x => x is Gamepad);
+        var newDevice = InputSystem.devices[0];
 
         Assert.That(newDevice.usages, Has.Count.EqualTo(1));
         Assert.That(newDevice.usages, Has.Exactly(1).EqualTo(CommonUsages.LeftHand));
+    }
+
+    // We have code that will automatically query the enabled state of devices on creation
+    // but if the IOCTL is not implemented, we still need to be able to maintain a device's
+    // enabled state.
+    [Test]
+    [Category("Editor")]
+    public void Editor_DomainReload_PreservesEnabledState()
+    {
+        var device = InputSystem.AddDevice<Gamepad>();
+        InputSystem.DisableDevice(device);
+
+        Assert.That(device.enabled, Is.False);
+
+        SimulateDomainReload();
+
+        var newDevice = InputSystem.devices[0];
+
+        Assert.That(newDevice.enabled, Is.False);
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -152,38 +152,79 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
-    public void Editor_DomainReload_FirstPlayerLoopUpdateCausesDevicesToBeRecreated()
+    public void Editor_DomainReload_InputSystemInitializationCausesDevicesToBeRecreated()
     {
         InputSystem.AddDevice<Gamepad>();
 
-        // This test quite invasively goes into InputSystem internals. Unfortunately, we
-        // have no proper way of simulating domain reloads ATM. So we directly call various
-        // internal methods here in a sequence similar to what we'd get during a domain reload.
-
-        InputSystem.s_SystemObject.OnBeforeSerialize();
-        runtime.onPlayModeChanged(PlayModeStateChange.ExitingEditMode);
-        runtime.isInPlayMode = false;
-        InputSystem.s_SystemObject = null;
-        InputSystem.InitializeInEditor(runtime);
-        runtime.isInPlayMode = true;
-        runtime.onPlayModeChanged(PlayModeStateChange.EnteredPlayMode);
+        SimulateDomainReload();
 
         Assert.That(InputSystem.devices, Has.Count.EqualTo(1));
         Assert.That(InputSystem.devices[0], Is.TypeOf<Gamepad>());
+    }
+
+    // https://fogbugz.unity3d.com/f/cases/1192379/
+    [Test]
+    [Category("Editor")]
+    public void Editor_DomainReload_CustomDevicesAreRestoredAsLayoutsBecomeAvailable()
+    {
+        ////REVIEW: Consider switching away from explicit registration and switch to implicit discovery
+        ////        through reflection. Explicit registration has proven surprisingly fickle and puts the
+        ////        burden squarely on users.
+
+        // We may have several [InitializeOnLoad] classes each registering a piece of data
+        // with the input system. The first [InitializeOnLoad] code that gets picked by the
+        // Unity runtime is the one that will trigger initialization of the input system.
+        //
+        // However, if we have a later one in the sequence registering a device layout, we
+        // cannot successfully recreate devices using that layout until that code has executed,
+        // too.
+        //
+        // What we do to solve this is to keep information on devices that we fail to restore
+        // after a domain around until the very first full input update. At that point, we
+        // warn about every
+
+        const string kLayout = @"
+            {
+                ""name"" : ""CustomDevice"",
+                ""extend"" : ""Gamepad""
+            }
+        ";
+
+        InputSystem.RegisterLayout(kLayout);
+        InputSystem.AddDevice("CustomDevice");
+
+        SimulateDomainReload();
+
+        Assert.That(InputSystem.devices, Is.Empty);
+
+        InputSystem.RegisterLayout(kLayout);
+
+        Assert.That(InputSystem.devices, Has.Count.EqualTo(1));
+        Assert.That(InputSystem.devices[0].layout, Is.EqualTo("CustomDevice"));
+    }
+
+    [Test]
+    [Category("Editor")]
+    public void Editor_DomainReload_RetainsUnsupportedDevices()
+    {
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            interfaceName = "SomethingUnknown",
+            product = "UnknownProduct"
+        });
+        InputSystem.Update();
+
+        SimulateDomainReload();
+
+        Assert.That(InputSystem.GetUnsupportedDevices(), Has.Count.EqualTo(1));
+        Assert.That(InputSystem.GetUnsupportedDevices()[0].interfaceName, Is.EqualTo("SomethingUnknown"));
+        Assert.That(InputSystem.GetUnsupportedDevices()[0].product, Is.EqualTo("UnknownProduct"));
     }
 
     [Test]
     [Category("Editor")]
     [Ignore("TODO")]
     public void TODO_Editor_DomainReload_PreservesVariantsOnDevices()
-    {
-        Assert.Fail();
-    }
-
-    [Test]
-    [Category("Editor")]
-    [Ignore("TODO")]
-    public void TODO_Editor_DomainReload_PreservesCurrentStatusOfDevices()
     {
         Assert.Fail();
     }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,8 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed touch taps triggering when they shouldn't on Android.
+- Fixed custom devices registered from `[InitializeOnLoad]` code being lost on domain reload (case 1192379).
+  * This happened when there were multiple pieces of `[InitializeOnLoad]` code that accessed the input system in the project and the `RegisterLayout` for the custom device happened to not be the first in sequence.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/Documentation~/Devices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Devices.md
@@ -74,7 +74,7 @@ Once a [layout](Layouts.md) has been chosen for a device, it is used to instanti
 
 >__Note__: Valid [`InputDevices`](../api/UnityEngine.InputSystem.InputDevice.html) and [`InputControls`](../api/UnityEngine.InputSystem.InputControl.html) cannot be created by manually instantiating them with `new`. To guide the creation process, [layouts](Layouts.md) must be used.
 
-When the Input System has finished putting an [`InputDevice`](../api/UnityEngine.InputSystem.InputDevice.html) together, it will call [`FinishSetup`](../api/UnityEngine.InputSystem.InputDevice.html#UnityEngine_InputSystem_InputControl_FinishSetup_) on each control of the device and on the device itself. This can be used to finalize the setup of controls.
+When the Input System has finished putting an [`InputDevice`](../api/UnityEngine.InputSystem.InputDevice.html) together, it will call [`FinishSetup`](../api/UnityEngine.InputSystem.InputControl.html#UnityEngine_InputSystem_InputControl_FinishSetup_) on each control of the device and on the device itself. This can be used to finalize the setup of controls.
 
 After an [`InputDevice`](../api/UnityEngine.InputSystem.InputDevice.html) is fully assembled, it will be added to the system. As part of this process, [`MakeCurrent`](../api/UnityEngine.InputSystem.InputDevice.html#UnityEngine_InputSystem_InputDevice_MakeCurrent_) will be called on the device and [`InputDeviceChange.Added`](../api/UnityEngine.InputSystem.InputDeviceChange.html#UnityEngine_InputSystem_InputDeviceChange_Added) will be signaled on [`InputSystem.onDeviceChange`](../api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_onDeviceChange).
 

--- a/Packages/com.unity.inputsystem/Documentation~/Devices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Devices.md
@@ -1,7 +1,10 @@
 # Devices
 
 * [Device descriptions](#device-descriptions)
+    * [Capabilities](#capabilities)
+    * [Matching](#matching)
     * [Hijacking the matching process](#hijacking-the-matching-process)
+* [Device creation](#device-creation)
 * [Native Devices](#native-devices)
     * [Disconnected Devices](#disconnected-devices)
 * [Device IDs](#device-ids)
@@ -32,7 +35,7 @@ Every description has a set of standard fields:
 |[`manufacturer`](../api/UnityEngine.InputSystem.Layouts.InputDeviceDescription.html#UnityEngine_InputSystem_Layouts_InputDeviceDescription_manufacturer)|Name of the manufacturer as reported by the Device/driver itself.|
 |[`version`](../api/UnityEngine.InputSystem.Layouts.InputDeviceDescription.html#UnityEngine_InputSystem_Layouts_InputDeviceDescription_version)|If available, provides the version of the driver or hardware for the Device.|
 |[`serial`](../api/UnityEngine.InputSystem.Layouts.InputDeviceDescription.html#UnityEngine_InputSystem_Layouts_InputDeviceDescription_serial)|If available, provides the serial number for the Device.|
-|[`capabilities`](../api/UnityEngine.InputSystem.Layouts.InputDeviceDescription.html#UnityEngine_InputSystem_Layouts_InputDeviceDescription_capabilities)|A string in JSON format describing Device/interface-specific capabilities. See the [section on capabililities](#capabilities).|
+|[`capabilities`](../api/UnityEngine.InputSystem.Layouts.InputDeviceDescription.html#UnityEngine_InputSystem_Layouts_InputDeviceDescription_capabilities)|A string in JSON format describing Device/interface-specific capabilities. See the [section on capabilities](#capabilities).|
 
 ### Capabilities
 
@@ -61,9 +64,25 @@ InputSystem.RegisterLayoutMatcher<MyDevice>(
 
 If multiple matchers are matching the same [`InputDeviceDescription`](../api/UnityEngine.InputSystem.Layouts.InputDeviceDescription.html), the Input System chooses the matcher that has the larger number of properties to match against.
 
-### Hijacking the matching process
+#### Hijacking the matching process
 
 You can overrule the internal matching process from outside and thus select a different layout for a Device than the system would normally choose. This also makes it possible to build new layouts on the fly. To do this, add a custom handler to the  [`InputSystem.onFindControlLayoutForDevice`](../api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_onFindLayoutForDevice) event. If your handler returns a non-null layout string, then the Input System will use this layout.
+
+### Device creation
+
+Once a [layout](Layouts.md) has been chosen for a device, it is used to instantiate an [`InputDevice`](../api/UnityEngine.InputSystem.InputDevice.html) and populate it with [`InputControls`](../api/UnityEngine.InputSystem.InputControl.html) as dictated by the layout. This process is performed automatically and internally.
+
+>__Note__: Valid [`InputDevices`](../api/UnityEngine.InputSystem.InputDevice.html) and [`InputControls`](../api/UnityEngine.InputSystem.InputControl.html) cannot be created by manually instantiating them with `new`. To guide the creation process, [layouts](Layouts.md) must be used.
+
+When the Input System has finished putting an [`InputDevice`](../api/UnityEngine.InputSystem.InputDevice.html) together, it will call [`FinishSetup`](../api/UnityEngine.InputSystem.InputDevice.html#UnityEngine_InputSystem_InputControl_FinishSetup_) on each control of the device and on the device itself. This can be used to finalize the setup of controls.
+
+After an [`InputDevice`](../api/UnityEngine.InputSystem.InputDevice.html) is fully assembled, it will be added to the system. As part of this process, [`MakeCurrent`](../api/UnityEngine.InputSystem.InputDevice.html#UnityEngine_InputSystem_InputDevice_MakeCurrent_) will be called on the device and [`InputDeviceChange.Added`](../api/UnityEngine.InputSystem.InputDeviceChange.html#UnityEngine_InputSystem_InputDeviceChange_Added) will be signaled on [`InputSystem.onDeviceChange`](../api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_onDeviceChange).
+
+#### Domain reloads in the Editor
+
+In the Editor, the C# application domain will be reloaded whenever scripts are recompiled and reloaded or when going into play mode. This requires the Input System to reinitialize itself after each domain reload. During this process, it will attempt to recreate devices that had been instantiated before the domain reload. It will, however, not take the state of each such Device across. This means that Devices will reset to default state on domain reloads.
+
+Note that layout registrations are __not__ persisted across domain reloads. Instead, the Input System relies on all registrations to become available as part of the initialization process (e.g. by using `[InitializeOnLoad]` to run registration as part of the domain startup code in the Editor). This allows registrations and layouts to be changed in script and the change to immediately take effect after a domain reload.
 
 ## Native Devices
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -323,10 +323,6 @@ namespace UnityEngine.InputSystem
         ///
         /// The primary effect of being noise is on <see cref="InputDevice.MakeCurrent"/> and
         /// on interactive rebinding (see <see cref="InputActionRebindingExtensions.RebindingOperation"/>).
-        ///
-        /// If noise filtering on <c>.current</c> is enabled (see <see cref="InputSettings.filterNoiseOnCurrent"/>),
-        /// when seeing input for a potentially noisy device (i.e. any device with any control
-        /// marked as noisy), the system will perform a check
         /// </remarks>
         /// <seealso cref="InputControlLayout.ControlItem.isNoisy"/>
         /// <seealso cref="InputControlAttribute.noisy"/>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -20,6 +20,8 @@ using UnityEngine.InputSystem.Layouts;
 
 ////REVIEW: how do we do stuff like smoothing over time?
 
+////TODO: allow easier access to the default state such that you can easily create a state event containing only default state
+
 namespace UnityEngine.InputSystem
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
@@ -225,13 +225,14 @@ namespace UnityEngine.InputSystem.Layouts
         /// </remarks>
         public bool Equals(InputDeviceDescription other)
         {
-            return string.Equals(m_InterfaceName, other.m_InterfaceName, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(m_DeviceClass, other.m_DeviceClass, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(m_Manufacturer, other.m_Manufacturer, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(m_Product, other.m_Product, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(m_Serial, other.m_Serial, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(m_Version, other.m_Version, StringComparison.InvariantCultureIgnoreCase) &&
-                string.Equals(m_Capabilities, other.m_Capabilities, StringComparison.InvariantCultureIgnoreCase);
+            return m_InterfaceName.InvariantEqualsIgnoreCase(other.m_InterfaceName) &&
+                m_DeviceClass.InvariantEqualsIgnoreCase(other.m_DeviceClass) &&
+                m_Manufacturer.InvariantEqualsIgnoreCase(other.m_Manufacturer) &&
+                m_Product.InvariantEqualsIgnoreCase(other.m_Product) &&
+                m_Serial.InvariantEqualsIgnoreCase(other.m_Serial) &&
+                m_Version.InvariantEqualsIgnoreCase(other.m_Version) &&
+                ////REVIEW: this would ideally compare JSON contents not just the raw string
+                m_Capabilities.InvariantEqualsIgnoreCase(other.m_Capabilities);
         }
 
         /// <summary>
@@ -245,7 +246,7 @@ namespace UnityEngine.InputSystem.Layouts
         {
             if (ReferenceEquals(null, obj))
                 return false;
-            return obj is InputDeviceDescription && Equals((InputDeviceDescription)obj);
+            return obj is InputDeviceDescription description && Equals(description);
         }
 
         /// <summary>
@@ -256,7 +257,7 @@ namespace UnityEngine.InputSystem.Layouts
         {
             unchecked
             {
-                var hashCode = (m_InterfaceName != null ? m_InterfaceName.GetHashCode() : 0);
+                var hashCode = m_InterfaceName != null ? m_InterfaceName.GetHashCode() : 0;
                 hashCode = (hashCode * 397) ^ (m_DeviceClass != null ? m_DeviceClass.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (m_Manufacturer != null ? m_Manufacturer.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (m_Product != null ? m_Product.GetHashCode() : 0);

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -437,9 +437,6 @@ namespace UnityEngine.InputSystem.Layouts
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0", Justification = "False positive.")]
         public bool Equals(InputDeviceMatcher other)
         {
-            if (other == null)
-                return false;
-
             if (m_Patterns == other.m_Patterns)
                 return true;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -360,6 +360,13 @@ namespace UnityEngine.InputSystem
         /// matchers matches a given <see cref="InputDeviceDescription"/> (see <see cref="InputDeviceMatcher.MatchPercentage"/>)
         /// better than any other matcher (for the same or any other layout), then the given layout
         /// will be used for the discovered device.
+        ///
+        /// Note that registering a matcher may immediately lead to devices being created or recreated.
+        /// If <paramref name="matcher"/> matches any devices currently on the list of unsupported devices
+        /// (see <see cref="GetUnsupportedDevices()"/>), new <see cref="InputDevice"/>s will be created
+        /// using the layout called <paramref name="layoutName"/>. Also, if <paramref name="matcher"/>
+        /// matches the description of a device better than the matcher (if any) for the device's currently
+        /// used layout, the device will be recreated using the given layout.
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="layoutName"/> is <c>null</c> or empty/</exception>
         /// <exception cref="ArgumentException"><paramref name="matcher"/> is empty (<see cref="InputDeviceMatcher.empty"/>).</exception>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -7,6 +7,7 @@ using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.Layouts;
+using UnityEngine.Scripting;
 
 ////REVIEW: there will probably be lots of cases where the HID device creation process just needs a little tweaking; we should
 ////        have better mechanism to do that without requiring to replace the entire process wholesale
@@ -34,7 +35,7 @@ namespace UnityEngine.InputSystem.HID
     /// construct more specific device representations such as Gamepad.
     /// </remarks>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1724:TypeNamesShouldNotMatchNamespaces")]
-    [Scripting.Preserve]
+    [Preserve]
     public class HID : InputDevice
     {
         internal const string kHIDInterface = "HID";

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDSupport.cs
@@ -60,7 +60,7 @@ namespace UnityEngine.InputSystem.HID
             /// </summary>
             public HIDPageUsage(HID.GenericDesktop usage)
             {
-                this.page = HID.UsagePage.GenericDesktop;
+                page = HID.UsagePage.GenericDesktop;
                 this.usage = (int)usage;
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1,11 +1,12 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine.Events;
-using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.UI;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
+
+////TODO: allow PlayerInput to be set up in a way where it's in an unpaired/non-functional state and expects additional configuration
 
 ////REVIEW: having everything coupled to component enable/disable is quite restrictive; can we allow PlayerInputs
 ////        to be disabled without them leaving the game? would help when wanting to keep players around in the background

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/StringHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/StringHelpers.cs
@@ -506,5 +506,12 @@ namespace UnityEngine.InputSystem.Utilities
                     buffer.Append(ch);
             return buffer.ToString();
         }
+
+        public static bool InvariantEqualsIgnoreCase(this string left, string right)
+        {
+            if (string.IsNullOrEmpty(left))
+                return string.IsNullOrEmpty(right);
+            return string.Equals(left, right, StringComparison.InvariantCultureIgnoreCase);
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/InputSystem/InputTestFixture.cs
@@ -530,5 +530,19 @@ namespace UnityEngine.InputSystem
                 return this;
             }
         }
+
+        #if UNITY_EDITOR
+        internal void SimulateDomainReload()
+        {
+            // This quite invasively goes into InputSystem internals. Unfortunately, we
+            // have no proper way of simulating domain reloads ATM. So we directly call various
+            // internal methods here in a sequence similar to what we'd get during a domain reload.
+
+            InputSystem.s_SystemObject.OnBeforeSerialize();
+            InputSystem.s_SystemObject = null;
+            InputSystem.InitializeInEditor(runtime);
+        }
+
+        #endif
     }
 }


### PR DESCRIPTION
First piece of `[InitializeOnLoad]` code accessing the input system would cause devices that couldn't be instantly recreated to be lost even if a needed `RegisterLayout` call would come in later during initialization after domain reload.