### PR TITLE
FIX: DUALSHOCK 4 controller initialization bug on iOS w/ touchpadButton

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
@@ -109,7 +109,7 @@ namespace UnityEngine.InputSystem.DualShock
         {
             base.FinishSetup();
 
-            touchpadButton = GetChildControl<ButtonControl>("touchpadButton");
+            touchpadButton = TryGetChildControl<ButtonControl>("touchpadButton");
             optionsButton = startButton;
             shareButton = selectButton;
 


### PR DESCRIPTION
A fix for issue #1142