### PR TITLE
FIX: Open VR Oculus Touch controller input

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
@@ -348,7 +348,6 @@ namespace UnityEngine.InputSystem.XR
             InputSystem.RegisterLayout<Unity.XR.OpenVR.OpenVROculusTouchController>(
                 matches: new InputDeviceMatcher()
                     .WithInterface(XRUtilities.InterfaceMatchAnyVersion)
-                    .WithManufacturer("HTC")
                     .WithProduct(@"^(OpenVR Controller\(Oculus)")
             );
 


### PR DESCRIPTION
**1. What has changed?**

Oculus touch controller did not correctly work with OpenVR (the device was being registered as an `XRController`, which does not have any inputs). Removed the `WithManufacturer` call to the line registering the `OpenVROculusTouchController`, which was preventing touch controllers from being correctly registered as ` OpenVROculusTouchController` (and giving the input system access to all the buttons/triggers/sticks).

**2. Where should the reviewer begin?**

Modified code.

**3. How can this be tested?**

Add any button mapping to InputActions for XR Controllers, like `<XRController>/primaryButton` and fire a debug message when the action is performed. Before this change, the action would be correctly performed only with the Oculus SDK. After the change, the action should fire correctly.

**4. Additional notes**

This was tested in Unity 2019.1.2f and 2019.2.9f1, using Oculus Touch CV1 Controllers, in both OpenVR and Oculus SDKs.

Not sure if there is a pull request format for this repo, but I didn't spot one. Apologies if this fix is not comprehensive/is a known issue.