### PR TITLE
Readonlyarray enumerator struct

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -682,6 +682,7 @@ class APIVerificationTests
         public UnityEngine.InputSystem.Controls.ButtonControl shareButton { get; }
         public UnityEngine.InputSystem.Controls.ButtonControl touchpadButton { get; }
         public UnityEngine.InputSystem.Utilities.ReadOnlyArray<UnityEngine.InputSystem.Controls.TouchControl> touches { get; }
+        public virtual System.Collections.Generic.IEnumerator<TValue> GetEnumerator();
     ")]
     public void API_MinorVersionsHaveNoBreakingChanges()
     {

--- a/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
@@ -14,13 +14,13 @@ public class ReadOnlyArrayTests
         foreach (var element in array)
             foo1 = element + 1;
         Assert.That(() =>
-            {
-                var foo = 1.0f;
-                foreach (var element in array)
-                    foo = element + 1;
-            },
-            Is.Not.AllocatingGCMemory());
+        {
+            var foo = 1.0f;
+            foreach (var element in array)
+                foo = element + 1;
+        }, Is.Not.AllocatingGCMemory());
     }
+
     [Test]
     public void WithoutForEach()
     {
@@ -30,11 +30,10 @@ public class ReadOnlyArrayTests
         for (var i = 0; i < array.Count; ++i)
             foo1 = array[i] + 1;
         Assert.That(() =>
-            {
-                var foo = 1.0f;
-                for (var i = 0; i < array.Count; ++i)
-                    foo = array[i] + 1;
-            },
-            Is.Not.AllocatingGCMemory());
+        {
+            var foo = 1.0f;
+            for (var i = 0; i < array.Count; ++i)
+                foo = array[i] + 1;
+        }, Is.Not.AllocatingGCMemory());
     }
 }

--- a/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
@@ -6,34 +6,16 @@ using Is = NUnit.Framework.Is;
 public class ReadOnlyArrayTests
 {
     [Test]
-    public void WithForEach()
+    [Category("Utilities")]
+    [Retry(2)] // Warm up JIT
+    public void Utilities_ReadOnlyArray_ForEachDoesNotAllocateGCMemory()
     {
         var array = new ReadOnlyArray<float>(new float[] { 1, 2, 3, 4 });
-        // Warm up.
-        var foo1 = 1.0f;
-        foreach (var element in array)
-            foo1 = element + 1;
         Assert.That(() =>
         {
             var foo = 1.0f;
             foreach (var element in array)
                 foo = element + 1;
-        }, Is.Not.AllocatingGCMemory());
-    }
-
-    [Test]
-    public void WithoutForEach()
-    {
-        var array = new ReadOnlyArray<float>(new float[] { 1, 2, 3, 4 });
-        // Warm up.
-        var foo1 = 1.0f;
-        for (var i = 0; i < array.Count; ++i)
-            foo1 = array[i] + 1;
-        Assert.That(() =>
-        {
-            var foo = 1.0f;
-            for (var i = 0; i < array.Count; ++i)
-                foo = array[i] + 1;
         }, Is.Not.AllocatingGCMemory());
     }
 }

--- a/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.TestTools.Constraints;
 using Is = NUnit.Framework.Is;

--- a/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using UnityEngine.InputSystem.Utilities;
+using UnityEngine.TestTools.Constraints;
+using Is = NUnit.Framework.Is;
+
+public class ReadOnlyArrayTests
+{
+    [Test]
+    public void WithForEach()
+    {
+        var array = new ReadOnlyArray<float>(new float[] { 1, 2, 3, 4 });
+        // Warm up.
+        var foo1 = 1.0f;
+        foreach (var element in array)
+            foo1 = element + 1;
+        Assert.That(() =>
+            {
+                var foo = 1.0f;
+                foreach (var element in array)
+                    foo = element + 1;
+            },
+            Is.Not.AllocatingGCMemory());
+    }
+    [Test]
+    public void WithoutForEach()
+    {
+        var array = new ReadOnlyArray<float>(new float[] { 1, 2, 3, 4 });
+        // Warm up.
+        var foo1 = 1.0f;
+        for (var i = 0; i < array.Count; ++i)
+            foo1 = array[i] + 1;
+        Assert.That(() =>
+            {
+                var foo = 1.0f;
+                for (var i = 0; i < array.Count; ++i)
+                    foo = array[i] + 1;
+            },
+            Is.Not.AllocatingGCMemory());
+    }
+}

--- a/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs.meta
+++ b/Assets/Tests/InputSystem/Utilities/ReadOnlyArrayTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cc1b95d7d8ef4467b33c22b65ae6cdce
+timeCreated: 1594741730

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -145,7 +145,7 @@ namespace UnityEngine.InputSystem.Utilities
             private readonly int m_IndexEnd;
             private int m_Index;
 
-            public Enumerator(TValue[] array, int index, int length)
+            internal Enumerator(TValue[] array, int index, int length)
             {
                 m_Array = array;
                 m_IndexStart = index - 1; // First call to MoveNext() moves us to first valid index.
@@ -153,10 +153,12 @@ namespace UnityEngine.InputSystem.Utilities
                 m_Index = m_IndexStart;
             }
 
+            /// <inheritdoc/>>
             public void Dispose()
             {
             }
 
+            /// <inheritdoc/>>
             public bool MoveNext()
             {
                 if (m_Index < m_IndexEnd)
@@ -164,11 +166,13 @@ namespace UnityEngine.InputSystem.Utilities
                 return (m_Index != m_IndexEnd);
             }
 
+            /// <inheritdoc/>>
             public void Reset()
             {
                 m_Index = m_IndexStart;
             }
 
+            /// <inheritdoc/>>
             public TValue Current
             {
                 get

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -81,10 +81,21 @@ namespace UnityEngine.InputSystem.Utilities
             return -1;
         }
 
-        /// <inheritdoc />
-        public IEnumerator<TValue> GetEnumerator()
+        /// <summary>
+        /// Returns an enumerator that iterates through the read-only array.
+        /// <returns>
+        /// <see cref="ReadOnlyArray{TValue}.Enumerator"/>
+        /// An enumerator for the read-only array.
+        /// </returns>
+        /// </summary>
+        public Enumerator GetEnumerator()
         {
-            return new Enumerator<TValue>(m_Array, m_StartIndex, m_Length);
+            return new Enumerator(m_Array, m_StartIndex, m_Length);
+        }
+
+        IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+        {
+            return GetEnumerator();
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -123,14 +134,17 @@ namespace UnityEngine.InputSystem.Utilities
             }
         }
 
-        internal class Enumerator<T> : IEnumerator<T>
+        /// <summary>
+        /// Enumerates the elements of a ReadOnlyArray{TValue}.
+        /// </summary>
+        public struct Enumerator : IEnumerator<TValue>
         {
-            private readonly T[] m_Array;
+            private readonly TValue[] m_Array;
             private readonly int m_IndexStart;
             private readonly int m_IndexEnd;
             private int m_Index;
 
-            public Enumerator(T[] array, int index, int length)
+            public Enumerator(TValue[] array, int index, int length)
             {
                 m_Array = array;
                 m_IndexStart = index - 1; // First call to MoveNext() moves us to first valid index.
@@ -154,7 +168,7 @@ namespace UnityEngine.InputSystem.Utilities
                 m_Index = m_IndexStart;
             }
 
-            public T Current
+            public TValue Current
             {
                 get
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -135,7 +135,8 @@ namespace UnityEngine.InputSystem.Utilities
         }
 
         /// <summary>
-        /// Enumerates the elements of a ReadOnlyArray{TValue}.
+        /// <see cref="ReadOnlyArray{TValue}"/>
+        /// Enumerates the elements of a read-only array.
         /// </summary>
         public struct Enumerator : IEnumerator<TValue>
         {


### PR DESCRIPTION
**Purpose of this PR**
Removes memory allocation caused by using `foreach` on `ReadOnlyArray<T>`, provided it is used with its explicit type and not through an `IEnumerable<T>` downcast.

**API Changes**
This PR exposes the `ReadOnlyArray<T>.Enumerator` struct to the public API as well as the strongly-typed `ReadOnlyArray<T>.GetEnumerator()` using aforementioned `Enumerator` type.

**Testing status**
New unit test in `ReadOnlyArrayTests.cs`:
- `Utilities_ReadOnlyArray_ForEachDoesNotAllocateGCMemory` (should fail without this PR and succeed with it)
