### PR TITLE
XR Haptics can now use an interface.

### DIFF
--- a/.yamato/analyze.yml
+++ b/.yamato/analyze.yml
@@ -9,7 +9,7 @@ code_analyser:
     - mkdir Tools/CodeAnalyzerTestProject/Microsoft.CodeQuality.Analyzers
     - curl -L https://www.nuget.org/api/v2/package/Microsoft.CodeQuality.Analyzers/2.9.2 -o Tools/CodeAnalyzerTestProject/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.zip
     - unzip Tools/CodeAnalyzerTestProject/Microsoft.CodeQuality.Analyzers/Microsoft.CodeQuality.Analyzers.zip -d Tools/CodeAnalyzerTestProject/Microsoft.CodeQuality.Analyzers
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci project test --project-path Tools/CodeAnalyzerTestProject -u 2019.1
   triggers:

--- a/.yamato/promotion.yml
+++ b/.yamato/promotion.yml
@@ -11,7 +11,7 @@ promote:
   commands:
     - mv ./Assets/Samples ./Packages/com.unity.inputsystem
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package promote --package-path ./Packages/com.unity.inputsystem/
   triggers:

--- a/.yamato/publish-samples.yml
+++ b/.yamato/publish-samples.yml
@@ -5,7 +5,7 @@ test_sample_projects:
     image: buildfarm/mac:stable
     flavor: m1.mac
   commands:
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u 2019.1
     - Editor=.Editor/Unity.app/Contents/MacOS/Unity Method=Publish sh ExternalSampleProjects/publish.sh 

--- a/.yamato/test-samples.yml
+++ b/.yamato/test-samples.yml
@@ -5,7 +5,7 @@ test_sample_projects:
     image: buildfarm/mac:stable
     flavor: m1.mac
   commands:
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u 2019.1
     - Editor=.Editor/Unity.app/Contents/MacOS/Unity Method=DryRun sh ExternalSampleProjects/publish.sh 

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -45,7 +45,7 @@ platforms:
   commands:
     - mv ./Assets/Samples ./Packages/com.unity.inputsystem
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }}
     {% if platform.installscript %}
@@ -72,7 +72,7 @@ publish:
   commands:
     - mv ./Assets/Samples ./Packages/com.unity.inputsystem
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
-    - npm install upm-ci-utils@stable -g --registry https://api.bintray.com/npm/unity/unity-npm
+    - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     - upm-ci package publish --package-path ./Packages/com.unity.inputsystem/
   triggers:

--- a/Assets/QA/Tests/XRHaptics/XRHaptics.cs
+++ b/Assets/QA/Tests/XRHaptics/XRHaptics.cs
@@ -28,9 +28,9 @@ public class XRHaptics : MonoBehaviour
 
     public void Update()
     {
-        var leftHandController = InputSystem.GetDevice<XRControllerWithRumble>(CommonUsages.LeftHand);
+        var leftHandController = InputSystem.GetDevice<InputDevice>(CommonUsages.LeftHand) as IXRRumble;
         leftHapticDetected.color = leftHandController != null ? Color.red : Color.white;
-        var rightHandController = InputSystem.GetDevice<XRControllerWithRumble>(CommonUsages.RightHand);
+        var rightHandController = InputSystem.GetDevice<InputDevice>(CommonUsages.RightHand) as IXRRumble;
         rightHapticDetected.color = rightHandController != null ? Color.red : Color.white;
 
         UpdateTimer();
@@ -45,13 +45,13 @@ public class XRHaptics : MonoBehaviour
         {
             m_Timer -= m_RumblePeriod;
 
-            XRControllerWithRumble controller;
+            IXRRumble controller;
 
             switch (state)
             {
                 case RumbleState.Left:
-                    controller = InputSystem.GetDevice<XRControllerWithRumble>(CommonUsages.LeftHand);
-                    controller.SendImpulse(1f, m_RumblePeriod);
+                    controller = InputSystem.GetDevice<InputDevice>(CommonUsages.LeftHand) as IXRRumble;
+                    controller?.SendImpulse(1f, m_RumblePeriod);
                     leftTryingToRumble.color = Color.red;
                     leftTryingToRumbleHalf.color = Color.white;
                     rightTryingToRumble.color = Color.white;
@@ -59,9 +59,8 @@ public class XRHaptics : MonoBehaviour
                     state = RumbleState.LeftHalf;
                     break;
                 case RumbleState.LeftHalf:
-                    controller = InputSystem.GetDevice<XRControllerWithRumble>(CommonUsages.LeftHand);
-                    controller.SendImpulse(0.5f, m_RumblePeriod);
-
+                    controller = InputSystem.GetDevice<InputDevice>(CommonUsages.LeftHand) as IXRRumble;
+                    controller?.SendImpulse(0.5f, m_RumblePeriod);
                     leftTryingToRumble.color = Color.white;
                     leftTryingToRumbleHalf.color = Color.red;
                     rightTryingToRumble.color = Color.white;
@@ -69,8 +68,8 @@ public class XRHaptics : MonoBehaviour
                     state = RumbleState.Right;
                     break;
                 case RumbleState.Right:
-                    controller = InputSystem.GetDevice<XRControllerWithRumble>(CommonUsages.RightHand);
-                    controller.SendImpulse(1f, m_RumblePeriod);
+                    controller = InputSystem.GetDevice<InputDevice>(CommonUsages.RightHand) as IXRRumble;
+                    controller?.SendImpulse(1f, m_RumblePeriod);
                     leftTryingToRumble.color = Color.white;
                     leftTryingToRumbleHalf.color = Color.white;
                     rightTryingToRumble.color = Color.red;
@@ -78,8 +77,8 @@ public class XRHaptics : MonoBehaviour
                     state = RumbleState.RightHalf;
                     break;
                 case RumbleState.RightHalf:
-                    controller = InputSystem.GetDevice<XRControllerWithRumble>(CommonUsages.RightHand);
-                    controller.SendImpulse(0.5f, m_RumblePeriod);
+                    controller = InputSystem.GetDevice<InputDevice>(CommonUsages.RightHand) as IXRRumble;
+                    controller?.SendImpulse(0.5f, m_RumblePeriod);
                     leftTryingToRumble.color = Color.white;
                     leftTryingToRumbleHalf.color = Color.white;
                     rightTryingToRumble.color = Color.white;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -244,10 +244,10 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe float EvaluateMagnitude(void* statePtr)
         {
-            if (m_MinValue.isEmpty || m_MaxValue.isEmpty)
-                return -1;
-
             var value = ReadValueFromState(statePtr);
+            if (m_MinValue.isEmpty || m_MaxValue.isEmpty)
+                return Mathf.Abs(value);
+
             var min = m_MinValue.ToSingle();
             var max = m_MaxValue.ToSingle();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
@@ -89,21 +89,48 @@ namespace UnityEngine.InputSystem.XR
         }
     }
 
+    /// <summary>
+    /// This interfaces is used by various <cref="InputDevice"> instances that can process haptic impulses.
+    /// </summary>
     public interface IXRRumble
     {
+        /// <summary>
+        /// True when the underlying system will be able to react to <cref="IXRRumble.SendImpulse"> commands.  In order to see what channels are available see ,<cref="IXRRumble.numChannels">
+        /// </summary>
         bool supportsImpulse { get; }
+        /// <summary>
+        /// The number of channels available to receive a <cref="IXRRumble.SendImpulse"> command to.  Each channel can represent a motor, or diffrent reaction from the underlying device.
+        /// </summary>
         int numChannels { get; }
 
+        /// <summary>
+        /// Sends an impulse of a set <cref="amplitude"> and <cref="duration">.
+        /// </summary>
+        /// <remarks>This will always send the impulse over channel 0, see <cref="bool SendImpulse(int, float, float)"> for information on channels</remarks>
+        /// <param name="amplitude">The overall power of the impulse from 0.0 to 1.0, where 1.0 is the strongest impulse available to the device.</param>
+        /// <param name="duration">How long, in seconds, the impulse should last for.</param>
+        /// <returns>True if the impulse was successfully received, false otherwise.</returns>
         bool SendImpulse(float amplitude, float duration);
+
+        /// <summary>
+        /// Sends an impulse of a set <cref="amplitude"> and <cref="duration">.
+        /// </summary>
+        /// <param name="channel">A channel represents an individual motor or other output that can react to impulses being sent to the same source <cref="InputDevice"></param>
+        /// <param name="amplitude">The overall power of the impulse from 0.0 to 1.0, where 1.0 is the strongest impulse available to the device.</param>
+        /// <param name="duration">How long, in seconds, the impulse should last for.</param>
+        /// <returns>True if the impulse was successfully received, false otherwise.</returns>
         bool SendImpulse(int channel, float amplitude, float duration);
     }
 
     /// <summary>
-    /// Identifies a controller that is capable of rumble or haptics.
+    /// A specialized sub group of XRController that supports basic rumble commands.
     /// </summary>
     [Preserve]
     public class XRControllerWithRumble : XRController, IXRRumble
     {
+        /// <summary>
+        /// True when the underlying system will be able to react to <cref="IXRRumble.SendImpulse"> commands.  In order to see what channels are available see ,<cref="IXRRumble.numChannels">
+        /// </summary>
         public bool supportsImpulse
         {
             get
@@ -114,6 +141,9 @@ namespace UnityEngine.InputSystem.XR
             }
         }
 
+        /// <summary>
+        /// The number of channels available to receive a <cref="IXRRumble.SendImpulse"> command to.  Each channel can represent a motor, or diffrent reaction from the underlying device.
+        /// </summary>
         public int numChannels
         {
             get
@@ -124,11 +154,25 @@ namespace UnityEngine.InputSystem.XR
             }
         }
 
+        /// <summary>
+        /// Sends an impulse of a set <cref="amplitude"> and <cref="duration">.
+        /// </summary>
+        /// <remarks>This will always send the impulse over channel 0, see <cref="bool SendImpulse(int, float, float)"> for information on channels</remarks>
+        /// <param name="amplitude">The overall power of the impulse from 0.0 to 1.0, where 1.0 is the strongest impulse available to the device.</param>
+        /// <param name="duration">How long, in seconds, the impulse should last for.</param>
+        /// <returns>True if the impulse was successfully received, false otherwise.</returns>
         public bool SendImpulse(float amplitude, float duration)
         {
             return SendImpulse(0, amplitude, duration);
         }
 
+        /// <summary>
+        /// Sends an impulse of a set <cref="amplitude"> and <cref="duration">.
+        /// </summary>
+        /// <param name="channel">A channel represents an individual motor or other output that can react to impulses being sent to the same source <cref="InputDevice"></param>
+        /// <param name="amplitude">The overall power of the impulse from 0.0 to 1.0, where 1.0 is the strongest impulse available to the device.</param>
+        /// <param name="duration">How long, in seconds, the impulse should last for.</param>
+        /// <returns>True if the impulse was successfully received, false otherwise.</returns>
         public bool SendImpulse(int channel, float amplitude, float duration)
         {
             var command = SendHapticImpulseCommand.Create(channel, amplitude, duration);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
@@ -89,16 +89,50 @@ namespace UnityEngine.InputSystem.XR
         }
     }
 
+    public interface IXRRumble
+    {
+        bool supportsImpulse { get; }
+        int numChannels { get; }
+
+        bool SendImpulse(float amplitude, float duration);
+        bool SendImpulse (int channel, float amplitude, float duration);
+    }
+
     /// <summary>
     /// Identifies a controller that is capable of rumble or haptics.
     /// </summary>
     [Preserve]
-    public class XRControllerWithRumble : XRController
+    public class XRControllerWithRumble : XRController, IXRRumble
     {
-        public void SendImpulse(float amplitude, float duration)
+        public bool supportsImpulse 
+        { 
+            get
+            {
+                var command = GetHapticCapabilitiesCommand.Create();
+                ExecuteCommand(ref command);
+                return command.capabilities.supportsImpulse;
+            }
+        }
+
+        public int numChannels 
+        { 
+            get
+            {
+                var command = GetHapticCapabilitiesCommand.Create();
+                ExecuteCommand(ref command);
+                return command.capabilities.numChannels;
+            }
+        }
+
+        public bool SendImpulse(float amplitude, float duration)
         {
-            var command = SendHapticImpulseCommand.Create(0, amplitude, duration);
-            ExecuteCommand(ref command);
+            return SendImpulse(0, amplitude, duration);
+        }
+
+        public bool SendImpulse(int channel, float amplitude, float duration)
+        {
+            var command = SendHapticImpulseCommand.Create(channel, amplitude, duration);
+            return ExecuteCommand(ref command) > 0;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
@@ -95,7 +95,7 @@ namespace UnityEngine.InputSystem.XR
         int numChannels { get; }
 
         bool SendImpulse(float amplitude, float duration);
-        bool SendImpulse (int channel, float amplitude, float duration);
+        bool SendImpulse(int channel, float amplitude, float duration);
     }
 
     /// <summary>
@@ -104,8 +104,8 @@ namespace UnityEngine.InputSystem.XR
     [Preserve]
     public class XRControllerWithRumble : XRController, IXRRumble
     {
-        public bool supportsImpulse 
-        { 
+        public bool supportsImpulse
+        {
             get
             {
                 var command = GetHapticCapabilitiesCommand.Create();
@@ -114,8 +114,8 @@ namespace UnityEngine.InputSystem.XR
             }
         }
 
-        public int numChannels 
-        { 
+        public int numChannels
+        {
             get
             {
                 var command = GetHapticCapabilitiesCommand.Create();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetHapticCapabilitiesCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetHapticCapabilitiesCommand.cs
@@ -7,16 +7,14 @@ namespace UnityEngine.InputSystem.XR.Haptics
 {
     public struct HapticCapabilities
     {
-        public HapticCapabilities(uint numChannels, uint frequencyHz, uint maxBufferSize)
+        public HapticCapabilities(int numChannels, bool supportsImpulse)
         {
             this.numChannels = numChannels;
-            this.frequencyHz = frequencyHz;
-            this.maxBufferSize = maxBufferSize;
+            this.supportsImpulse = supportsImpulse;
         }
 
-        public uint numChannels { get; private set; }
-        public uint frequencyHz { get; private set; }
-        public uint maxBufferSize { get; private set; }
+        public int numChannels { get; private set; }
+        public bool supportsImpulse { get; private set; }
     }
 
     [StructLayout(LayoutKind.Explicit, Size = kSize)]
@@ -24,7 +22,7 @@ namespace UnityEngine.InputSystem.XR.Haptics
     {
         static FourCC Type => new FourCC('X', 'H', 'C', '0');
 
-        const int kSize = InputDeviceCommand.kBaseCommandSize + sizeof(uint) * 3;
+        const int kSize = InputDeviceCommand.kBaseCommandSize + sizeof(int) + (sizeof(bool) * 2) + (sizeof(uint) * 3);
 
         public FourCC typeStatic => Type;
 
@@ -32,15 +30,24 @@ namespace UnityEngine.InputSystem.XR.Haptics
         InputDeviceCommand baseCommand;
 
         [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
-        public uint numChannels;
+        private int numChannels;
 
-        [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(uint))]
-        public uint frequencyHz;
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(int))]
+        private bool supportsImpulse;
 
-        [FieldOffset(InputDeviceCommand.kBaseCommandSize + (sizeof(uint) * 2))]
-        public uint maxBufferSize;
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(int) + sizeof(bool))]
+        private bool supportsBuffer;
 
-        public HapticCapabilities capabilities => new HapticCapabilities(numChannels, frequencyHz, maxBufferSize);
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(int) + (sizeof(bool) * 2))]
+        private uint frequencyHz;
+
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(int) + (sizeof(bool) * 2) + (sizeof(uint)))]
+        private uint maxBufferSize;
+
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize + sizeof(int) + (sizeof(bool) * 2) + (sizeof(uint) * 2))]
+        private uint optimalBufferSize;
+
+        public HapticCapabilities capabilities => new HapticCapabilities(numChannels, supportsImpulse);
 
         public static GetHapticCapabilitiesCommand Create()
         {


### PR DESCRIPTION
- Added IXRRumble as an interface that can do XR-type rumble events
- XRControllerWithRumble now inherits from IXRRumble
- XR Rumble can now check if rumble is supported, and can send a rumble event to multiple channels.
- Updated Test Scene.