### PR TITLE
FIX: Actions and bindings getting forcibly expanded all the time.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -25,6 +25,7 @@ however, it has to be formatted properly to pass verification tests.
 - The control picker in the .inputactions editor will no longer incorrectly filter out layouts such as `Xbox One Gamepad (on XB1)` when using them in control schemes. Also, it will no longer filter out controls from base layouts (such as `Gamepad`) ([case 1219415](https://issuetracker.unity3d.com/issues/impossible-to-choose-gamepad-as-binding-path-when-control-scheme-is-set-as-xboxone-scheme)).
 - `RebindOperation`s will no longer pick controls right away that are already actuated above the magnitude threshold when the operation starts. Instead, these controls will have to change their actuation from their initial level such that they cross the magnitude threshold configured in the operation ([case 1215784](https://issuetracker.unity3d.com/issues/unnecessary-slash-unwanted-binding-candidates-are-found-when-detecting-and-changing-an-input-value-of-an-input-device)).
 - Newly added actions and action maps are now scrolled to when there are more items than fit into view. Previously newly added item was appended but outside of the visible area.
+- Actions and bindings in the `.inputactions` editor are no longer force-expanded on every domain reload and whenever a new action or binding is added.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -319,6 +319,7 @@ namespace UnityEngine.InputSystem.Editor
             if (!schemeHasBindings)
                 return;
 
+            ////FIXME: this does not delete composites that have bindings in only one control scheme
             ////REVIEW: offer to do nothing and leave all bindings as is?
             var deleteBindings =
                 EditorUtility.DisplayDialog("Delete Bindings?",
@@ -459,7 +460,6 @@ namespace UnityEngine.InputSystem.Editor
 
             // Rebuild tree.
             m_ActionsTree.Reload();
-            m_ActionsTree.ExpandAll();
         }
 
         private void OnActionTreeSelectionChanged()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -899,6 +899,13 @@ namespace UnityEngine.InputSystem.Editor
             }
             menu.AddItem(s_DuplicateLabel, false, DuplicateSelection);
             menu.AddItem(s_DeleteLabel, false, DeleteDataOfSelectedItems);
+
+            if (itemType != typeof(ActionMapTreeItem))
+            {
+                menu.AddSeparator("");
+                menu.AddItem(s_ExpandAllLabel, false, ExpandAll);
+                menu.AddItem(s_CollapseAllLabel, false, CollapseAll);
+            }
         }
 
         public void BuildMenuToAddBindings(GenericMenu menu, ActionTreeItem actionItem = null)
@@ -1369,6 +1376,8 @@ namespace UnityEngine.InputSystem.Editor
         private static readonly GUIContent s_DeleteLabel = EditorGUIUtility.TrTextContent("Delete");
         private static readonly GUIContent s_DuplicateLabel = EditorGUIUtility.TrTextContent("Duplicate");
         private static readonly GUIContent s_RenameLabel = EditorGUIUtility.TrTextContent("Rename");
+        private static readonly GUIContent s_ExpandAllLabel = EditorGUIUtility.TrTextContent("Expand All");
+        private static readonly GUIContent s_CollapseAllLabel = EditorGUIUtility.TrTextContent("Collapse All");
 
         public static string SharedResourcesPath = "Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/Resources/";
         public static string ResourcesPath

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputEditorUserSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputEditorUserSettings.cs
@@ -2,6 +2,8 @@
 using System;
 using System.IO;
 
+////TODO: event diagnostics should have a bool here
+
 namespace UnityEngine.InputSystem.Editor
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
@@ -171,6 +171,7 @@ namespace UnityEngine.InputSystem.OnScreen
                 throw new ArgumentException(
                     $"The control path {controlPath} yields a control of type {m_Control.GetType().Name} which is not an InputControl with value type {typeof(TValue).Name}", nameof(value));
 
+            ////FIXME: this gives us a one-frame lag
             m_InputEventPtr.internalTime = InputRuntime.s_Instance.currentTime;
             control.WriteValueIntoEvent(value, m_InputEventPtr);
             InputSystem.QueueEvent(m_InputEventPtr);


### PR DESCRIPTION
The action editor was forcibly expanding the action tree view all the time. This happened every single time we reloaded the tree, i.e. any time an item (action or binding) was added or removed and on every domain reload.

I've removed the force expansion altogether. Which also means that the tree view now opens in a collapsed state, i.e. the bindings are hidden by default and only the actions visible. This seems in line with what we do elsewhere in Unity (e.g. we don't expand the scene hierarchy by default either).

Added context menu entries to force-expand/collapse the entire tree view.