### PR TITLE
FIX: No input coming through in UnityTests.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,6 +15,7 @@ using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.Profiling;
+using UnityEngine.TestTools;
 using UnityEngine.TestTools.Constraints;
 using UnityEngine.TestTools.Utils;
 using Is = UnityEngine.TestTools.Constraints.Is;
@@ -1675,5 +1677,18 @@ partial class CoreTests
                 Assert.That(eventPtr->type, Is.EqualTo(new FourCC()));
             }
         }
+    }
+
+    [UnityTest]
+    [Category("Events")]
+    public IEnumerator Events_CanTestInputDistributedOverFrames()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        Press(gamepad.buttonSouth, queueEventOnly: true);
+
+        yield return null;
+
+        Assert.That(gamepad.buttonSouth.isPressed, Is.True);
     }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed no input being processed when running a `[UnityTest]` over several frames. Before, this required calling `InputSystem.Update` manually.
+
 ## [1.0.0] - 2020-4-23
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2421,7 +2421,7 @@ namespace UnityEngine.InputSystem
             m_HasFocus = focus;
         }
 
-        private bool ShouldRunUpdate(InputUpdateType updateType)
+        internal bool ShouldRunUpdate(InputUpdateType updateType)
         {
             // We perform a "null" update after domain reloads and on startup to get our devices
             // in place before the runtime calls MonoBehaviour callbacks. See InputSystem.RunInitialUpdate().


### PR DESCRIPTION
If you had a `[UnityTest]` running over several frames, you'd expect input to happen as it normally does as part of the player loop. Because of how `InputTestFixture` cuts itself off from the Unity runtime, this did not happen. This changes fixes that.