### PR TITLE
FIX: Runtime errors when action for binding does not exist (case 1213085).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -6320,7 +6320,7 @@ partial class CoreTests
         map.AddBinding("<Gamepad>/buttonNorth", action: "DoesNotExist");
 
         // Also try the same for a composite binding.
-        map.AddBinding(new InputBinding { path = "1DAxis", isComposite = true });
+        map.AddBinding(new InputBinding { path = "1DAxis", isComposite = true, action = "DoesNotExist" });
         map.AddBinding(new InputBinding { name = "Positive", path = "<Gamepad>/leftTrigger", isPartOfComposite = true });
         map.AddBinding(new InputBinding { name = "Negative", path = "<Gamepad>/rightTrigger", isPartOfComposite = true });
 

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -6308,6 +6308,28 @@ partial class CoreTests
         Assert.That(action2.enabled, Is.False);
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1213085 (bindings that refer to non-existent actions should not lead to errors)
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanEnableAndDisableEntireMap_EvenWhenBindingsReferToNonExistentActions()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var map = new InputActionMap();
+        map.AddAction("action", binding: "<Gamepad>/buttonSouth");
+        map.AddBinding("<Gamepad>/buttonNorth", action: "DoesNotExist");
+
+        // Also try the same for a composite binding.
+        map.AddBinding(new InputBinding { path = "1DAxis", isComposite = true });
+        map.AddBinding(new InputBinding { name = "Positive", path = "<Gamepad>/leftTrigger", isPartOfComposite = true });
+        map.AddBinding(new InputBinding { name = "Negative", path = "<Gamepad>/rightTrigger", isPartOfComposite = true });
+
+        Assert.That(() => map.Enable(), Throws.Nothing);
+
+        Assert.That(() => Press(gamepad.buttonNorth), Throws.Nothing);
+        Assert.That(() => Press(gamepad.leftTrigger), Throws.Nothing);
+    }
+
     [Test]
     [Category("Actions")]
     public void Actions_CanEnableAndDisableSingleActionFromMap()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Mixing the enabling&disabling of single actions (as, for example, performed by `InputSystemUIInputModule`) with enabling&disabling of entire action maps (as, for example, performed by `PlayerInput`) no longer leaves to unresponsive input and `"should not reach here"` assertions ([forum thread](https://forum.unity.com/threads/error-while-switching-between-action-maps.825204/)).
 - Leaving play mode no longer leaves state change monitors lingering around from enabled actions.
+- Enabling action maps with bindings that do not refer to an existing action in the map no longer leads to asserts and exceptions when input on the bindings is received ([case 1213085](https://issuetracker.unity3d.com/issues/input-system-input-actions-cause-exceptions-and-should-not-get-here-errors-to-appear-after-deleting-an-action-map)).
 
 ## [1.0.0-preview.5] - 2020-02-14
 


### PR DESCRIPTION
Fixes [1213085](https://issuetracker.unity3d.com/issues/input-system-input-actions-cause-exceptions-and-should-not-get-here-errors-to-appear-after-deleting-an-action-map) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1213085)).