### PR TITLE
CHANGE: Obsolete InputDevice.all as it only leads to confusion (case 1231216).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -40,13 +40,10 @@ partial class CoreTests
         var mouse = InputSystem.AddDevice<Mouse>();
 
         Assert.That(InputSystem.devices, Is.EquivalentTo(new InputDevice[] { gamepad1, gamepad2, keyboard, mouse }));
-        // Alternate getter.
-        Assert.That(InputDevice.all, Is.EquivalentTo(new InputDevice[] { gamepad1, gamepad2, keyboard, mouse }));
 
         InputSystem.RemoveDevice(keyboard);
 
         Assert.That(InputSystem.devices, Is.EquivalentTo(new InputDevice[] { gamepad1, gamepad2, mouse }));
-        Assert.That(InputDevice.all, Is.EquivalentTo(new InputDevice[] { gamepad1, gamepad2, mouse }));
     }
 
     [Test]
@@ -1839,6 +1836,29 @@ partial class CoreTests
 
         Assert.That(Gamepad.all, Has.Count.EqualTo(2));
         Assert.That(Gamepad.all, Has.None.SameAs(gamepad2));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_CanQueryAllJoysticksWithSimpleGetter()
+    {
+        var joystick1 = InputSystem.AddDevice<Joystick>();
+        var joystick2 = InputSystem.AddDevice<Joystick>();
+        InputSystem.AddDevice<Keyboard>();
+
+        Assert.That(Joystick.all, Has.Count.EqualTo(2));
+        Assert.That(Joystick.all, Has.Exactly(1).SameAs(joystick1));
+        Assert.That(Joystick.all, Has.Exactly(1).SameAs(joystick2));
+
+        var joystick3 = InputSystem.AddDevice<Joystick>();
+
+        Assert.That(Joystick.all, Has.Count.EqualTo(3));
+        Assert.That(Joystick.all, Has.Exactly(1).SameAs(joystick3));
+
+        InputSystem.RemoveDevice(joystick2);
+
+        Assert.That(Joystick.all, Has.Count.EqualTo(2));
+        Assert.That(Joystick.all, Has.None.SameAs(joystick2));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,11 @@ however, it has to be formatted properly to pass verification tests.
 - `PlayerInputEditor` no longer leads to the player's `InputActionAsset` mistakenly getting replaced with a clone when the inspector is open on a `PlayerInput` component ([case 1228636](https://issuetracker.unity3d.com/issues/action-map-gets-lost-on-play-when-prefab-is-highlighted-in-inspector)).
 - The control picker in the .inputactions editor will no longer incorrectly filter out layouts such as `Xbox One Gamepad (on XB1)` when using them in control schemes. Also, it will no longer filter out controls from base layouts (such as `Gamepad`) ([case 1219415](https://issuetracker.unity3d.com/issues/impossible-to-choose-gamepad-as-binding-path-when-control-scheme-is-set-as-xboxone-scheme)).
 
+### Changed
+
+- `InputDevice.all` has been deprecated due to the confusion it creates with other getters like `Gamepad.all`. Use `InputSystem.devices` instead ([case 1231216](https://issuetracker.unity3d.com/issues/joystick-dot-all-lists-more-than-just-joysticks)).
+  * In the same vein, we added a new `Joystick.all` getter that works the same as `Gamepad.all`.
+
 ## [1.0.0-preview.6] - 2020-03-06
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -603,6 +603,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <seealso cref="InputSettings.filterNoiseOnCurrent"/>
         /// <seealso cref="InputDevice.MakeCurrent"/>
+        /// <seealso cref="all"/>
         public static Gamepad current { get; private set; }
 
         /// <summary>
@@ -616,6 +617,7 @@ namespace UnityEngine.InputSystem
         /// you need it. Whenever the gamepad setup changes, the value returned by this getter
         /// is invalidated.
         /// </remarks>
+        /// <seealso cref="current"/>
         public new static ReadOnlyArray<Gamepad> all => new ReadOnlyArray<Gamepad>(s_Gamepads, 0, s_GamepadCount);
 
         /// <inheritdoc />
@@ -682,8 +684,7 @@ namespace UnityEngine.InputSystem
             else
             {
                 Debug.Assert(false,
-                    string.Format("Gamepad {0} seems to not have been added but is being removed (gamepad list: {1})",
-                        this, string.Join(", ", all))); // Put in else to not allocate on normal path.
+                    $"Gamepad {this} seems to not have been added but is being removed (gamepad list: {string.Join(", ", all)})"); // Put in else to not allocate on normal path.
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -355,12 +355,9 @@ namespace UnityEngine.InputSystem
         /// <inheritdoc/>
         public override int valueSizeInBytes => (int)m_StateBlock.alignedSizeInBytes;
 
-        /// <summary>
-        /// Return all input devices currently added to the system.
-        /// </summary>
-        /// <remarks>
-        /// This is equivalent to <see cref="InputSystem.devices"/>.
-        /// </remarks>
+        // This one just leads to confusion as you can access it from subclasses and then be surprised
+        // that it doesn't only include members of those classes.
+        [Obsolete("Use 'InputSystem.devices' instead. (UnityUpgradable) -> InputSystem.devices", error: false)]
         public static ReadOnlyArray<InputDevice> all => InputSystem.devices;
 
         /// <summary>


### PR DESCRIPTION
Fixes [1231216](https://fogbugz.unity3d.com/f/cases/1231216/) ([Issue Tracker](https://issuetracker.unity3d.com/issues/joystick-dot-all-lists-more-than-just-joysticks)).

`InputDevice.all` simply was a bad idea in the first place. This obsoletes it in an upgradable way.

Also adds a `Joystick.all` getter as that is what the user was looking for in the first place.