### PR TITLE
FIX: VirtualMouseInput SW cursor not working when using HardwareCursorIfAvailable (case 1224591).

### DIFF
--- a/Assets/Samples/GamepadMouseCursor/VirtualMouseInput.cs
+++ b/Assets/Samples/GamepadMouseCursor/VirtualMouseInput.cs
@@ -2,6 +2,8 @@ using System;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.UI;
 
+////TODO: respect cursor lock mode
+
 ////TODO: investigate how driving the HW cursor behaves when FPS drops low
 ////      (also, maybe we can add support where we turn the gamepad mouse on and off automatically based on whether the system mouse is used)
 
@@ -10,6 +12,8 @@ using UnityEngine.UI;
 ////TODO: automatically scale mouse speed to resolution such that it stays constant regardless of resolution
 
 ////TODO: make it work with PlayerInput such that it will automatically look up actions in the actual PlayerInput instance it is used with (based on the action IDs it has)
+
+////REVIEW: should we default the SW cursor position to the center of the screen?
 
 ////REVIEW: consider this for inclusion directly in the input system
 
@@ -439,7 +443,9 @@ namespace UnityEngine.InputSystem.UI
                 InputState.Change(m_VirtualMouse.delta, delta);
 
                 // Update software cursor transform, if any.
-                if (m_CursorTransform != null && m_CursorMode == CursorMode.SoftwareCursor)
+                if (m_CursorTransform != null &&
+                    (m_CursorMode == CursorMode.SoftwareCursor ||
+                     (m_CursorMode == CursorMode.HardwareCursorIfAvailable && m_SystemMouse == null)))
                     m_CursorTransform.anchoredPosition = newPosition;
 
                 m_LastStickValue = stickValue;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- `VirtualMouseInput` not moving the software cursor when set to `HardwareCursorIsAvailable` but not having a hardware cursor ()
+
 ## [1.0.0-preview.6] - 2020-03-06
 
 ### Changed


### PR DESCRIPTION
Fixes [1224591](https://fogbugz.unity3d.com/f/cases/1224591/).