### PR TITLE
FIX: mousestates from different devices don't share the point position

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -730,55 +730,73 @@ namespace UnityEngine.InputSystem.UI
         void OnAction(InputAction.CallbackContext context)
         {
             var action = context.action;
+            bool mousePointValid = !float.IsNegativeInfinity(mousePoint.x);
             if (action == m_PointAction?.action)
             {
                 var index = GetMouseDeviceIndexForCallbackContext(context);
                 var state = mouseStates[index];
                 state.position = context.ReadValue<Vector2>();
+                mousePoint = state.position;
                 mouseStates[index] = state;
             }
             else if (action == m_ScrollWheelAction?.action)
             {
-                var index = GetMouseDeviceIndexForCallbackContext(context);
-                var state = mouseStates[index];
-                // The old input system reported scroll deltas in lines, we report pixels.
-                // Need to scale as the UI system expects lines.
-                const float kPixelPerLine = 20;
-                state.scrollDelta = context.ReadValue<Vector2>() * (1.0f / kPixelPerLine);
-                mouseStates[index] = state;
+                if (mousePointValid)
+                {
+                    var index = GetMouseDeviceIndexForCallbackContext(context);
+                    var state = mouseStates[index];
+                    // The old input system reported scroll deltas in lines, we report pixels.
+                    // Need to scale as the UI system expects lines.
+                    const float kPixelPerLine = 20;
+                    state.scrollDelta = context.ReadValue<Vector2>() * (1.0f / kPixelPerLine);
+                    state.position = mousePoint;
+                    mouseStates[index] = state;
+                }
             }
             else if (action == m_LeftClickAction?.action)
             {
-                var index = GetMouseDeviceIndexForCallbackContext(context);
-                var state = mouseStates[index];
+                if (mousePointValid)
+                {
+                    var index = GetMouseDeviceIndexForCallbackContext(context);
+                    var state = mouseStates[index];
 
-                var buttonState = state.leftButton;
-                buttonState.isDown = context.ReadValue<float>() > 0;
-                buttonState.clickCount = (context.control.device as Mouse)?.clickCount.ReadValue() ?? 0;
-                state.leftButton = buttonState;
-                mouseStates[index] = state;
+                    var buttonState = state.leftButton;
+                    buttonState.isDown = context.ReadValue<float>() > 0;
+                    buttonState.clickCount = (context.control.device as Mouse)?.clickCount.ReadValue() ?? 0;
+                    state.leftButton = buttonState;
+                    state.position = mousePoint;
+                    mouseStates[index] = state;
+                }
             }
             else if (action == m_RightClickAction?.action)
             {
-                var index = GetMouseDeviceIndexForCallbackContext(context);
-                var state = mouseStates[index];
+                if (mousePointValid)
+                {
+                    var index = GetMouseDeviceIndexForCallbackContext(context);
+                    var state = mouseStates[index];
 
-                var buttonState = state.rightButton;
-                buttonState.isDown = context.ReadValue<float>() > 0;
-                buttonState.clickCount = (context.control.device as Mouse)?.clickCount.ReadValue() ?? 0;
-                state.rightButton = buttonState;
-                mouseStates[index] = state;
+                    var buttonState = state.rightButton;
+                    buttonState.isDown = context.ReadValue<float>() > 0;
+                    buttonState.clickCount = (context.control.device as Mouse)?.clickCount.ReadValue() ?? 0;
+                    state.rightButton = buttonState;
+                    state.position = mousePoint;
+                    mouseStates[index] = state;
+                }
             }
             else if (action == m_MiddleClickAction?.action)
             {
-                var index = GetMouseDeviceIndexForCallbackContext(context);
-                var state = mouseStates[index];
+                if (mousePointValid)
+                {
+                    var index = GetMouseDeviceIndexForCallbackContext(context);
+                    var state = mouseStates[index];
 
-                var buttonState = state.middleButton;
-                buttonState.isDown = context.ReadValue<float>() > 0;
-                buttonState.clickCount = (context.control.device as Mouse)?.clickCount.ReadValue() ?? 0;
-                state.middleButton = buttonState;
-                mouseStates[index] = state;
+                    var buttonState = state.middleButton;
+                    buttonState.isDown = context.ReadValue<float>() > 0;
+                    buttonState.clickCount = (context.control.device as Mouse)?.clickCount.ReadValue() ?? 0;
+                    state.middleButton = buttonState;
+                    state.position = mousePoint;
+                    mouseStates[index] = state;
+                }
             }
             else if (action == m_MoveAction?.action)
             {
@@ -991,5 +1009,6 @@ namespace UnityEngine.InputSystem.UI
         [NonSerialized] private JoystickModel joystickState;
         [NonSerialized] private List<TrackedDeviceModel> trackedDeviceStates = new List<TrackedDeviceModel>();
         [NonSerialized] private List<MouseModel> mouseStates = new List<MouseModel>();
+        [NonSerialized] private Vector2 mousePoint = Vector2.negativeInfinity;
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -269,7 +269,6 @@ namespace UnityEngine.InputSystem.UI
         private void ProcessMouseButtonDrag(PointerEventData eventData, float pixelDragThresholdMultiplier = 1.0f)
         {
             if (!eventData.IsPointerMoving() ||
-                Cursor.lockState == CursorLockMode.Locked ||
                 eventData.pointerDrag == null)
                 return;
 
@@ -733,11 +732,16 @@ namespace UnityEngine.InputSystem.UI
             bool mousePointValid = !float.IsNegativeInfinity(mousePoint.x);
             if (action == m_PointAction?.action)
             {
-                var index = GetMouseDeviceIndexForCallbackContext(context);
-                var state = mouseStates[index];
-                state.position = context.ReadValue<Vector2>();
-                mousePoint = state.position;
-                mouseStates[index] = state;
+                GetMouseDeviceIndexForCallbackContext(context);
+                mousePoint = context.ReadValue<Vector2>();
+
+                // update the positions of all mouseStates
+                for (int i = 0; i < mouseStates.Count; ++i)
+                {
+                    var state = mouseStates[i];
+                    state.position = mousePoint;
+                    mouseStates[i] = state;
+                }
             }
             else if (action == m_ScrollWheelAction?.action)
             {


### PR DESCRIPTION
When the m_PointAction device is different from the m_ScrollWheelAction, m_LeftClickAction, m_RightClickAction, or m_MiddleClickAction, the position for the mouseStates for the different actions are set to the default value of (0,0).

For example, if I set the binding for the m_LeftClickAction to a keyboard press, and leave the m_PointAction as a the mouse position, two different mouseStates are created in InputSystemUIInputModule.cs since they are two different devices.  The subsequent ProcessMouseButton() function call will process the mouseState set by the m_LeftClickAction separately from the mouseState set by the m_PointAction.  Thus, ProcessMouseButton() does not get the position set in the mouseState set by the m_PointAction and always has the default value of (0,0).

This change stores the position retrieved from the m_PointAction, and stores it on the mouseStates set on the subsequent m_ScrollWheelAction, m_LeftClickAction, m_RightClickAction, or m_MiddleClickAction.  This removes the dependency that the device action mapping for m_PointAction must match that of the other actions.