### PR TITLE
FIX: Stack overflow in SwithCurrentActionMap (case 1232893).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -994,6 +994,31 @@ internal class PlayerInputTests : InputTestFixture
             }));
     }
 
+    // https://issuetracker.unity3d.com/issues/inputsystem-switchcurrentactionmap-causes-a-stackoverflow-when-called-by-each-pahse-of-an-action
+    // https://fogbugz.unity3d.com/f/cases/1232893/
+    [Test]
+    [Category("PlayerInput")]
+    public void PlayerInput_CanSwitchActionMapFromActionCallback()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var go = new GameObject();
+        go.SetActive(false);
+        var playerInput = go.AddComponent<PlayerInput>();
+        playerInput.defaultActionMap = "gameplay";
+        playerInput.notificationBehavior = PlayerNotifications.InvokeCSharpEvents;
+        playerInput.onActionTriggered += context => playerInput.SwitchCurrentActionMap("other");
+        playerInput.actions = InputActionAsset.FromJson(kActions);
+        go.SetActive(true);
+
+        Assert.That(playerInput.currentActionMap.name, Is.EqualTo("gameplay"));
+
+        // Start an action. Should immediately lead to a switch.
+        Set(gamepad.leftStick, new Vector2(0.2f, 0.3f));
+
+        Assert.That(playerInput.currentActionMap.name, Is.EqualTo("other"));
+    }
+
     [Test]
     [Category("PlayerInput")]
     public void PlayerInput_PlayerIndex_IsAssignedAutomatically()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed drag&drop reordering actions while having one control scheme selected causing bindings from other control schemes to be lost ([case 122800](https://issuetracker.unity3d.com/issues/input-system-bindings-get-cleared-for-other-control-scheme-actions-when-reordering-an-action-in-a-specific-control-scheme)).
+- Fixed stack overflow in `PlayerInput.SwitchCurrentActionMap` when called from action callback ([case 1232893](https://issuetracker.unity3d.com/issues/inputsystem-switchcurrentactionmap-causes-a-stackoverflow-when-called-by-each-pahse-of-an-action)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -436,7 +436,14 @@ namespace UnityEngine.InputSystem
             get => m_CurrentActionMap;
             set
             {
-                m_CurrentActionMap?.Disable();
+                // If someone switches maps from an action callback, we may get here recursively
+                // from Disable(). To avoid that, we null out the current action map while
+                // we disable it.
+                var oldMap = m_CurrentActionMap;
+                m_CurrentActionMap = null;
+                oldMap?.Disable();
+
+                // Switch to new map.
                 m_CurrentActionMap = value;
                 m_CurrentActionMap?.Enable();
             }


### PR DESCRIPTION
Fixes [1232893](https://issuetracker.unity3d.com/issues/inputsystem-switchcurrentactionmap-causes-a-stackoverflow-when-called-by-each-pahse-of-an-action) ([internal](https://fogbugz.unity3d.com/f/cases/1232893/)).