### PR TITLE
FIX: Foldouts not expanding with Unity 2019.3 (case 1213781).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -47,6 +47,7 @@ however, it has to be formatted properly to pass verification tests.
 - The list of device requirements for a control scheme in the action editor no longer displays devices with their internal layout name rather than their external display name.
 - `StackOverflowException` when `Invoke Unity Events` is selected in `PlayerInput` and it cannot find an action (#1033).
 - `HoldInteraction` now stays performed after timer has expired and cancels only on release of the control ([case 1195498](https://issuetracker.unity3d.com/issues/inputsystem-inputaction-dot-readvalue-returns-0-when-a-hold-action-is-performed-for-hold-time-amount-of-time)).
+- Foldouts in the various action UIs now properly toggle their expansion state when clicked in Unity 2019.3+ ([case 1213781](https://issuetracker.unity3d.com/issues/input-system-package-playerinput-component-events-menu-doesnt-expand-when-clicked-directly-on-the-arrow-icon)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -1167,7 +1167,7 @@ namespace UnityEngine.InputSystem.Editor
             var indent = (int)(position.x / kFoldoutWidth);
             position.x = foldoutOffset + (indent + 1) * kColorTagWidth + 2;
             position.width = kFoldoutWidth;
-            return EditorGUI.Foldout(position, expandedState, GUIContent.none, style);
+            return EditorGUI.Foldout(position, expandedState, GUIContent.none, true, style);
         }
 
         protected override void RowGUI(RowGUIArgs args)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
@@ -143,7 +143,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                     var editableParams = m_EditableParametersForEachListItem[i];
                     EditorGUILayout.BeginHorizontal();
                     if (editableParams.hasUIToShow)
-                        editableParams.visible = EditorGUILayout.Foldout(editableParams.visible, editableParams.name, Styles.s_FoldoutStyle);
+                        editableParams.visible = EditorGUILayout.Foldout(editableParams.visible, editableParams.name, true, Styles.s_FoldoutStyle);
                     else
                     {
                         GUILayout.Space(16);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
@@ -82,7 +82,7 @@ namespace UnityEngine.InputSystem.Editor
             EditorGUI.LabelField(bgRect, GUIContent.none, Styles.s_FoldoutBackgroundStyle);
             var foldoutRect = bgRect;
             foldoutRect.xMax -= k_PopupSize;
-            var retval = EditorGUI.Foldout(foldoutRect, folded, content, Styles.s_FoldoutStyle);
+            var retval = EditorGUI.Foldout(foldoutRect, folded, content, true, Styles.s_FoldoutStyle);
             if (addButton != null)
             {
                 var popupRect = bgRect;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -161,7 +161,7 @@ namespace UnityEngine.InputSystem.Editor
                     break;
 
                 case PlayerNotifications.InvokeUnityEvents:
-                    m_EventsGroupUnfolded = EditorGUILayout.Foldout(m_EventsGroupUnfolded, m_EventsGroupText);
+                    m_EventsGroupUnfolded = EditorGUILayout.Foldout(m_EventsGroupUnfolded, m_EventsGroupText, toggleOnLabelClick: true);
                     if (m_EventsGroupUnfolded)
                     {
                         // Action events. Group by action map.
@@ -173,7 +173,7 @@ namespace UnityEngine.InputSystem.Editor
                                 for (var n = 0; n < m_NumActionMaps; ++n)
                                 {
                                     m_ActionMapEventsUnfolded[n] = EditorGUILayout.Foldout(m_ActionMapEventsUnfolded[n],
-                                        m_ActionMapNames[n]);
+                                        m_ActionMapNames[n], toggleOnLabelClick: true);
                                     using (new EditorGUI.IndentLevelScope())
                                     {
                                         if (m_ActionMapEventsUnfolded[n])

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
@@ -66,7 +66,7 @@ namespace UnityEngine.InputSystem.Editor
                     break;
 
                 case PlayerNotifications.InvokeUnityEvents:
-                    m_EventsExpanded = EditorGUILayout.Foldout(m_EventsExpanded, m_EventsLabel);
+                    m_EventsExpanded = EditorGUILayout.Foldout(m_EventsExpanded, m_EventsLabel, toggleOnLabelClick: true);
                     if (m_EventsExpanded)
                     {
                         var playerJoinedEventProperty = serializedObject.FindProperty("m_PlayerJoinedEvent");


### PR DESCRIPTION
Fixes [1213781](https://issuetracker.unity3d.com/issues/input-system-package-playerinput-component-events-menu-doesnt-expand-when-clicked-directly-on-the-arrow-icon) ([internal](https://fogbugz.unity3d.com/f/cases/1213781/)).