### PR TITLE
FIX: Drag-reordering losing bindings (case 1228000).

### DIFF
--- a/.yamato/analyze.yml
+++ b/.yamato/analyze.yml
@@ -2,7 +2,7 @@ code_analyser:
   name : Code Analyzer
   agent:
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
   commands:
     - git submodule update --init

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -2,7 +2,7 @@ check_formatting:
   name : Check formatting
   agent:
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
   commands:
     - hg clone -b stable http://hg-mirror-slo.hq.unity3d.com/unity-extra/unity-meta

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -2,7 +2,7 @@ check_formatting:
   name : Check formatting
   agent:
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: buildfarm/mac:stable
     flavor: m1.mac
   commands:
     - hg clone -b stable http://hg-mirror-slo.hq.unity3d.com/unity-extra/unity-meta

--- a/.yamato/publish-samples.yml
+++ b/.yamato/publish-samples.yml
@@ -2,7 +2,7 @@ test_sample_projects:
   name : Publish Sample Projects
   agent:
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/test-samples.yml
+++ b/.yamato/test-samples.yml
@@ -2,7 +2,7 @@ test_sample_projects:
   name : Test Sample Projects
   agent:
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
   commands:
     - npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -32,7 +32,7 @@ platforms:
     flavor: m1.mac
     runtime: StandaloneOSX   
     scripting-backend: Il2Cpp 
-    installscript: ~/Library/Python/2.7/bin/unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP -w -u 
+    installscript: ~/Library/Python/3.7/bin/unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP -w -u 
 ---
 {% for editor in editors %}
 {% for platform in platforms %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -19,16 +19,16 @@ platforms:
     installscript: c:\python27\Scripts\unity-downloader-cli.exe -c editor -c StandaloneSupport-IL2CPP -w -u 
   - name: mac
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
   - name: mac_standalone
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
     runtime: StandaloneOSX
   - name: mac_standalone_il2cpp
     type: Unity::VM::osx
-    image: buildfarm/mac:stable
+    image: package-ci/mac:stable
     flavor: m1.mac
     runtime: StandaloneOSX   
     scripting-backend: Il2Cpp 

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -1519,6 +1519,43 @@ partial class CoreTests
         }
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1228000/
+    [Test]
+    [Category("Editor")]
+    public void Editor_ActionTree_CanCutAndPasteAction_WithControlSchemeFilterActive()
+    {
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = asset.AddActionMap("map");
+        var action1 = map.AddAction("action1");
+        map.AddAction("action2");
+        asset.AddControlScheme("scheme1");
+        asset.AddControlScheme("scheme2");
+        action1.AddBinding("<Gamepad>/buttonSouth", groups: "scheme1");
+        action1.AddBinding("<Keyboard>/space", groups: "scheme2");
+
+        var so = new SerializedObject(asset);
+        var tree = new InputActionTreeView(so)
+        {
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+        };
+        tree.SetItemSearchFilterAndReload("g:scheme1");
+
+        using (new EditorHelpers.FakeSystemCopyBuffer())
+        {
+            tree.SelectItem("map/action1");
+            tree.HandleCopyPasteCommandEvent(EditorGUIUtility.CommandEvent(InputActionTreeView.k_CutCommand));
+            tree.SelectItem("map/action2");
+            tree.HandleCopyPasteCommandEvent(EditorGUIUtility.CommandEvent(InputActionTreeView.k_PasteCommand));
+
+            Assert.That(tree.FindItemByPath("map/action1"), Is.Not.Null);
+            Assert.That(tree["map/action1"].childrenIncludingHidden.Count(), Is.EqualTo(2));
+            Assert.That(tree["map/action1"].childrenIncludingHidden.ToList()[0].As<BindingTreeItem>().path, Is.EqualTo("<Gamepad>/buttonSouth"));
+            Assert.That(tree["map/action1"].childrenIncludingHidden.ToList()[1].As<BindingTreeItem>().path, Is.EqualTo("<Keyboard>/space"));
+            Assert.That(tree["map/action1"].childrenIncludingHidden.ToList()[0].As<BindingTreeItem>().groups, Is.EqualTo("scheme1"));
+            Assert.That(tree["map/action1"].childrenIncludingHidden.ToList()[1].As<BindingTreeItem>().groups, Is.EqualTo("scheme2"));
+        }
+    }
+
     [Test]
     [Category("Editor")]
     public void Editor_ActionTree_CanFilterItems()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+#### Actions
+
+- Fixed drag&drop reordering actions while having one control scheme selected causing bindings from other control schemes to be lost ([case 122800](https://issuetracker.unity3d.com/issues/input-system-bindings-get-cleared-for-other-control-scheme-actions-when-reordering-an-action-in-a-specific-control-scheme)).
 ## [1.0.0] - 2020-4-23
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -160,10 +160,12 @@ namespace UnityEngine.InputSystem.Editor
                 item.parent.children.Remove(item);
 
                 // Add to list of hidden children.
-                var parent = (ActionTreeItemBase)item.parent;
-                if (parent.m_HiddenChildren == null)
-                    parent.m_HiddenChildren = new List<ActionTreeItemBase>();
-                parent.m_HiddenChildren.Add(item);
+                if (item.parent is ActionTreeItemBase parent)
+                {
+                    if (parent.m_HiddenChildren == null)
+                        parent.m_HiddenChildren = new List<ActionTreeItemBase>();
+                    parent.m_HiddenChildren.Add(item);
+                }
 
                 return;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -20,6 +20,8 @@ using UnityEngine.InputSystem.Utilities;
 
 ////FIXME: context menu cannot be brought up when there's no items in the tree
 
+////FIXME: RMB context menu for actions displays composites that aren't applicable to the action
+
 namespace UnityEngine.InputSystem.Editor
 {
     /// <summary>
@@ -156,6 +158,13 @@ namespace UnityEngine.InputSystem.Editor
             if (m_ItemFilterCriteria.Any(x => x.Matches(item) == FilterCriterion.Match.Failure))
             {
                 item.parent.children.Remove(item);
+
+                // Add to list of hidden children.
+                var parent = (ActionTreeItemBase)item.parent;
+                if (parent.m_HiddenChildren == null)
+                    parent.m_HiddenChildren = new List<ActionTreeItemBase>();
+                parent.m_HiddenChildren.Add(item);
+
                 return;
             }
 
@@ -497,9 +506,20 @@ namespace UnityEngine.InputSystem.Editor
                 }
 
                 // Paste items onto target.
-                PasteItems(copyBuffer.ToString(),
-                    new[] { new InsertLocation {item = target, childIndex = childIndex} },
-                    assignNewIDs: assignNewIDs);
+                var oldBindingGroupForNewBindings = bindingGroupForNewBindings;
+                try
+                {
+                    // With drag&drop, preserve binding groups.
+                    bindingGroupForNewBindings = null;
+
+                    PasteItems(copyBuffer.ToString(),
+                        new[] { new InsertLocation { item = target, childIndex = childIndex } },
+                        assignNewIDs: assignNewIDs);
+                }
+                finally
+                {
+                    bindingGroupForNewBindings = oldBindingGroupForNewBindings;
+                }
 
                 DragAndDrop.AcceptDrag();
             }
@@ -639,14 +659,8 @@ namespace UnityEngine.InputSystem.Editor
             buffer.Append(item.property.CopyToJson(ignoreObjectReferences: true));
             buffer.Append(k_EndOfTransmissionBlock);
 
-            ////FIXME: Relying on serialization this way to snapshot an entire object has the downside that
-            ////       these items work differently for copy-paste than others. For example, copying an action
-            ////       map will always copy its entire data, regardless of the current filter state. In contrast,
-            ////       copying an action will only copy the bindings that are visible according to the current
-            ////       view filter. This could be fixed by removing serializedDataIncludesChildren and allowing
-            ////       CopyToJson() to optionally ignore child properties.
-            if (!item.serializedDataIncludesChildren && item.hasChildren)
-                foreach (var child in item.children.OfType<ActionTreeItemBase>())
+            if (!item.serializedDataIncludesChildren && item.hasChildrenIncludingHidden)
+                foreach (var child in item.childrenIncludingHidden)
                     CopyItemData(child, buffer);
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
@@ -1,5 +1,7 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 
@@ -18,6 +20,24 @@ namespace UnityEngine.InputSystem.Editor
         public abstract GUIStyle colorTagStyle { get; }
         public string name { get; }
         public Guid guid { get; }
+
+        // For some operations (like copy-paste), we want to include information that we have filtered out.
+        internal List<ActionTreeItemBase> m_HiddenChildren;
+        public bool hasChildrenIncludingHidden => hasChildren || (m_HiddenChildren != null && m_HiddenChildren.Count > 0);
+        public IEnumerable<ActionTreeItemBase> hiddenChildren => m_HiddenChildren ?? Enumerable.Empty<ActionTreeItemBase>();
+        public IEnumerable<ActionTreeItemBase> childrenIncludingHidden
+        {
+            get
+            {
+                if (hasChildren)
+                    foreach (var child in children)
+                        if (child is ActionTreeItemBase item)
+                            yield return item;
+                if (m_HiddenChildren != null)
+                    foreach (var child in m_HiddenChildren)
+                        yield return child;
+            }
+        }
 
         // Action data is generally stored in arrays. Action maps are stored in m_ActionMaps arrays in assets,
         // actions are stored in m_Actions arrays on maps and bindings are stored in m_Bindings arrays on maps.


### PR DESCRIPTION
Fixes [1228000](https://fogbugz.unity3d.com/f/cases/1228000/) ([Issue Tracker](https://issuetracker.unity3d.com/issues/input-system-bindings-get-cleared-for-other-control-scheme-actions-when-reordering-an-action-in-a-specific-control-scheme)).