### PR TITLE
FIX: Changed WinUserInput so it is internal

### DIFF
--- a/Packages/com.unity.inputsystem/Tests/TestFixture/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/AssemblyInfo.cs
@@ -7,3 +7,4 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyVersion("1.0.0")]
 [assembly: InternalsVisibleTo("Unity.InputSystem.Tests.Editor")]
 [assembly: InternalsVisibleTo("Unity.InputSystem.Tests")]
+[assembly: InternalsVisibleTo("Unity.InputSystem.IntegrationTests")]

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/WinUserInput.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/WinUserInput.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 /// <summary>
 /// Used to send fake input events to Windows via user32.dll.
 /// </summary>
-public static class WinUserInput
+internal static class WinUserInput
 {
     [DllImport("user32.dll")]
     public static extern uint SendInput(


### PR DESCRIPTION
Made WinUserInput class internal. It's just for the RDP tests and does not have enough features for it to serve any other purpose. 