### PR TITLE
FIX: Don't set group for pasted composite binding

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -848,7 +848,7 @@ namespace UnityEngine.InputSystem.Editor
 
                 // If we have a binding group to set for new bindings, overwrite the binding's
                 // group with it.
-                if (!string.IsNullOrEmpty(bindingGroupForNewBindings))
+                if (!string.IsNullOrEmpty(bindingGroupForNewBindings) && tag != k_CompositeBindingTag)
                     InputActionSerializationHelpers.ChangeBinding(property,
                         groups: bindingGroupForNewBindings);
             }


### PR DESCRIPTION
When pasting a copied composite binding in the asset editor, if the editor is filtering to show only one scheme, the group will get set to that scheme on the composite binding when it should be left empty.

This PR skips setting the group if the binding is a composite.