### PR TITLE
FIX: Control picker empty when using 'Supported Devices' (case 1254150).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed drag&drop reordering actions while having one control scheme selected causing bindings from other control schemes to be lost ([case 122800](https://issuetracker.unity3d.com/issues/input-system-bindings-get-cleared-for-other-control-scheme-actions-when-reordering-an-action-in-a-specific-control-scheme)).
+- Fixed control picker ending up empty when listing devices in "Supported Devices" ([case 1254150](https://issuetracker.unity3d.com/product/unity/issues/guid/1254150/)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -514,7 +514,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     // If there's no device filter coming from a control scheme, filter by supported
                     // devices as given by settings.
-                    controlPathsToMatch = InputSystem.settings.supportedDevices;
+                    controlPathsToMatch = InputSystem.settings.supportedDevices.Select(x => $"<{x}>");
                 }
 
                 // Show properties for binding.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -261,6 +261,8 @@ namespace UnityEngine.InputSystem.Editor
                         new InputControlPickerState(),
                         path =>
                         {
+                            ////REVIEW: Why are we converting from a layout into a plain string here instead of just using path strings in supportedDevices?
+                            ////        Why not just have InputSettings.supportedDevices be a list of paths?
                             var layoutName = InputControlPath.TryGetDeviceLayout(path) ?? path;
                             var existingIndex = m_Settings.supportedDevices.IndexOf(x => x == layoutName);
                             if (existingIndex != -1)


### PR DESCRIPTION
Fixes [1254150](https://issuetracker.unity3d.com/product/unity/issues/guid/1254150/) ([internal](https://fogbugz.unity3d.com/f/cases/1254150/)).