### PR TITLE
FIX: Hold interaction not staying performed (case 1195498).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -191,9 +191,6 @@ internal partial class CoreTests
     [Category("Actions")]
     public void Actions_CanPerformHoldInteraction()
     {
-        //rewrite this to use InputActionTrace and the new ActionConstraint stuff
-        //poll action value after action has been performed and make sure it returns the current button value
-
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         var action = new InputAction(binding: "<Gamepad>/{primaryAction}", interactions: "hold(duration=0.4)");

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -191,111 +191,65 @@ internal partial class CoreTests
     [Category("Actions")]
     public void Actions_CanPerformHoldInteraction()
     {
-        const int timeOffset = 123;
-        runtime.currentTimeOffsetToRealtimeSinceStartup = timeOffset;
-        runtime.currentTime = 10 + timeOffset;
+        //rewrite this to use InputActionTrace and the new ActionConstraint stuff
+        //poll action value after action has been performed and make sure it returns the current button value
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
-        var performedReceivedCalls = 0;
-        InputAction performedAction = null;
-        InputControl performedControl = null;
-
-        var startedReceivedCalls = 0;
-        InputAction startedAction = null;
-        InputControl startedControl = null;
-
-        var canceledReceivedCalls = 0;
-        InputAction canceledAction = null;
-        InputControl canceledControl = null;
-
         var action = new InputAction(binding: "<Gamepad>/{primaryAction}", interactions: "hold(duration=0.4)");
-        action.performed +=
-            ctx =>
-        {
-            ++performedReceivedCalls;
-            performedAction = ctx.action;
-            performedControl = ctx.control;
-
-            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(ctx.duration, Is.GreaterThanOrEqualTo(0.4));
-        };
-        action.started +=
-            ctx =>
-        {
-            ++startedReceivedCalls;
-            startedAction = ctx.action;
-            startedControl = ctx.control;
-
-            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(ctx.duration, Is.EqualTo(0.0));
-        };
-        action.canceled +=
-            ctx =>
-        {
-            ++canceledReceivedCalls;
-            canceledAction = ctx.action;
-            canceledControl = ctx.control;
-
-            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(ctx.duration, Is.GreaterThan(0.0));
-            Assert.That(ctx.duration, Is.LessThan(0.4));
-        };
         action.Enable();
 
-        InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 10.0);
-        InputSystem.Update();
+        using (var trace = new InputActionTrace(action))
+        {
+            // Press.
+            Press(gamepad.buttonSouth, time: 10);
 
-        Assert.That(startedReceivedCalls, Is.EqualTo(1));
-        Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(canceledReceivedCalls, Is.Zero);
-        Assert.That(startedAction, Is.SameAs(action));
-        Assert.That(startedControl, Is.SameAs(gamepad.buttonSouth));
+            Assert.That(trace, Started<HoldInteraction>(action, gamepad.buttonSouth, time: 10, value: 1.0));
+            Assert.That(action.ReadValue<float>(), Is.EqualTo(1));
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
 
-        startedReceivedCalls = 0;
+            trace.Clear();
 
-        InputSystem.QueueStateEvent(gamepad, new GamepadState(), 10.25);
-        InputSystem.Update();
+            // Release in less than hold time.
+            Release(gamepad.buttonSouth, time: 10.25);
 
-        Assert.That(startedReceivedCalls, Is.Zero);
-        Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(canceledReceivedCalls, Is.EqualTo(1));
-        Assert.That(canceledAction, Is.SameAs(action));
-        Assert.That(canceledControl, Is.SameAs(gamepad.buttonSouth));
-        Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
+            Assert.That(trace, Canceled<HoldInteraction>(action, gamepad.buttonSouth, duration: 0.25, time: 10.25, value: 0.0));
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
+            Assert.That(action.ReadValue<float>(), Is.Zero);
 
-        canceledReceivedCalls = 0;
+            trace.Clear();
 
-        InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 10.5);
-        InputSystem.Update();
+            // Press again.
+            Press(gamepad.buttonSouth, time: 10.5);
 
-        Assert.That(startedReceivedCalls, Is.EqualTo(1));
-        Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(canceledReceivedCalls, Is.Zero);
-        Assert.That(startedAction, Is.SameAs(action));
-        Assert.That(startedControl, Is.SameAs(gamepad.buttonSouth));
-        Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
+            Assert.That(trace, Started<HoldInteraction>(action, gamepad.buttonSouth, time: 10.5, value: 1.0));
+            Assert.That(action.ReadValue<float>(), Is.EqualTo(1));
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
 
-        startedReceivedCalls = 0;
+            trace.Clear();
 
-        runtime.currentTime = 10.75 + timeOffset;
-        InputSystem.Update();
+            // Let time pass but stay under hold time.
+            currentTime = 10.75;
+            InputSystem.Update();
 
-        Assert.That(startedReceivedCalls, Is.Zero);
-        Assert.That(performedReceivedCalls, Is.Zero);
-        Assert.That(canceledReceivedCalls, Is.Zero);
-        Assert.That(startedAction, Is.SameAs(action));
-        Assert.That(startedControl, Is.SameAs(gamepad.buttonSouth));
-        Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
+            Assert.That(trace, Is.Empty);
 
-        runtime.currentTime = 11 + timeOffset;
-        InputSystem.Update();
+            // Now exceed hold time. Make sure action performs and *stays* performed.
+            currentTime = 11;
+            InputSystem.Update();
 
-        Assert.That(startedReceivedCalls, Is.Zero);
-        Assert.That(performedReceivedCalls, Is.EqualTo(1));
-        Assert.That(canceledReceivedCalls, Is.Zero);
-        Assert.That(performedAction, Is.SameAs(action));
-        Assert.That(performedControl, Is.SameAs(gamepad.buttonSouth));
-        Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
+            Assert.That(trace,
+                Performed<HoldInteraction>(action, gamepad.buttonSouth, time: 11, duration: 0.5, value: 1.0));
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Performed));
+            Assert.That(action.ReadValue<float>(), Is.EqualTo(1));
+
+            trace.Clear();
+
+            // Release button.
+            Release(gamepad.buttonSouth, time: 11.5);
+
+            Assert.That(trace, Canceled<HoldInteraction>(action, gamepad.buttonSouth, time: 11.5, duration: 1, value: 0.0));
+        }
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -46,6 +46,7 @@ however, it has to be formatted properly to pass verification tests.
 - "Invalid user" `ArgumentException` when turning the same `PlayerInput` on and off ([case 1198889](https://issuetracker.unity3d.com/issues/input-system-package-argumentexception-invalid-user-error-is-thrown-when-the-callback-disables-game-object-with-playerinput)).
 - The list of device requirements for a control scheme in the action editor no longer displays devices with their internal layout name rather than their external display name.
 - `StackOverflowException` when `Invoke Unity Events` is selected in `PlayerInput` and it cannot find an action (#1033).
+- `HoldInteraction` now stays performed after timer has expired and cancels only on release of the control ([case 1195498](https://issuetracker.unity3d.com/issues/inputsystem-inputaction-dot-readvalue-returns-0-when-a-hold-action-is-performed-for-hold-time-amount-of-time)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -12,7 +12,16 @@ namespace UnityEngine.InputSystem.Interactions
     /// </summary>
     /// <remarks>
     /// The action is started when the control is pressed. If the control is released before the
-    /// set <see cref="duration"/>, the action is canceled.
+    /// set <see cref="duration"/>, the action is canceled. As soon as the hold time is reached,
+    /// the action performs. The action then stays performed until the control is released, at
+    /// which point the action cancels.
+    ///
+    /// <example>
+    /// <code>
+    /// // Action that requires A button on gamepad to be held for half a second.
+    /// var action = new InputAction(binding: "&lt;Gamepad&gt;/buttonSouth", interactions: "hold(duration=0.5)");
+    /// </code>
+    /// </example>
     /// </remarks>
     [Preserve]
     [DisplayName("Hold")]
@@ -49,7 +58,7 @@ namespace UnityEngine.InputSystem.Interactions
         {
             if (context.timerHasExpired)
             {
-                context.Performed();
+                context.PerformedAndStayPerformed();
                 return;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -649,7 +649,7 @@ namespace UnityEngine.InputSystem
             m_UsageCount = default;
         }
 
-        internal bool RequestRequest()
+        internal bool RequestReset()
         {
             var resetCommand = RequestResetCommand.Create();
             var result = device.ExecuteCommand(ref resetCommand);

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2410,7 +2410,7 @@ namespace UnityEngine.InputSystem
                             new InputEventPtr((InputEvent*)stateEventPtr));
 
                         // Tell the backend to reset.
-                        device.RequestRequest();
+                        device.RequestReset();
                     }
                 }
             }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1677,7 +1677,7 @@ namespace UnityEngine.InputSystem
         {
             if (device == null)
                 throw new ArgumentNullException(nameof(device));
-            return device.RequestRequest();
+            return device.RequestReset();
         }
 
         ////REVIEW: should there be a global pause state? what about haptics that are issued *while* paused?


### PR DESCRIPTION
Fixes [1195498](https://issuetracker.unity3d.com/issues/inputsystem-inputaction-dot-readvalue-returns-0-when-a-hold-action-is-performed-for-hold-time-amount-of-time) ([internal](https://fogbugz.unity3d.com/f/cases/1195498/)).