### PR TITLE
FIX: Input in editor leaking into play mode (case 1191342).

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -51,7 +51,7 @@ platforms:
     {% if platform.installscript %}
     - {{ platform.installscript }} {{ editor.version }}
     {% endif %}
-    - upm-ci~/tools/utr/utr --testproject $PWD --editor-location=.Editor --artifacts_path=upm-ci~/test-results/isolation-com.unity.inputsystem.tests --suite=playmode --api-profile=NET_4_6 --stdout-filter=minimal {% if platform.runtime %} --platform {{ platform.runtime }} {% endif %} {% if platform.scripting-backend %} --scripting-backend {{ platform.scripting-backend }} {% endif %} 
+    - upm-ci~/tools/utr/utr --testproject . --editor-location=.Editor --artifacts_path=upm-ci~/test-results/isolation-com.unity.inputsystem.tests --suite=playmode --api-profile=NET_4_6 --stdout-filter=minimal {% if platform.runtime %} --platform {{ platform.runtime }} {% endif %} {% if platform.scripting-backend %} --scripting-backend {{ platform.scripting-backend }} {% endif %} 
   triggers:
     branches:
       only:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -48,7 +48,9 @@ platforms:
     - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }}
-    - {% if platform.installscript %} {{ platform.installscript }} {{ editor.version }} {% endif %} 
+    {% if platform.installscript %}
+    - {{ platform.installscript }} {{ editor.version }}
+    {% endif %}
     - upm-ci~/tools/utr/utr --testproject $PWD --editor-location=.Editor --artifacts_path=upm-ci~/test-results/isolation-com.unity.inputsystem.tests --suite=playmode --api-profile=NET_4_6 --stdout-filter=minimal {% if platform.runtime %} --platform {{ platform.runtime }} {% endif %} {% if platform.scripting-backend %} --scripting-backend {{ platform.scripting-backend }} {% endif %} 
   triggers:
     branches:

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2165,13 +2165,19 @@ partial class CoreTests
     {
         var mouse = InputSystem.AddDevice<Mouse>();
 
+        // We need to actually pass time and have a non-zero start time for this to work.
+        currentTime = 1;
         InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingEditMode);
         InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(234, 345) });
+        currentTime = 2;
         InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredPlayMode);
 
         InputSystem.Update();
 
         Assert.That(mouse.position.ReadValue(), Is.EqualTo(default(Vector2)));
+
+        // Make sure the event was not left in the buffer.
+        Assert.That(runtime.m_EventCount, Is.EqualTo(0));
     }
 
     ////TODO: tests for InputAssetImporter; for this we need C# mocks to be able to cut us off from the actual asset DB

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2150,6 +2150,30 @@ partial class CoreTests
         throw new NotImplementedException();
     }
 
+    // While going into play mode, the editor will be unresponsive. So what will happen is that when the user clicks the
+    // play mode button and then moves the mouse around while Unity is busy going into play mode, the game will receive
+    // a huge pointer motion delta in one of its first frames. If pointer motion is tied to camera motion, for example,
+    // this will usually lead to the camera looking down at the ground because after clicking the play mode button at the
+    // top of the UI, the user will likely move the pointer down towards the game view area thus generating a large down
+    // motion delta.
+    //
+    // What we do to counter this is to record the time of when we enter play mode and then record the time again when
+    // we have fully entered play mode. All the events in-between we discard.
+    [Test]
+    [Category("Editor")]
+    public void Editor_InputEventsOccurringWhileGoingIntoPlayMode_AreDiscarded()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingEditMode);
+        InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(234, 345) });
+        InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredPlayMode);
+
+        InputSystem.Update();
+
+        Assert.That(mouse.position.ReadValue(), Is.EqualTo(default(Vector2)));
+    }
+
     ////TODO: tests for InputAssetImporter; for this we need C# mocks to be able to cut us off from the actual asset DB
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,8 @@ however, it has to be formatted properly to pass verification tests.
 
 - `InputUser` in combination with touchscreens no longer throws `InvalidOperationException` complaining about incorrect state format.
  * In a related change, `InputControlExtensions.GetStatePtrFromStateEvent` now works with touch events, too.
+- Input that occurs in-between pressing the play button and the game starting no longer leaks into the game (case 1191342).
+  * This usually manifested itself as large accumulated mouse deltas leading to such effects as the camera immediately jerking around on game start.
 
 ## [1.0.0-preview.3] - 2019-11-14
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -3,6 +3,8 @@ using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 #endif
 
+////TODO: change this so that the interaction stays performed when the tap count is reached until the button is released
+
 namespace UnityEngine.InputSystem.Interactions
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2490,6 +2490,7 @@ namespace UnityEngine.InputSystem
                 //       play mode in the editor.
                 #if UNITY_EDITOR
                 if ((updateType & InputUpdateType.Editor) == 0 &&
+                    InputSystem.s_SystemObject.exitEditModeTime != 0 &&
                     currentEventTimeInternal >= InputSystem.s_SystemObject.exitEditModeTime &&
                     (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
                      InputSystem.s_SystemObject.enterPlayModeTime == 0))

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2490,17 +2490,16 @@ namespace UnityEngine.InputSystem
                 //       play mode in the editor.
                 #if UNITY_EDITOR
                 if ((updateType & InputUpdateType.Editor) == 0 &&
-                    InputSystem.s_SystemObject.exitEditModeTime != 0 &&
+                    InputSystem.s_SystemObject.exitEditModeTime > 0 &&
                     currentEventTimeInternal >= InputSystem.s_SystemObject.exitEditModeTime &&
                     (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
                      InputSystem.s_SystemObject.enterPlayModeTime == 0))
                 {
                     eventBuffer.AdvanceToNextEvent(ref currentEventReadPtr, ref currentEventWritePtr,
-                        ref numEventsRetainedInBuffer, ref remainingEventCount, leaveEventInBuffer: true);
+                        ref numEventsRetainedInBuffer, ref remainingEventCount, leaveEventInBuffer: false);
                     continue;
                 }
                 #endif
-
 
                 // If we're timeslicing, check if the event time is within limits.
                 if (timesliceEvents && currentEventTimeInternal >= currentTime)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2456,16 +2456,40 @@ namespace UnityEngine.InputSystem
                 if (remainingEventCount == 0)
                     break;
 
+                var currentEventTimeInternal = currentEventReadPtr->internalTime;
+
+                // In the editor, we discard all input events that occur in-between exiting edit mode and having
+                // entered play mode as otherwise we'll spill a bunch of UI events that have occurred while the
+                // UI was sort of neither in this mode nor in that mode. This would usually lead to the game receiving
+                // an accumulation of spurious inputs right in one of its first updates.
+                //
+                // NOTE: There's a chance the solution here will prove inadequate on the long run. We may do things
+                //       here such as throwing partial touches away and then letting the rest of a touch go through.
+                //       Could be that ultimately we need to issue a full reset of all devices at the beginning of
+                //       play mode in the editor.
+                #if UNITY_EDITOR
+                if ((updateType & InputUpdateType.Editor) == 0 &&
+                    currentEventTimeInternal >= InputSystem.s_SystemObject.exitEditModeTime &&
+                    (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
+                     InputSystem.s_SystemObject.enterPlayModeTime == 0))
+                {
+                    eventBuffer.AdvanceToNextEvent(ref currentEventReadPtr, ref currentEventWritePtr,
+                        ref numEventsRetainedInBuffer, ref remainingEventCount, leaveEventInBuffer: true);
+                    continue;
+                }
+                #endif
+
+
                 // If we're timeslicing, check if the event time is within limits.
-                if (timesliceEvents && currentEventReadPtr->internalTime >= currentTime)
+                if (timesliceEvents && currentEventTimeInternal >= currentTime)
                 {
                     eventBuffer.AdvanceToNextEvent(ref currentEventReadPtr, ref currentEventWritePtr,
                         ref numEventsRetainedInBuffer, ref remainingEventCount, leaveEventInBuffer: true);
                     continue;
                 }
 
-                if (currentEventReadPtr->internalTime <= currentTime)
-                    totalEventLag += currentTime - currentEventReadPtr->internalTime;
+                if (currentEventTimeInternal <= currentTime)
+                    totalEventLag += currentTime - currentEventTimeInternal;
 
                 // Grab device for event. In before-render updates, we already had to
                 // check the device.
@@ -2486,10 +2510,9 @@ namespace UnityEngine.InputSystem
                 }
 
                 // Give listeners a shot at the event.
-                var listenerCount = m_EventListeners.length;
-                if (listenerCount > 0)
+                if (m_EventListeners.length > 0)
                 {
-                    for (var i = 0; i < listenerCount; ++i)
+                    for (var i = 0; i < m_EventListeners.length; ++i)
                         m_EventListeners[i](new InputEventPtr(currentEventReadPtr), device);
 
                     // If a listener marks the event as handled, we don't process it further.
@@ -2503,7 +2526,6 @@ namespace UnityEngine.InputSystem
 
                 // Process.
                 var currentEventType = currentEventReadPtr->type;
-                var currentEventTimeInternal = currentEventReadPtr->internalTime;
                 switch (currentEventType)
                 {
                     case StateEvent.Type:

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3034,6 +3034,7 @@ namespace UnityEngine.InputSystem
             [SerializeField] public InputRemoting.SerializedState remotingState;
             #if UNITY_EDITOR
             [SerializeField] public InputEditorUserSettings.SerializedState userSettings;
+            [SerializeField] public string systemObject;
             #endif
             ////REVIEW: preserve InputUser state? (if even possible)
         }
@@ -3070,6 +3071,7 @@ namespace UnityEngine.InputSystem
                 remotingState = s_Remote?.SaveState() ?? new InputRemoting.SerializedState(),
                 #if UNITY_EDITOR
                 userSettings = InputEditorUserSettings.s_Settings,
+                systemObject = JsonUtility.ToJson(s_SystemObject),
                 #endif
             });
 
@@ -3100,6 +3102,7 @@ namespace UnityEngine.InputSystem
 
             #if UNITY_EDITOR
             InputEditorUserSettings.s_Settings = state.userSettings;
+            JsonUtility.FromJsonOverwrite(state.systemObject, s_SystemObject);
             #endif
 
             // Get devices that keep global lists (like Gamepad) to re-initialize them

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2801,12 +2801,18 @@ namespace UnityEngine.InputSystem
             Profiling.Profiler.EndSample();
         }
 
-        private static void OnPlayModeChange(PlayModeStateChange change)
+        internal static void OnPlayModeChange(PlayModeStateChange change)
         {
             switch (change)
             {
                 case PlayModeStateChange.ExitingEditMode:
                     s_SystemObject.settings = JsonUtility.ToJson(settings);
+                    s_SystemObject.exitEditModeTime = InputRuntime.s_Instance.currentTime;
+                    s_SystemObject.enterPlayModeTime = -1;
+                    break;
+
+                case PlayModeStateChange.EnteredPlayMode:
+                    s_SystemObject.enterPlayModeTime = InputRuntime.s_Instance.currentTime;
                     break;
 
                 ////TODO: also nuke all callbacks installed on InputActions and InputActionMaps

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2808,7 +2808,7 @@ namespace UnityEngine.InputSystem
                 case PlayModeStateChange.ExitingEditMode:
                     s_SystemObject.settings = JsonUtility.ToJson(settings);
                     s_SystemObject.exitEditModeTime = InputRuntime.s_Instance.currentTime;
-                    s_SystemObject.enterPlayModeTime = -1;
+                    s_SystemObject.enterPlayModeTime = 0;
                     break;
 
                 case PlayModeStateChange.EnteredPlayMode:

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystemObject.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystemObject.cs
@@ -15,6 +15,8 @@ namespace UnityEngine.InputSystem
         [SerializeField] public InputSystem.State systemState;
         [SerializeField] public bool newInputBackendsCheckedAsEnabled;
         [SerializeField] public string settings;
+        [SerializeField] public double exitEditModeTime;
+        [SerializeField] public double enterPlayModeTime;
 
         public void OnBeforeSerialize()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
@@ -8,6 +8,8 @@ using UnityEngine.InputSystem.Utilities;
 
 ////TODO: make this survive domain reloads
 
+////TODO: allow feeding into more than one control
+
 namespace UnityEngine.InputSystem.OnScreen
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -359,7 +359,7 @@ namespace UnityEngine.InputSystem
 
         private int m_NextDeviceId = 1;
         private int m_NextEventId = 1;
-        private int m_EventCount;
+        internal int m_EventCount;
         private int m_EventWritePosition;
         private NativeArray<byte> m_EventBuffer = new NativeArray<byte>(1024 * 1024, Allocator.Persistent);
         private List<PairedUser> m_UserPairings;


### PR DESCRIPTION
Fixes https://fogbugz.unity3d.com/f/cases/1191342/ (https://issuetracker.unity3d.com/issues/input-system-input-from-before-game-has-started-may-leak-into-game).

When pressing play, any input that happened in-between the editor exiting edit mode and it having entered play mode, would leak into the game. This often resulted in a large mouse delta hitting one of the first frames of the game.