### PR TITLE
FIX: Correct the maxValue when reading a multi-bit axis

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -370,7 +370,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 }
                 else if (sizeInBits <= 31)
                 {
-                    var maxValue = (float)(1 << (int)sizeInBits);
+                    var maxValue = (float)((1 << (int)sizeInBits) - 1);
                     var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
                     if (format == FormatSBit)
                     {
@@ -594,7 +594,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 }
                 else if (sizeInBits != 31)
                 {
-                    var maxValue = (float)(1 << (int)sizeInBits);
+                    var maxValue = (float)((1 << (int)sizeInBits) - 1);
                     var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
                     if (format == FormatSBit)
                     {


### PR DESCRIPTION
When reading a multi-bit axis, the returned float (or double) value will never return 1.0.

For example, an axis with 7 bits and a raw value range of [0, 127], will return [0, 0.9921875].

This change fixes the maxValue calculation so that it will return [0, 1].

The maxValue for writing was already correct.
