### PR TITLE
FIX: Rebinds including already actuated controls (case 1215784).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -407,17 +407,25 @@ internal partial class CoreTests
         InputSystem.RegisterLayout(layout);
         var device = InputSystem.AddDevice("TestLayout");
 
-        using (var rebind = action.PerformInteractiveRebinding().OnMatchWaitForAnother(0).Start())
+        using (var rebind = new InputActionRebindingExtensions.RebindingOperation()
+                   .WithAction(action)
+                   .OnMatchWaitForAnother(0)
+                   .Start())
         {
             Set((ButtonControl)device["noisyButton"], 0.678f);
 
             Assert.That(rebind.completed, Is.False);
             Assert.That(action.bindings[0].overridePath, Is.Null);
 
+            Set((ButtonControl)device["noisyButton"], 0f);
+
             // Can disable the behavior. This is most useful in combination with a custom
             // OnPotentialMatch() callback or when the selection-by-magnitude logic will do
             // a good enough job.
-            rebind.WithoutIgnoringNoisyControls();
+            rebind.Cancel();
+            rebind
+                .WithoutIgnoringNoisyControls()
+                .Start();
 
             Set((ButtonControl)device["noisyButton"], 0.789f);
 
@@ -449,8 +457,7 @@ internal partial class CoreTests
             // a candidate as well as leftStick/x. However, leftStick/right is synthetic so X axis should
             // win. Note that if we set expectedControlType to "Button", leftStick/x will get ignored
             // and leftStick/left will get picked.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = new Vector2(1, 0)});
-            InputSystem.Update();
+            Set(gamepad.leftStick, Vector2.right);
 
             Assert.That(rebind.completed, Is.False);
             Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick.x, gamepad.leftStick.right}));
@@ -458,16 +465,15 @@ internal partial class CoreTests
             Assert.That(rebind.scores[0], Is.GreaterThan(rebind.scores[1]));
 
             // Reset.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState());
-            InputSystem.Update();
-            rebind.RemoveCandidate(gamepad.leftStick.x);
-            rebind.RemoveCandidate(gamepad.leftStick.right);
+            Set(gamepad.leftStick, Vector2.zero);
 
             // Switch to looking only for buttons. leftStick/x will no longer be a suitable pick.
-            rebind.WithExpectedControlType("Button");
+            rebind.Cancel();
+            rebind
+                .WithExpectedControlType("Button")
+                .Start();
 
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = new Vector2(1, 0)});
-            InputSystem.Update();
+            Set(gamepad.leftStick, Vector2.right);
 
             Assert.That(rebind.completed, Is.True);
             Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/leftStick/right"));
@@ -572,33 +578,71 @@ internal partial class CoreTests
         }
     }
 
-    // If a control is already actuated when we initiate a rebind, we first require it to go
-    // back to its default value.
+    // We want to be able to deal with controls that are already actuated when the rebinding starts and
+    // also with controls that don't usually go back to default values at all.
+    //
+    // What we require is that when we detect sufficient actuation on a control in an event, we compare
+    // it to the control's current actuation level when we first considered it. This is expected to work
+    // regardless of whether we are suppressing events or not.
+    //
+    // https://fogbugz.unity3d.com/f/cases/1215784/
     [Test]
     [Category("Actions")]
-    public void Actions_InteractiveRebinding_RequiresControlToBeActuatedStartingWithDefaultValue()
+    public void Actions_InteractiveRebinding_WhenControlAlreadyActuated_HasToCrossMagnitudeThresholdFromCurrentActuation()
     {
         var action = new InputAction(binding: "<Gamepad>/buttonSouth");
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
-        // Put buttonNorth in pressed state.
-        InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.North));
-        InputSystem.Update();
+        // Actuate some controls.
+        Press(gamepad.buttonNorth);
+        Set(gamepad.leftTrigger, 0.75f);
 
-        using (var rebind = new InputActionRebindingExtensions.RebindingOperation().WithAction(action).Start())
+        using (var rebind = new InputActionRebindingExtensions.RebindingOperation()
+                   .WithAction(action)
+                   .WithMagnitudeHavingToBeGreaterThan(0.25f)
+                   .Start())
         {
-            // Reset buttonNorth to unpressed state.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState());
-            InputSystem.Update();
+            Release(gamepad.buttonNorth);
 
             Assert.That(rebind.completed, Is.False);
+            Assert.That(rebind.candidates, Is.Empty);
 
-            // Now press it again.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.North));
-            InputSystem.Update();
+            Set(gamepad.leftTrigger, 0.9f);
+
+            Assert.That(rebind.completed, Is.False);
+            Assert.That(rebind.candidates, Is.Empty);
+
+            Set(gamepad.leftTrigger, 0f);
+
+            Assert.That(rebind.completed, Is.False);
+            Assert.That(rebind.candidates, Is.Empty);
+
+            Set(gamepad.leftTrigger, 0.7f);
 
             Assert.That(rebind.completed, Is.True);
-            Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/buttonNorth"));
+            Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/leftTrigger"));
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_InteractiveRebinding_CanGetActuationMagnitudeOfCandidateControls()
+    {
+        var action = new InputAction(binding: "<Gamepad>/buttonSouth");
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        using (var rebind = new InputActionRebindingExtensions.RebindingOperation()
+                   .WithAction(action)
+                   .WithMagnitudeHavingToBeGreaterThan(0.25f)
+                   .OnMatchWaitForAnother(1)
+                   .Start())
+        {
+            Set(gamepad.leftTrigger, 0.75f);
+
+            Assert.That(rebind.candidates, Has.Count.EqualTo(1));
+            Assert.That(rebind.magnitudes, Has.Count.EqualTo(rebind.candidates.Count));
+            Assert.That(rebind.candidates[0], Is.SameAs(gamepad.leftTrigger));
+            Assert.That(rebind.magnitudes[0], Is.EqualTo(0.75).Within(0.00001));
         }
     }
 
@@ -801,14 +845,12 @@ internal partial class CoreTests
                        .WithMagnitudeHavingToBeGreaterThan(0.5f)
                        .Start())
         {
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.4f});
-            InputSystem.Update();
+            Set(gamepad.leftTrigger, 0.4f);
 
             Assert.That(rebind.completed, Is.False);
             Assert.That(rebind.candidates, Is.Empty);
 
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.6f});
-            InputSystem.Update();
+            Set(gamepad.leftTrigger, 0.6f);
 
             Assert.That(rebind.completed, Is.True);
             Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/leftTrigger"));

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,6 +23,7 @@ however, it has to be formatted properly to pass verification tests.
 - Player joins with `PlayerInputManager` from button presses no longer fail if there are multiple devices of the same type present and the join was not on the first gamepad ([case 226920](https://fogbugz.unity3d.com/f/cases/1226920/)).
 - `PlayerInputEditor` no longer leads to the player's `InputActionAsset` mistakenly getting replaced with a clone when the inspector is open on a `PlayerInput` component ([case 1228636](https://issuetracker.unity3d.com/issues/action-map-gets-lost-on-play-when-prefab-is-highlighted-in-inspector)).
 - The control picker in the .inputactions editor will no longer incorrectly filter out layouts such as `Xbox One Gamepad (on XB1)` when using them in control schemes. Also, it will no longer filter out controls from base layouts (such as `Gamepad`) ([case 1219415](https://issuetracker.unity3d.com/issues/impossible-to-choose-gamepad-as-binding-path-when-control-scheme-is-set-as-xboxone-scheme)).
+- `RebindOperation`s will no longer pick controls right away that are already actuated above the magnitude threshold when the operation starts. Instead, these controls will have to change their actuation from their initial level such that they cross the magnitude threshold configured in the operation ([case 1215784](https://issuetracker.unity3d.com/issues/unnecessary-slash-unwanted-binding-candidates-are-found-when-detecting-and-changing-an-input-value-of-an-input-device)).
 
 ## [1.0.0-preview.6] - 2020-03-06
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -288,14 +288,13 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Add a new binding to the action.
         /// </summary>
-        /// <param name="action">A disabled action to add the binding to.</param>
-        /// <param name="binding"></param>
+        /// <param name="action">An action to add the binding to.</param>
+        /// <param name="binding">Binding to add to the action or default. Binding can be further configured via
+        /// the struct returned by the method.</param>
         /// <returns>
         /// Returns a fluent-style syntax structure that allows performing additional modifications
         /// based on the new binding.
         /// </returns>
-        /// <exception cref="InvalidOperationException"><paramref name="action"/> is enabled or is part
-        /// of an <see cref="InputActionMap"/> that is enabled.</exception>
         /// <remarks>
         /// This works both with actions that are part of an action set as well as with actions that aren't.
         ///
@@ -314,8 +313,6 @@ namespace UnityEngine.InputSystem
         {
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
-            if (binding.path == null)
-                throw new ArgumentException("Binding path cannot be null", nameof(binding));
 
             ////REVIEW: should this reference actions by ID?
             Debug.Assert(action.m_Name != null || action.isSingletonAction);

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
@@ -154,13 +154,13 @@ namespace UnityEngine.InputSystem.Utilities
             return -1;
         }
 
-        public static int IndexOfReference<TValue>(TValue[] array, TValue value, int count = -1)
+        public static int IndexOfReference<TValue>(this TValue[] array, TValue value, int count = -1)
             where TValue : class
         {
             return IndexOfReference(array, value, 0, count);
         }
 
-        public static int IndexOfReference<TValue>(TValue[] array, TValue value, int startIndex, int count)
+        public static int IndexOfReference<TValue>(this TValue[] array, TValue value, int startIndex, int count)
             where TValue : class
         {
             if (array == null)
@@ -175,7 +175,7 @@ namespace UnityEngine.InputSystem.Utilities
             return -1;
         }
 
-        public static int IndexOfValue<TValue>(TValue[] array, TValue value, int startIndex = 0, int count = -1)
+        public static int IndexOfValue<TValue>(this TValue[] array, TValue value, int startIndex = 0, int count = -1)
             where TValue : struct, IEquatable<TValue>
         {
             if (array == null)


### PR DESCRIPTION
Fixes [12115784](https://fogbugz.unity3d.com/f/cases/1215784/).

- [Issue Tracker](https://issuetracker.unity3d.com/issues/unnecessary-slash-unwanted-binding-candidates-are-found-when-detecting-and-changing-an-input-value-of-an-input-device)
- [Forum Thread](https://forum.unity.com/threads/too-many-rebinding-candidates-now.818355/)
