### PR TITLE
FIX: ArgumentExceptions 'Invalid user' when re-enabling PlayerInputs (case 1198889).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UserTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UserTests.cs
@@ -481,18 +481,20 @@ internal class UserTests : InputTestFixture
         var user = InputUser.PerformPairingWithDevice(gamepad1);
         InputUser.PerformPairingWithDevice(gamepad2, user: user);
 
+        var originalUser = user;
         user.UnpairDevicesAndRemoveUser();
 
+        Assert.That(user, Is.EqualTo(default(InputUser)));
         Assert.That(user.valid, Is.False);
         Assert.That(InputUser.all, Is.Empty);
         Assert.That(receivedChanges, Is.EquivalentTo(new[]
         {
-            new UserChange(user, InputUserChange.Added),
-            new UserChange(user, InputUserChange.DevicePaired, gamepad1),
-            new UserChange(user, InputUserChange.DevicePaired, gamepad2),
-            new UserChange(user, InputUserChange.DeviceUnpaired, gamepad1),
-            new UserChange(user, InputUserChange.DeviceUnpaired, gamepad2),
-            new UserChange(user, InputUserChange.Removed),
+            new UserChange(originalUser, InputUserChange.Added),
+            new UserChange(originalUser, InputUserChange.DevicePaired, gamepad1),
+            new UserChange(originalUser, InputUserChange.DevicePaired, gamepad2),
+            new UserChange(originalUser, InputUserChange.DeviceUnpaired, gamepad1),
+            new UserChange(originalUser, InputUserChange.DeviceUnpaired, gamepad2),
+            new UserChange(originalUser, InputUserChange.Removed),
         }));
     }
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview.5] - 2020-12-12
+
+### Fixed
+
+#### Actions
+
+- "Invalid user" `ArgumentException` when turning the same `PlayerInput` on and off ([case 1198889](https://issuetracker.unity3d.com/issues/input-system-package-argumentexception-invalid-user-error-is-thrown-when-the-callback-disables-game-object-with-playerinput)).
+
 ## [1.0.0-preview.4] - 2020-01-24
 
 This release includes a number of Quality-of-Life improvements for a range of common problems that users have reported.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -691,6 +691,8 @@ namespace UnityEngine.InputSystem.Users
 
             var userIndex = index;
             RemoveUser(userIndex);
+
+            m_Id = default;
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "1.0.0-preview.4",
+	"version": "1.0.0-preview.5",
 	"unity": "2019.1",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1198889/