### PR TITLE
FIX: Errors when matching fields in InputDeviceDescription.capabilities.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -3265,6 +3265,7 @@ partial class CoreTests
         public string stringCap;
         public int intCap;
         public float floatCap;
+        public float floatCapWithExponent;
         public bool boolCap;
         public NestedCaps nestedCap;
         public string[] arrayCap;
@@ -3315,6 +3316,8 @@ partial class CoreTests
             .WithCapability("intCap", "1234");
         var matchFloatCapWithString = new InputDeviceMatcher()
             .WithCapability("floatCap", "1.234");
+        var matchFloatWithExponentCapWithString = new InputDeviceMatcher()
+            .WithCapability("floatCapWithExponent", "1.234e-10");
         var matchBoolCapWithString = new InputDeviceMatcher()
             .WithCapability("boolCap", "true");
         var matchNone = new InputDeviceMatcher()
@@ -3328,6 +3331,7 @@ partial class CoreTests
                 stringCap = "string",
                 intCap = 1234,
                 floatCap = 1.234f,
+                floatCapWithExponent = 1.234e-10f,
                 boolCap = true,
                 nestedCap = new TestDeviceCapabilities.NestedCaps
                 {
@@ -3348,6 +3352,7 @@ partial class CoreTests
         Assert.That(matchIntCapWithRegex.MatchPercentage(description), Is.EqualTo(1 / 2.0).Within(0.0001));
         Assert.That(matchIntCapWithString.MatchPercentage(description), Is.EqualTo(1 / 2.0).Within(0.0001));
         Assert.That(matchFloatCapWithString.MatchPercentage(description), Is.EqualTo(1 / 2.0).Within(0.0001));
+        Assert.That(matchFloatWithExponentCapWithString.MatchPercentage(description), Is.EqualTo(1 / 2.0).Within(0.0001));
         Assert.That(matchBoolCapWithString.MatchPercentage(description), Is.EqualTo(1 / 2.0).Within(0.0001));
         Assert.That(matchNone.MatchPercentage(description), Is.EqualTo(0).Within(0.0001));
     }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,8 @@ however, it has to be formatted properly to pass verification tests.
 - Can now override built-in Android gamepad layouts. Previously, the input system would always choose its default defaults even after registering more specific layouts using `InputSystem.RegisterLayout`.
 - `InputControlPath.TryGetControlLayout` no longer throws `NotImplementedException` for `<Mouse>/scroll/x` and similar paths where the layout is modifying a control it inherited from its base layout ([thread](https://forum.unity.com/threads/notimplementedexception-when-using-inputcontrolpath-trygetcontrollayout-on-mouse-controls.847129/)).
 - Fixed compilation errors when disabling built-in VR and XR packages. ([case 1214248](https://issuetracker.unity3d.com/issues/enable-input-system-symbol-is-not-being-updated-when-the-input-system-is-changed-in-player-settings/)).
+- No longer throws `NotImplementedException` when matching against a field of `InputDeviceDescription.capabilities` when the value of the field used scientific notation.
+- No longer incorrectly matches fields of `InputDeviceDescription.capabilities` by prefix only (i.e. previously it would find the field "foo" when actually looking for "foobar").
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2292,7 +2292,7 @@ namespace UnityEngine.InputSystem
                 m_SettingsChangedListeners[i]();
         }
 
-        private void AddAvailableDevicesThatAreNowRecognized()
+        internal void AddAvailableDevicesThatAreNowRecognized()
         {
             for (var i = 0; i < m_AvailableDeviceCount; ++i)
             {
@@ -3319,10 +3319,12 @@ namespace UnityEngine.InputSystem
             using (InputDeviceBuilder.Ref())
             {
                 DeviceState[] retainedDeviceStates = null;
+                var deviceStates = m_SavedDeviceStates;
                 var deviceCount = m_SavedDeviceStates.LengthSafe();
+                m_SavedDeviceStates = null; // Prevent layout matcher registering themselves on the fly from picking anything off this list.
                 for (var i = 0; i < deviceCount; ++i)
                 {
-                    ref var deviceState = ref m_SavedDeviceStates[i];
+                    ref var deviceState = ref deviceStates[i];
 
                     var device = TryGetDeviceById(deviceState.deviceId);
                     if (device != null)
@@ -3425,7 +3427,7 @@ namespace UnityEngine.InputSystem
             catch (Exception exception)
             {
                 Debug.LogError(
-                    $"Could not re-recreate input device '{deviceState.description}' with layout '{deviceState.layout}' and variants '{deviceState.variants}' after domain reload");
+                    $"Could not recreate input device '{deviceState.description}' with layout '{deviceState.layout}' and variants '{deviceState.variants}' after domain reload");
                 Debug.LogException(exception);
                 return true; // Don't try again.
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -114,7 +114,6 @@ namespace UnityEngine.InputSystem.HID
             if (!hasUsableElements)
                 return null;
 
-
             ////TODO: we should be able to differentiate a HID joystick from other joysticks in bindings alone
             // Determine base layout.
             var baseType = typeof(HID);

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -87,7 +87,7 @@ namespace UnityEngine.InputSystem.Utilities
                 }
 
                 // See if we have a match.
-                if (m_Position < m_Length && m_Text[m_Position] == '"' && (pathPosition == pathLength || path[pathPosition] == '/' || path[pathPosition] == '['))
+                if (m_Position < m_Length && m_Text[m_Position] == '"' && (pathPosition >= pathLength || path[pathPosition] == '/' || path[pathPosition] == '['))
                 {
                     // Have matched a property name. Navigate to value.
                     ++m_Position;
@@ -95,7 +95,7 @@ namespace UnityEngine.InputSystem.Utilities
                         return false;
 
                     // Check if we have matched everything in the path.
-                    if (pathPosition == pathLength)
+                    if (pathPosition >= pathLength)
                         return true;
                     if (path[pathPosition] == '/')
                     {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -87,7 +87,7 @@ namespace UnityEngine.InputSystem.Utilities
                 }
 
                 // See if we have a match.
-                if (m_Position < m_Length && m_Text[m_Position] == '"')
+                if (m_Position < m_Length && m_Text[m_Position] == '"' && (pathPosition == pathLength || path[pathPosition] == '/' || path[pathPosition] == '['))
                 {
                     // Have matched a property name. Navigate to value.
                     ++m_Position;
@@ -374,6 +374,7 @@ namespace UnityEngine.InputSystem.Utilities
             var integralPart = 0L;
             var fractionalPart = 0.0;
             var fractionalDivisor = 10.0;
+            var exponent = 0;
 
             // Parse sign.
             if (m_Text[m_Position] == '-')
@@ -416,11 +417,36 @@ namespace UnityEngine.InputSystem.Utilities
             }
 
             if (m_Position < m_Length && (m_Text[m_Position] == 'e' || m_Text[m_Position] == 'E'))
-                throw new NotImplementedException("exponents");
+            {
+                ++m_Position;
+                var isNegative = false;
+                if (m_Position < m_Length && m_Text[m_Position] == '-')
+                {
+                    isNegative = true;
+                    ++m_Position;
+                }
+                else if (m_Position < m_Length && m_Text[m_Position] == '+')
+                {
+                    ++m_Position;
+                }
+
+                var multiplier = 1;
+                while (m_Position < m_Length && char.IsDigit(m_Text[m_Position]))
+                {
+                    var digit = m_Text[m_Position] - '0';
+                    exponent *= multiplier;
+                    exponent += digit;
+                    multiplier *= 10;
+                    ++m_Position;
+                }
+
+                if (isNegative)
+                    exponent *= -1;
+            }
 
             if (!m_DryRun)
             {
-                if (!haveFractionalPart)
+                if (!haveFractionalPart && exponent == 0)
                 {
                     if (negative)
                         result = -integralPart;
@@ -429,10 +455,14 @@ namespace UnityEngine.InputSystem.Utilities
                 }
                 else
                 {
+                    float value;
                     if (negative)
-                        result = (float)-(integralPart + fractionalPart);
+                        value = (float)-(integralPart + fractionalPart);
                     else
-                        result = (float)(integralPart + fractionalPart);
+                        value = (float)(integralPart + fractionalPart);
+                    if (exponent != 0)
+                        value *= Mathf.Pow(10, exponent);
+                    result = value;
                 }
             }
 


### PR DESCRIPTION
Fixes two problems in `JSONParser` that have surfaced in [thread](https://forum.unity.com/threads/new-input-system-making-a-custom-hid-device-work-in-android.836071/).

- Support for numbers using scientific notation was not implemented.
- When looking for a specific property, the parser incorrectly accepted a string that was a prefix only.

The change also surfaced a problem in `InputManager` with device recreation and a bogus test in `HIDTests` along with some problems around `HIDSupport.suppportedHIDUsages`. Fixed those as well.