### PR TITLE
FIX: Wrong display names for devices in control schemes.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview.5] - 2020-12-12
+
+### Fixed
+
+- The list of device requirements for a control scheme in the action editor no longer displays devices with their internal layout name rather than their external display name.
+
 ## [1.0.0-preview.4] - 2020-01-24
 
 This release includes a number of Quality-of-Life improvements for a range of common problems that users have reported.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
@@ -326,12 +326,15 @@ namespace UnityEngine.InputSystem.Editor
         {
             ////TODO: need something more flexible to produce correct results for more than the simple string we produce here
             var deviceLayout = InputControlPath.TryGetDeviceLayout(requirement.controlPath);
+            var deviceLayoutText = !string.IsNullOrEmpty(deviceLayout)
+                ? EditorInputControlLayoutCache.GetDisplayName(deviceLayout)
+                : string.Empty;
             var usages = InputControlPath.TryGetDeviceUsages(requirement.controlPath);
 
             if (usages != null && usages.Length > 0)
-                return $"{deviceLayout} {string.Join("}{", usages)}";
+                return $"{deviceLayoutText} {string.Join("}{", usages)}";
 
-            return deviceLayout;
+            return deviceLayoutText;
         }
 
         // Notifications.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/EditorInputControlLayoutCache.cs
@@ -112,6 +112,20 @@ namespace UnityEngine.InputSystem.Editor
             return matchers;
         }
 
+        public static string GetDisplayName(string layoutName)
+        {
+            if (string.IsNullOrEmpty(layoutName))
+                throw new ArgumentException("Layout name cannot be null or empty", nameof(layoutName));
+
+            var layout = TryGetLayout(layoutName);
+            if (layout == null)
+                return layoutName;
+
+            if (!string.IsNullOrEmpty(layout.displayName))
+                return layout.displayName;
+            return layout.name;
+        }
+
         /// <summary>
         /// List the controls that may be present on controls or devices of the given layout by virtue
         /// of being defined in other layouts based on it.

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "1.0.0-preview.4",
+	"version": "1.0.0-preview.5",
 	"unity": "2019.1",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Minor cosmetic issue. You'd pick "PS4 Controller" (display name) from the list and then it'd say "DualShockGamepad" (layout name) in the list instead.