### PR TITLE
FIX: InvalidOperationExceptions with InputUser and touch input (case 1196522).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -981,6 +981,11 @@ partial class CoreTests
         {
             InputState.Change(this, eventPtr);
         }
+
+        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset)
+        {
+            return false;
+        }
     }
 
     [Test]
@@ -1073,6 +1078,11 @@ partial class CoreTests
                 }
 
             Assert.Fail();
+        }
+
+        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset)
+        {
+            return false;
         }
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -957,7 +957,7 @@ partial class CoreTests
     {
         var touchscreen = InputSystem.AddDevice<Touchscreen>();
 
-        using (var trace = new InputEventTrace(touchscreen))
+        using (var trace = new InputEventTrace { deviceId = touchscreen.deviceId })
         {
             trace.Enable();
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview.4] - 2019-12-12
+
+### Changed
+
+- `InputControlExtensions.GetStatePtrFromStateEvent` no longer throws `InvalidOperationException` when the state format for the event does not match that of the device. It simply returns `null` instead (same as when control is found in the event's state).
+
+### Fixed
+
+- `InputUser` in combination with touchscreens no longer throws `InvalidOperationException` complaining about incorrect state format.
+ * In a related change, `InputControlExtensions.GetStatePtrFromStateEvent` now works with touch events, too.
+
 ## [1.0.0-preview.3] - 2019-11-14
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1,8 +1,9 @@
 using System;
-using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.Serialization;
+
+////TODO: add way to retrieve the binding correspond to a control
 
 ////TODO: add way to retrieve the currently ongoing interaction and also add way to know how long it's been going on
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -16,6 +16,29 @@ namespace UnityEngine.InputSystem
     public static class InputControlExtensions
     {
         /// <summary>
+        /// Find a control of the given type in control hierarchy of <paramref name="control"/>.
+        /// </summary>
+        /// <param name="control">Control whose parents to inspect.</param>
+        /// <typeparam name="TControl">Type of control to look for. Actual control type can be
+        /// subtype of this.</typeparam>
+        /// <remarks>The found control of type <typeparamref name="TControl"/> which may be either
+        /// <paramref name="control"/> itself or one of its parents. If no such control was found,
+        /// returns <c>null</c>.</remarks>
+        /// <exception cref="ArgumentNullException"><paramref name="control"/> is <c>null</c>.</exception>
+        public static TControl FindInParentChain<TControl>(this InputControl control)
+            where TControl : InputControl
+        {
+            if (control == null)
+                throw new ArgumentNullException(nameof(control));
+
+            for (var parent = control; parent != null; parent = parent.parent)
+                if (parent is TControl parentOfType)
+                    return parentOfType;
+
+            return null;
+        }
+
+        /// <summary>
         /// Return true if the given control is actuated.
         /// </summary>
         /// <param name="control"></param>
@@ -113,16 +136,38 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Read the value of the given control from an event.
+        /// Read the value for the given control from the given event.
         /// </summary>
-        /// <param name="control"></param>
-        /// <param name="inputEvent">Input event. This must be a <see cref="StateEvent"/> or <seealso cref="DeltaStateEvent"/>.
+        /// <param name="control">Control to read value for.</param>
+        /// <param name="inputEvent">Event to read value from. Must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</param>
+        /// <typeparam name="TValue">Type of value to read.</typeparam>
+        /// <exception cref="ArgumentNullException"><paramref name="control"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="inputEvent"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</exception>
+        /// <returns>The value for the given control as read out from the given event or <c>default(TValue)</c> if the given
+        /// event does not contain a value for the control (e.g. if it is a <see cref="DeltaStateEvent"/> not containing the relevant
+        /// portion of the device's state memory).</returns>
+        public static TValue ReadValueFromEvent<TValue>(this InputControl<TValue> control, InputEventPtr inputEvent)
+            where TValue : struct
+        {
+            if (control == null)
+                throw new ArgumentNullException(nameof(control));
+            if (!ReadValueFromEvent(control, inputEvent, out var value))
+                return default;
+            return value;
+        }
+
+        /// <summary>
+        /// Check if the given event contains a value for the given control and if so, read the value.
+        /// </summary>
+        /// <param name="control">Control to read value for.</param>
+        /// <param name="inputEvent">Input event. This must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.
         /// Note that in the case of a <see cref="DeltaStateEvent"/>, the control may not actually be part of the event. In this
         /// case, the method returns false and stores <c>default(TValue)</c> in <paramref name="value"/>.</param>
         /// <param name="value">Variable that receives the control value.</param>
-        /// <typeparam name="TValue"></typeparam>
+        /// <typeparam name="TValue">Type of value to read.</typeparam>
         /// <returns>True if the value has been successfully read from the event, false otherwise.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="control"/> is null.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="control"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="inputEvent"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</exception>
         /// <seealso cref="ReadUnprocessedValueFromEvent{TValue}(InputControl{TValue},InputEventPtr)"/>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", MessageId = "2#")]
         public static unsafe bool ReadValueFromEvent<TValue>(this InputControl<TValue> control, InputEventPtr inputEvent, out TValue value)
@@ -457,6 +502,26 @@ namespace UnityEngine.InputSystem
             return control.CompareValue(control.currentStatePtr, control.GetStatePtrFromStateEvent(eventPtr));
         }
 
+        /// <summary>
+        /// Given a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>, return the raw memory pointer that can
+        /// be used, for example, with <see cref="InputControl{T}.ReadValueFromState"/> to read out the value of <paramref name="control"/>
+        /// contained in the event.
+        /// </summary>
+        /// <param name="control">Control to access state for in the given state event.</param>
+        /// <param name="eventPtr">A <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> containing input state.</param>
+        /// <returns>A pointer that can be used with methods such as <see cref="InputControl{TValue}.ReadValueFromState"/> or <c>null</c>
+        /// if <paramref name="eventPtr"/> does not contain state for the given <paramref name="control"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="control"/> is <c>null</c> -or- <paramref name="eventPtr"/> is invalid.</exception>
+        /// <exception cref="ArgumentException"><paramref name="eventPtr"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</exception>
+        /// <remarks>
+        /// Note that the given state event must have the same state format (see <see cref="InputStateBlock.format"/>) as the device
+        /// to which <paramref name="control"/> belongs. If this is not the case, the method will invariably return <c>null</c>.
+        ///
+        /// In practice, this means that the method cannot be used with touch events or, in general, with events sent to devices
+        /// that implement <see cref="IInputStateCallbackReceiver"/> (which <see cref="Touchscreen"/> does) except if the event
+        /// is in the same state format as the device. Touch events will generally be sent as state events containing only the
+        /// state of a single <see cref="Controls.TouchControl"/>, not the state of the entire <see cref="Touchscreen"/>.
+        /// </remarks>
         public static unsafe void* GetStatePtrFromStateEvent(this InputControl control, InputEventPtr eventPtr)
         {
             if (control == null)
@@ -489,7 +554,7 @@ namespace UnityEngine.InputSystem
             }
             else
             {
-                throw new ArgumentException("Event must be a state or delta state event", "eventPtr");
+                throw new ArgumentException("Event must be a state or delta state event", nameof(eventPtr));
             }
 
             // Make sure we have a state event compatible with our device. The event doesn't
@@ -498,11 +563,18 @@ namespace UnityEngine.InputSystem
             // to read.
             var device = control.device;
             if (stateFormat != device.m_StateBlock.format)
-                throw new InvalidOperationException(
-                    $"Cannot read control '{control.path}' from {eventPtr.type} with format {stateFormat}; device '{device}' expects format {device.m_StateBlock.format}");
+            {
+                // If the device is an IInputStateCallbackReceiver, there's a chance it actually recognizes
+                // the state format in the event and can correlate it to the state as found on the device.
+                if (!device.hasStateCallbacks ||
+                    !((IInputStateCallbackReceiver)device).GetStateOffsetForEvent(control, eventPtr, ref stateOffset))
+                    return null;
+            }
 
             // Once a device has been added, global state buffer offsets are baked into control hierarchies.
             // We need to unsubtract those offsets here.
+            // NOTE: If the given device has not actually been added to the system, the offset is simply 0
+            //       and this is a harmless NOP.
             stateOffset += device.m_StateBlock.byteOffset;
 
             // Return null if state is out of range.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -613,6 +613,29 @@ namespace UnityEngine.InputSystem
             return MatchesRecursive(ref parser, control);
         }
 
+        /// <summary>
+        /// Check whether the given path matches <paramref name="control"/> or any of its parents.
+        /// </summary>
+        /// <param name="expected">A control path.</param>
+        /// <param name="control">An input control.</param>
+        /// <returns>True if the given path matches at least a partial path to <paramref name="control"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="expected"/> is <c>null</c> or empty -or-
+        /// <paramref name="control"/> is <c>null</c>.</exception>
+        /// <remarks>
+        /// <example>
+        /// <code>
+        /// // True as the path matches the Keyboard device itself, i.e. the parent of
+        /// // Keyboard.aKey.
+        /// InputControlPath.MatchesPrefix("&lt;Keyboard&gt;", Keyboard.current.aKey);
+        ///
+        /// // False as the path matches none of the controls leading to Keyboard.aKey.
+        /// InputControlPath.MatchesPrefix("&lt;Gamepad&gt;", Keyboard.current.aKey);
+        ///
+        /// // True as the path matches Keyboard.aKey itself.
+        /// InputControlPath.MatchesPrefix("&lt;Keyboard&gt;/a", Keyboard.current.aKey);
+        /// </code>
+        /// </example>
+        /// </remarks>
         public static bool MatchesPrefix(string expected, InputControl control)
         {
             if (string.IsNullOrEmpty(expected))

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -594,6 +594,18 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        internal bool hasStateCallbacks
+        {
+            get => (m_DeviceFlags & DeviceFlags.HasStateCallbacks) == DeviceFlags.HasStateCallbacks;
+            set
+            {
+                if (value)
+                    m_DeviceFlags |= DeviceFlags.HasStateCallbacks;
+                else
+                    m_DeviceFlags &= ~DeviceFlags.HasStateCallbacks;
+            }
+        }
+
         internal void AddDeviceUsage(InternedString usage)
         {
             var controlUsageCount = m_UsageToControl.LengthSafe();

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -248,5 +248,10 @@ namespace UnityEngine.InputSystem
         {
             OnStateEvent(eventPtr);
         }
+
+        bool IInputStateCallbackReceiver.GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset)
+        {
+            return false;
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/ActionEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/ActionEvent.cs
@@ -19,7 +19,7 @@ namespace UnityEngine.InputSystem.LowLevel
     [StructLayout(LayoutKind.Explicit, Size = InputEvent.kBaseEventSize + 16 + 1)]
     internal unsafe struct ActionEvent : IInputEventTypeInfo
     {
-        public const int Type = 0x4143544E; // 'ACTN'
+        public static FourCC Type => new FourCC('A', 'C', 'T', 'N');
 
         ////REVIEW: should we decouple this from InputEvent? we get deviceId which we don't really have a use for
         [FieldOffset(0)] public InputEvent baseEvent;
@@ -123,10 +123,7 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public FourCC typeStatic
-        {
-            get { return Type; }
-        }
+        public FourCC typeStatic => Type;
 
         public static int GetEventSizeWithValueSize(int valueSizeInBytes)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeviceConfigurationEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeviceConfigurationEvent.cs
@@ -20,10 +20,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         ////REVIEW: have some kind of payload that allows indicating what changed in the config?
 
-        public FourCC typeStatic
-        {
-            get { return Type; }
-        }
+        public FourCC typeStatic => Type;
 
         public unsafe InputEventPtr ToEventPtr()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Events/IMECompositionEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/IMECompositionEvent.cs
@@ -109,7 +109,7 @@ namespace UnityEngine.InputSystem.LowLevel
         int size;
 
         [FieldOffset(sizeof(int))]
-        fixed char buffer[LowLevel.IMECompositionEvent.kIMECharBufferSize];
+        fixed char buffer[IMECompositionEvent.kIMECharBufferSize];
 
         public IMECompositionString(string characters)
         {
@@ -119,7 +119,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 return;
             }
 
-            Debug.Assert(characters.Length < LowLevel.IMECompositionEvent.kIMECharBufferSize);
+            Debug.Assert(characters.Length < IMECompositionEvent.kIMECharBufferSize);
             size = characters.Length;
             for (var i = 0; i < size; i++)
                 buffer[i] = characters[i];

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -442,6 +442,7 @@ namespace UnityEngine.InputSystem.Editor
                     if (oldActionEvents != null && oldActionEvents.Any(x => x.actionId == action.id.ToString()))
                         continue;
 
+                    ////FIXME: adds bindings to the name
                     AddEntry(action, new PlayerInput.ActionEvent(action.id, action.ToString()));
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -73,10 +73,7 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
         [InputControl(name = "rightStick", offset = (uint)iOSAxis.RightStickX * sizeof(float) + kAxisOffset)]
         public fixed float axisValues[MaxAxis];
 
-        public FourCC format
-        {
-            get { return kFormat; }
-        }
+        public FourCC format => kFormat;
 
         public iOSGameControllerState WithButton(iOSButton button, bool value = true, float rawValue = 1.0f)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/State/IInputStateCallbackReceiver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/IInputStateCallbackReceiver.cs
@@ -1,3 +1,14 @@
+// In retrospect, allowing Touchscreen to do what it does the way it does it was a mistake. It came out of thinking that
+// we need Touchscreen to have a large pool of TouchStates from which to dynamically allocate -- as this was what the old
+// input system does. This made it unfeasible/unwise to put the burden of touch allocation on platform backends and thus
+// led to the current setup where backends are sending TouchState events which Touchscreen dynamically incorporates.
+//
+// This shouldn't have happened.
+//
+// Ultimately, this led to IInputStateCallbackReceiver in its current form. While quite flexible in what it allows you to
+// do, it introduces a lot of additional complication and deviation from an otherwise very simple model based on trivially
+// understood chunks of input state.
+
 namespace UnityEngine.InputSystem.LowLevel
 {
     /// <summary>
@@ -11,10 +22,15 @@ namespace UnityEngine.InputSystem.LowLevel
     /// However, some devices need to apply custom logic whenever new input is received. An example of this is <see cref="Pointer.delta"/>
     /// which needs to accumulate deltas as they are received within a frame and then reset the delta at the beginning of a new frame.
     ///
+    /// Also, devices like <see cref="Touchscreen"/> extensively customize event handling in order to implement features such as
+    /// tap detection and primary touch handling. This is what allows the device to receive state events in <see cref="TouchState"/>
+    /// format even though that is not the format of the device itself (which is mainly a composite of several TouchStates).
+    ///
     /// This interface allows to bypass the built-in logic and instead intercept and manually handle state updates.
     /// </remarks>
     /// <seealso cref="InputDevice"/>
     /// <seealso cref="Pointer"/>
+    /// <seealso cref="Touchscreen"/>
     public interface IInputStateCallbackReceiver
     {
         /// <summary>
@@ -41,5 +57,28 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <seealso cref="StateEvent"/>
         /// <seealso cref="DeltaStateEvent"/>
         void OnStateEvent(InputEventPtr eventPtr);
+
+        /// <summary>
+        /// Compute an offset that correlates <paramref name="control"/> with the state in <paramref name="eventPtr"/>.
+        /// </summary>
+        /// <param name="control">Control the state of which we want to access within <paramref name="eventPtr"/>.</param>
+        /// <param name="eventPtr">An input event. Must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/></param>
+        /// <param name="offset"></param>
+        /// <returns>False if the correlation failed or true if <paramref name="offset"/> has been set and should be used
+        /// as the offset for the state of <paramref name="control"/>.</returns>
+        /// <remarks>
+        /// This method will only be called if the given state event has a state format different than that of the device. In that case,
+        /// the memory of the input state captured in the given state event cannot be trivially correlated with the control.
+        ///
+        /// The input system calls the method to know which offset (if any) in the device's state block to consider the state
+        /// in <paramref name="eventPtr"/> relative to when accessing the state for <paramref name="control"/> as found in
+        /// the event.
+        ///
+        /// An example of when this is called is for touch events. These are normally sent in <see cref="TouchState"/> format
+        /// which, however, is not the state format of <see cref="Touchscreen"/> (which uses a composite of several TouchStates).
+        /// When trying to access the state in <paramref name="eventPtr"/> to, for example, read out the touch position,
+        /// </remarks>
+        /// <seealso cref="InputControlExtensions.GetStatePtrFromStateEvent"/>
+        bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset);
     }
 }

--- a/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
@@ -20,7 +20,8 @@ using UnityEngine.InputSystem.LowLevel;
 public class IntegrationTests
 {
     [Test]
-    public void CanSendAndReceiveEvents()
+    [Category("Integration")]
+    public void Integration_CanSendAndReceiveEvents()
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();
 

--- a/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
@@ -2,6 +2,9 @@ using NUnit.Framework;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.LowLevel;
 
+// Disable irrelevant warning about there not being underscores in method names.
+#pragma warning disable CA1707
+
 // These tests are the only ones that we put *in* the package. The rest of our tests live in Assets/Tests and run separately
 // from our CI and not through upm-ci. This also means that IntegrationTests is the only thing we put on trunk through our
 // verified package.

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "1.0.0-preview.3",
+	"version": "1.0.0-preview.4",
 	"unity": "2019.1",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Fixes https://issuetracker.unity3d.com/issues/new-input-system-playerinput-generates-error-from-touch-events-for-new-webgl-touch-device ([internal](https://fogbugz.unity3d.com/f/cases/1196522/)).