### PR TITLE
FIX: Missing InputActionReferences when renaming actions (case 1129145).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,9 @@ however, it has to be formatted properly to pass verification tests.
 
 #### Actions
 
+- References to `InputActionReference` objects created by the importer for `.inputactions` files are no longer broken when the action referenced by the object is renamed ([case 1229145](https://issuetracker.unity3d.com/issues/inputsystem-inputactionreference-loses-guid-when-its-action-is-moved-or-renamed-in-the-inputaction-asset)).
+  * __THIS IS A BREAKING CHANGE__: Unfortunately, this change impacts Unity internal file IDs of `InputActionReference` objects created by the `.inputactions` file importer. This means that previously created references to `InputActionReference` objects will become missing and need to be recreated.
+  * __HOW TO FIX BROKEN REFERENCES__: Locate the sub-object in the `.inputactions` asset for the action you are referencing and replace the now missing references with the newly created objects.
 - Controls are now re-resolved after adding or removing bindings from actions ([case 1218544](https://issuetracker.unity3d.com/issues/input-system-package-does-not-re-resolve-bindings-when-adding-a-new-binding-to-a-map-that-has-already-generated-its-state)).
 - Adding a new action now sets `expectedControlType` to `Button` as expected ([case 1221015](https://issuetracker.unity3d.com/issues/input-system-default-value-of-expectedcontroltype-is-not-being-set-when-creating-a-new-action)).
 - Player joins with `PlayerInputManager` from button presses no longer fail if there are multiple devices of the same type present and the join was not on the first gamepad ([case 226920](https://fogbugz.unity3d.com/f/cases/1226920/)).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
@@ -1,6 +1,16 @@
 using System;
 using System.Linq;
 
+////REVIEW: Can we somehow make this a simple struct? The one problem we have is that we can't put struct instances as sub-assets into
+////        the import (i.e. InputActionImporter can't do AddObjectToAsset with them). However, maybe there's a way around that. The thing
+////        is that we really want to store the asset reference plus the action GUID on the *user* side, i.e. the referencing side. Right
+////        now, what happens is that InputActionImporter puts these objects along with the reference and GUID they contain in the
+////        *imported* object, i.e. right with the asset. This partially defeats the whole purpose of having these objects and it means
+////        that now the GUID doesn't really matter anymore. Rather, it's the file ID that now has to be stable.
+////
+////        If we always store the GUID and asset reference on the user side, we can put the serialized data *anywhere* and it'll remain
+////        save and proper no matter what we do in InputActionImporter.
+
 ////REVIEW: should this throw if you try to assign an action that is not a singleton?
 
 ////REVIEW: akin to this, also have an InputActionMapReference?
@@ -49,7 +59,7 @@ namespace UnityEngine.InputSystem
                     if (m_Asset == null)
                         return null;
 
-                    m_Action = m_Asset.FindAction(new Guid(m_ActionId));
+                    m_Action = m_Asset.FindAction(m_ActionId);
                 }
 
                 return m_Action;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
@@ -3,6 +3,8 @@ using System;
 using System.IO;
 using UnityEditor;
 
+////TODO: ensure that GUIDs in the asset are unique
+
 namespace UnityEngine.InputSystem.Editor
 {
     /// <summary>


### PR DESCRIPTION
Fixes [1129145](https://fogbugz.unity3d.com/f/cases/1229145/) ([Issue Tracker](https://issuetracker.unity3d.com/issues/inputsystem-inputactionreference-loses-guid-when-its-action-is-moved-or-renamed-in-the-inputaction-asset)).

This one isn't so great. The problem is fixed but a reimport will break all existing InputActionReferences that are referenced elsewhere in the project. I couldn't come up with a way to avoid that.

The problem is that I had used the "<map>/<action>" names for actions as the names passed to `AddObjectToAsset` which meant these names were fed into the name hashing that ultimately generates local file IDs. So... change action name -> different file ID -> missing InputActionReference.

With the change, we now use the action GUID as the name to generate a hash for an InputActionReference. So that's stable. BUT.... it breaks any existing InputActionReference already in the project :(