### PR TITLE
CHANGE: Enforce started/performed/canceled cycle on button and value actions.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -1507,10 +1507,7 @@ partial class CoreTests
 
             Release(gamepad.buttonNorth);
 
-            var actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[0].control, Is.SameAs(gamepad.buttonNorth));
+            Assert.That(trace, Started(action, gamepad.buttonNorth).AndThen(Performed(action, gamepad.buttonNorth)).AndThen(Canceled(action, gamepad.buttonNorth)));
 
             trace.Clear();
 
@@ -1522,10 +1519,7 @@ partial class CoreTests
 
             Release(gamepad.buttonNorth);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[0].control, Is.SameAs(gamepad.buttonNorth));
+            Assert.That(trace, Started(action, gamepad.buttonNorth).AndThen(Performed(action, gamepad.buttonNorth)).AndThen(Canceled(action, gamepad.buttonNorth)));
 
             trace.Clear();
 
@@ -1536,10 +1530,7 @@ partial class CoreTests
 
             Release(keyboard.aKey);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[0].control, Is.SameAs(keyboard.aKey));
+            Assert.That(trace, Started(action, keyboard.aKey).AndThen(Performed(action, keyboard.aKey)).AndThen(Canceled(action, keyboard.aKey)));
 
             trace.Clear();
 
@@ -1558,19 +1549,13 @@ partial class CoreTests
 
             Release(keyboard.aKey);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[0].control, Is.SameAs(keyboard.aKey));
+            Assert.That(trace, Started(action, keyboard.aKey).AndThen(Performed(action, keyboard.aKey)).AndThen(Canceled(action, keyboard.aKey)));
 
             trace.Clear();
 
             Release(gamepad.buttonNorth);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[0].control, Is.SameAs(gamepad.buttonNorth));
+            Assert.That(trace, Started(action, gamepad.buttonNorth).AndThen(Performed(action, gamepad.buttonNorth)).AndThen(Canceled(action, gamepad.buttonNorth)));
         }
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -4,10 +4,90 @@ using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Interactions;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.InputSystem.XR;
 using UnityEngine.Scripting;
 
 internal partial class CoreTests
 {
+    [Preserve]
+    class InteractionThatOnlyPerforms : IInputInteraction<float>
+    {
+        public bool stayPerformed;
+
+        public void Process(ref InputInteractionContext context)
+        {
+            if (context.ControlIsActuated())
+            {
+                if (stayPerformed)
+                    context.PerformedAndStayPerformed();
+                else
+                    context.Performed();
+            }
+        }
+
+        public void Reset()
+        {
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_StartedAndCanceledAreEnforcedImplicitly()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        InputSystem.RegisterInteraction<InteractionThatOnlyPerforms>();
+
+        var action1 = new InputAction(name: "action1", type: InputActionType.Button, binding: "<Gamepad>/buttonSouth", interactions: "interactionThatOnlyPerforms(stayPerformed=true)");
+        var action2 = new InputAction(name: "action2", type: InputActionType.Button, binding: "<Gamepad>/buttonSouth", interactions: "interactionThatOnlyPerforms(stayPerformed=false)");
+        var action3 = new InputAction(name: "action3", type: InputActionType.Button, binding: "<Gamepad>/buttonSouth");
+        var action4 = new InputAction(name: "action4", type: InputActionType.Value, binding: "<Gamepad>/buttonSouth");
+
+        // Pass-Through is special (as always).
+        var action5 = new InputAction(name: "action5", type: InputActionType.PassThrough, binding: "<Gamepad>/buttonSouth");
+        var action6 = new InputAction(name: "action6", type: InputActionType.PassThrough, binding: "<Gamepad>/buttonSouth", interactions: "press");
+
+        action1.Enable();
+        action2.Enable();
+        action3.Enable();
+        action4.Enable();
+        action5.Enable();
+        action6.Enable();
+
+        using (var trace1 = new InputActionTrace(action1))
+        using (var trace2 = new InputActionTrace(action2))
+        using (var trace3 = new InputActionTrace(action3))
+        using (var trace4 = new InputActionTrace(action4))
+        using (var trace5 = new InputActionTrace(action5))
+        using (var trace6 = new InputActionTrace(action6))
+        {
+            Press(gamepad.buttonSouth);
+
+            Assert.That(trace1, Started(action1).AndThen(Performed(action1)));
+            Assert.That(trace2, Started(action2).AndThen(Performed(action2)).AndThen(Canceled(action2)));
+            Assert.That(trace3, Started(action3).AndThen(Performed(action3)));
+            Assert.That(trace4, Started(action4).AndThen(Performed(action4)));
+            Assert.That(trace5, Performed(action5));
+            Assert.That(trace6, Started(action6).AndThen(Performed(action6)));
+
+            trace1.Clear();
+            trace2.Clear();
+            trace3.Clear();
+            trace4.Clear();
+            trace5.Clear();
+            trace6.Clear();
+
+            Release(gamepad.buttonSouth);
+
+            Assert.That(trace1, Is.Empty);
+            Assert.That(trace2, Is.Empty);
+            Assert.That(trace3, Canceled(action3));
+            Assert.That(trace4, Canceled(action4));
+            Assert.That(trace5, Performed(action5)); // Any value change performs.
+            Assert.That(trace6, Canceled(action6));
+        }
+    }
+
     [Test]
     [Category("Actions")]
     public void Actions_WhenTransitionFromOneInteractionToNext_GetCallbacks()
@@ -49,7 +129,7 @@ internal partial class CoreTests
         InputSystem.AddDevice<Keyboard>();
 
         // Test all three press behaviors concurrently.
-        var pressOnlyAction = new InputAction("PressOnly", binding: "<Gamepad>/buttonSouth", interactions: "press");
+        var pressOnlyAction = new InputAction("PressOnly", binding: "<Gamepad>/buttonSouth", interactions: "press(behavior=0)");
         pressOnlyAction.AddBinding("<Keyboard>/a");
         var releaseOnlyAction = new InputAction("ReleaseOnly", binding: "<Gamepad>/buttonSouth", interactions: "press(behavior=1)");
         releaseOnlyAction.AddBinding("<Keyboard>/s");
@@ -60,83 +140,50 @@ internal partial class CoreTests
         releaseOnlyAction.Enable();
         pressAndReleaseAction.Enable();
 
-        using (var trace = new InputActionTrace())
+        using (var pressOnly = new InputActionTrace(pressOnlyAction))
+        using (var releaseOnly = new InputActionTrace(releaseOnlyAction))
+        using (var pressAndRelease = new InputActionTrace(pressAndReleaseAction))
         {
-            trace.SubscribeToAll();
-
             runtime.currentTime = 1;
             Press(gamepad.buttonSouth);
 
-            var actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(5));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Performed).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Performed).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(releaseOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
+            Assert.That(pressOnly,
+                Started<PressInteraction>(pressOnlyAction, gamepad.buttonSouth, value: 1.0, time: 1)
+                    .AndThen(Performed<PressInteraction>(pressOnlyAction, gamepad.buttonSouth, time: 1, duration: 0, value: 1.0)));
+            Assert.That(releaseOnly, Started<PressInteraction>(releaseOnlyAction, gamepad.buttonSouth, time: 1, value: 1.0));
+            Assert.That(pressAndRelease,
+                Started<PressInteraction>(pressAndReleaseAction, gamepad.buttonSouth, time: 1, value: 1.0)
+                    .AndThen(Performed<PressInteraction>(pressAndReleaseAction, gamepad.buttonSouth, time: 1, duration: 0, value: 1.0)));
 
-            trace.Clear();
+            pressOnly.Clear();
+            releaseOnly.Clear();
+            pressAndRelease.Clear();
 
             runtime.currentTime = 2;
             Release(gamepad.buttonSouth);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(3));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(releaseOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Performed).And.With.Property("duration")
-                    .EqualTo(1));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Performed).And.With.Property("duration")
-                    .EqualTo(0));
+            Assert.That(pressOnly, Canceled<PressInteraction>(pressOnlyAction, gamepad.buttonSouth, value: 0.0, time: 2, duration: 1));
+            Assert.That(releaseOnly,
+                Performed<PressInteraction>(releaseOnlyAction, gamepad.buttonSouth, value: 0.0, time: 2, duration: 1)
+                    .AndThen(Canceled<PressInteraction>(releaseOnlyAction, gamepad.buttonSouth, value: 0.0, time: 2, duration: 1)));
+            Assert.That(pressAndRelease,
+                Performed<PressInteraction>(pressAndReleaseAction, gamepad.buttonSouth, value: 0.0, time: 2, duration: 1)
+                    .AndThen(Canceled<PressInteraction>(pressAndReleaseAction, gamepad.buttonSouth, value: 0.0, time: 2, duration: 1)));
 
-            trace.Clear();
+            pressOnly.Clear();
+            releaseOnly.Clear();
+            pressAndRelease.Clear();
 
             runtime.currentTime = 5;
             Press(gamepad.buttonSouth);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(5));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Performed).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(pressAndReleaseAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Performed).And.With.Property("duration")
-                    .EqualTo(0));
-            Assert.That(actions,
-                Has.Exactly(1).With.Property("action").SameAs(releaseOnlyAction).And.With.Property("phase")
-                    .EqualTo(InputActionPhase.Started).And.With.Property("duration")
-                    .EqualTo(0));
+            Assert.That(pressOnly,
+                Started<PressInteraction>(pressOnlyAction, gamepad.buttonSouth, value: 1.0, time: 5)
+                    .AndThen(Performed<PressInteraction>(pressOnlyAction, gamepad.buttonSouth, time: 5, duration: 0, value: 1.0)));
+            Assert.That(releaseOnly, Started<PressInteraction>(releaseOnlyAction, gamepad.buttonSouth, time: 5, value: 1.0));
+            Assert.That(pressAndRelease,
+                Started<PressInteraction>(pressAndReleaseAction, gamepad.buttonSouth, time: 5, value: 1.0)
+                    .AndThen(Performed<PressInteraction>(pressAndReleaseAction, gamepad.buttonSouth, time: 5, duration: 0, value: 1.0)));
         }
     }
 
@@ -513,7 +560,7 @@ internal partial class CoreTests
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         var action = new InputAction("test", binding: "<Gamepad>/leftTrigger", interactions: "CancelingTest");
-        int performedCount = 0;
+        var performedCount = 0;
         float performedValue = -1;
         action.performed += ctx =>
         {
@@ -521,7 +568,7 @@ internal partial class CoreTests
             performedCount++;
         };
 
-        int canceledCount = 0;
+        var canceledCount = 0;
         float canceledValue = -1;
         action.canceled += ctx =>
         {

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -24,6 +24,8 @@ using TouchPhase = UnityEngine.InputSystem.TouchPhase;
 using Vector2 = UnityEngine.Vector2;
 using Vector3 = UnityEngine.Vector3;
 
+////TODO: set display name from product string only for layout builders (and give them control); for other layouts, let the layout dictate the display name
+
 ////TODO: test that device re-creation doesn't lose flags and such
 
 partial class CoreTests

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/IInputInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/IInputInteraction.cs
@@ -314,9 +314,21 @@ namespace UnityEngine.InputSystem
             if (interactionType == null)
                 return interaction;
 
+            return GetDisplayName(interactionType);
+        }
+
+        public static string GetDisplayName(Type interactionType)
+        {
+            if (interactionType == null)
+                throw new ArgumentNullException(nameof(interactionType));
+
             var displayNameAttribute = interactionType.GetCustomAttribute<DisplayNameAttribute>();
             if (displayNameAttribute == null)
-                return interaction;
+            {
+                if (interactionType.Name.EndsWith("Interaction"))
+                    return interactionType.Name.Substring(0, interactionType.Name.Length - "Interaction".Length);
+                return interactionType.Name;
+            }
 
             return displayNameAttribute.DisplayName;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -854,7 +854,7 @@ namespace UnityEngine.InputSystem
                 interactionIndex = kInvalidIndex,
                 time = time,
                 startTime = time,
-                passThrough = actionIndex != kInvalidIndex && actionStates[actionIndex].passThrough,
+                isPassThrough = actionIndex != kInvalidIndex && actionStates[actionIndex].isPassThrough,
             };
 
             // If we have pending initial state checks that will run in the next update,
@@ -1207,6 +1207,10 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// The default interaction does not have its own <see cref="InteractionState"/>. Whatever we do in here,
         /// we store directly on the action state.
+        ///
+        /// The default interaction is basically a sort of optimization where we don't require having an explicit
+        /// interaction object. Conceptually, it can be thought of, however, as putting this interaction on any
+        /// binding that doesn't have any other interaction on it.
         /// </remarks>
         private void ProcessDefaultInteraction(ref TriggerState trigger, int actionIndex)
         {
@@ -1219,7 +1223,7 @@ namespace UnityEngine.InputSystem
                 {
                     // Pass-through actions we perform on every value change and then go back
                     // to waiting.
-                    if (trigger.passThrough)
+                    if (trigger.isPassThrough)
                     {
                         ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
                             phaseAfterPerformedOrCanceled: InputActionPhase.Waiting);
@@ -1251,6 +1255,15 @@ namespace UnityEngine.InputSystem
                         ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
                             phaseAfterPerformedOrCanceled: InputActionPhase.Started);
                     }
+                    break;
+                }
+
+                case InputActionPhase.Performed:
+                {
+                    Debug.Assert(actionStates[actionIndex].isPassThrough,
+                        "Only pass-through actions should be left in performed state by default interaction");
+                    ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
+                        phaseAfterPerformedOrCanceled: InputActionPhase.Performed);
                     break;
                 }
 
@@ -1407,8 +1420,7 @@ namespace UnityEngine.InputSystem
             // Update interaction state.
             interactionStates[interactionIndex].phase = newPhase;
             interactionStates[interactionIndex].triggerControlIndex = trigger.controlIndex;
-            if (newPhase == InputActionPhase.Started)
-                interactionStates[interactionIndex].startTime = trigger.time;
+            interactionStates[interactionIndex].startTime = trigger.startTime;
 
             ////REVIEW: If we want to defer triggering of actions, this is the point where we probably need to cut things off
             // See if it affects the phase of an associated action.
@@ -1515,9 +1527,58 @@ namespace UnityEngine.InputSystem
 
             // Ignore if action is disabled.
             var actionState = &actionStates[actionIndex];
-            if (actionState->phase == InputActionPhase.Disabled)
+            if (actionState->isDisabled)
                 return;
 
+            // Enforce transition constraints.
+            if (actionState->isPassThrough && trigger.interactionIndex == kInvalidIndex)
+            {
+                // No constraints on pass-through actions except if there are interactions driving the action.
+                ChangePhaseOfActionInternal(actionIndex, actionState, newPhase, ref trigger);
+                if (actionState->isDisabled)
+                    return;
+            }
+            else if (newPhase == InputActionPhase.Performed && actionState->phase == InputActionPhase.Waiting)
+            {
+                // Going from waiting to performed, we make a detour via started.
+                ChangePhaseOfActionInternal(actionIndex, actionState, InputActionPhase.Started, ref trigger);
+                if (actionState->isDisabled)
+                    return;
+
+                // Then we perform.
+                ChangePhaseOfActionInternal(actionIndex, actionState, newPhase, ref trigger);
+                if (actionState->isDisabled)
+                    return;
+
+                // And finally, if we're going back to waiting, we make a detour via canceled.
+                if (phaseAfterPerformedOrCanceled == InputActionPhase.Waiting)
+                    ChangePhaseOfActionInternal(actionIndex, actionState, InputActionPhase.Canceled, ref trigger);
+                if (actionState->isDisabled)
+                    return;
+
+                actionState->phase = phaseAfterPerformedOrCanceled;
+            }
+            else
+            {
+                ChangePhaseOfActionInternal(actionIndex, actionState, newPhase, ref trigger);
+                if (actionState->isDisabled)
+                    return;
+
+                if (newPhase == InputActionPhase.Performed || newPhase == InputActionPhase.Canceled)
+                    actionState->phase = phaseAfterPerformedOrCanceled;
+            }
+
+            // If we're now waiting, reset control state. This is important for the disambiguation code
+            // to not consider whatever control actuation happened on the action last.
+            if (actionState->phase == InputActionPhase.Waiting)
+            {
+                actionState->controlIndex = kInvalidIndex;
+                actionState->flags &= ~TriggerState.Flags.HaveMagnitude;
+            }
+        }
+
+        private void ChangePhaseOfActionInternal(int actionIndex, TriggerState* actionState, InputActionPhase newPhase, ref TriggerState trigger)
+        {
             // Update action state.
             Debug.Assert(trigger.mapIndex == actionState->mapIndex,
                 "Map index on trigger does not correspond to map index of trigger state");
@@ -1530,6 +1591,8 @@ namespace UnityEngine.InputSystem
                 newState.lastTriggeredInUpdate = InputUpdate.s_UpdateStepCount;
             else
                 newState.lastTriggeredInUpdate = actionState->lastTriggeredInUpdate;
+            if (newPhase == InputActionPhase.Started)
+                newState.startTime = newState.time;
             *actionState = newState;
 
             // Let listeners know.
@@ -1549,26 +1612,14 @@ namespace UnityEngine.InputSystem
                 case InputActionPhase.Performed:
                 {
                     CallActionListeners(actionIndex, map, newPhase, ref action.m_OnPerformed, "performed");
-                    if (actionState->phase != InputActionPhase.Disabled) // Action may have been disabled in callback.
-                        actionState->phase = phaseAfterPerformedOrCanceled;
                     break;
                 }
 
                 case InputActionPhase.Canceled:
                 {
                     CallActionListeners(actionIndex, map, newPhase, ref action.m_OnCanceled, "canceled");
-                    if (actionState->phase != InputActionPhase.Disabled) // Action may have been disabled in callback.
-                        actionState->phase = phaseAfterPerformedOrCanceled;
                     break;
                 }
-            }
-
-            // If we're now waiting, reset control state. This is important for the disambiguation code
-            // to not consider whatever control actuation happened on the action last.
-            if (actionState->phase == InputActionPhase.Waiting)
-            {
-                actionState->controlIndex = kInvalidIndex;
-                actionState->flags &= ~TriggerState.Flags.HaveMagnitude;
             }
         }
 
@@ -2488,6 +2539,12 @@ namespace UnityEngine.InputSystem
                 set => m_Phase = (byte)value;
             }
 
+            public bool isDisabled => phase == InputActionPhase.Disabled;
+            public bool isWaiting => phase == InputActionPhase.Waiting;
+            public bool isStarted => phase == InputActionPhase.Started;
+            public bool isPerformed => phase == InputActionPhase.Performed;
+            public bool isCanceled => phase == InputActionPhase.Canceled;
+
             /// <summary>
             /// The time the binding got triggered.
             /// </summary>
@@ -2631,7 +2688,7 @@ namespace UnityEngine.InputSystem
             /// Whether the action associated with the trigger state is marked as pass-through.
             /// </summary>
             /// <seealso cref="InputActionType.PassThrough"/>
-            public bool passThrough
+            public bool isPassThrough
             {
                 get => (flags & Flags.PassThrough) != 0;
                 set
@@ -2651,7 +2708,7 @@ namespace UnityEngine.InputSystem
             /// We use this to gate some of the more expensive checks that are pointless to
             /// perform if we don't have to disambiguate input from concurrent sources.
             ///
-            /// Always disabled if <see cref="passThrough"/> is true.
+            /// Always disabled if <see cref="isPassThrough"/> is true.
             /// </remarks>
             public bool mayNeedConflictResolution
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -515,7 +515,7 @@ namespace UnityEngine.InputSystem
                         mapIndex = mapIndex,
                         controlIndex = InputActionState.kInvalidIndex,
                         interactionIndex = InputActionState.kInvalidIndex,
-                        passThrough = isPassThroughAction,
+                        isPassThrough = isPassThroughAction,
                         mayNeedConflictResolution = mayNeedConflictResolution,
                     };
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputInteractionContext.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputInteractionContext.cs
@@ -129,29 +129,37 @@ namespace UnityEngine.InputSystem
 
         public void Performed()
         {
+            if (m_TriggerState.phase == InputActionPhase.Waiting)
+                m_TriggerState.startTime = time;
             m_State.ChangePhaseOfInteraction(InputActionPhase.Performed, ref m_TriggerState);
         }
 
         public void PerformedAndStayStarted()
         {
+            if (m_TriggerState.phase == InputActionPhase.Waiting)
+                m_TriggerState.startTime = time;
             m_State.ChangePhaseOfInteraction(InputActionPhase.Performed, ref m_TriggerState,
                 phaseAfterPerformed: InputActionPhase.Started);
         }
 
         public void PerformedAndStayPerformed()
         {
+            if (m_TriggerState.phase == InputActionPhase.Waiting)
+                m_TriggerState.startTime = time;
             m_State.ChangePhaseOfInteraction(InputActionPhase.Performed, ref m_TriggerState,
                 phaseAfterPerformed: InputActionPhase.Performed);
         }
 
         public void Canceled()
         {
-            m_State.ChangePhaseOfInteraction(InputActionPhase.Canceled, ref m_TriggerState);
+            if (m_TriggerState.phase != InputActionPhase.Canceled)
+                m_State.ChangePhaseOfInteraction(InputActionPhase.Canceled, ref m_TriggerState);
         }
 
         public void Waiting()
         {
-            m_State.ChangePhaseOfInteraction(InputActionPhase.Waiting, ref m_TriggerState);
+            if (m_TriggerState.phase != InputActionPhase.Waiting)
+                m_State.ChangePhaseOfInteraction(InputActionPhase.Waiting, ref m_TriggerState);
         }
 
         public void SetTimeout(float seconds)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -69,16 +69,12 @@ namespace UnityEngine.InputSystem.Interactions
                         if (!isActuated)
                         {
                             m_WaitingForRelease = false;
-                            // We need to reset the action to waiting state in order to stop it from triggering
-                            // continuously. However, we do not want to cancel here as that will trigger the action.
-                            // So go back directly to waiting here.
-                            context.Waiting();
+                            context.Canceled();
                         }
                     }
                     else if (isActuated)
                     {
-                        context.Started();
-                        context.Performed();
+                        context.PerformedAndStayPerformed();
                         m_WaitingForRelease = true;
                     }
                     break;
@@ -88,6 +84,7 @@ namespace UnityEngine.InputSystem.Interactions
                     {
                         m_WaitingForRelease = false;
                         context.Performed();
+                        context.Canceled();
                     }
                     else if (isActuated)
                     {
@@ -101,15 +98,14 @@ namespace UnityEngine.InputSystem.Interactions
                     {
                         if (!isActuated)
                         {
-                            context.Started();
                             context.Performed();
+                            context.Canceled();
                         }
                         m_WaitingForRelease = isActuated;
                     }
                     else if (isActuated)
                     {
-                        context.Started();
-                        context.Performed();
+                        context.PerformedAndStayPerformed();
                         m_WaitingForRelease = true;
                     }
                     break;
@@ -178,11 +174,16 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
+            EditorGUILayout.HelpBox(s_HelpBoxText);
             target.behavior = (PressBehavior)EditorGUILayout.EnumPopup(s_PressBehaviorLabel, target.behavior);
             m_PressPointSetting.OnGUI();
         }
 
         private CustomOrDefaultSetting m_PressPointSetting;
+
+        private static readonly GUIContent s_HelpBoxText = EditorGUIUtility.TrTextContent("Note that the 'Press' interaction is only "
+            + "necessary when wanting to customize button press behavior. For default press behavior, simply set the action type to 'Button' "
+            + "and use the action without interactions added to it.");
 
         private static readonly GUIContent s_PressBehaviorLabel = EditorGUIUtility.TrTextContent("Trigger Behavior",
             "Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "


### PR DESCRIPTION
Fixes [1196050](https://issuetracker.unity3d.com/issues/input-system-ui-becomes-unresponsive-after-the-first-ui-button-press) ([internal](https://fogbugz.unity3d.com/f/cases/1196050/)).

This is an attempt to make started/performed/canceled more predictable and consistent by forcing a transition to `performed` to go through `started` and forcing a transition back to waiting to go through `canceled`.

Includes a do-over of `PressInteraction` to solve the many surprises the interaction has led to.