### PR TITLE
FIX: Allow overriding composite binding parameters

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -289,7 +289,7 @@ namespace UnityEngine.InputSystem
                                     : InputActionState.kInvalidIndex;
 
                                 // Instantiate. For composites, the path is the name of the composite.
-                                var composite = InstantiateBindingComposite(unresolvedBinding.path);
+                                var composite = InstantiateBindingComposite(unresolvedBinding.effectivePath);
                                 currentCompositeIndex =
                                     ArrayHelpers.AppendWithCapacity(ref composites, ref totalCompositeCount, composite);
                                 currentCompositeBindingIndex = bindingIndex;


### PR DESCRIPTION
Currently, the ```InputBindingResolver``` uses the binding's path to instantiate a composite binding.
Any parameters are stored in the path as well.
For example, ```"MyCustomComposite(someParameter=true)"```

If any overrides to the path were made at runtime (e.g. to change the parameter to false) they are ignored when the binding is resolved.

This PR changes the ```InputBindingResolver``` to use ```effectivePath``` instead of ```path``` so that parameters of the composite can be changed at runtime.