### PR TITLE
FIX: Ungrouped bindings not getting enabled.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4132,8 +4132,9 @@ partial class CoreTests
 
         action.bindingMask = new InputBinding {groups = "gamepad"};
 
-        Assert.That(action.controls, Has.Count.EqualTo(1));
+        Assert.That(action.controls, Has.Count.EqualTo(2));
         Assert.That(action.controls, Has.Exactly(1).SameAs(gamepad.buttonSouth));
+        Assert.That(action.controls, Has.Exactly(1).SameAs(mouse.leftButton));
         Assert.That(action.bindingMask, Is.EqualTo(new InputBinding {groups = "gamepad"}));
 
         action.bindingMask = null;
@@ -4206,8 +4207,9 @@ partial class CoreTests
         map.bindingMask = new InputBinding {groups = "gamepad"};
 
         Assert.That(action1.controls, Has.Count.EqualTo(1));
-        Assert.That(action2.controls, Has.Count.Zero);
         Assert.That(action1.controls, Has.Exactly(1).SameAs(gamepad.buttonSouth));
+        Assert.That(action2.controls, Has.Count.EqualTo(1));
+        Assert.That(action2.controls, Has.Exactly(1).SameAs(mouse.leftButton));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4254,6 +4254,26 @@ partial class CoreTests
         Assert.That(action2.controls, Has.Exactly(1).SameAs(keyboard.bKey));
     }
 
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenMaskingByGroup_BindingsNotInAnyGroupWillBeActive()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var mouse = InputSystem.AddDevice<Mouse>();
+        InputSystem.AddDevice<Keyboard>();
+
+        var action = new InputAction();
+        action.AddBinding("<Gamepad>/buttonSouth", groups: "Gamepad");
+        action.AddBinding("<Keyboard>/space", groups: "Keyboard&Mouse");
+        action.AddBinding("<Pointer>/press");
+
+        action.bindingMask = InputBinding.MaskByGroup("Gamepad");
+
+        Assert.That(action.controls, Has.Count.EqualTo(2));
+        Assert.That(action.controls, Has.Exactly(1).SameAs(gamepad.buttonSouth));
+        Assert.That(action.controls, Has.Exactly(1).SameAs(mouse.press));
+    }
+
     // When we have an .inputactions asset, at runtime we should end up with a single array of resolved
     // controls, single array of trigger states, and so on. The expectation is that users won't generally
     // go and configure each map in an asset in a wildly different way. Rather, the maps will usually perform

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.EventSystems;
 using UnityEngine.Scripting;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
@@ -113,6 +114,40 @@ internal class PlayerInputTests : InputTestFixture
 
         Assert.That(instance.devices, Is.EquivalentTo(new[] { gamepad }));
         Assert.That(ui.actionsAsset.devices, Is.EquivalentTo(new[] { gamepad }));
+    }
+
+    [Test]
+    [Category("PlayerInput")]
+    public void PlayerInput_CanUseSameActionsForUIInputModule()
+    {
+        var actions = InputActionAsset.FromJson(kActions);
+        var mouse = InputSystem.AddDevice<Mouse>();
+        InputSystem.AddDevice<Keyboard>();
+
+        var eventSystemGO = new GameObject();
+        eventSystemGO.SetActive(false);
+        eventSystemGO.AddComponent<EventSystem>();
+        var uiModule = eventSystemGO.AddComponent<InputSystemUIInputModule>();
+        uiModule.actionsAsset = actions;
+        uiModule.move = InputActionReference.Create(actions["UI/Navigate"]);
+        uiModule.point = InputActionReference.Create(actions["UI/Point"]);
+        uiModule.leftClick = InputActionReference.Create(actions["UI/Click"]);
+
+        var playerGO = new GameObject();
+        playerGO.SetActive(false);
+        var player = playerGO.AddComponent<PlayerInput>();
+        player.actions = actions;
+        player.defaultActionMap = "Gameplay";
+        player.defaultControlScheme = "Keyboard&Mouse";
+
+        eventSystemGO.SetActive(true);
+        playerGO.SetActive(true);
+
+        Assert.That(actions.FindActionMap("Gameplay").enabled, Is.True);
+        Assert.That(actions.FindActionMap("UI").enabled, Is.True);
+        Assert.That(actions["UI/Navigate"].controls, Is.Empty);
+        Assert.That(actions["UI/Point"].controls, Is.EquivalentTo(new[] { mouse.position }));
+        Assert.That(actions["UI/Click"].controls, Is.EquivalentTo(new[] { mouse.leftButton }));
     }
 
     [Test]
@@ -1525,10 +1560,14 @@ internal class PlayerInputTests : InputTestFixture
                 {
                     ""name"" : ""ui"",
                     ""actions"" : [
-                        { ""name"" : ""navigate"" }
+                        { ""name"" : ""navigate"", ""type"" : ""PassThrough"" },
+                        { ""name"" : ""point"", ""type"" : ""PassThrough"" },
+                        { ""name"" : ""click"", ""type"" : ""PassThrough"" }
                     ],
                     ""bindings"" : [
-                        { ""path"" : ""<Gamepad>/dpad"", ""action"" : ""navigate"", ""groups"" : ""Gamepad"" }
+                        { ""path"" : ""<Gamepad>/dpad"", ""action"" : ""navigate"", ""groups"" : ""Gamepad"" },
+                        { ""path"" : ""<Mouse>/position"", ""action"" : ""point"", ""groups"" : ""Keyboard&Mouse"" },
+                        { ""path"" : ""<Mouse>/leftButton"", ""action"" : ""click"", ""groups"" : ""Keyboard&Mouse"" }
                     ]
                 },
                 {

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed actions ending up being disabled if switching to a control scheme that has no binding for the action (case 1187377).
 - Fixed part of composite not being bound leading to subsequent part bindings not being functional (case 1189867).
 - Fixed `ArgumentNullException` when adding a device and a binding in an action map had an empty path (case 1187163).
+- Fixed bindings that are not associated with any control scheme not getting enabled with other control schemes as they should.
 
 ## [1.0.0-preview.1] - 2019-10-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
@@ -638,8 +638,10 @@ namespace UnityEngine.InputSystem
 
             if (groups != null)
             {
-                if (binding.groups == null
-                    || !StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(groups, binding.groups, Separator))
+                // We consider bindings that are not assigned to any group to be a match
+                // for any group.
+                if (!string.IsNullOrEmpty(binding.groups)
+                    && !StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(groups, binding.groups, Separator))
                     return false;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
@@ -615,7 +615,7 @@ namespace UnityEngine.InputSystem
         }
 
         // Internally we pass by reference to not unnecessarily copy the struct.
-        internal bool Matches(ref InputBinding binding)
+        internal bool Matches(ref InputBinding binding, MatchOptions options = default)
         {
             if (path != null)
             {
@@ -638,9 +638,11 @@ namespace UnityEngine.InputSystem
 
             if (groups != null)
             {
-                // We consider bindings that are not assigned to any group to be a match
-                // for any group.
-                if (!string.IsNullOrEmpty(binding.groups)
+                var haveGroupsOnBinding = !string.IsNullOrEmpty(binding.groups);
+                if (!haveGroupsOnBinding && (options & MatchOptions.EmptyGroupMatchesAny) == 0)
+                    return false;
+
+                if (haveGroupsOnBinding
                     && !StringHelpers.CharacterSeparatedListsHaveAtLeastOneCommonElement(groups, binding.groups, Separator))
                     return false;
             }
@@ -652,6 +654,12 @@ namespace UnityEngine.InputSystem
             }
 
             return true;
+        }
+
+        [Flags]
+        internal enum MatchOptions
+        {
+            EmptyGroupMatchesAny = 1 << 0,
         }
 
         [Flags]

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -224,15 +224,17 @@ namespace UnityEngine.InputSystem
                         var bindingIsDisabled = string.IsNullOrEmpty(path);
 
                         // Also, disabled if binding doesn't match with our binding mask (might be empty).
-                        bindingIsDisabled |= !isComposite && bindingMask != null && !bindingMask.Value.Matches(ref unresolvedBinding);
+                        bindingIsDisabled |= !isComposite && bindingMask != null &&
+                            !bindingMask.Value.Matches(ref unresolvedBinding,
+                            InputBinding.MatchOptions.EmptyGroupMatchesAny);
 
                         // Also, disabled if binding doesn't match the binding mask on the map (might be empty).
                         bindingIsDisabled |= !isComposite && bindingMaskOnThisMap != null &&
-                            !bindingMaskOnThisMap.Value.Matches(ref unresolvedBinding);
+                            !bindingMaskOnThisMap.Value.Matches(ref unresolvedBinding, InputBinding.MatchOptions.EmptyGroupMatchesAny);
 
                         // Finally, also disabled if binding doesn't match the binding mask on the action (might be empty).
                         bindingIsDisabled |= !isComposite && action?.m_BindingMask != null &&
-                            !action.m_BindingMask.Value.Matches(ref unresolvedBinding);
+                            !action.m_BindingMask.Value.Matches(ref unresolvedBinding, InputBinding.MatchOptions.EmptyGroupMatchesAny);
 
                         // If the binding isn't disabled, resolve its controls, processors, and interactions.
                         if (!bindingIsDisabled)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -489,6 +489,8 @@ namespace UnityEngine.InputSystem.Editor
             }
             if (m_SelectedDefaultActionMap <= 0)
                 playerInput.defaultActionMap = null;
+            else
+                playerInput.defaultActionMap = m_ActionMapOptions[m_SelectedDefaultActionMap].text;
 
             serializedObject.Update();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -1,9 +1,7 @@
 #if UNITY_EDITOR
-
 using System;
 using System.Linq;
 using UnityEditor;
-using UnityEngine.InputSystem.Editor;
 
 namespace UnityEngine.InputSystem.UI.Editor
 {
@@ -16,7 +14,7 @@ namespace UnityEngine.InputSystem.UI.Editor
             {
                 foreach (var action in actions)
                 {
-                    if (string.Compare(action.action.name, actionName, true) == 0)
+                    if (string.Compare(action.action.name, actionName, StringComparison.InvariantCultureIgnoreCase) == 0)
                         return action;
                 }
             }
@@ -34,7 +32,7 @@ namespace UnityEngine.InputSystem.UI.Editor
             return null;
         }
 
-        static private readonly string[] s_ActionNames = new[]
+        private static readonly string[] s_ActionNames =
         {
             "Point",
             "LeftClick",
@@ -46,23 +44,23 @@ namespace UnityEngine.InputSystem.UI.Editor
             "Cancel",
             "TrackedDevicePosition",
             "TrackedDeviceOrientation",
-            "TrackedDeviceSelect",
+            "TrackedDeviceSelect"
         };
 
-        string MakeNiceUIName(string name)
+        private static readonly string[] s_ActionNiceNames =
         {
-            string result = "";
-
-            for (var i = 0; i < name.Length; i++)
-            {
-                char ch = name[i];
-                if (char.IsUpper(ch) && i > 0)
-                    result += ' ';
-                result += ch;
-            }
-
-            return result;
-        }
+            "Point",
+            "Left Click",
+            "Middle Click",
+            "Right Click",
+            "Scroll Wheel",
+            "Move",
+            "Submit",
+            "Cancel",
+            "Tracked Position",
+            "Tracked Orientation",
+            "Tracked Select"
+        };
 
         private SerializedProperty[] m_ReferenceProperties;
         private SerializedProperty m_ActionsAsset;
@@ -78,7 +76,7 @@ namespace UnityEngine.InputSystem.UI.Editor
 
             m_ActionsAsset = serializedObject.FindProperty("m_ActionsAsset");
             m_AvailableActionsInAsset = GetAllActionsFromAsset(m_ActionsAsset.objectReferenceValue as InputActionAsset);
-            // Ugly hack: GenericMenu iterprets "/" as a submenu path. But luckily, "/" is not the only slash we have in Unicode.
+            // Ugly hack: GenericMenu interprets "/" as a submenu path. But luckily, "/" is not the only slash we have in Unicode.
             m_AvailableActionsInAssetNames = new[] { "None" }.Concat(m_AvailableActionsInAsset?.Select(x => x.name.Replace("/", "\uFF0F")) ?? new string[0]).ToArray();
         }
 
@@ -131,7 +129,7 @@ namespace UnityEngine.InputSystem.UI.Editor
                 {
                     int index = Array.IndexOf(m_AvailableActionsInAsset, m_ReferenceProperties[i].objectReferenceValue) + 1;
                     EditorGUI.BeginChangeCheck();
-                    index = EditorGUILayout.Popup(MakeNiceUIName(s_ActionNames[i]), index, m_AvailableActionsInAssetNames);
+                    index = EditorGUILayout.Popup(s_ActionNiceNames[i], index, m_AvailableActionsInAssetNames);
 
                     if (EditorGUI.EndChangeCheck())
                         m_ReferenceProperties[i].objectReferenceValue = index > 0 ? m_AvailableActionsInAsset[index - 1] : null;


### PR DESCRIPTION
No idea when I broke this. Probably a good while back.

Also fixes a regression I introduced in https://github.com/Unity-Technologies/InputSystem/commit/9af31bc5d12b506406871b5b63cddc363de82736#diff-070ad50002721b57ff26d22e80f642af where it seemed like the default action map was set on PlayerInput but it wasn't really.