### PR TITLE
FIX: TryGetControlLayout throwing for <Mouse>/scroll/x.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -1930,7 +1930,10 @@ partial class CoreTests
         // If only a device layout is given, can't know control layout.
         Assert.That(InputControlPath.TryGetControlLayout("/<gamepad>"), Is.Null);
 
-        ////TODO: make sure we can find layouts from control layout modifying child paths
+        // Try it with controls that are modifying children by path.
+        Assert.That(InputControlPath.TryGetControlLayout("<Mouse>/scroll/x"), Is.EqualTo("Axis"));
+        Assert.That(InputControlPath.TryGetControlLayout("<Touchscreen>/primaryTouch/tap"), Is.EqualTo("Button"));
+
         ////TODO: make sure that finding by usage can look arbitrarily deep into the hierarchy
     }
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- `InputControlPath.TryGetControlLayout` no longer throws `NotImplementedException` for `<Mouse>/scroll/x` and similar paths where the layout is modifying a control it inherited from its base layout ([thread](https://forum.unity.com/threads/notimplementedexception-when-using-inputcontrolpath-trygetcontrollayout-on-mouse-controls.847129/)).
+
 ## [1.0.0-preview.6] - 2020-03-06
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -436,9 +436,6 @@ namespace UnityEngine.InputSystem
             var controlCount = layout.controls.Count;
             for (var i = 0; i < controlCount; ++i)
             {
-                if (layout.m_Controls[i].isModifyingExistingControl)
-                    throw new NotImplementedException();
-
                 ////TODO: shortcut the search if we have a match and there's no wildcards to consider
 
                 // Skip control layout if it doesn't match.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -47,8 +47,8 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <value>Scroll wheel delta.</value>
         /// <seealso cref="Mouse.scroll"/>
         [InputControl(displayName = "Scroll")]
-        [InputControl(name = "scroll/x", aliases = new[] { "horizontal" }, usage = "ScrollHorizontal", displayName = "Scroll Left/Right")]
-        [InputControl(name = "scroll/y", aliases = new[] { "vertical" }, usage = "ScrollVertical", displayName = "Scroll Up/Down", shortDisplayName = "Wheel")]
+        [InputControl(name = "scroll/x", aliases = new[] { "horizontal" }, usage = "ScrollHorizontal", displayName = "Left/Right")]
+        [InputControl(name = "scroll/y", aliases = new[] { "vertical" }, usage = "ScrollVertical", displayName = "Up/Down", shortDisplayName = "Wheel")]
         [FieldOffset(16)]
         public Vector2 scroll;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -359,7 +359,7 @@ namespace UnityEngine.InputSystem.Users
         /// <example>
         /// <code>
         /// // Activate support for listening to device activity.
-        /// InputUser.listenForUnpairedDeviceActivity = true;
+        /// ++InputUser.listenForUnpairedDeviceActivity;
         ///
         /// // When a button on an unpaired device is pressed, pair the device to a new
         /// // or existing user.
@@ -372,12 +372,6 @@ namespace UnityEngine.InputSystem.Users
         ///
         ///         // Pair the device to a user.
         ///         InputUser.PerformPairingWithDevice(usedControl.device);
-        ///     };
-        ///
-        /// InputUser.onChange +=
-        ///     (user, change) =>
-        ///     {
-        ///         ////TODO
         ///     };
         /// </code>
         /// </example>


### PR DESCRIPTION
[Thread](https://forum.unity.com/threads/notimplementedexception-when-using-inputcontrolpath-trygetcontrollayout-on-mouse-controls.847129/).