### PR TITLE
CHANGE: Make Vector2Composite treat controls as analog by default.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4772,7 +4772,7 @@ partial class CoreTests
 
         // Set up classic WASD control.
         var action = new InputAction();
-        action.AddCompositeBinding("Dpad")
+        action.AddCompositeBinding("Dpad(analog=false)")
             .With("Up", "<Gamepad>/leftstick/up")
             .With("Down", "<Gamepad>/leftstick/down")
             .With("Left", "<Gamepad>/leftstick/left")
@@ -5048,7 +5048,7 @@ partial class CoreTests
         //       the WASD and arrow block can be mixed. An alternative setup would be to set up
         //       to separate Dpad composites, one for WASD and one for the arrow block. In that setup,
         //       the two will not mix but rather produce two independent 2D vectors. Which one gets
-        //       to drive the associated action is whichver had the last input event.
+        //       to drive the associated action is whichever had the last input event.
         var action = new InputAction();
         action.AddCompositeBinding("Dpad")
             .With("Up", "/<Keyboard>/w")

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4728,6 +4728,39 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_CanCreateVector2Composite_FromAnalogControls()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        // Get rid of deadzoning for simpler test.
+        InputSystem.settings.defaultDeadzoneMin = 0;
+        InputSystem.settings.defaultDeadzoneMin = 1;
+
+        var analogAction = new InputAction("analog", type: InputActionType.Value);
+        var digitalAction = new InputAction("digital", type: InputActionType.Value);
+
+        analogAction.AddCompositeBinding("2DVector(analog=true,normalize=false)")
+            .With("Up", "<Gamepad>/leftStick/up")
+            .With("Down", "<Gamepad>/leftStick/down")
+            .With("Left", "<Gamepad>/leftStick/left")
+            .With("Right", "<Gamepad>/leftStick/right");
+        digitalAction.AddCompositeBinding("2DVector(analog=false,normalize=false)")
+            .With("Up", "<Gamepad>/leftStick/up")
+            .With("Down", "<Gamepad>/leftStick/down")
+            .With("Left", "<Gamepad>/leftStick/left")
+            .With("Right", "<Gamepad>/leftStick/right");
+
+        analogAction.Enable();
+        digitalAction.Enable();
+
+        Set(gamepad.leftStick, new Vector2(-0.234f, 0.345f));
+
+        Assert.That(analogAction.ReadValue<Vector2>(), Is.EqualTo(new Vector2(-0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(digitalAction.ReadValue<Vector2>(), Is.EqualTo(new Vector2(-1, 1)).Using(Vector2EqualityComparer.Instance));
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_Vector2Composite_RespectsButtonPressurePoint()
     {
         // The stick has deadzones on the up/down/left/right buttons to get rid of stick

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,14 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [1.0.0-preview.4] - 2019-12-12
 
+### Changed
+
+
+#### Actions
+
+- `Vector2Composite` will now treat controls bound in the composite as analog by default, i.e. the actual values of the controls will be reflected in the resulting vector.
+  * A new parameter called `analog` has been added that if set to `false` reverts to the previous behavior of treating controls as buttons.
+
 ### Added
 
 - `Keyboard` now has a `FindKeyOnCurrentKeyboardLayout` method to look up key controls by their display names.

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -108,6 +108,7 @@ In addition, you can set the following parameters on a 2D vector Composite:
 |Parameter|Description|
 |---------|-----------|
 |[`normalize`](../api/UnityEngine.InputSystem.Composites.Vector2Composite.html#UnityEngine_InputSystem_Composites_Vector2Composite_normalize)|Whether the resulting vector should be normalized or not. If this is disabled, then, for example, pressing both [`up`](../api/UnityEngine.InputSystem.Composites.Vector2Composite.html#UnityEngine_InputSystem_Composites_Vector2Composite_up) and [`right`](../api/UnityEngine.InputSystem.Composites.Vector2Composite.html#UnityEngine_InputSystem_Composites_Vector2Composite_right)  yields a vector `(1,1)` which has a length greater than 1. This can be undesirable in situations where the vector's magnitude matters (for example, when scaling running speed by the length of the input vector).<br><br>This is true by default.|
+|[`analog`](../api/UnityEngine.InputSystem.Composites.Vector2Composite.html#UnityEngine_InputSystem_Composites_Vector2Composite_analog)|Whether the controls bound in the composite should be treated as analog controls or not. This is on by default. This means that if, for example, you bind `up` to the left trigger on a gamepad and `down` to the right trigger and the left trigger is at 0.25 and the right trigger at 0, the resulting vector will be `(0,0.25)`. If, however, you turn this option off, the triggers will be treated as digital buttons (either on=1 or off=0) and the resulting vector from the same inputs will be `(0,1)`.|
 
 ### Button with one modifier
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -64,17 +64,37 @@ namespace UnityEngine.InputSystem.Composites
         /// vectors will have a magnitude > 1 (i.e. will be <c>new Vector2(1,1)</c>, for example,
         /// instead of <c>new Vector2(1,1).normalized</c>).
         /// </summary>
+        /// <value>Whether the normalize the resulting vector.</value>
         public bool normalize = true;
+
+        /// <summary>
+        /// If true (default), the up/down/left/right inputs will be treated as analog meaning that
+        /// their actual values will be used. If this is false, the values will be read as buttons
+        /// meaning that instead if an input value is below the button press threshold, the value
+        /// that is used is 0 and otherwise the value that is used is 1.
+        /// </summary>
+        /// <value>Whether to treat part bindings as analog controls.</value>
+        public bool analog = true;
 
         /// <inheritdoc />
         public override Vector2 ReadValue(ref InputBindingCompositeContext context)
         {
-            var upIsPressed = context.ReadValueAsButton(up);
-            var downIsPressed = context.ReadValueAsButton(down);
-            var leftIsPressed = context.ReadValueAsButton(left);
-            var rightIsPressed = context.ReadValueAsButton(right);
+            if (!analog)
+            {
+                var upIsPressed = context.ReadValueAsButton(up);
+                var downIsPressed = context.ReadValueAsButton(down);
+                var leftIsPressed = context.ReadValueAsButton(left);
+                var rightIsPressed = context.ReadValueAsButton(right);
 
-            return DpadControl.MakeDpadVector(upIsPressed, downIsPressed, leftIsPressed, rightIsPressed, normalize);
+                return DpadControl.MakeDpadVector(upIsPressed, downIsPressed, leftIsPressed, rightIsPressed, normalize);
+            }
+
+            var upValue = context.ReadValue<float>(up);
+            var downValue = context.ReadValue<float>(down);
+            var leftValue = context.ReadValue<float>(left);
+            var rightValue = context.ReadValue<float>(right);
+
+            return DpadControl.MakeDpadVector(upValue, downValue, leftValue, rightValue, normalize);
         }
 
         /// <inheritdoc />

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -143,7 +143,7 @@ namespace UnityEngine.InputSystem.Controls
                 // If press is diagonal, adjust coordinates to produce vector of length 1.
                 // pow(0.707107) is roughly 0.5 so sqrt(pow(0.707107)+pow(0.707107)) is ~1.
                 const float diagonal = 0.707107f;
-                if (Mathf.Approximately(0, result.x) && Mathf.Approximately(0, result.y))
+                if (!Mathf.Approximately(0, result.x) && !Mathf.Approximately(0, result.y))
                     result = new Vector2(result.x * diagonal, result.y * diagonal);
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -134,6 +134,22 @@ namespace UnityEngine.InputSystem.Controls
             return result;
         }
 
+        public static Vector2 MakeDpadVector(float up, float down, float left, float right, bool normalize = true)
+        {
+            var result = new Vector2(-left + right, up - down);
+
+            if (normalize)
+            {
+                // If press is diagonal, adjust coordinates to produce vector of length 1.
+                // pow(0.707107) is roughly 0.5 so sqrt(pow(0.707107)+pow(0.707107)) is ~1.
+                const float diagonal = 0.707107f;
+                if (Mathf.Approximately(0, result.x) && Mathf.Approximately(0, result.y))
+                    result = new Vector2(result.x * diagonal, result.y * diagonal);
+            }
+
+            return result;
+        }
+
         internal enum ButtonBits
         {
             Up,


### PR DESCRIPTION
Unlike `AxisComposite`, which already uses the actual values from controls, `Vector2Composite` ATM treats every part control as a button and thus uses 1 and 0 values only. This is usually undesirable.

If made the default behavior be for source values to come through and added an `analog` parameter to allow reverting to the old behavior. For classic WASD, it makes no difference as keys themselves are digital controls.