### PR TITLE
FIX: PlayerInputEditor corrupting actions field of PlayerInput (case 1228636).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+#### Actions
+
+- `PlayerInputEditor` no longer leads to the player's `InputActionAsset` mistakenly getting replaced with a clone when the inspector is open on a `PlayerInput` component ([case 1228636](https://issuetracker.unity3d.com/issues/action-map-gets-lost-on-play-when-prefab-is-highlighted-in-inspector)).
+
 ## [1.0.0-preview.6] - 2020-03-06
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -717,7 +717,7 @@ namespace UnityEngine.InputSystem
                 if (m_UIInputModule == value)
                     return;
 
-                if (m_UIInputModule != null && this.m_UIInputModule.actionsAsset == m_Actions)
+                if (m_UIInputModule != null && m_UIInputModule.actionsAsset == m_Actions)
                     m_UIInputModule.actionsAsset = null;
 
                 m_UIInputModule = value;
@@ -853,6 +853,8 @@ namespace UnityEngine.InputSystem
             SwitchCurrentControlScheme(scheme.Value.name, devices);
             return true;
         }
+
+        ////REVIEW: these should just be SwitchControlScheme
 
         public void SwitchCurrentControlScheme(string controlScheme, params InputDevice[] devices)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -27,6 +27,19 @@ namespace UnityEngine.InputSystem.Editor
         {
             InputActionImporter.onImport += Refresh;
             InputUser.onChange += OnUserChange;
+
+            // Look up properties.
+            m_ActionsProperty = serializedObject.FindProperty("m_Actions");
+            m_DefaultControlSchemeProperty = serializedObject.FindProperty("m_DefaultControlScheme");
+            m_NeverAutoSwitchControlSchemesProperty = serializedObject.FindProperty("m_NeverAutoSwitchControlSchemes");
+            m_DefaultActionMapProperty = serializedObject.FindProperty("m_DefaultActionMap");
+            m_UIInputModuleProperty = serializedObject.FindProperty("m_UIInputModule");
+            m_NotificationBehaviorProperty = serializedObject.FindProperty("m_NotificationBehavior");
+            m_CameraProperty = serializedObject.FindProperty("m_Camera");
+            m_ActionEventsProperty = serializedObject.FindProperty("m_ActionEvents");
+            m_DeviceLostEventProperty = serializedObject.FindProperty("m_DeviceLostEvent");
+            m_DeviceRegainedEventProperty = serializedObject.FindProperty("m_DeviceRegainedEvent");
+            m_ControlsChangedEventProperty = serializedObject.FindProperty("m_ControlsChangedEvent");
         }
 
         public void OnDestroy()
@@ -49,14 +62,11 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void OnInspectorGUI()
         {
-            ////TODO: cache properties
-
             EditorGUI.BeginChangeCheck();
 
             // Action config section.
             EditorGUI.BeginChangeCheck();
-            var actionsProperty = serializedObject.FindProperty("m_Actions");
-            EditorGUILayout.PropertyField(actionsProperty);
+            EditorGUILayout.PropertyField(m_ActionsProperty);
             if (EditorGUI.EndChangeCheck() || !m_ActionAssetInitialized)
                 OnActionAssetChange();
             ++EditorGUI.indentLevel;
@@ -68,25 +78,23 @@ namespace UnityEngine.InputSystem.Editor
                     m_ControlSchemeOptions);
                 if (selected != m_SelectedDefaultControlScheme)
                 {
-                    var defaultControlSchemeProperty = serializedObject.FindProperty("m_DefaultControlScheme");
                     if (selected == 0)
                     {
-                        defaultControlSchemeProperty.stringValue = null;
+                        m_DefaultControlSchemeProperty.stringValue = null;
                     }
                     else
                     {
-                        defaultControlSchemeProperty.stringValue =
+                        m_DefaultControlSchemeProperty.stringValue =
                             m_ControlSchemeOptions[selected].text;
                     }
                     m_SelectedDefaultControlScheme = selected;
                 }
 
-                var neverAutoSwitchProperty = serializedObject.FindProperty("m_NeverAutoSwitchControlSchemes");
-                var neverAutoSwitchValueOld = neverAutoSwitchProperty.boolValue;
+                var neverAutoSwitchValueOld = m_NeverAutoSwitchControlSchemesProperty.boolValue;
                 var neverAutoSwitchValueNew = !EditorGUILayout.Toggle(m_AutoSwitchText, !neverAutoSwitchValueOld);
                 if (neverAutoSwitchValueOld != neverAutoSwitchValueNew)
                 {
-                    neverAutoSwitchProperty.boolValue = neverAutoSwitchValueNew;
+                    m_NeverAutoSwitchControlSchemesProperty.boolValue = neverAutoSwitchValueNew;
                     serializedObject.ApplyModifiedProperties();
                 }
             }
@@ -98,18 +106,17 @@ namespace UnityEngine.InputSystem.Editor
                     m_ActionMapOptions);
                 if (selected != m_SelectedDefaultActionMap)
                 {
-                    var defaultActionMapProperty = serializedObject.FindProperty("m_DefaultActionMap");
                     if (selected == 0)
                     {
-                        defaultActionMapProperty.stringValue = null;
+                        m_DefaultActionMapProperty.stringValue = null;
                     }
                     else
                     {
                         // Use ID rather than name.
-                        var asset = (InputActionAsset)serializedObject.FindProperty("m_Actions").objectReferenceValue;
+                        var asset = (InputActionAsset)m_ActionsProperty.objectReferenceValue;
                         var actionMap = asset.FindActionMap(m_ActionMapOptions[selected].text);
                         if (actionMap != null)
-                            defaultActionMapProperty.stringValue = actionMap.id.ToString();
+                            m_DefaultActionMapProperty.stringValue = actionMap.id.ToString();
                     }
                     m_SelectedDefaultActionMap = selected;
                 }
@@ -118,41 +125,38 @@ namespace UnityEngine.InputSystem.Editor
             DoHelpCreateAssetUI();
 
             // UI config section.
-            var uiModuleProperty = serializedObject.FindProperty("m_UIInputModule");
             if (m_UIPropertyText == null)
-                m_UIPropertyText = EditorGUIUtility.TrTextContent("UI Input Module", uiModuleProperty.tooltip);
+                m_UIPropertyText = EditorGUIUtility.TrTextContent("UI Input Module", m_UIInputModuleProperty.tooltip);
             EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(uiModuleProperty, m_UIPropertyText);
+            EditorGUILayout.PropertyField(m_UIInputModuleProperty, m_UIPropertyText);
             if (EditorGUI.EndChangeCheck())
                 serializedObject.ApplyModifiedProperties();
 
-            if (uiModuleProperty.objectReferenceValue != null)
+            if (m_UIInputModuleProperty.objectReferenceValue != null)
             {
-                var uiModule = uiModuleProperty.objectReferenceValue as InputSystemUIInputModule;
-                if (actionsProperty.objectReferenceValue != null && uiModule.actionsAsset != actionsProperty.objectReferenceValue)
+                var uiModule = m_UIInputModuleProperty.objectReferenceValue as InputSystemUIInputModule;
+                if (m_ActionsProperty.objectReferenceValue != null && uiModule.actionsAsset != m_ActionsProperty.objectReferenceValue)
                 {
                     EditorGUILayout.HelpBox("The referenced InputSystemUIInputModule is configured using differnet input actions then this PlayerInput. They should match if you want to synchronize PlayerInput actions to the UI input.", MessageType.Warning);
                     if (GUILayout.Button(m_FixInputModuleText))
-                        InputSystemUIInputModuleEditor.ReassignActions(uiModule, actionsProperty.objectReferenceValue as InputActionAsset);
+                        InputSystemUIInputModuleEditor.ReassignActions(uiModule, m_ActionsProperty.objectReferenceValue as InputActionAsset);
                 }
             }
 
             // Camera section.
-            var cameraProperty = serializedObject.FindProperty("m_Camera");
             if (m_CameraPropertyText == null)
-                m_CameraPropertyText = EditorGUIUtility.TrTextContent("Camera", cameraProperty.tooltip);
+                m_CameraPropertyText = EditorGUIUtility.TrTextContent("Camera", m_CameraProperty.tooltip);
             EditorGUI.BeginChangeCheck();
-            EditorGUILayout.PropertyField(cameraProperty, m_CameraPropertyText);
+            EditorGUILayout.PropertyField(m_CameraProperty, m_CameraPropertyText);
             if (EditorGUI.EndChangeCheck())
                 serializedObject.ApplyModifiedProperties();
 
             // Notifications/event section.
             EditorGUI.BeginChangeCheck();
-            var notificationsProperty = serializedObject.FindProperty("m_NotificationBehavior");
-            EditorGUILayout.PropertyField(notificationsProperty, m_NotificationBehaviorText);
+            EditorGUILayout.PropertyField(m_NotificationBehaviorProperty, m_NotificationBehaviorText);
             if (EditorGUI.EndChangeCheck() || !m_NotificationBehaviorInitialized)
                 OnNotificationBehaviorChange();
-            switch ((PlayerNotifications)notificationsProperty.intValue)
+            switch ((PlayerNotifications)m_NotificationBehaviorProperty.intValue)
             {
                 case PlayerNotifications.SendMessages:
                 case PlayerNotifications.BroadcastMessages:
@@ -169,7 +173,6 @@ namespace UnityEngine.InputSystem.Editor
                         {
                             using (new EditorGUI.IndentLevelScope())
                             {
-                                var actionEvents = serializedObject.FindProperty("m_ActionEvents");
                                 for (var n = 0; n < m_NumActionMaps; ++n)
                                 {
                                     m_ActionMapEventsUnfolded[n] = EditorGUILayout.Foldout(m_ActionMapEventsUnfolded[n],
@@ -183,7 +186,7 @@ namespace UnityEngine.InputSystem.Editor
                                                 if (m_ActionMapIndices[i] != n)
                                                     continue;
 
-                                                EditorGUILayout.PropertyField(actionEvents.GetArrayElementAtIndex(i), m_ActionNames[i]);
+                                                EditorGUILayout.PropertyField(m_ActionEventsProperty.GetArrayElementAtIndex(i), m_ActionNames[i]);
                                             }
                                         }
                                     }
@@ -192,9 +195,9 @@ namespace UnityEngine.InputSystem.Editor
                         }
 
                         // Misc events.
-                        EditorGUILayout.PropertyField(serializedObject.FindProperty("m_DeviceLostEvent"));
-                        EditorGUILayout.PropertyField(serializedObject.FindProperty("m_DeviceRegainedEvent"));
-                        EditorGUILayout.PropertyField(serializedObject.FindProperty("m_ControlsChangedEvent"));
+                        EditorGUILayout.PropertyField(m_DeviceLostEventProperty);
+                        EditorGUILayout.PropertyField(m_DeviceRegainedEventProperty);
+                        EditorGUILayout.PropertyField(m_ControlsChangedEventProperty);
                     }
                     break;
             }
@@ -212,7 +215,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void DoHelpCreateAssetUI()
         {
-            if (serializedObject.FindProperty("m_Actions").objectReferenceValue != null)
+            if (m_ActionsProperty.objectReferenceValue != null)
             {
                 // All good. We already have an asset.
                 return;
@@ -271,8 +274,7 @@ namespace UnityEngine.InputSystem.Editor
                         var importedObject = AssetDatabase.LoadAssetAtPath<InputActionAsset>(relativePath);
 
                         // Set it on the PlayerInput component.
-                        var actionsProperty = serializedObject.FindProperty("m_Actions");
-                        actionsProperty.objectReferenceValue = importedObject;
+                        m_ActionsProperty.objectReferenceValue = importedObject;
                         serializedObject.ApplyModifiedProperties();
 
                         // Open the asset.
@@ -324,7 +326,7 @@ namespace UnityEngine.InputSystem.Editor
             Debug.Assert(m_ActionAssetInitialized);
             serializedObject.ApplyModifiedProperties();
 
-            var notificationBehavior = (PlayerNotifications)serializedObject.FindProperty("m_NotificationBehavior").intValue;
+            var notificationBehavior = (PlayerNotifications)m_NotificationBehaviorProperty.intValue;
             switch (notificationBehavior)
             {
                 // Create text that lists all the messages sent by the component.
@@ -386,7 +388,7 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionAssetInitialized = true;
 
             var playerInput = (PlayerInput)target;
-            var asset = playerInput.actions;
+            var asset = (InputActionAsset)m_ActionsProperty.objectReferenceValue;
             if (asset == null)
             {
                 m_ControlSchemeOptions = null;
@@ -398,7 +400,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // If we're sending Unity events, read out the event list.
-            if ((PlayerNotifications)serializedObject.FindProperty("m_NotificationBehavior").intValue ==
+            if ((PlayerNotifications)m_NotificationBehaviorProperty.intValue ==
                 PlayerNotifications.InvokeUnityEvents)
             {
                 ////FIXME: this should preserve the same order that we have in the asset
@@ -538,6 +540,18 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private GUIContent[] m_ControlSchemeOptions;
         [NonSerialized] private int m_SelectedDefaultActionMap;
         [NonSerialized] private GUIContent[] m_ActionMapOptions;
+
+        [NonSerialized] private SerializedProperty m_ActionsProperty;
+        [NonSerialized] private SerializedProperty m_DefaultControlSchemeProperty;
+        [NonSerialized] private SerializedProperty m_DefaultActionMapProperty;
+        [NonSerialized] private SerializedProperty m_NeverAutoSwitchControlSchemesProperty;
+        [NonSerialized] private SerializedProperty m_NotificationBehaviorProperty;
+        [NonSerialized] private SerializedProperty m_UIInputModuleProperty;
+        [NonSerialized] private SerializedProperty m_ActionEventsProperty;
+        [NonSerialized] private SerializedProperty m_CameraProperty;
+        [NonSerialized] private SerializedProperty m_DeviceLostEventProperty;
+        [NonSerialized] private SerializedProperty m_DeviceRegainedEventProperty;
+        [NonSerialized] private SerializedProperty m_ControlsChangedEventProperty;
 
         [NonSerialized] private bool m_NotificationBehaviorInitialized;
         [NonSerialized] private bool m_ActionAssetInitialized;


### PR DESCRIPTION
Fixes [1228636](https://fogbugz.unity3d.com/f/cases/1228636/).

- [Issue Tracker](https://issuetracker.unity3d.com/issues/action-map-gets-lost-on-play-when-prefab-is-highlighted-in-inspector)
