### PR TITLE
"REVERT: Missing InputActionReferences when renaming actions (case 1129145)."

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,9 +20,6 @@ however, it has to be formatted properly to pass verification tests.
 
 #### Actions
 
-- References to `InputActionReference` objects created by the importer for `.inputactions` files are no longer broken when the action referenced by the object is renamed ([case 1229145](https://issuetracker.unity3d.com/issues/inputsystem-inputactionreference-loses-guid-when-its-action-is-moved-or-renamed-in-the-inputaction-asset)).
-  * __THIS IS A BREAKING CHANGE__: Unfortunately, this change impacts Unity internal file IDs of `InputActionReference` objects created by the `.inputactions` file importer. This means that previously created references to `InputActionReference` objects will become missing and need to be recreated.
-  * __HOW TO FIX BROKEN REFERENCES__: Locate the sub-object in the `.inputactions` asset for the action you are referencing and replace the now missing references with the newly created objects.
 - Controls are now re-resolved after adding or removing bindings from actions ([case 1218544](https://issuetracker.unity3d.com/issues/input-system-package-does-not-re-resolve-bindings-when-adding-a-new-binding-to-a-map-that-has-already-generated-its-state)).
 - Can now have spaces and special characters in action names when using `PlayerInput` with the `SendMessages` or `BroadcastMessages` behavior. Previously, an incorrect method name was generated (fix contributed by [BHSPitMonkey](https://github.com/BHSPitMonkey) in [#1022](https://github.com/Unity-Technologies/InputSystem/pull/1022); [case 1214519](https://issuetracker.unity3d.com/issues/player-input-send-messages-wont-trigger-when-input-action-name-contains-spaces)).
 - Adding a new action now sets `expectedControlType` to `Button` as expected ([case 1221015](https://issuetracker.unity3d.com/issues/input-system-default-value-of-expectedcontroltype-is-not-being-set-when-creating-a-new-action)).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
@@ -1,16 +1,6 @@
 using System;
 using System.Linq;
 
-////REVIEW: Can we somehow make this a simple struct? The one problem we have is that we can't put struct instances as sub-assets into
-////        the import (i.e. InputActionImporter can't do AddObjectToAsset with them). However, maybe there's a way around that. The thing
-////        is that we really want to store the asset reference plus the action GUID on the *user* side, i.e. the referencing side. Right
-////        now, what happens is that InputActionImporter puts these objects along with the reference and GUID they contain in the
-////        *imported* object, i.e. right with the asset. This partially defeats the whole purpose of having these objects and it means
-////        that now the GUID doesn't really matter anymore. Rather, it's the file ID that now has to be stable.
-////
-////        If we always store the GUID and asset reference on the user side, we can put the serialized data *anywhere* and it'll remain
-////        save and proper no matter what we do in InputActionImporter.
-
 ////REVIEW: should this throw if you try to assign an action that is not a singleton?
 
 ////REVIEW: akin to this, also have an InputActionMapReference?
@@ -59,7 +49,7 @@ namespace UnityEngine.InputSystem
                     if (m_Asset == null)
                         return null;
 
-                    m_Action = m_Asset.FindAction(m_ActionId);
+                    m_Action = m_Asset.FindAction(new Guid(m_ActionId));
                 }
 
                 return m_Action;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
@@ -3,8 +3,6 @@ using System;
 using System.IO;
 using UnityEditor;
 
-////TODO: ensure that GUIDs in the asset are unique
-
 namespace UnityEngine.InputSystem.Editor
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR
 using System;
 using System.IO;
-using System.Linq;
 using UnityEditor;
 using UnityEditor.Experimental.AssetImporters;
 using UnityEngine.InputSystem.Utilities;
@@ -23,7 +22,7 @@ namespace UnityEngine.InputSystem.Editor
     [ScriptedImporter(kVersion, InputActionAsset.Extension)]
     internal class InputActionImporter : ScriptedImporter
     {
-        private const int kVersion = 11;
+        private const int kVersion = 10;
 
         private const string kActionIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/InputAction.png";
         private const string kAssetIcon = "Packages/com.unity.inputsystem/InputSystem/Editor/Icons/InputActionAsset.png";
@@ -91,27 +90,25 @@ namespace UnityEngine.InputSystem.Editor
             ctx.AddObjectToAsset("<root>", asset, assetIcon);
             ctx.SetMainObject(asset);
 
-            // Make sure all the elements in the asset have GUIDs and that they are indeed unique.
+            // Make sure all the elements in the asset have GUIDs.
             var maps = asset.actionMaps;
             foreach (var map in maps)
             {
                 // Make sure action map has GUID.
-                if (string.IsNullOrEmpty(map.m_Id) || asset.actionMaps.Count(x => x.m_Id == map.m_Id) > 1)
+                if (string.IsNullOrEmpty(map.m_Id))
                     map.GenerateId();
 
                 // Make sure all actions have GUIDs.
                 foreach (var action in map.actions)
                 {
-                    var actionId = action.m_Id;
-                    if (string.IsNullOrEmpty(actionId) || asset.actionMaps.Sum(m => m.actions.Count(a => a.m_Id == actionId)) > 1)
+                    if (string.IsNullOrEmpty(action.m_Id))
                         action.GenerateId();
                 }
 
                 // Make sure all bindings have GUIDs.
                 for (var i = 0; i < map.m_Bindings.LengthSafe(); ++i)
                 {
-                    var bindingId = map.m_Bindings[i].m_Id;
-                    if (string.IsNullOrEmpty(bindingId) || asset.actionMaps.Sum(m => m.bindings.Count(b => b.m_Id == bindingId)) > 1)
+                    if (string.IsNullOrEmpty(map.m_Bindings[i].m_Id))
                         map.m_Bindings[i].GenerateId();
                 }
             }
@@ -131,7 +128,7 @@ namespace UnityEngine.InputSystem.Editor
                         objectName = $"{map.name}/{action.name}";
 
                     actionReference.name = objectName;
-                    ctx.AddObjectToAsset(action.m_Id, actionReference, actionIcon);
+                    ctx.AddObjectToAsset(objectName, actionReference, actionIcon);
                 }
             }
 


### PR DESCRIPTION
Reverts Unity-Technologies/InputSystem#1100

This PR broke every scene with an `InputSystemUIInputModule` in it. Obviously won't fly...