### PR TITLE
FIX: Processors on composite bindings not getting invoked (case 1207082).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -2764,6 +2764,46 @@ partial class CoreTests
         Assert.That(receivedVector.Value.y, Is.EqualTo(0.5678).Within(0.00001));
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1207082/
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanAddProcessorsToCompositeBindings()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        var action = new InputAction();
+        action.AddCompositeBinding("2DVector", processors: "invertVector2(invertX=true,invertY=true)")
+            .With("Up", "<Keyboard>/w")
+            .With("Down", "<Keyboard>/s")
+            .With("Left", "<Keyboard>/a")
+            .With("Right", "<Keyboard>/d");
+
+        action.Enable();
+
+        // Left -> Right.
+        Press(keyboard.aKey);
+
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(1, 0)));
+
+        // Right -> Left.
+        Release(keyboard.aKey);
+        Press(keyboard.dKey);
+
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(-1, 0)));
+
+        // Up -> Down.
+        Release(keyboard.dKey);
+        Press(keyboard.wKey);
+
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(0, -1)));
+
+        // Down -> Up.
+        Release(keyboard.wKey);
+        Press(keyboard.sKey);
+
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(0, 1)));
+    }
+
     [Test]
     [Category("Actions")]
     public void Actions_CanAddScaleProcessor()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Leaving play mode no longer leaves state change monitors lingering around from enabled actions.
 - Enabling action maps with bindings that do not refer to an existing action in the map no longer leads to asserts and exceptions when input on the bindings is received ([case 1213085](https://issuetracker.unity3d.com/issues/input-system-input-actions-cause-exceptions-and-should-not-get-here-errors-to-appear-after-deleting-an-action-map)).
 - `PressInteraction` no longer misses the next button press if it gets reset from within the `performed` callback ([case 1205285](https://issuetracker.unity3d.com/issues/inputsystem-problem-with-button-state-after-deactivating-and-reactivating-an-action-map)).
+- Reading the value of a composite binding no longer causes processors from the last active part binding to be applied rather than the processors of the composite itself, if any ([case 1207082](https://issuetracker.unity3d.com/issues/input-system-invert-processors-have-no-effect-on-the-inputaction-dot-callbackcontext-value)).
 
 ## [1.0.0-preview.5] - 2020-02-14
 

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -29,7 +29,7 @@ Composite Bindings (that is, Bindings that are made up of other Bindings) solve 
 
 To see how to create Composites in the editor UI, see documentation on [editing Composite Bindings](ActionAssets.md#editing-composite-bindings).
 
-To create composites in code, you can use the [`AddCompositeBinding`](../api/UnityEngine.InputSystem.InputActionSetupExtensions.html#UnityEngine_InputSystem_InputActionSetupExtensions_AddCompositeBinding_UnityEngine_InputSystem_InputAction_System_String_System_String_) syntax.
+To create composites in code, you can use the [`AddCompositeBinding`](../api/UnityEngine.InputSystem.InputActionSetupExtensions.html#UnityEngine_InputSystem_InputActionSetupExtensions_AddCompositeBinding_UnityEngine_InputSystem_InputAction_System_String_System_String_System_String_) syntax.
 
 ```CSharp
 myAction.AddCompositeBinding("Axis")

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -375,7 +375,7 @@ namespace UnityEngine.InputSystem
             return new BindingSyntax(actionMap, null, bindingIndex);
         }
 
-        public static CompositeSyntax AddCompositeBinding(this InputAction action, string composite, string interactions = null)
+        public static CompositeSyntax AddCompositeBinding(this InputAction action, string composite, string interactions = null, string processors = null)
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
@@ -385,7 +385,7 @@ namespace UnityEngine.InputSystem
             var actionMap = action.GetOrCreateActionMap();
 
             ////REVIEW: use 'name' instead of 'path' field here?
-            var binding = new InputBinding {path = composite, interactions = interactions, isComposite = true, action = action.name};
+            var binding = new InputBinding {path = composite, interactions = interactions, processors = processors, isComposite = true, action = action.name};
             var bindingIndex = AddBindingInternal(actionMap, binding);
             return new CompositeSyntax(actionMap, action, bindingIndex);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -2004,6 +2004,9 @@ namespace UnityEngine.InputSystem
                 };
 
                 value = compositeOfType.ReadValue(ref context);
+
+                // Switch bindingIndex to that of composite so that we use the right processors.
+                bindingIndex = compositeBindingIndex;
             }
             else
             {


### PR DESCRIPTION
Fixes [1207082](https://issuetracker.unity3d.com/issues/input-system-invert-processors-have-no-effect-on-the-inputaction-dot-callbackcontext-value) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1207082/)).

Turns out that not only were the processors on composite bindings not getting invoked, the code would instead invoke processors applied to part bindings, if present -- which likely would not even have the right value type and thus throw.