### PR TITLE
FIX: Expected control type not set for new action (case 1221015).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -352,6 +352,8 @@ partial class CoreTests
 
         Assert.That(asset.actionMaps[0].actions, Has.Count.EqualTo(3));
         Assert.That(asset.actionMaps[0].actions[2].name, Is.EqualTo("New action"));
+        Assert.That(asset.actionMaps[0].actions[2].type, Is.EqualTo(InputActionType.Button));
+        Assert.That(asset.actionMaps[0].actions[2].expectedControlType, Is.EqualTo("Button"));
         Assert.That(asset.actionMaps[0].actions[2].m_Id, Is.Not.Empty);
         Assert.That(asset.actionMaps[0].actions[2].bindings, Has.Count.Zero);
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+#### Actions
+
+- Adding a new action now sets `expectedControlType` to `Button` as expected ([case 1221015](https://issuetracker.unity3d.com/issues/input-system-default-value-of-expectedcontroltype-is-not-being-set-when-creating-a-new-action)).
+
 ## [1.0.0-preview.6] - 2020-03-06
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -172,7 +172,7 @@ namespace UnityEngine.InputSystem.Editor
             actionProperty.FindPropertyRelative("m_Name").stringValue = actionName;
             actionProperty.FindPropertyRelative("m_Type").intValue = (int)InputActionType.Button;  // Default to creating button actions.
             actionProperty.FindPropertyRelative("m_Id").stringValue = Guid.NewGuid().ToString();
-            actionProperty.FindPropertyRelative("m_ExpectedControlType").stringValue = string.Empty;
+            actionProperty.FindPropertyRelative("m_ExpectedControlType").stringValue = "Button";
 
             return actionProperty;
         }


### PR DESCRIPTION
Fixes [1221015](https://fogbugz.unity3d.com/f/cases/1221015/).

- [Issue Tracker](https://issuetracker.unity3d.com/issues/input-system-default-value-of-expectedcontroltype-is-not-being-set-when-creating-a-new-action)
