### PR TITLE
CHANGE: Overhaul focus logic to fix problems such as stuck keys on alt-tabbing (case 1206199).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -52,6 +52,13 @@ partial class CoreTests
     public void Actions_TimeoutsDoNotGetTriggeredInEditorUpdates()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        // Devices get reset when losing focus so when we switch from the player to the editor,
+        // actions would get cancelled anyway. To avoid, create a device that runs in the background
+        // and enabled runInBackground.
+        SetCanRunInBackground(gamepad, true);
+        runtime.runInBackground = true;
+
         var action = new InputAction(binding: "<Gamepad>/buttonSouth", interactions: "hold");
         action.Enable();
 

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -5,7 +5,6 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -793,7 +793,7 @@ partial class CoreTests
 
     [Test]
     [Category("Devices")]
-    public unsafe void Devices_NoisyControlsAreToggledOnInNoiseMask()
+    public unsafe void Devices_NoisyControlsAreToggledOffInNoiseMask()
     {
         InputSystem.AddDevice<Mouse>(); // Noise.
 
@@ -814,12 +814,12 @@ partial class CoreTests
 
         const int kNumButtons = 14; // Buttons without left and right trigger which aren't stored in the buttons field.
 
-        // All the gamepads buttons should have the flag off as they aren't noise. However, the leftover
+        // All the gamepads buttons should have the flag on as they aren't noise. However, the leftover
         // bits in the "buttons" field should be marked as noise as they are not actively used by any control.
-        Assert.That(*(uint*)(noiseMaskPtr + device.stateBlock.byteOffset), Is.EqualTo(0xFFFFFFFF << kNumButtons));
+        Assert.That(*(uint*)(noiseMaskPtr + device.stateBlock.byteOffset), Is.EqualTo((1 << kNumButtons) - 1));
 
-        // The noisy control we added should be flagged as noise.
-        Assert.That(*(uint*)(noiseMaskPtr + device["noisyControl"].stateBlock.byteOffset), Is.EqualTo(0xFFFFFFFF));
+        // The noisy control we added should be flagged as noise by having their bits off.
+        Assert.That(*(uint*)(noiseMaskPtr + device["noisyControl"].stateBlock.byteOffset), Is.Zero);
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -3904,7 +3904,7 @@ partial class CoreTests
     [Test]
     [Category("Devices")]
     [Ignore("TODO")]
-    public void TODO_Devices_AltTabbingDoesAlterKeyboardState()
+    public void TODO_Devices_AltTabbingDoesNOTAlterKeyboardState()
     {
         ////TODO: add support for explicitly suppressing alt-tab, if enabled
         Assert.Fail();

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -644,10 +644,7 @@ partial class CoreTests
             return this;
         }
 
-        public FourCC format
-        {
-            get { return new FourCC('T', 'E', 'S', 'T'); }
-        }
+        public FourCC format => new FourCC('T', 'E', 'S', 'T');
     }
 
     [InputControlLayout(stateType = typeof(StateWithMultiBitControl))]

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -128,6 +128,11 @@ internal class EnhancedTouchTests : InputTestFixture
     [TestCase(InputSettings.UpdateMode.ProcessEventsInFixedUpdate)]
     public void EnhancedTouch_SupportsEditorUpdates(InputSettings.UpdateMode updateMode)
     {
+        // To better observe that play mode and edit mode state is indeed independent and handled
+        // correctly, suppress resetting of the touch device when focus is lost to the player.
+        runtime.runInBackground = true;
+        SetCanRunInBackground(Touchscreen.current);
+
         InputEditorUserSettings.lockInputToGameView = false;
         InputSystem.settings.updateMode = updateMode;
         runtime.currentTimeForFixedUpdate += Time.fixedDeltaTime;

--- a/Assets/Tests/InputSystem/Utilities/MemoryHelperTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/MemoryHelperTests.cs
@@ -126,27 +126,33 @@ internal class MemoryHelperTests
             var array2Ptr = (byte*)array2.GetUnsafePtr();
             var maskPtr = (byte*)mask.GetUnsafePtr();
 
+            // Set bit #2 in array1.
             MemoryHelpers.SetBitsInBuffer(array1Ptr, 0, 2, 1, true);
 
-            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.True);
+            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.False);
 
+            // Set bit #2 in mask.
             MemoryHelpers.SetBitsInBuffer(maskPtr, 0, 2, 1, true);
 
-            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.False);
+            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.True);
 
             UnsafeUtility.MemClear(array1Ptr, 8);
             UnsafeUtility.MemClear(array2Ptr, 8);
             UnsafeUtility.MemClear(maskPtr, 8);
 
+            // Set 24 bits in array1 starting at bit #5.
             MemoryHelpers.SetBitsInBuffer(array1Ptr, 0, 5, 24, true);
 
-            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 5, 24, maskPtr), Is.True);
+            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 5, 24, maskPtr), Is.False);
 
+            // Set 20 bits in mask starting at bit #5.
             MemoryHelpers.SetBitsInBuffer(maskPtr, 0, 5, 20, true);
+            // Set 24 bits in array2 starting at bit #5.
             MemoryHelpers.SetBitsInBuffer(array2Ptr, 0, 5, 24, true);
 
             Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 5, 24, maskPtr), Is.True);
 
+            // Set 21 bits in mask starting at bit #7.
             MemoryHelpers.SetBitsInBuffer(maskPtr, 0, 7, 21, true);
 
             Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 5, 24, maskPtr), Is.True);

--- a/Assets/Tests/InputSystem/Utilities/MemoryHelperTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/MemoryHelperTests.cs
@@ -129,12 +129,12 @@ internal class MemoryHelperTests
             // Set bit #2 in array1.
             MemoryHelpers.SetBitsInBuffer(array1Ptr, 0, 2, 1, true);
 
-            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.False);
+            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.True);
 
             // Set bit #2 in mask.
             MemoryHelpers.SetBitsInBuffer(maskPtr, 0, 2, 1, true);
 
-            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.True);
+            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 2, 1, maskPtr), Is.False);
 
             UnsafeUtility.MemClear(array1Ptr, 8);
             UnsafeUtility.MemClear(array2Ptr, 8);
@@ -143,7 +143,7 @@ internal class MemoryHelperTests
             // Set 24 bits in array1 starting at bit #5.
             MemoryHelpers.SetBitsInBuffer(array1Ptr, 0, 5, 24, true);
 
-            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 5, 24, maskPtr), Is.False);
+            Assert.That(MemoryHelpers.MemCmpBitRegion(array1Ptr, array2Ptr, 5, 24, maskPtr), Is.True);
 
             // Set 20 bits in mask starting at bit #5.
             MemoryHelpers.SetBitsInBuffer(maskPtr, 0, 5, 20, true);
@@ -228,14 +228,14 @@ internal class MemoryHelperTests
             maskPtr[4] = 0xC0;
             maskPtr[5] = 0x11;
 
-            MemoryHelpers.MemCpyExceptMasked(toPtr, fromPtr, 6, maskPtr);
+            MemoryHelpers.MemCpyMasked(toPtr, fromPtr, 6, maskPtr);
 
-            Assert.That(toPtr[0], Is.EqualTo(0xF0));
-            Assert.That(toPtr[1], Is.EqualTo(0xF1));
-            Assert.That(toPtr[2], Is.EqualTo(0x1F));
-            Assert.That(toPtr[3], Is.EqualTo(0x10));
-            Assert.That(toPtr[4], Is.EqualTo(0x48));
-            Assert.That(toPtr[5], Is.EqualTo(0xC0));
+            Assert.That(toPtr[0], Is.EqualTo(0x0F));
+            Assert.That(toPtr[1], Is.EqualTo(0x00));
+            Assert.That(toPtr[2], Is.EqualTo(0x02));
+            Assert.That(toPtr[3], Is.EqualTo(0x01));
+            Assert.That(toPtr[4], Is.EqualTo(0x80));
+            Assert.That(toPtr[5], Is.EqualTo(0x01));
         }
     }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -60,6 +60,11 @@ This release includes a number of Quality-of-Life improvements for a range of co
 
 ### Changed
 
+- The logic for resetting devices on focus loss has changed somewhat:
+  * When focus is lost, all devices are forcibly reset to their default state. As before, a `RequestResetCommand` for each device is also sent to the backend but regardless of whether the device responds or not, the input state for the device will be overwritten to default.
+  * __Noisy controls are exempted from resets__. The assumption here is that noisy controls most often represent sensor readings of some kind (e.g. tracking data) and snapping the values back to their default will usually
+  * If `Application.runInBackground` is `true`, all devices that return `true` from `InputDevice.canRunInBackground` are exempted from resets entirely. This, for example, allows XR devices to continue running regardless of focus change.
+  * This fixes problems such as keyboard keys getting stuck when alt-tabbing between applications (case 1206199).
 - `InputControlExtensions.GetStatePtrFromStateEvent` no longer throws `InvalidOperationException` when the state format for the event does not match that of the device. It simply returns `null` instead (same as when control is found in the event's state).
 
 #### Actions
@@ -86,6 +91,8 @@ This release includes a number of Quality-of-Life improvements for a range of co
   * This usually manifested itself as large accumulated mouse deltas leading to such effects as the camera immediately jerking around on game start.
 - Removing a device no longer has the potential of corrupting state change monitors (and thus actions getting triggered) from other devices.
   * This bug led to input being missed on a device once another device had been removed.
+- Noise masks for controls were initialized incorrectly, leading to incorrect input noise detection.
+- `TrackedDevice` layout is no longer incorrectly registered as `Tracked Device`.
 
 ## [1.0.0-preview.3] - 2019-11-14
 

--- a/Packages/com.unity.inputsystem/Documentation~/Controls.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Controls.md
@@ -195,14 +195,19 @@ There are two mechanisms that most notably make use of Control actuation:
 
 ## Noisy Controls
 
-The Input System can label a Control as being noisy . You can query this using the  [`InputControl.noisy`](../api/UnityEngine.InputSystem.InputControl.html#UnityEngine_InputSystem_InputControl_noisy) property.
+The Input System can label a Control as being "noisy". You can query this using the  [`InputControl.noisy`](../api/UnityEngine.InputSystem.InputControl.html#UnityEngine_InputSystem_InputControl_noisy) property.
+
+Noisy Controls are those that can change value without any actual or no intentional user interaction being required. A good example of this is a gravity sensor in a cellphone (and pretty much any other kind of sensor). Even if the cellphone is perfectly still, there are usually fluctuations in gravity readings. Another example are orientation readings from an HMD.
 
 If a Control is marked as noisy, it means that:
 
 1. The Control is not considered for [interactive rebinding](ActionBindings.md#run-time-rebinding). [`InputActionRebindingExceptions.RebindingOperation`](../api/UnityEngine.InputSystem.InputActionRebindingExtensions.RebindingOperation.html) ignores the Control by default (you can bypass this using [`WithoutIgnoringNoisyControls`](../api/UnityEngine.InputSystem.InputActionRebindingExtensions.RebindingOperation.html#UnityEngine_InputSystem_InputActionRebindingExtensions_RebindingOperation_WithoutIgnoringNoisyControls)).
-2. The system performs additional event filtering, then calls [`InputDevice.MakeCurrent`](../api/UnityEngine.InputSystem.InputDevice.html#UnityEngine_InputSystem_InputDevice_MakeCurrent). If an input event for a Device contains no state change on a Control that is not marked noisy, then the Device will not be made current based on the event. This avoids, for example, a plugged in PS4 controller constantly making itself the current gamepad ([`Gamepad.current`](../api/UnityEngine.InputSystem.Gamepad.html#UnityEngine_InputSystem_Gamepad_current)) due to its sensors constantly feeding data into the system.
+2. If toggled on in the project settings, the system performs additional event filtering, then calls [`InputDevice.MakeCurrent`](../api/UnityEngine.InputSystem.InputDevice.html#UnityEngine_InputSystem_InputDevice_MakeCurrent). If an input event for a Device contains no state change on a Control that is not marked noisy, then the Device will not be made current based on the event. This avoids, for example, a plugged in PS4 controller constantly making itself the current gamepad ([`Gamepad.current`](../api/UnityEngine.InputSystem.Gamepad.html#UnityEngine_InputSystem_Gamepad_current)) due to its sensors constantly feeding data into the system.
+3. When the application loses focus and Devices are [reset](Devices.md#device-resets) as a result, the state of noisy Controls will be preserved as is. This ensures that sensor readinds will remain at their last value rather than being reset to default values.
 
->**Note**: If any control on a device is noisy, the device itself is flagged as noisy.
+>**Note**: If any Control on a Device is noisy, the Device itself is flagged as noisy.
+
+Parallel to the [`input state`](../api/UnityEngine.InputSystem.InputControl.html#UnityEngine_InputSystem_InputControl_currentStatePtr) and the [`default state`](../api/UnityEngine.InputSystem.InputControl.html#UnityEngine_InputSystem_InputControl_defaultStatePtr) that the Input System keeps for all Devices currently present, it also maintains a [`noise mask`](../api/UnityEngine.InputSystem.InputControl.html#UnityEngine_InputSystem_InputControl_noiseMaskPtr) in which only bits for state that is __not__ noise are set. This can be used to very efficiently mask out noise in input.
 
 ## Synthetic Controls
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -325,6 +325,12 @@ namespace UnityEngine.InputSystem
         ///
         /// The primary effect of being noise is on <see cref="InputDevice.MakeCurrent"/> and
         /// on interactive rebinding (see <see cref="InputActionRebindingExtensions.RebindingOperation"/>).
+        /// However, being noisy also affects automatic resetting of controls that happens when the application
+        /// loses focus. While other controls are reset to their default value (except if <c>Application.runInBackground</c>
+        /// is true and the device the control belongs to is marked as <see cref="InputDevice.canRunInBackground"/>),
+        /// noisy controls will not be reset but rather remain at their current value. This is based on the assumption
+        /// that noisy controls most often represent sensor values and snapping the last sampling value back to default
+        /// will usually have undesirable effects on an application's simulation logic.
         /// </remarks>
         /// <seealso cref="InputControlLayout.ControlItem.isNoisy"/>
         /// <seealso cref="InputControlAttribute.noisy"/>
@@ -779,6 +785,18 @@ namespace UnityEngine.InputSystem
 
         protected internal unsafe void* defaultStatePtr => InputStateBuffers.s_DefaultStateBuffer;
 
+        /// <summary>
+        /// Return the memory that holds the noise mask for the control.
+        /// </summary>
+        /// <value>Noise bit mask for the control.</value>
+        /// <remarks>
+        /// Like with all state blocks, the specific memory block for the control is found at the memory
+        /// region specified by <see cref="stateBlock"/>.
+        ///
+        /// The noise mask indicates which bits in a state belong to noisy data. Every bit that is set means that
+        /// the corresponding bit of a control's state is noise.
+        /// </remarks>
+        /// <seealso cref="noisy"/>
         protected internal unsafe void* noiseMaskPtr => InputStateBuffers.s_NoiseMaskBuffer;
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -793,8 +793,10 @@ namespace UnityEngine.InputSystem
         /// Like with all state blocks, the specific memory block for the control is found at the memory
         /// region specified by <see cref="stateBlock"/>.
         ///
-        /// The noise mask indicates which bits in a state belong to noisy data. Every bit that is set means that
-        /// the corresponding bit of a control's state is noise.
+        /// The noise mask can be overlaid as a bit mask over the state for the control. When doing so, all state
+        /// that is noise will be masked out whereas all state that isn't will come through unmodified. In other words,
+        /// any bit that is set in the noise mask indicates that the corresponding bit in the control's state memory
+        /// is noise.
         /// </remarks>
         /// <seealso cref="noisy"/>
         protected internal unsafe void* noiseMaskPtr => InputStateBuffers.s_NoiseMaskBuffer;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -366,9 +366,10 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Check if the given state corresponds to the default state of the control.
         /// </summary>
+        /// <param name="control">Control to check the state for in <paramref name="statePtr"/>.</param>
         /// <param name="statePtr">Pointer to a state buffer containing the <see cref="InputControl.stateBlock"/> for <paramref name="control"/>.</param>
-        /// <param name="maskPtr">If not null, only bits set to true in the buffer will be taken into account. This can be used
-        /// to mask out noise.</param>
+        /// <param name="maskPtr">If not null, only bits set to <c>false</c> (!) in the buffer will be taken into account. This can be used
+        /// to mask out noise, i.e. every bit that is set in the mask is considered to represent noise.</param>
         /// <returns>True if the control/device is in its default state.</returns>
         /// <remarks>
         /// Note that default does not equate all zeroes. Stick axes, for example, that are stored as unsigned byte

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayoutAttribute.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayoutAttribute.cs
@@ -32,6 +32,10 @@ namespace UnityEngine.InputSystem.Layouts
 
         internal bool? updateBeforeRenderInternal;
 
+        /// <summary>
+        /// Whether the device should receive events in <see cref="LowLevel.InputUpdateType.BeforeRender"/> updates.
+        /// </summary>
+        /// <seealso cref="InputDevice.updateBeforeRender"/>
         public bool updateBeforeRender
         {
             get => updateBeforeRenderInternal.Value;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -181,6 +181,7 @@ namespace UnityEngine.InputSystem.LowLevel
         }
     }
 
+    ////NOTE: The bit positions here based on the enum value are also used in native.
     /// <summary>
     /// Enum of common gamepad buttons.
     /// </summary>
@@ -196,22 +197,22 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// The up button on a gamepad's dpad.
         /// </summary>
-        DpadUp,
+        DpadUp = 0,
 
         /// <summary>
         /// The down button on a gamepad's dpad.
         /// </summary>
-        DpadDown,
+        DpadDown = 1,
 
         /// <summary>
         /// The left button on a gamepad's dpad.
         /// </summary>
-        DpadLeft,
+        DpadLeft = 2,
 
         /// <summary>
         /// The right button on a gamepad's dpad.
         /// </summary>
-        DpadRight,
+        DpadRight = 3,
 
         // Face buttons. We go with a north/south/east/west naming as that
         // clearly disambiguates where we expect the respective button to be.
@@ -222,7 +223,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <remarks>
         /// Identical to <see cref="Y"/> and <see cref="Triangle"/> which are the Xbox and PlayStation controller names for this button.
         /// </remarks>
-        North,
+        North = 4,
 
         /// <summary>
         /// The right action button on a gamepad.
@@ -230,7 +231,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <remarks>
         /// Identical to <see cref="B"/> and <see cref="Circle"/> which are the Xbox and PlayStation controller names for this button.
         /// </remarks>
-        East,
+        East = 5,
 
         /// <summary>
         /// The lower action button on a gamepad.
@@ -238,7 +239,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <remarks>
         /// Identical to <see cref="A"/> and <see cref="Cross"/> which are the Xbox and PlayStation controller names for this button.
         /// </remarks>
-        South,
+        South = 6,
 
         /// <summary>
         /// The left action button on a gamepad.
@@ -246,48 +247,51 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <remarks>
         /// Identical to <see cref="X"/> and <see cref="Square"/> which are the Xbox and PlayStation controller names for this button.
         /// </remarks>
-        West,
+        West = 7,
 
 
         /// <summary>
         /// The button pressed by pressing down the left stick on a gamepad.
         /// </summary>
-        LeftStick,
+        LeftStick = 8,
 
         /// <summary>
         /// The button pressed by pressing down the right stick on a gamepad.
         /// </summary>
-        RightStick,
+        RightStick = 9,
 
         /// <summary>
         /// The left shoulder button on a gamepad.
         /// </summary>
-        LeftShoulder,
+        LeftShoulder = 10,
 
         /// <summary>
         /// The right shoulder button on a gamepad.
         /// </summary>
-        RightShoulder,
-
-        /// <summary>
-        /// The left trigger button on a gamepad.
-        /// </summary>
-        LeftTrigger,
-
-        /// <summary>
-        /// The right trigger button on a gamepad.
-        /// </summary>
-        RightTrigger,
+        RightShoulder = 11,
 
         /// <summary>
         /// The start button.
         /// </summary>
-        Start,
+        Start = 12,
 
         /// <summary>
         /// The select button.
         /// </summary>
-        Select,
+        Select = 13,
+
+        // For values that are not part of the buttons bitmask in GamepadState, assign large values that are outside
+        // the 32bit bit range.
+
+        /// <summary>
+        /// The left trigger button on a gamepad.
+        /// </summary>
+        LeftTrigger = 32,
+
+        /// <summary>
+        /// The right trigger button on a gamepad.
+        /// </summary>
+        RightTrigger = 33,
 
         /// <summary>
         /// The X button on an Xbox controller.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -223,6 +223,7 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        ////TODO: rename this to canReceiveInputInBackground
         /// <summary>
         /// If true, the device is capable of delivering input while the application is running in the background.
         /// </summary>
@@ -638,6 +639,13 @@ namespace UnityEngine.InputSystem
             for (var i = m_UsageStartIndex; i < m_UsageCount; ++i)
                 m_UsagesForEachControl[i] = default;
             m_UsageCount = default;
+        }
+
+        internal bool RequestRequest()
+        {
+            var resetCommand = RequestResetCommand.Create();
+            var result = device.ExecuteCommand(ref resetCommand);
+            return result >= 0;
         }
 
         internal void NotifyAdded()

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -225,13 +225,21 @@ namespace UnityEngine.InputSystem
 
         ////TODO: rename this to canReceiveInputInBackground
         /// <summary>
-        /// If true, the device is capable of delivering input while the application is running in the background.
+        /// If true, the device is capable of delivering input while the application is running in the background, i.e.
+        /// while <c>Application.isFocused</c> is false.
         /// </summary>
+        /// <value>Whether the device can generate input while in the background.</value>
         /// <remarks>
-        /// Note that by default, even if capable of doing so, devices will not generate input while the application is not
-        /// focused. To enable the behavior, use <see cref="InputSettings.runInBackground"/>.
+        /// Note that processing input in the background requires <c>Application.runInBackground</c> to be enabled in the
+        /// player preferences. If this is enabled, the input system will keep running by virtue of being part of the Unity
+        /// player loop which will keep running in the background. Note, however, that this does not necessarily mean that
+        /// the application will necessarily receive input.
+        ///
+        /// Only a select set of hardware, platform, and SDK/API combinations support gathering input while not having
+        /// input focus. The most notable set of devices are HMDs and VR controllers.
+        ///
+        /// The value of this property is determined by sending <see cref="QueryCanRunInBackground"/> to the device.
         /// </remarks>
-        /// <seealso cref="InputSettings.runInBackground"/>
         public bool canRunInBackground
         {
             get

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -152,6 +152,8 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         double currentTimeOffsetToRealtimeSinceStartup { get; }
 
+        bool runInBackground { get; }
+
         ScreenOrientation screenOrientation { get; }
 
         // If analytics are enabled, the runtime receives analytics events from the input manager.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Collections;
 using UnityEngine.InputSystem.Composites;
 using UnityEngine.InputSystem.Controls;
 using Unity.Collections.LowLevel.Unsafe;
@@ -1570,7 +1571,7 @@ namespace UnityEngine.InputSystem
             RegisterControlLayout("HumiditySensor", typeof(HumiditySensor));
             RegisterControlLayout("AmbientTemperatureSensor", typeof(AmbientTemperatureSensor));
             RegisterControlLayout("StepCounter", typeof(StepCounter));
-            RegisterControlLayout("Tracked Device", typeof(TrackedDevice));
+            RegisterControlLayout("TrackedDevice", typeof(TrackedDevice));
 
             // Register processors.
             processors.AddTypeRegistration("Invert", typeof(InvertProcessor));
@@ -1986,19 +1987,22 @@ namespace UnityEngine.InputSystem
             // Assume that everything in the device is noise. This way we also catch memory regions
             // that are not actually covered by a control and implicitly mark them as noise (e.g. the
             // report ID in HID input reports).
+            var noiseMaskBuffer = m_StateBuffers.noiseMaskBuffer;
+            MemoryHelpers.MemSet((byte*)noiseMaskBuffer + device.m_StateBlock.byteOffset,
+                (int)device.m_StateBlock.alignedSizeInBytes, 0xFF);
 
             ////FIXME: this needs to properly take leaf vs non-leaf controls into account
 
-            // Go through controls and for each one that isn't noisy, enable the control's
+            // Go through controls and for each one that isn't noisy, clear the control's
             // bits in the mask.
-            var noiseMaskBuffer = m_StateBuffers.noiseMaskBuffer;
             for (var n = 0; n < controlCount; ++n)
             {
                 var control = controls[n];
                 if (control.noisy)
                     continue;
 
-                var stateBlock = control.m_StateBlock;
+                ref var stateBlock = ref control.m_StateBlock;
+
                 Debug.Assert(stateBlock.byteOffset != InputStateBlock.InvalidOffset, "Byte offset is invalid on control's state block");
                 Debug.Assert(stateBlock.bitOffset != InputStateBlock.InvalidOffset, "Bit offset is invalid on control's state block");
                 Debug.Assert(stateBlock.sizeInBits != InputStateBlock.InvalidOffset, "Size is invalid on control's state block");
@@ -2007,7 +2011,7 @@ namespace UnityEngine.InputSystem
                     device.stateBlock.byteOffset + device.stateBlock.alignedSizeInBytes, "Control state block lies outside of state buffer");
 
                 MemoryHelpers.SetBitsInBuffer(noiseMaskBuffer, (int)stateBlock.byteOffset, (int)stateBlock.bitOffset,
-                    (int)stateBlock.sizeInBits, true);
+                    (int)stateBlock.sizeInBits, false);
             }
         }
 
@@ -2308,16 +2312,109 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        private void OnFocusChanged(bool focus)
+        private unsafe void OnFocusChanged(bool focus)
         {
-            m_HasFocus = focus;
-            var deviceCount = m_DevicesCount;
-            for (var i = 0; i < deviceCount; ++i)
+            ////REVIEW: should we also flush the event queue on focus loss?
+
+            // On focus loss, reset devices.
+            if (!focus)
             {
-                var device = m_Devices[i];
-                if (!InputSystem.TrySyncDevice(device))
-                    InputSystem.TryResetDevice(device);
+                // When running in background is enabled for the application, we only reset devices that aren't
+                // marked as canRunInBackground.
+                var runInBackground = m_Runtime.runInBackground;
+
+                // Find the size of the largest state block. This determines the amount of temporary memory we
+                // need to allocate.
+                var largestDeviceStateBlock = 0;
+                var deviceCount = m_DevicesCount;
+                for (var i = 0; i < deviceCount; ++i)
+                    largestDeviceStateBlock = Math.Max(largestDeviceStateBlock, (int)m_Devices[i].m_StateBlock.alignedSizeInBytes);
+
+                // Allocate temp memory to hold one state event.
+                ////REVIEW: the need for an event here is sufficiently obscure to warrant scrutiny; likely, there's a better way
+                ////        to tell synthetic input (or input sources in general) apart
+                // NOTE: We wrap the reset in an artificial state event so that it appears to the rest of the system
+                //       like any other input. If we don't do that but rather just call UpdateState() with a null event
+                //       pointer, the change will be considered an internal state change and will get ignored by some
+                //       pieces of code (such as EnhancedTouch which filters out internal state changes of Touchscreen
+                //       by ignoring any change that is not coming from an input event).
+                using (var tempBuffer =
+                           new NativeArray<byte>(InputEvent.kBaseEventSize + sizeof(int) + largestDeviceStateBlock, Allocator.Temp))
+                {
+                    var stateEventPtr = (StateEvent*)tempBuffer.GetUnsafePtr();
+                    var statePtr = stateEventPtr->state;
+                    var currentTime = m_Runtime.currentTime;
+                    var updateType = defaultUpdateType;
+
+                    for (var i = 0; i < deviceCount; ++i)
+                    {
+                        var device = m_Devices[i];
+
+                        // Skip disabled devices.
+                        if (!device.enabled)
+                            continue;
+
+                        // If the app will keep running in the background and the device is marked as being
+                        // able to run in the background, don't touch it.
+                        if (runInBackground && device.canRunInBackground)
+                            continue;
+
+                        // Set up the state event.
+                        ref var stateBlock = ref device.m_StateBlock;
+                        var deviceStateBlockSize = stateBlock.alignedSizeInBytes;
+                        stateEventPtr->baseEvent.type = StateEvent.Type;
+                        stateEventPtr->baseEvent.sizeInBytes = InputEvent.kBaseEventSize + sizeof(int) + deviceStateBlockSize;
+                        stateEventPtr->baseEvent.time = currentTime;
+                        stateEventPtr->baseEvent.deviceId = device.deviceId;
+                        stateEventPtr->baseEvent.eventId = -1;
+                        stateEventPtr->stateFormat = device.m_StateBlock.format;
+
+                        // Set up new state.
+                        var defaultStatePtr = device.defaultStatePtr;
+                        if (device.noisy)
+                        {
+                            // The device has noisy controls. We don't want to reset those as they mostly
+                            // represent sensor input and resetting sensor samples to default values isn't a good
+                            // a good idea.
+                            //
+                            // Copy everything from defaultStatePtr except for the bits that are flagged in the
+                            // device's noise mask.
+
+                            var currentStatePtr = device.currentStatePtr;
+                            var noiseMaskPtr = device.noiseMaskPtr;
+
+                            // To preserve values from noisy controls, we need to first copy their current values.
+                            UnsafeUtility.MemCpy(statePtr,
+                                (byte*)currentStatePtr + stateBlock.byteOffset,
+                                deviceStateBlockSize);
+
+                            // And then we copy over default values masked by noise bits.
+                            MemoryHelpers.MemCpyExceptMasked(statePtr,
+                                (byte*)defaultStatePtr + stateBlock.byteOffset,
+                                (int)deviceStateBlockSize,
+                                (byte*)noiseMaskPtr + stateBlock.byteOffset);
+                        }
+                        else
+                        {
+                            // No noisy controls in device. Just take the default state and put it in the event
+                            // as is.
+                            UnsafeUtility.MemCpy(statePtr,
+                                (byte*)defaultStatePtr + stateBlock.byteOffset,
+                                deviceStateBlockSize);
+                        }
+
+                        // Perform the reset.
+                        UpdateState(device, updateType, statePtr, 0, deviceStateBlockSize, currentTime,
+                            new InputEventPtr((InputEvent*)stateEventPtr));
+
+                        // Tell the backend to reset.
+                        device.RequestRequest();
+                    }
+                }
             }
+
+            // We set this *after* the block above as defaultUpdateType is influenced by the setting.
+            m_HasFocus = focus;
         }
 
         private bool ShouldRunUpdate(InputUpdateType updateType)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1677,10 +1677,7 @@ namespace UnityEngine.InputSystem
         {
             if (device == null)
                 throw new ArgumentNullException(nameof(device));
-
-            var resetCommand = RequestResetCommand.Create();
-            var result = device.ExecuteCommand(ref resetCommand);
-            return result >= 0;
+            return device.RequestRequest();
         }
 
         ////REVIEW: should there be a global pause state? what about haptics that are issued *while* paused?

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -182,6 +182,8 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
 
+        public bool runInBackground => Application.runInBackground;
+
         private Action m_ShutdownMethod;
         private InputUpdateDelegate m_OnUpdate;
         private Action<InputUpdateType> m_OnBeforeUpdate;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
@@ -6,6 +6,8 @@ using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: should we make this ExecuteInEditMode?
 
+////TODO: give more control over when an OSC creates a new devices; going simply by name of layout only is inflexible
+
 ////TODO: make this survive domain reloads
 
 ////TODO: allow feeding into more than one control
@@ -93,6 +95,7 @@ namespace UnityEngine.InputSystem.OnScreen
             var deviceInfoIndex = -1;
             for (var i = 0; i < s_OnScreenDevices.length; ++i)
             {
+                ////FIXME: this does not take things such as different device usages into account
                 if (s_OnScreenDevices[i].device.m_Layout == internedLayoutName)
                 {
                     deviceInfoIndex = i;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -112,7 +112,7 @@ namespace UnityEngine.InputSystem.Switch
     /// <summary>
     /// A Nintendo Switch Pro controller connected to a desktop mac/windows PC using the HID interface.
     /// </summary>
-    [InputControlLayout(stateType = typeof(SwitchProControllerHIDInputState), displayName = "Switch Controller (on HID)")]
+    [InputControlLayout(stateType = typeof(SwitchProControllerHIDInputState), displayName = "Switch Pro Controller")]
     [Scripting.Preserve]
     public class SwitchProControllerHID : Gamepad
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -150,18 +150,16 @@ namespace UnityEngine.InputSystem.Utilities
                 // to mask out parts of the bits we're reading.
                 var byteMask = 0xFF << (int)bitOffset;
                 if (bitCount + bitOffset < 8)
-                {
                     byteMask &= 0xFF >> (int)(8 - (bitCount + bitOffset));
-                }
 
                 if (maskPtr != null)
                 {
-                    byteMask &= *maskPtr;
+                    byteMask &= ~*maskPtr;
                     ++maskPtr;
                 }
 
-                var byte1 = *bytePtr1 & ~byteMask;
-                var byte2 = *bytePtr2 & ~byteMask;
+                var byte1 = *bytePtr1 & byteMask;
+                var byte2 = *bytePtr2 & byteMask;
 
                 if (byte1 != byte2)
                     return false;
@@ -189,9 +187,9 @@ namespace UnityEngine.InputSystem.Utilities
                     {
                         var byte1 = bytePtr1[i];
                         var byte2 = bytePtr2[i];
-                        var byteMask = maskPtr[i];
+                        var byteMask = ~maskPtr[i];
 
-                        if ((byte1 & ~byteMask) != (byte2 & ~byteMask))
+                        if ((byte1 & byteMask) != (byte2 & byteMask))
                             return false;
                     }
                 }
@@ -215,11 +213,11 @@ namespace UnityEngine.InputSystem.Utilities
                 if (maskPtr != null)
                 {
                     maskPtr += byteCount;
-                    byteMask &= *maskPtr;
+                    byteMask &= ~*maskPtr;
                 }
 
-                var byte1 = *bytePtr1 & ~byteMask;
-                var byte2 = *bytePtr2 & ~byteMask;
+                var byte1 = *bytePtr1 & byteMask;
+                var byte2 = *bytePtr2 & byteMask;
 
                 if (byte1 != byte2)
                     return false;

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -252,6 +252,24 @@ namespace UnityEngine.InputSystem
             InputSystem.Update();
         }
 
+        /// <summary>
+        /// Add support for <see cref="QueryCanRunInBackground"/> to <paramref name="device"/> and return
+        /// <paramref name="value"/> as <see cref="QueryCanRunInBackground.canRunInBackground"/>.
+        /// </summary>
+        /// <param name="device"></param>
+        internal unsafe void SetCanRunInBackground(InputDevice device, bool canRunInBackground = true)
+        {
+            runtime.SetDeviceCommandCallback(device, (id, command) =>
+            {
+                if (command->type == QueryCanRunInBackground.Type)
+                {
+                    ((QueryCanRunInBackground*)command)->canRunInBackground = canRunInBackground;
+                    return InputDeviceCommand.GenericSuccess;
+                }
+                return InputDeviceCommand.GenericFailure;
+            });
+        }
+
         public ActionConstraint Started(InputAction action, InputControl control = null, double? time = null)
         {
             return new ActionConstraint(InputActionPhase.Started, action, control, time: time);

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -321,7 +321,7 @@ namespace UnityEngine.InputSystem
         public double currentTimeForFixedUpdate { get; set; }
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;
-        
+
         public bool dontAdvanceTimeNextDynamicUpdate { get; set; }
 
         public bool runInBackground { get; set; } = false;

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -320,6 +320,8 @@ namespace UnityEngine.InputSystem
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;
 
+        public bool runInBackground { get; set; } = false;
+
         public ScreenOrientation screenOrientation { set; get; } = ScreenOrientation.Portrait;
 
         public List<PairedUser> userAccountPairings


### PR DESCRIPTION
This PR intends to address bugs arising from the current focus handling, like e.g. a stuck alt key when alt-tabbing on Windows (case 1206199).

It essentially replaces the previous focus handling with a much more nuanced mechanism.

* When focus is lost in the player, devices are reset.
* A reset consists of sending a reset *request* to the backend, like before, but regardless of how the backend responds to that, the input system will now perform an immediate reset of a device's state back to its default state.
* Noisy controls are not touched and will remain at their current value. This preserves sensor readings at their last value instead of snapping them back to default.
* When `Application.runInBackground` is enabled, devices that return `true` from `InputDevice.canRunInBackground` will be exempted from resets and will be left alone.

Working on this, I also found a couple bugs with noise masks and associated memory checks.