### PR TITLE
Swaps the TrackedPoseDriver over to using InputActionProperty's

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -355,14 +355,25 @@ internal class XRTests : InputTestFixture
 
         using (StateEvent.From(device, out var stateEvent))
         {
-            var positionAction = new InputAction();
-            positionAction.AddBinding("<TestHMD>/vector3");
-
-            var rotationAction = new InputAction();
+            InputActionAsset iaa = new InputActionAsset();
+            var amap = iaa.AddActionMap("test");
+            
+            var rotationAction = amap.AddAction("rotation");
             rotationAction.AddBinding("<TestHMD>/quaternion");
 
-            tpd.positionAction = positionAction;
-            tpd.rotationAction = rotationAction;
+            var positionAction = amap.AddAction("position");            
+            positionAction.AddBinding("<TestHMD>/vector3");
+
+            var pa = new InputActionReference();
+            pa.Set(positionAction);
+            pa.name = "PositionAction";
+
+            var ra = new InputActionReference();
+            ra.Set(rotationAction);
+            ra.name = "RotationAction";
+
+            tpd.positionAction = pa;
+            tpd.rotationAction = ra;                                
 
             // before render only
             var go1 = tpd.gameObject;

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -372,8 +372,10 @@ internal class XRTests : InputTestFixture
             ra.Set(rotationAction);
             ra.name = "RotationAction";
 
-            tpd.positionAction = pa;
-            tpd.rotationAction = ra;                                
+            tpd.positionAction = new InputActionProperty(pa);
+            tpd.rotationAction = new InputActionProperty(ra);
+
+            tpd.BindActions();
 
             // before render only
             var go1 = tpd.gameObject;

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -357,11 +357,11 @@ internal class XRTests : InputTestFixture
         {
             InputActionAsset iaa = new InputActionAsset();
             var amap = iaa.AddActionMap("test");
-            
+
             var rotationAction = amap.AddAction("rotation");
             rotationAction.AddBinding("<TestHMD>/quaternion");
 
-            var positionAction = amap.AddAction("position");            
+            var positionAction = amap.AddAction("position");
             positionAction.AddBinding("<TestHMD>/vector3");
 
             var pa = new InputActionReference();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -49,28 +49,44 @@ namespace UnityEngine.InputSystem.XR
         }
 
         [SerializeField]
-        InputActionReference m_PositionAction;
-        public InputActionReference positionAction
+        InputActionProperty m_PositionAction;
+        public InputActionProperty positionAction
         {
             get { return m_PositionAction; }
             set
             {
-                UnbindPosition();
+                bool rebind = false;
+                if (m_PositionBound)
+                {
+                    UnbindPosition();
+                    rebind = true;
+                }
                 m_PositionAction = value;
-                BindActions();
+                if (rebind)
+                {
+                    BindPosition();
+                }
             }
         }
 
         [SerializeField]
-        InputActionReference m_RotationAction;
-        public InputActionReference rotationAction
+        InputActionProperty m_RotationAction;
+        public InputActionProperty rotationAction
         {
             get { return m_RotationAction; }
             set
             {
-                UnbindRotation();
+                bool rebind = false;
+                if(m_RotationBound)
+                {
+                    UnbindRotation();
+                    rebind = true;
+                }
                 m_RotationAction = value;
-                BindActions();
+                if(rebind)
+                {
+                    BindRotation();
+                }
             }
         }
 
@@ -79,7 +95,7 @@ namespace UnityEngine.InputSystem.XR
         bool m_RotationBound = false;
         bool m_PositionBound = false;
 
-        void BindActions()
+        public void BindActions()
         {
             BindPosition();
             BindRotation();
@@ -89,13 +105,13 @@ namespace UnityEngine.InputSystem.XR
         {
             if (!m_PositionBound && m_PositionAction != null)
             {
-                m_PositionAction?.action.Rename($"{gameObject.name} - TPD - Position");
+                m_PositionAction.action?.Rename($"{gameObject.name} - TPD - Position");
                 if (m_PositionAction != null && m_PositionAction.action != null)
                 {
                     m_PositionAction.action.performed += OnPositionUpdate;
                 }
                 m_PositionBound = true;
-                m_PositionAction?.action.Enable();
+                m_PositionAction.action?.Enable();
             }
         }
 
@@ -103,17 +119,17 @@ namespace UnityEngine.InputSystem.XR
         {
             if (!m_RotationBound && m_RotationAction != null)
             {
-                m_RotationAction?.action.Rename($"{gameObject.name} - TPD - Rotation");
+                m_RotationAction.action?.Rename($"{gameObject.name} - TPD - Rotation");
                 if (m_RotationAction != null && m_RotationAction.action != null)
                 {
                     m_RotationAction.action.performed += OnRotationUpdate;
                 }
                 m_RotationBound = true;
-                m_RotationAction?.action.Enable();
+                m_RotationAction.action?.Enable();
             }
         }
 
-        void UnbindActions()
+        public void UnbindActions()
         {
             UnbindPosition();
             UnbindRotation();
@@ -123,7 +139,7 @@ namespace UnityEngine.InputSystem.XR
         {
             if (m_PositionAction != null && m_PositionBound)
             {
-                m_PositionAction?.action.Disable();
+                m_PositionAction.action?.Disable();
                 if (m_PositionAction != null && m_PositionAction.action != null)
                 {
                     m_PositionAction.action.performed -= OnPositionUpdate;
@@ -136,7 +152,7 @@ namespace UnityEngine.InputSystem.XR
         {
             if (m_RotationAction != null && m_RotationBound)
             {
-                m_RotationAction?.action.Disable();
+                m_RotationAction.action?.Disable();
                 if (m_RotationAction != null && m_RotationAction.action != null)
                 {
                     m_RotationAction.action.performed -= OnRotationUpdate;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -49,8 +49,8 @@ namespace UnityEngine.InputSystem.XR
         }
 
         [SerializeField]
-        InputAction m_PositionAction;
-        public InputAction positionAction
+        InputActionReference m_PositionAction;
+        public InputActionReference positionAction
         {
             get { return m_PositionAction; }
             set
@@ -62,8 +62,8 @@ namespace UnityEngine.InputSystem.XR
         }
 
         [SerializeField]
-        InputAction m_RotationAction;
-        public InputAction rotationAction
+        InputActionReference m_RotationAction;
+        public InputActionReference rotationAction
         {
             get { return m_RotationAction; }
             set
@@ -89,10 +89,13 @@ namespace UnityEngine.InputSystem.XR
         {
             if (!m_PositionBound && m_PositionAction != null)
             {
-                m_PositionAction.Rename($"{gameObject.name} - TPD - Position");
-                m_PositionAction.performed += OnPositionUpdate;
+                m_PositionAction?.action.Rename($"{gameObject.name} - TPD - Position");
+                if (m_PositionAction != null && m_PositionAction.action != null)
+                {
+                    m_PositionAction.action.performed += OnPositionUpdate;
+                }
                 m_PositionBound = true;
-                m_PositionAction.Enable();
+                m_PositionAction?.action.Enable();
             }
         }
 
@@ -100,10 +103,13 @@ namespace UnityEngine.InputSystem.XR
         {
             if (!m_RotationBound && m_RotationAction != null)
             {
-                m_RotationAction.Rename($"{gameObject.name} - TPD - Rotation");
-                m_RotationAction.performed += OnRotationUpdate;
+                m_RotationAction?.action.Rename($"{gameObject.name} - TPD - Rotation");
+                if (m_RotationAction != null && m_RotationAction.action != null)
+                {
+                    m_RotationAction.action.performed += OnRotationUpdate;
+                }
                 m_RotationBound = true;
-                m_RotationAction.Enable();
+                m_RotationAction?.action.Enable();
             }
         }
 
@@ -117,8 +123,11 @@ namespace UnityEngine.InputSystem.XR
         {
             if (m_PositionAction != null && m_PositionBound)
             {
-                m_PositionAction.Disable();
-                m_PositionAction.performed -= OnPositionUpdate;
+                m_PositionAction?.action.Disable();
+                if (m_PositionAction != null && m_PositionAction.action != null)
+                {
+                    m_PositionAction.action.performed -= OnPositionUpdate;
+                }
                 m_PositionBound = false;
             }
         }
@@ -127,8 +136,11 @@ namespace UnityEngine.InputSystem.XR
         {
             if (m_RotationAction != null && m_RotationBound)
             {
-                m_RotationAction.Disable();
-                m_RotationAction.performed -= OnRotationUpdate;
+                m_RotationAction?.action.Disable();
+                if (m_RotationAction != null && m_RotationAction.action != null)
+                {
+                    m_RotationAction.action.performed -= OnRotationUpdate;
+                }
                 m_RotationBound = false;
             }
         }
@@ -163,8 +175,8 @@ namespace UnityEngine.InputSystem.XR
 
         void OnDisable()
         {
-            UnbindActions();
             InputSystem.onAfterUpdate -= UpdateCallback;
+            UnbindActions();            
         }
 
         protected virtual void OnDestroy()

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -77,13 +77,13 @@ namespace UnityEngine.InputSystem.XR
             set
             {
                 bool rebind = false;
-                if(m_RotationBound)
+                if (m_RotationBound)
                 {
                     UnbindRotation();
                     rebind = true;
                 }
                 m_RotationAction = value;
-                if(rebind)
+                if (rebind)
                 {
                     BindRotation();
                 }
@@ -192,7 +192,7 @@ namespace UnityEngine.InputSystem.XR
         void OnDisable()
         {
             InputSystem.onAfterUpdate -= UpdateCallback;
-            UnbindActions();            
+            UnbindActions();
         }
 
         protected virtual void OnDestroy()


### PR DESCRIPTION
Swaps the TrackedPoseDriver bundled with the new input system to use InputActionProperty's rather than InputActions. 

This also includes an updated test which passes locally. 

Tested locally with oculus quest. 