### PR TITLE
FIX: Display names in UI being wrong for XR controllers and HMDs (#1021).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview.4] - 2020-12-12
+
+### Fixed
+
+- XR controllers and HMDs have proper display names in the UI again. This regressed in preview.4 such that all XR controllers were displayed as just "XR Controller" in the UI and all HMDs were displayed as "XR HMD".
+
 ## [1.0.0-preview.4] - 2020-01-24
 
 This release includes a number of Quality-of-Life improvements for a range of common problems that users have reported.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.0.0-preview.5] - 2020-12-12
+
 ### Fixed
 
 - XR controllers and HMDs have proper display names in the UI again. This regressed in preview.4 such that all XR controllers were displayed as just "XR Controller" in the UI and all HMDs were displayed as "XR HMD".

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -11,6 +11,8 @@ using UnityEngine.InputSystem.Utilities;
 // - By group (e.g. "search for binding on action 'fire' with group 'keyboard&mouse' and override it with '<Keyboard>/space'")
 // - By action (e.g. "bind action 'fire' from whatever it is right now to '<Gamepad>/leftStick'")
 
+////TODO: make this work implicitly with PlayerInputs such that rebinds can be restricted to the device's of a specific player
+
 ////TODO: allow rebinding by GUIDs now that we have IDs on bindings
 
 ////FIXME: properly work with composites

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/GoogleVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/GoogleVR.cs
@@ -9,7 +9,7 @@ namespace Unity.XR.GoogleVr
     /// <summary>
     /// A head-mounted display powered by Google Daydream.
     /// </summary>
-    [InputControlLayout]
+    [InputControlLayout(displayName = "Daydream Headset")]
     [Preserve]
     public class DaydreamHMD : XRHMD
     {
@@ -18,7 +18,7 @@ namespace Unity.XR.GoogleVr
     /// <summary>
     /// An XR controller powered by Google Daydream.
     /// </summary>
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Daydream Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
     [Preserve]
     public class DaydreamController : XRController
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/Oculus.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/Oculus.cs
@@ -10,6 +10,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// An Oculus VR headset (such as the Oculus Rift series of devices).
     /// </summary>
+    [InputControlLayout(displayName = "Oculus Headset")]
     [Preserve]
     public class OculusHMD : XRHMD
     {
@@ -80,7 +81,7 @@ namespace Unity.XR.Oculus.Input
     /// An Oculus Touch controller.
     /// </summary>
     [Preserve]
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Oculus Touch Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
     public class OculusTouchController : XRControllerWithRumble
     {
         [Preserve]
@@ -189,6 +190,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// An Oculus Remote controller.
     /// </summary>
+    [InputControlLayout(displayName = "Oculus Remote")]
     [Preserve]
     public class OculusRemote : InputDevice
     {
@@ -215,6 +217,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// A Standalone VR headset that includes on-headset controls.
     /// </summary>
+    [InputControlLayout(displayName = "Oculus Headset (w/ on-headset controls)")]
     [Preserve]
     public class OculusHMDExtended : OculusHMD
     {
@@ -238,7 +241,7 @@ namespace Unity.XR.Oculus.Input
     /// A Gear VR controller.
     /// </summary>
     [Preserve]
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "GearVR Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
     public class GearVRTrackedController : XRController
     {
         [Preserve]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
@@ -7,7 +7,7 @@ using UnityEngine.Scripting;
 
 namespace Unity.XR.OpenVR
 {
-    [InputControlLayout]
+    [InputControlLayout(displayName = "OpenVR Headset")]
     [Preserve]
     public class OpenVRHMD : XRHMD
     {
@@ -51,7 +51,7 @@ namespace Unity.XR.OpenVR
         }
     }
 
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "OpenVR Controller (Windows MR)", commonUsages = new[] { "LeftHand", "RightHand" })]
     [Preserve]
     public class OpenVRControllerWMR : XRController
     {
@@ -115,7 +115,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An HTC Vive Wand controller.
     /// </summary>
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Vive Wand", commonUsages = new[] { "LeftHand", "RightHand" })]
     [Preserve]
     public class ViveWand : XRControllerWithRumble
     {
@@ -172,7 +172,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An HTC Vive lighthouse.
     /// </summary>
-    [InputControlLayout]
+    [InputControlLayout(displayName = "Vive Lighthouse")]
     [Preserve]
     public class ViveLighthouse : TrackedDevice
     {
@@ -181,6 +181,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An HTC Vive tracker.
     /// </summary>
+    [InputControlLayout(displayName = "Vive Tracker")]
     [Preserve]
     public class ViveTracker : TrackedDevice
     {
@@ -200,7 +201,7 @@ namespace Unity.XR.OpenVR
         }
     }
 
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Handed Vive Tracker", commonUsages = new[] { "LeftHand", "RightHand" })]
     [Preserve]
     public class HandedViveTracker : ViveTracker
     {
@@ -235,7 +236,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An Oculus Touch controller.
     /// </summary>
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Oculus Touch Controller (OpenVR)", commonUsages = new[] { "LeftHand", "RightHand" })]
     [Preserve]
     public class OpenVROculusTouchController : XRControllerWithRumble
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
@@ -51,7 +51,7 @@ namespace Unity.XR.OpenVR
         }
     }
 
-    [InputControlLayout(displayName = "OpenVR Controller (Windows MR)", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Windows MR Controller (OpenVR)", commonUsages = new[] { "LeftHand", "RightHand" })]
     [Preserve]
     public class OpenVRControllerWMR : XRController
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/WindowsMR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/WindowsMR.cs
@@ -10,6 +10,7 @@ namespace UnityEngine.XR.WindowsMR.Input
     /// A Windows Mixed Reality XR headset.
     /// </summary>
     [Preserve]
+    [InputControlLayout(displayName = "Windows MR Headset")]
     public class WMRHMD : XRHMD
     {
         [Preserve]
@@ -30,7 +31,7 @@ namespace UnityEngine.XR.WindowsMR.Input
     /// A Windows Mixed Reality XR controller.
     /// </summary>
     [Preserve]
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "HoloLens Hand", commonUsages = new[] { "LeftHand", "RightHand" })]
     public class HololensHand : XRController
     {
         [Preserve]
@@ -58,7 +59,7 @@ namespace UnityEngine.XR.WindowsMR.Input
     }
 
     [Preserve]
-    [InputControlLayout(commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Windows MR Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
     public class WMRSpatialController : XRControllerWithRumble
     {
         [Preserve]


### PR DESCRIPTION
Was regressed by the fact that `XRController` and `XRHMD` now assign a `displayName`. Since that propery is inherited and none of the XR layouts was setting a display name, this broke display names on all the XR layouts.