### PR TITLE
Fixed PrimitiveValue.FromString to handle NaN value

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
@@ -402,6 +402,12 @@ namespace UnityEngine.InputSystem.Utilities
                 if (long.TryParse(hexDigits, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var hexResult))
                     return new PrimitiveValue(hexResult);
             }
+            
+            // vJoy may produce NaN value, so we need just to ignore it and everything should work ok.
+            if (value.Equals("NaN"))
+            {
+                return new PrimitiveValue(0);
+            }
 
             ////TODO: allow trailing width specifier
             throw new NotImplementedException();


### PR DESCRIPTION
Issue: https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed
vJoy may produce NaN value that breaks the process of adding a device.