### PR TITLE
Changing the name and version of the OpenVR package define

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
@@ -332,7 +332,7 @@ namespace UnityEngine.InputSystem.XR
             InputSystem.RegisterLayout<UnityEngine.XR.WindowsMR.Input.WMRSpatialController>(
                 matches: new InputDeviceMatcher()
                     .WithInterface(XRUtilities.InterfaceMatchAnyVersion)
-                    .WithProduct(@"(^(Spatial Controller))|(^(OpenVR Controller\(WindowsMR))")
+                    .WithProduct(@"(^(Spatial Controller))")
             );
             InputSystem.RegisterLayout<UnityEngine.XR.WindowsMR.Input.HololensHand>(
                 matches: new InputDeviceMatcher()

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -27,8 +27,8 @@
             "define": "DISABLE_BUILTIN_INPUT_SYSTEM_GOOGLEVR"
         },
         {
-            "name": "com.unity.xr.openvr",
-            "expression": "1.0.0",
+            "name": "com.valve.openvr",
+            "expression": "0.9.0",
             "define": "DISABLE_BUILTIN_INPUT_SYSTEM_OPENVR"
         },
         {


### PR DESCRIPTION
This will match the initial beta version of the package release. Fixes warnings about overriding layouts and possible other collisions.