### PR TITLE
FIX: HID devices with 32 bit reportSize failing to load (#871, #902)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -536,7 +536,7 @@ namespace UnityEngine.InputSystem.HID
             {
                 get
                 {
-                    var maxValue = (1 << reportSizeInBits) - 1;
+                    var maxValue = ((long)1 << reportSizeInBits) - 1;
                     if (isSigned)
                         return logicalMin / (float)((maxValue + 1) / 2);
                     return logicalMin / (float)maxValue;
@@ -547,7 +547,7 @@ namespace UnityEngine.InputSystem.HID
             {
                 get
                 {
-                    var maxValue = (1 << reportSizeInBits) - 1;
+                    var maxValue = ((long)1 << reportSizeInBits) - 1;
                     if (isSigned)
                         return logicalMax / (float)((maxValue + 1) / 2);
                     return logicalMax / (float)maxValue;
@@ -797,7 +797,7 @@ namespace UnityEngine.InputSystem.HID
 
                                     // Test upper bound.
                                     var maxPlusOne = logicalMax + 1;
-                                    if (maxPlusOne <= (1 << reportSizeInBits) - 1)
+                                    if (maxPlusOne <= ((long)1 << reportSizeInBits) - 1)
                                         return new PrimitiveValue(maxPlusOne);
                                 }
                                 break;

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -368,9 +368,9 @@ namespace UnityEngine.InputSystem.LowLevel
                 {
                     value = MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1.0f : (format == FormatSBit ? -1.0f : 0.0f);
                 }
-                else if (sizeInBits <= 31)
+                else if (sizeInBits <= 32)
                 {
-                    var maxValue = (float)(1 << (int)sizeInBits);
+                    var maxValue = (float)((long)1 << (int)sizeInBits);
                     var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
                     if (format == FormatSBit)
                     {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -232,7 +232,7 @@ namespace UnityEngine.InputSystem.Utilities
         {
             if (ptr == null)
                 throw new ArgumentNullException(nameof(ptr));
-            if (bitCount >= sizeof(int) * 8)
+            if (bitCount > sizeof(int) * 8)
                 throw new ArgumentException("Trying to read more than 32 bits as int", nameof(bitCount));
 
             // Shift the pointer up on larger bitmasks and retry.
@@ -278,8 +278,8 @@ namespace UnityEngine.InputSystem.Utilities
         {
             if (ptr == null)
                 throw new ArgumentNullException(nameof(ptr));
-            if (bitCount >= sizeof(int) * 8)
-                throw new ArgumentException("Trying to write more than 32 bits as int", nameof(bitCount));
+            if (bitCount > sizeof(int) * 8)
+                throw new ArgumentException("Trying to write more than 32 bits as int - " + bitCount, nameof(bitCount));
 
             // Bits out of byte.
             if (bitOffset + bitCount <= 8)


### PR DESCRIPTION
Tested with the Official Wii U Gamecube Controller Adapter. I also profiled memory usage in editor, since whilst working on this I did cause the editor to crash a few times due to introduced memory leaks.