### PR TITLE
FIX: Fixed compilation issues in TrackedDeviceRaycaster when disabling built-in XR module.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed compilation issues in `TrackedDeviceRaycaster` when disabling built-in XR module.
+
 ## [1.0.0-preview.7] - 2020-04-17
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/TrackedDeviceRaycaster.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/TrackedDeviceRaycaster.cs
@@ -1,4 +1,4 @@
-#if PACKAGE_DOCS_GENERATION || (UNITY_INPUT_SYSTEM_ENABLE_UI && UNITY_INPUT_SYSTEM_ENABLE_XR)
+#if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
 using System;
 using System.Collections.Generic;
 using UnityEngine.EventSystems;


### PR DESCRIPTION
We dont need the XR module to be present. It was causing issues in InputSystemUIInputModule
https://unity.slack.com/archives/C09Q7LYP9/p1587378159092800