### PR TITLE
FIX: Format action notification message names with MakeTypeName

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1251,10 +1251,7 @@ namespace UnityEngine.InputSystem
             foreach (var action in m_Actions)
             {
                 action.MakeSureIdIsInPlace();
-
-                var name = action.name;
-                if (char.IsLower(name[0]))
-                    name = char.ToUpper(name[0]) + name.Substring(1);
+                var name = CSharpCodeHelpers.MakeTypeName(action.name);
                 m_ActionMessageNames[action.m_Id] = "On" + name;
             }
         }


### PR DESCRIPTION
Today, if an Action name contains a space (or other characters not allowed in C# method names), the message will not get delivered.

As an example, if an Action is named "**Toggle Menu**" in the InputActionAsset, `PlayerInput.OnActionTriggered` will try to send a message named `OnToggle Menu` (despite the PlayerInput Inspector panel claiming `Will SendMessage() to GameObject: OnToggleMenu`).

The Inspector panel filters the Action name through `CSharpCodeHelpers.MakeTypeName`:

https://github.com/Unity-Technologies/InputSystem/blob/828102bd8927c2fc369cf0ebeba3812c57edb99f/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs#L351-L355

As does InputActionCodeGenerator when generating the C# Interfaces for each Action Map:

https://github.com/Unity-Technologies/InputSystem/blob/828102bd8927c2fc369cf0ebeba3812c57edb99f/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs#L276-L280

This PR matches that logic when actually dispatching the message.