### PR TITLE
FIX: AndroidSupport not allowing to override its gamepad/joystick layouts.

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
@@ -436,5 +436,39 @@ internal class AndroidTests : InputTestFixture
             Assert.That(control.ReadValue().eulerAngles, Is.EqualTo(new Vector3(rotation.x, rotation.y, Mathf.Repeat(rotation.z - 90.0f, 360.0f))).Using(Vector3EqualityComparer.Instance));
         }
     }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_CanOverrideAndroidGamepadLayouts()
+    {
+        const string json = @"
+            {
+                ""name"" : ""CustomDevice"",
+                ""extend"" : ""Gamepad"",
+                ""device"" : {
+                    ""interface"" : ""Android"",
+                    ""deviceClass"" : ""AndroidGameController"",
+                    ""product"" : ""MyProduct""
+                }
+            }
+        ";
+
+        InputSystem.RegisterLayout(json);
+
+        runtime.ReportNewInputDevice(new InputDeviceDescription
+        {
+            interfaceName = "Android",
+            deviceClass = "AndroidGameController",
+            product = "MyProduct",
+            capabilities = new AndroidDeviceCapabilities
+            {
+                productId = 0x12345,
+                vendorId = 0x53421
+            }.ToJson()
+        });
+        InputSystem.Update();
+
+        Assert.That(InputSystem.devices[0].layout, Is.EqualTo("CustomDevice"));
+    }
 }
 #endif // UNITY_EDITOR || UNITY_ANDROID

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- Can now override built-in Android gamepad layouts. Previously, the input system would always choose its default defaults even after registering more specific layouts using `InputSystem.RegisterLayout`.
+
 ## [1.0.0-preview.6] - 2020-03-06
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
@@ -154,8 +154,13 @@ namespace UnityEngine.InputSystem.Android
         }
 
         internal static string OnFindLayoutForDevice(ref InputDeviceDescription description,
-            string matchedTemplate, InputDeviceExecuteCommandDelegate executeCommandDelegate)
+            string matchedLayout, InputDeviceExecuteCommandDelegate executeCommandDelegate)
         {
+            // If we already have a matching layout, someone registered a better match.
+            // We only want to act as a fallback.
+            if (!string.IsNullOrEmpty(matchedLayout) && matchedLayout != "AndroidGamepad" && matchedLayout != "AndroidJoystick")
+                return null;
+
             if (description.interfaceName != "Android" || string.IsNullOrEmpty(description.capabilities))
                 return null;
 


### PR DESCRIPTION
[Forum thread.](https://forum.unity.com/threads/new-input-system-making-a-custom-hid-device-work-in-android.836071/#post-5609002)