### PR TITLE
FIX: TouchControl.tapCount resetting to 0 with ScriptDebugging enable…

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -760,7 +760,7 @@ partial class CoreTests
 
     [Test]
     [Category("State")]
-    public void State_CurrentTimeCalculatedCorrectly()
+    public void State_CurrentTimeTakesOffsetToRealtimeSinceStartupIntoAccount()
     {
         runtime.currentTime += 2;
         runtime.currentTimeOffsetToRealtimeSinceStartup = 1;

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -758,6 +758,17 @@ partial class CoreTests
         Assert.That(positionMonitorFired);
     }
 
+    [Test]
+    [Category("State")]
+    public void State_CurrentTimeCalculatedCorrectly()
+    {
+        runtime.currentTime += 2;
+        runtime.currentTimeOffsetToRealtimeSinceStartup = 1;
+
+        Assert.That(InputState.currentTime, Is.EqualTo(1));
+        Assert.Greater(InputRuntime.s_Instance.currentTime, InputState.currentTime);
+    }
+
     // For certain actions, we want to be able to tell whether a specific input arrives in time.
     // For example, we may want to only trigger an action if a specific button was released within
     // a certain amount of time. To support this, the system allows putting timeouts on individual

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -25,6 +25,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a bug that prevented DualShock controllers from working on tvOS. (case 1221223).
 - `GravitySensor`, `LinearAccelerationSensor`, and `AttitudeSensor` not being initialized on iOS ([case 1251382](https://issuetracker.unity3d.com/product/unity/issues/guid/1251382/)).
 - Fixed compilation issues with XR and VR references when building to platforms that do not have complete XR and VR implementations.
+- Fixed `TouchControl.tapCount` resetting to 0 when "Script Debugging" is enabled (case 1194636).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         public static uint updateCount => InputUpdate.s_UpdateStepCount;
 
-        public static double currentTime => InputRuntime.s_Instance.currentTime + InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
+        public static double currentTime => InputRuntime.s_Instance.currentTime - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
 
         /// <summary>
         /// Callback that is triggered when the state of an input device changes.


### PR DESCRIPTION
Fix InputState.currentTime calculation where s_CurrentTimeOffsetToRealtimeSinceStartup is added to currentTime instead of being subtracted. This exposes a bug that resets tapCount to 0 when "Script Debugging" is enabled because the value of s_CurrentTimeOffsetToRealtimeSinceStartup is greater due to delayed startup while waiting for debugger to attach.