### PR TITLE
FIX: Fixed warning being generated during player build

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased]
 
 ### Fixed
+- Fixed CS0109 warning being generated during player build due to use of `new` with the `PlayerInput.camera property`. (case 1174688)
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -695,7 +695,12 @@ namespace UnityEngine.InputSystem
         ///
         /// Associating a camera with a player is necessary only when using split-screen (see <see cref="PlayerInputManager.splitScreen"/>).
         /// </remarks>
-        public new Camera camera
+        public
+        #if UNITY_EDITOR
+        // camera property is deprecated and only available in Editor.
+        new
+        #endif
+        Camera camera
         {
             get => m_Camera;
             set => m_Camera = value;


### PR DESCRIPTION
FIX: Fixed warning being generated during player build due to use of new with camera property. (case 1174688)
This property is only available in the Editor so we should only include the `new` keyword when UNITY_EDITOR is true.