### PR TITLE
FIX: Assets not checked out from VC before modifications (case 1222972).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -25,6 +25,8 @@ however, it has to be formatted properly to pass verification tests.
 - The control picker in the .inputactions editor will no longer incorrectly filter out layouts such as `Xbox One Gamepad (on XB1)` when using them in control schemes. Also, it will no longer filter out controls from base layouts (such as `Gamepad`) ([case 1219415](https://issuetracker.unity3d.com/issues/impossible-to-choose-gamepad-as-binding-path-when-control-scheme-is-set-as-xboxone-scheme)).
 - `RebindOperation`s will no longer pick controls right away that are already actuated above the magnitude threshold when the operation starts. Instead, these controls will have to change their actuation from their initial level such that they cross the magnitude threshold configured in the operation ([case 1215784](https://issuetracker.unity3d.com/issues/unnecessary-slash-unwanted-binding-candidates-are-found-when-detecting-and-changing-an-input-value-of-an-input-device)).
 - Newly added actions and action maps are now scrolled to when there are more items than fit into view. Previously newly added item was appended but outside of the visible area.
+- The importer for `.inputactions` assets will now check out from version control the generated .cs file when overwriting it &ndash; which only happens if the contents differ ([case 1222972](https://issuetracker.unity3d.com/issues/inputsystem-editor-generated-c-number-file-is-not-checked-out-when-overwriting)).
+- The editor for `.inputactions` assets will now check out from version control the asset before saving it.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
@@ -153,7 +153,7 @@ namespace UnityEngine.InputSystem.Editor
             var existingJson = File.ReadAllText(assetPath);
             if (m_ImportedAssetJson != existingJson)
             {
-                ////TODO: has to be made to work with version control
+                EditorHelpers.CheckOut(assetPath);
                 File.WriteAllText(assetPath, m_ImportedAssetJson);
                 AssetDatabase.ImportAsset(assetPath);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -44,6 +44,8 @@ namespace UnityEngine.InputSystem.Editor
             string actionToSelect = null;
 
             // Grab InputActionAsset.
+            // NOTE: We defer checking out an asset until we save it. This allows a user to open an .inputactions asset and look at it
+            //       without forcing a checkout.
             var obj = EditorUtility.InstanceIDToObject(instanceId);
             var asset = obj as InputActionAsset;
             if (asset == null)
@@ -713,6 +715,13 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (m_ActionAssetManager.dirty)
                 return;
+
+            // If our asset has disappeared from disk, just close the window.
+            if (string.IsNullOrEmpty(AssetDatabase.GUIDToAssetPath(m_ActionAssetManager.guid)))
+            {
+                Close();
+                return;
+            }
 
             // Don't touch the UI state if the serialized data is still the same.
             if (!m_ActionAssetManager.ReInitializeIfAssetHasChanged())

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -5,6 +5,8 @@ using System.Text;
 using UnityEngine.InputSystem.Utilities;
 using UnityEditor;
 
+////TODO: suffix map properties with Map or Actions (e.g. "PlayerMap" instead of "Player")
+
 ////TODO: unify the generated events so that performed, canceled, and started all go into a single event
 
 ////TODO: look up actions and maps by ID rather than by name
@@ -18,6 +20,8 @@ using UnityEditor;
 ////TODO: protect generated wrapper against modifications made to asset
 
 ////TODO: make capitalization consistent in the generated code
+
+////TODO: instead of loading from JSON, generate the structure in code
 
 ////REVIEW: allow putting *all* of the data from the inputactions asset into the generated class?
 
@@ -358,6 +362,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Write.
+            EditorHelpers.CheckOut(filePath);
             File.WriteAllText(filePath, code);
             return true;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 using System;
 using UnityEditor;
+using UnityEditor.VersionControl;
 
 namespace UnityEngine.InputSystem.Editor
 {
@@ -8,6 +9,38 @@ namespace UnityEngine.InputSystem.Editor
     {
         public static Action<string> SetSystemCopyBufferContents = s => EditorGUIUtility.systemCopyBuffer = s;
         public static Func<string> GetSystemCopyBufferContents = () => EditorGUIUtility.systemCopyBuffer;
+
+        public static void CheckOut(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                throw new ArgumentNullException(nameof(path));
+
+            // Make path relative to project folder.
+            var projectPath = Application.dataPath;
+            if (path.StartsWith(projectPath) && path.Length > projectPath.Length &&
+                (path[projectPath.Length] == '/' || path[projectPath.Length] == '\\'))
+                path = path.Substring(0, projectPath.Length + 1);
+
+            #if UNITY_2019_3_OR_NEWER
+            AssetDatabase.MakeEditable(path);
+            #else
+            if (!Provider.isActive)
+                return;
+            var asset = Provider.GetAssetByPath(path);
+            if (asset == null)
+                return;
+            var task = Provider.Checkout(path, CheckoutMode.Asset);
+            task.Wait();
+            #endif
+        }
+
+        public static void CheckOut(Object asset)
+        {
+            if (asset == null)
+                throw new ArgumentNullException(nameof(asset));
+            var path = AssetDatabase.GetAssetPath(asset);
+            CheckOut(path);
+        }
 
         // It seems we're getting instabilities on the farm from using EditorGUIUtility.systemCopyBuffer directly in tests.
         // Ideally, we'd have a mocking library to just work around that but well, we don't. So this provides a solution

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
@@ -29,7 +29,7 @@ namespace UnityEngine.InputSystem.Editor
             var asset = Provider.GetAssetByPath(path);
             if (asset == null)
                 return;
-            var task = Provider.Checkout(path, CheckoutMode.Asset);
+            var task = Provider.Checkout(asset, CheckoutMode.Asset);
             task.Wait();
             #endif
         }


### PR DESCRIPTION
Fixes [1222972](https://fogbugz.unity3d.com/f/cases/1222972/).

- [Issue Tracker](https://issuetracker.unity3d.com/issues/inputsystem-editor-generated-c-number-file-is-not-checked-out-when-overwriting)
