### PR TITLE
FIX: Several issues in EnhancedTouch (case 1230756).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -74,6 +74,17 @@ internal class EnhancedTouchTests : InputTestFixture
     [Test]
     [Category("EnhancedTouch")]
     [Property("EnhancedTouchDisabled", 1)]
+    public void EnhancedTouch_ThrowsExceptionWhenNotEnabled()
+    {
+        Assert.That(() => Touch.activeFingers, Throws.InvalidOperationException);
+        Assert.That(() => Touch.activeTouches, Throws.InvalidOperationException);
+        Assert.That(() => Touch.fingers, Throws.InvalidOperationException);
+        Assert.That(() => Touch.screens, Throws.InvalidOperationException);
+    }
+
+    [Test]
+    [Category("EnhancedTouch")]
+    [Property("EnhancedTouchDisabled", 1)]
     public void EnhancedTouch_CanBeDisabledAndEnabled()
     {
         InputSystem.AddDevice<Touchscreen>();
@@ -169,82 +180,147 @@ internal class EnhancedTouchTests : InputTestFixture
     [Category("EnhancedTouch")]
     public void EnhancedTouch_CanGetActiveTouches()
     {
+        // Begin and move in same frame.
         BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
         MoveTouch(1, new Vector2(0.234f, 0.345f), queueEventOnly: true);
+        // Begin only.
         BeginTouch(2, new Vector2(0.345f, 0.456f), queueEventOnly: true);
-        BeginTouch(3, new Vector3(0.456f, 0.567f), queueEventOnly: true);
-        EndTouch(3, new Vector3(0.567f, 0.678f), queueEventOnly: true);
+        // Begin, move, and end in same frame.
+        BeginTouch(3, new Vector2(0.456f, 0.567f), queueEventOnly: true);
+        MoveTouch(3, new Vector2(0.111f, 0.222f), queueEventOnly: true); // This one should get ignored.
+        EndTouch(3, new Vector2(0.567f, 0.678f), queueEventOnly: true);
+        // Begin only but reusing previous touch ID.
         BeginTouch(3, new Vector2(0.678f, 0.789f), queueEventOnly: true);
+
         InputSystem.Update();
 
         Assert.That(Touch.activeTouches, Has.Count.EqualTo(4));
-        Assert.That(Touch.activeTouches[0].touchId, Is.EqualTo(1));
-        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Moved));
-        Assert.That(Touch.activeTouches[0].screenPosition,
-            Is.EqualTo(new Vector2(0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].touchId, Is.EqualTo(2));
-        Assert.That(Touch.activeTouches[1].phase, Is.EqualTo(TouchPhase.Began));
-        Assert.That(Touch.activeTouches[1].screenPosition,
-            Is.EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[2].touchId, Is.EqualTo(3));
-        Assert.That(Touch.activeTouches[2].phase, Is.EqualTo(TouchPhase.Ended));
-        Assert.That(Touch.activeTouches[2].screenPosition,
-            Is.EqualTo(new Vector2(0.567f, 0.678f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[3].touchId, Is.EqualTo(3));
-        Assert.That(Touch.activeTouches[3].phase, Is.EqualTo(TouchPhase.Began));
-        Assert.That(Touch.activeTouches[3].screenPosition,
-            Is.EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance));
+
+        // When we begin and move a touch in the same frame, the phase should be Began, *NOT* Moved.
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.123f, 0.234f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        // A touch that begins and ends in the same frame, will see a Began in the current frame and a separate Ended in the next
+        // (even though there was no actual activity on the touch that frame).
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.456f, 0.567f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        InputSystem.Update();
+
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(4));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Moved)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(new Vector2(0.111f, 0.111f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        // Ended record for touch touch #3 that began and ended in previous frame.
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Ended)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.567f, 0.678f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(new Vector2(0.111f, 0.111f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
 
         InputSystem.Update();
 
         Assert.That(Touch.activeTouches, Has.Count.EqualTo(3));
-        Assert.That(Touch.activeTouches[0].touchId, Is.EqualTo(1));
-        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Stationary));
-        Assert.That(Touch.activeTouches[0].screenPosition,
-            Is.EqualTo(new Vector2(0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].touchId, Is.EqualTo(2));
-        Assert.That(Touch.activeTouches[1].phase, Is.EqualTo(TouchPhase.Stationary));
-        Assert.That(Touch.activeTouches[1].screenPosition,
-            Is.EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[2].touchId, Is.EqualTo(3));
-        Assert.That(Touch.activeTouches[2].phase, Is.EqualTo(TouchPhase.Stationary));
-        Assert.That(Touch.activeTouches[2].screenPosition,
-            Is.EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
 
         InputSystem.Update();
 
         Assert.That(Touch.activeTouches, Has.Count.EqualTo(3));
-        Assert.That(Touch.activeTouches[0].touchId, Is.EqualTo(1));
-        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Stationary));
-        Assert.That(Touch.activeTouches[0].screenPosition,
-            Is.EqualTo(new Vector2(0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].touchId, Is.EqualTo(2));
-        Assert.That(Touch.activeTouches[1].phase, Is.EqualTo(TouchPhase.Stationary));
-        Assert.That(Touch.activeTouches[1].screenPosition,
-            Is.EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[2].touchId, Is.EqualTo(3));
-        Assert.That(Touch.activeTouches[2].phase, Is.EqualTo(TouchPhase.Stationary));
-        Assert.That(Touch.activeTouches[2].screenPosition,
-            Is.EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.234f, 0.345f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.345f, 0.456f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.678f, 0.789f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(default(Vector2)));
 
         EndTouch(3, new Vector2(0.111f, 0.222f), queueEventOnly: true);
         EndTouch(2, new Vector2(0.222f, 0.333f), queueEventOnly: true);
         EndTouch(1, new Vector2(0.333f, 0.444f), queueEventOnly: true);
+
         InputSystem.Update();
 
         Assert.That(Touch.activeTouches, Has.Count.EqualTo(3));
-        Assert.That(Touch.activeTouches[0].touchId, Is.EqualTo(1));
-        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Ended));
-        Assert.That(Touch.activeTouches[0].screenPosition,
-            Is.EqualTo(new Vector2(0.333f, 0.444f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].touchId, Is.EqualTo(2));
-        Assert.That(Touch.activeTouches[1].phase, Is.EqualTo(TouchPhase.Ended));
-        Assert.That(Touch.activeTouches[1].screenPosition,
-            Is.EqualTo(new Vector2(0.222f, 0.333f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[2].touchId, Is.EqualTo(3));
-        Assert.That(Touch.activeTouches[2].phase, Is.EqualTo(TouchPhase.Ended));
-        Assert.That(Touch.activeTouches[2].screenPosition,
-            Is.EqualTo(new Vector2(0.111f, 0.222f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Ended)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.333f, 0.444f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(new Vector2(0.099f, 0.099f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Ended)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.222f, 0.333f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(new Vector2(-0.123f, -0.123f)).Using(Vector2EqualityComparer.Instance));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Ended)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.111f, 0.222f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("delta").EqualTo(new Vector2(-0.567f, -0.567f)).Using(Vector2EqualityComparer.Instance));
 
         InputSystem.Update();
 
@@ -255,39 +331,107 @@ internal class EnhancedTouchTests : InputTestFixture
     [Category("EnhancedTouch")]
     public void EnhancedTouch_DeltasInActiveTouchesAccumulateAndReset()
     {
+        // Only Began in frame.
         BeginTouch(1, new Vector2(0.111f, 0.222f), queueEventOnly: true);
+        // Began and Moved in same frame.
         BeginTouch(2, new Vector2(0.222f, 0.333f), queueEventOnly: true);
         MoveTouch(2, new Vector2(0.333f, 0.444f), queueEventOnly: true);
+        // Began and Ended in same frame.
+        BeginTouch(3, new Vector2(0.123f, 0.234f), queueEventOnly: true);
+        EndTouch(3, new Vector2(0.234f, 0.345f), queueEventOnly: true);
+
         InputSystem.Update();
 
-        Assert.That(Touch.activeTouches[0].delta,
-            Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].delta,
-            Is.EqualTo(new Vector2(0.111f, 0.111f)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(3));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.111f, 0.222f)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.222f, 0.333f)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Began)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.123f, 0.234f)));
+
+        InputSystem.Update();
+
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(3)); // Touch #3 ends this frame.
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.111f, 0.222f)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Moved)
+            .And.With.Property("delta").EqualTo(new Vector2(0.111f, 0.111f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.333f, 0.444f)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(3)
+            .And.With.Property("phase").EqualTo(TouchPhase.Ended)
+            .And.With.Property("delta").EqualTo(new Vector2(0.111f, 0.111f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.234f, 0.345f)));
 
         MoveTouch(1, new Vector2(0.444f, 0.555f), queueEventOnly: true); // Generates delta to (0.111,0.111)!
         MoveTouch(1, new Vector2(0.555f, 0.666f), queueEventOnly: true);
         MoveTouch(1, new Vector2(0.666f, 0.777f), queueEventOnly: true);
+
         InputSystem.Update();
 
-        Assert.That(Touch.activeTouches[0].delta,
-            Is.EqualTo(new Vector2(0.555f, 0.555f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].delta,
-            Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(2));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Moved)
+            .And.With.Property("delta").EqualTo(new Vector2(0.555f, 0.555f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.666f, 0.777f)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.333f, 0.444f)));
 
         MoveTouch(1, new Vector2(0.777f, 0.888f), queueEventOnly: true);
         EndTouch(1, new Vector2(0.888f, 0.999f), queueEventOnly: true);
-        InputSystem.Update();
-
-        Assert.That(Touch.activeTouches[0].delta,
-            Is.EqualTo(new Vector2(0.222f, 0.222f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[1].delta,
-            Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
 
         InputSystem.Update();
 
-        Assert.That(Touch.activeTouches[0].delta,
-            Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(2));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(1)
+            .And.With.Property("phase").EqualTo(TouchPhase.Ended)
+            .And.With.Property("delta").EqualTo(new Vector2(0.222f, 0.222f)).Using(Vector2EqualityComparer.Instance)
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.888f, 0.999f)));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.333f, 0.444f)));
+
+        InputSystem.Update();
+
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
+
+        Assert.That(Touch.activeTouches, Has.Exactly(1)
+            .With.Property("touchId").EqualTo(2)
+            .And.With.Property("phase").EqualTo(TouchPhase.Stationary)
+            .And.With.Property("delta").EqualTo(default(Vector2))
+            .And.With.Property("screenPosition").EqualTo(new Vector2(0.333f, 0.444f)));
     }
 
     // Unlike when looking at activeTouches (given that "active" is a frame-to-frame concept here)
@@ -361,6 +505,7 @@ internal class EnhancedTouchTests : InputTestFixture
         BeginTouch(2, new Vector2(0.111f, 0.222f), queueEventOnly: true);
         EndTouch(2, new Vector2(0.111f, 0.222f), queueEventOnly: true);
         InputSystem.Update();
+        InputSystem.Update(); // The end touch lingers for one frame.
 
         runtime.currentTime = 0.876;
         BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
@@ -692,7 +837,7 @@ internal class EnhancedTouchTests : InputTestFixture
 
         TouchSimulation.Enable();
 
-        Set(pointer.position, new Vector2(123, 234));
+        Set(pointer.position, new Vector2(123, 234), queueEventOnly: true);
         Press(pointer.press);
 
         Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
@@ -701,7 +846,7 @@ internal class EnhancedTouchTests : InputTestFixture
         Assert.That(Touch.activeTouches[0].screenPosition, Is.EqualTo(new Vector2(123, 234)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].delta, Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Began));
-        Assert.That(Touch.activeTouches[0].tapCount, Is.EqualTo(0));
+        Assert.That(Touch.activeTouches[0].tapCount, Is.Zero);
         Assert.That(Touch.activeTouches[0].isTap, Is.False);
 
         Move(pointer.position, new Vector2(234, 345));
@@ -712,7 +857,7 @@ internal class EnhancedTouchTests : InputTestFixture
         Assert.That(Touch.activeTouches[0].screenPosition, Is.EqualTo(new Vector2(234, 345)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].delta, Is.EqualTo(new Vector2(111, 111)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Moved));
-        Assert.That(Touch.activeTouches[0].tapCount, Is.EqualTo(0));
+        Assert.That(Touch.activeTouches[0].tapCount, Is.Zero);
         Assert.That(Touch.activeTouches[0].isTap, Is.False);
 
         Release(pointer.press);
@@ -723,7 +868,7 @@ internal class EnhancedTouchTests : InputTestFixture
         Assert.That(Touch.activeTouches[0].screenPosition, Is.EqualTo(new Vector2(234, 345)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].delta, Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Ended));
-        Assert.That(Touch.activeTouches[0].tapCount, Is.EqualTo(0));
+        Assert.That(Touch.activeTouches[0].tapCount, Is.Zero);
         Assert.That(Touch.activeTouches[0].isTap, Is.False);
 
         PressAndRelease(pointer.press);
@@ -733,11 +878,29 @@ internal class EnhancedTouchTests : InputTestFixture
         Assert.That(Touch.activeTouches[0].screen, Is.SameAs(TouchSimulation.instance.simulatedTouchscreen));
         Assert.That(Touch.activeTouches[0].screenPosition, Is.EqualTo(new Vector2(234, 345)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[0].delta, Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Ended));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Began)); // Ended comes in next frame.
         Assert.That(Touch.activeTouches[0].tapCount, Is.EqualTo(1));
         Assert.That(Touch.activeTouches[0].isTap, Is.True);
 
         PressAndRelease(pointer.press);
+
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(2));
+        Assert.That(Touch.activeTouches[0].touchId, Is.EqualTo(2));
+        Assert.That(Touch.activeTouches[0].screen, Is.SameAs(TouchSimulation.instance.simulatedTouchscreen));
+        Assert.That(Touch.activeTouches[0].screenPosition, Is.EqualTo(new Vector2(234, 345)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches[0].delta, Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Ended));
+        Assert.That(Touch.activeTouches[0].tapCount, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].isTap, Is.True);
+        Assert.That(Touch.activeTouches[1].touchId, Is.EqualTo(3));
+        Assert.That(Touch.activeTouches[1].screen, Is.SameAs(TouchSimulation.instance.simulatedTouchscreen));
+        Assert.That(Touch.activeTouches[1].screenPosition, Is.EqualTo(new Vector2(234, 345)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches[1].delta, Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Touch.activeTouches[1].phase, Is.EqualTo(TouchPhase.Began));
+        Assert.That(Touch.activeTouches[1].tapCount, Is.EqualTo(2));
+        Assert.That(Touch.activeTouches[1].isTap, Is.True);
+
+        InputSystem.Update();
 
         Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
         Assert.That(Touch.activeTouches[0].touchId, Is.EqualTo(3));
@@ -747,6 +910,10 @@ internal class EnhancedTouchTests : InputTestFixture
         Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Ended));
         Assert.That(Touch.activeTouches[0].tapCount, Is.EqualTo(2));
         Assert.That(Touch.activeTouches[0].isTap, Is.True);
+
+        InputSystem.Update();
+
+        Assert.That(Touch.activeTouches, Is.Empty);
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -27,6 +27,11 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed compilation issues with XR and VR references when building to platforms that do not have complete XR and VR implementations.
 - Fixed possible `NullReferenceException`s on ARMs with controls that receive automatic memory offsets.
 - Fixed `TouchControl.tapCount` resetting to 0 when "Script Debugging" is enabled (case 1194636).
+- Fixed `Touch.activeTouches` not having a `TouchPhase.Began` entry for touches that moved in the same frame that they began in ([case 1230656](https://issuetracker.unity3d.com/issues/input-system-mobile-enhancedtouch-screen-taps-start-with-moved-or-stationary-phase-instead-of-began)).
+- Fixed sequential taps causing touches to get stuck in `Touch.activeTouches`.
+- Improved performance of `Touch.activeTouches` (most notably, a lot of time was spent in endlessly repetitive safety checks).
+- Fixed `EnhancedTouch` APIs not indicating that they need to be enabled with `EnhancedTouchSupport.Enable()`.
+  - The APIs now throw `InvalidOperationException` when used without being enabled.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/Documentation~/Touch.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Touch.md
@@ -9,7 +9,7 @@ Touch support is divided into:
 * low-level support implemented in the [`Touchscreen`](#touchscreen-device) class.
 * high-level support implemented in the [`EnhancedTouch.Touch`](#enhancedtouchtouch-class) class.
 
->__NOTE__: It is recommended to __NOT__ use [`Touchscreen`](#touchscreen-device) for polling. If you want to read out touches similar to [`UnityEngine.Input.touches`](https://docs.unity3d.com/ScriptReference/Input-touches.html), check out [`EnhancedTouch`](#enhancedtouchtouch-class). If you read out touch state from [`Touchscreen`](#touchscreen-device) directly inside of `Update` or `FixedUpdate` methods, you will miss changes in touch state.
+>__Note__: You should not use [`Touchscreen`](#touchscreen-device) for polling. If you want to read out touches similar to [`UnityEngine.Input.touches`](https://docs.unity3d.com/ScriptReference/Input-touches.html), see [`EnhancedTouch`](#enhancedtouchtouch-class). If you read out touch state from [`Touchscreen`](#touchscreen-device) directly inside of the `Update` or `FixedUpdate` methods, your app will miss changes in touch state.
 
 Touch input is supported on Android, iOS, Windows, and the Universal Windows Platform (UWP).
 
@@ -60,7 +60,7 @@ If you bind a single Action to input from multiple touches, you should set the A
 
 The [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.html) class provides a polling API for touches similar to [`UnityEngine.Input.touches`](https://docs.unity3d.com/ScriptReference/Input-touches.html). You can use it to query touches on a frame-by-frame basis.
 
-As the API comes with a certain overhead due to having to record touches as they happen, it must be explicitly enabled. You can do so by calling [`EnhancedTouchSupport.Enable()`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html#UnityEngine_InputSystem_EnhancedTouch_EnhancedTouchSupport_Enable):
+Because the API comes with a certain overhead due to having to record touches as they happen, you must explicitly enable it. To do this, call [`EnhancedTouchSupport.Enable()`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html#UnityEngine_InputSystem_EnhancedTouch_EnhancedTouchSupport_Enable):
 
 ```
     using UnityEngine.InputSystem.EnhancedTouch;

--- a/Packages/com.unity.inputsystem/Documentation~/Touch.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Touch.md
@@ -1,13 +1,15 @@
 # Touch support
 
 * [`Touchscreen` Device](#touchscreen-device)
+* [Using Touch with Actions](#using-touch-with-actionsactionsmd)
 * [`Touch` class](#enhancedtouchtouch-class)
-    * [Using Touch with Actions](#using-touch-with-actionsactionsmd)
 * [Touch Simulation](#touch-simulation)
 
 Touch support is divided into:
 * low-level support implemented in the [`Touchscreen`](#touchscreen-device) class.
 * high-level support implemented in the [`EnhancedTouch.Touch`](#enhancedtouchtouch-class) class.
+
+>__NOTE__: It is recommended to __NOT__ use [`Touchscreen`](#touchscreen-device) for polling. If you want to read out touches similar to [`UnityEngine.Input.touches`](https://docs.unity3d.com/ScriptReference/Input-touches.html), check out [`EnhancedTouch`](#enhancedtouchtouch-class). If you read out touch state from [`Touchscreen`](#touchscreen-device) directly inside of `Update` or `FixedUpdate` methods, you will miss changes in touch state.
 
 Touch input is supported on Android, iOS, Windows, and the Universal Windows Platform (UWP).
 
@@ -56,7 +58,9 @@ If you bind a single Action to input from multiple touches, you should set the A
 
 ## `EnhancedTouch.Touch` Class
 
-The [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.html) class provides enhanced touch support. To enable it, call [`EnhancedTouchSupport.Enable()`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html#UnityEngine_InputSystem_EnhancedTouch_EnhancedTouchSupport_Enable):
+The [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.html) class provides a polling API for touches similar to [`UnityEngine.Input.touches`](https://docs.unity3d.com/ScriptReference/Input-touches.html). You can use it to query touches on a frame-by-frame basis.
+
+As the API comes with a certain overhead due to having to record touches as they happen, it must be explicitly enabled. You can do so by calling [`EnhancedTouchSupport.Enable()`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html#UnityEngine_InputSystem_EnhancedTouch_EnhancedTouchSupport_Enable):
 
 ```
     using UnityEngine.InputSystem.EnhancedTouch;
@@ -66,7 +70,7 @@ The [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.h
     EnhancedTouchSupport.Enable();
 ```
 
->__Note__: Touch and [`Touchscreen`](../api/UnityEngine.InputSystem.Touchscreen.html) don't require [`EnhancedTouchSupport`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html) to be enabled. You only need to call [`EnhancedTouchSupport.Enable()`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html#UnityEngine_InputSystem_EnhancedTouch_EnhancedTouchSupport_Enable) if you want to use the [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.html) API.
+>__Note__: [`Touchscreen`](../api/UnityEngine.InputSystem.Touchscreen.html) does not require [`EnhancedTouchSupport`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html) to be enabled. You only need to call [`EnhancedTouchSupport.Enable()`](../api/UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.html#UnityEngine_InputSystem_EnhancedTouch_EnhancedTouchSupport_Enable) if you want to use the [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.html) API.
 
 The [`EnhancedTouch.Touch`](../api/UnityEngine.InputSystem.EnhancedTouch.Touch.html) API is designed to provide access to touch information along two dimensions:
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastTouchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastTouchscreen.cs
@@ -518,7 +518,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 35,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -998,7 +998,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 91,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -1370,7 +1370,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 147,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -1742,7 +1742,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 203,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -2114,7 +2114,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 259,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -2486,7 +2486,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 315,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -2858,7 +2858,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 371,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -3230,7 +3230,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 427,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -3602,7 +3602,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 483,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -3974,7 +3974,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 539,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)
@@ -4346,7 +4346,7 @@ namespace UnityEngine.InputSystem
                 {
                     format = new FourCC(1112101920),
                     byteOffset = 595,
-                    bitOffset = 5,
+                    bitOffset = 4,
                     sizeInBits = 1
                 })
                 .WithMinAndMax(0, 1)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -29,11 +29,11 @@ namespace UnityEngine.InputSystem.LowLevel
     [Flags]
     internal enum TouchFlags : byte
     {
+        IndirectTouch = 1 << 0,
+
         // NOTE: Leaving the first 3 bits for native.
 
-        IndirectTouch = 1 << 0,
         PrimaryTouch = 1 << 3,
-
         TapPress = 1 << 4,
         TapRelease = 1 << 5,
 
@@ -87,7 +87,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// After a touch has ended or been canceled, an ID can be reused.
         /// </remarks>
         /// <seealso cref="TouchControl.touchId"/>
-        [InputControl(displayName = "Touch ID", layout = "Integer", synthetic = true)]
+        [InputControl(displayName = "Touch ID", layout = "Integer", synthetic = true, dontReset = true)]
         [FieldOffset(0)]
         public int touchId;
 
@@ -96,7 +96,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <value>Screen-space position of the touch.</value>
         /// <seealso cref="TouchControl.position"/>
-        [InputControl(displayName = "Position")]
+        [InputControl(displayName = "Position", dontReset = true)]
         [FieldOffset(4)]
         public Vector2 position;
 
@@ -159,7 +159,7 @@ namespace UnityEngine.InputSystem.LowLevel
         byte displayIndex;
 
         [InputControl(name = "indirectTouch", displayName = "Indirect Touch?", layout = "Button", bit = 0, synthetic = true)]
-        [InputControl(name = "tap", displayName = "Tap", layout = "Button", bit = 5)]
+        [InputControl(name = "tap", displayName = "Tap", layout = "Button", bit = 4)]
         [FieldOffset(35)]
         public byte flags;
 
@@ -215,9 +215,8 @@ namespace UnityEngine.InputSystem.LowLevel
         phase == TouchPhase.Stationary;
 
         /// <summary>
-        /// Whether  TODO
+        /// Whether, after not having any touch contacts, this is part of the first touch contact that started.
         /// </summary>
-        /// <value>Whether the touch is the first TODO</value>
         /// <remarks>
         /// This flag will be set internally by <see cref="Touchscreen"/>. Generally, it is
         /// not necessary to set this bit manually when feeding data to Touchscreens.
@@ -276,7 +275,7 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
-        public bool isTapRelease
+        internal bool isTapRelease
         {
             get => (flags & (byte)TouchFlags.TapRelease) != 0;
             set
@@ -851,10 +850,10 @@ namespace UnityEngine.InputSystem
                     if (primaryTouchState->isNoneEndedOrCanceled)
                     {
                         newTouchState.isPrimaryTouch = true;
-                        InputState.Change(primaryTouch, newTouchState, eventPtr: eventPtr);
+                        InputState.Change(primaryTouch, ref newTouchState, eventPtr: eventPtr);
                     }
 
-                    InputState.Change(touches[i], newTouchState, eventPtr: eventPtr);
+                    InputState.Change(touches[i], ref newTouchState, eventPtr: eventPtr);
 
                     Profiler.EndSample();
                     return;
@@ -927,12 +926,12 @@ namespace UnityEngine.InputSystem
             // Press.
             state.isTapPress = true;
             state.isTapRelease = false;
-            InputState.Change(control, state, eventPtr: eventPtr);
+            InputState.Change(control, ref state, eventPtr: eventPtr);
 
             // Release.
             state.isTapPress = false;
             state.isTapRelease = true;
-            InputState.Change(control, state, eventPtr: eventPtr);
+            InputState.Change(control, ref state, eventPtr: eventPtr);
             state.isTapRelease = false;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -87,7 +87,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// After a touch has ended or been canceled, an ID can be reused.
         /// </remarks>
         /// <seealso cref="TouchControl.touchId"/>
-        [InputControl(displayName = "Touch ID", layout = "Integer", synthetic = true, dontReset = true)]
+        [InputControl(displayName = "Touch ID", layout = "Integer", synthetic = true)]
         [FieldOffset(0)]
         public int touchId;
 
@@ -96,7 +96,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <value>Screen-space position of the touch.</value>
         /// <seealso cref="TouchControl.position"/>
-        [InputControl(displayName = "Position", dontReset = true)]
+        [InputControl(displayName = "Position")]
         [FieldOffset(4)]
         public Vector2 position;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -451,7 +451,7 @@ namespace UnityEngine.InputSystem.Editor
                                     var code = InputLayoutCodeGenerator.GenerateCodeFileForDeviceLayout(layoutItem.layoutName, fileName, prefix: "Fast");
                                     File.WriteAllText(fileName, code);
                                     if (isInAssets)
-                                        AssetDatabase.ImportAsset(fileName);
+                                        AssetDatabase.Refresh();
                                 }
                             });
                         }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
@@ -60,6 +60,11 @@ namespace UnityEngine.InputSystem.LowLevel
             if (!ptr.IsA<DeltaStateEvent>())
                 throw new InvalidCastException($"Cannot cast event with type '{ptr.type}' into DeltaStateEvent");
 
+            return FromUnchecked(ptr);
+        }
+
+        internal static DeltaStateEvent* FromUnchecked(InputEventPtr ptr)
+        {
             return (DeltaStateEvent*)ptr.data;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
@@ -244,7 +244,14 @@ namespace UnityEngine.InputSystem.LowLevel
             // end up overwriting the data we need to find the next event in memory.
             var newReadPos = currentReadPos;
             if (numRemainingEvents > 1)
+            {
+                // Don't perform safety check in non-debug builds.
+                #if UNITY_EDITOR || DEVELOPMENT_BUILD
                 newReadPos = InputEvent.GetNextInMemoryChecked(currentReadPos, ref this);
+                #else
+                newReadPos = InputEvent.GetNextInMemory(currentReadPos);
+                #endif
+            }
 
             // If the current event should be left in the buffer, advance write position.
             if (leaveEventInBuffer)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventPtr.cs
@@ -140,10 +140,11 @@ namespace UnityEngine.InputSystem.LowLevel
         {
             get
             {
-                if (IsA<StateEvent>())
-                    return StateEvent.From(this)->stateFormat;
-                if (IsA<DeltaStateEvent>())
-                    return DeltaStateEvent.From(this)->stateFormat;
+                var eventType = type;
+                if (eventType == StateEvent.Type)
+                    return StateEvent.FromUnchecked(this)->stateFormat;
+                if (eventType == DeltaStateEvent.Type)
+                    return DeltaStateEvent.FromUnchecked(this)->stateFormat;
                 throw new InvalidOperationException("Event must be a StateEvent or DeltaStateEvent but is " + this);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
@@ -1,11 +1,18 @@
+using System;
+using System.Diagnostics;
 using UnityEngine.InputSystem.LowLevel;
-using UnityEngine.InputSystem.Utilities;
+
+////REVIEW: this *really* should be renamed to TouchPolling or something like that
+
+////REVIEW: Should this auto-enable itself when the API is used? Problem with this is that it means the first touch inputs will get missed
+////        as by the time the API is polled, we're already into the first frame.
 
 ////TODO: gesture support
-////TODO: mouse/touch simulation support
 ////TODO: high-frequency touch support
 
 ////REVIEW: have TouchTap, TouchSwipe, etc. wrapper MonoBehaviours like LeanTouch?
+
+////TODO: as soon as we can break the API, remove the EnhancedTouchSupport class altogether and rename UnityEngine.InputSystem.EnhancedTouch to TouchPolling
 
 namespace UnityEngine.InputSystem.EnhancedTouch
 {
@@ -158,6 +165,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 return;
             TearDownState();
             SetUpState();
+        }
+
+        [Conditional("DEVELOPMENT_BUILD")]
+        [Conditional("UNITY_EDITOR")]
+        internal static void CheckEnabled()
+        {
+            if (!enabled)
+                throw new InvalidOperationException("EnhancedTouch API is not enabled; call EnhancedTouchSupport.Enable()");
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -148,7 +148,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         private unsafe void OnTouchRecorded(InputStateHistory.Record record)
         {
             var recordIndex = record.recordIndex;
-            var touchHeader = m_StateHistory.GetRecordHeaderUnchecked(recordIndex);
+            var touchHeader = m_StateHistory.GetRecordUnchecked(recordIndex);
             var touchState = (TouchState*)touchHeader->statePtrWithoutControlIndex; // m_StateHistory is bound to a single TouchControl.
             touchState->updateStepCount = InputUpdate.s_UpdateStepCount;
 
@@ -170,7 +170,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 if (recordIndex != m_StateHistory.m_HeadIndex)
                 {
                     var previousRecordIndex = recordIndex == 0 ? m_StateHistory.historyDepth - 1 : recordIndex - 1;
-                    var previousTouchHeader = m_StateHistory.GetRecordHeaderUnchecked(previousRecordIndex);
+                    var previousTouchHeader = m_StateHistory.GetRecordUnchecked(previousRecordIndex);
                     var previousTouchState = (TouchState*)previousTouchHeader->statePtrWithoutControlIndex;
                     touchState->delta -= previousTouchState->delta;
                     touchState->beganInSameFrame = previousTouchState->beganInSameFrame &&

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -1,6 +1,5 @@
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.LowLevel;
-using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.EnhancedTouch
@@ -79,7 +78,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         }
 
         /// <summary>
-        /// The currently ongoing for the finger or <c>default(Touch)</c> (with <see cref="Touch.valid"/> abeing false)
+        /// The currently ongoing touch for the finger or <c>default(Touch)</c> (with <see cref="Touch.valid"/> being false)
         /// if no touch is currently in progress on the finger.
         /// </summary>
         public Touch currentTouch
@@ -127,7 +126,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             m_StateHistory.StartRecording();
         }
 
-        private static bool ShouldRecordTouch(InputControl control, double time, InputEventPtr eventPtr)
+        private static unsafe bool ShouldRecordTouch(InputControl control, double time, InputEventPtr eventPtr)
         {
             // We only want to record changes that come from events. We ignore internal state
             // changes that Touchscreen itself generates. This includes the resetting of deltas.
@@ -135,12 +134,12 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             if (!eventPtr.valid)
                 return false;
 
-            var touchControl = (TouchControl)control;
-            var touch = touchControl.ReadValue();
+            // Direct memory access for speed.
+            var currentTouchState = (TouchState*)((byte*)control.currentStatePtr + control.stateBlock.byteOffset);
 
-            // Touchscreen will record a button down and button up a TouchControl when a tap occurs.
+            // Touchscreen will record a button down and button up on a TouchControl when a tap occurs.
             // We only want to record the button down, not the button up.
-            if (touch.phase == TouchPhase.Ended && !touch.isTap && touch.tapCount > 0)
+            if (currentTouchState->isTapRelease)
                 return false;
 
             return true;
@@ -148,12 +147,17 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
         private unsafe void OnTouchRecorded(InputStateHistory.Record record)
         {
-            var touchState = (TouchState*)record.GetUnsafeMemoryPtr();
+            var recordIndex = record.recordIndex;
+            var touchHeader = m_StateHistory.GetRecordHeaderUnchecked(recordIndex);
+            var touchState = (TouchState*)touchHeader->statePtrWithoutControlIndex; // m_StateHistory is bound to a single TouchControl.
+            touchState->updateStepCount = InputUpdate.s_UpdateStepCount;
+
+            // Invalidate activeTouches.
             Touch.s_PlayerState.haveBuiltActiveTouches = false;
 
             // Record the extra data we maintain for each touch.
-            var extraData = (Touch.ExtraDataPerTouchState*)record.GetUnsafeExtraMemoryPtr();
-            extraData->updateStepCount = Touch.s_PlayerState.updateStepCount;
+            var extraData = (Touch.ExtraDataPerTouchState*)((byte*)touchHeader + m_StateHistory.bytesPerRecord -
+                UnsafeUtility.SizeOf<Touch.ExtraDataPerTouchState>());
             extraData->uniqueId = ++Touch.s_PlayerState.lastId;
 
             // We get accumulated deltas from Touchscreen. Store the accumulated
@@ -161,14 +165,25 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             extraData->accumulatedDelta = touchState->delta;
             if (touchState->phase != TouchPhase.Began)
             {
-                var previous = record.previous;
-                if (previous.valid)
-                    touchState->delta -= ((TouchState*)previous.GetUnsafeMemoryPtr())->delta;
+                // Inlined (instead of just using record.previous) for speed. Bypassing
+                // the safety checks here.
+                if (recordIndex != m_StateHistory.m_HeadIndex)
+                {
+                    var previousRecordIndex = recordIndex == 0 ? m_StateHistory.historyDepth - 1 : recordIndex - 1;
+                    var previousTouchHeader = m_StateHistory.GetRecordHeaderUnchecked(previousRecordIndex);
+                    var previousTouchState = (TouchState*)previousTouchHeader->statePtrWithoutControlIndex;
+                    touchState->delta -= previousTouchState->delta;
+                    touchState->beganInSameFrame = previousTouchState->beganInSameFrame &&
+                        previousTouchState->updateStepCount == touchState->updateStepCount;
+                }
+            }
+            else
+            {
+                touchState->beganInSameFrame = true;
             }
 
             // Trigger callback.
-            var statePtr = (TouchState*)record.GetUnsafeMemoryPtr();
-            switch (statePtr->phase)
+            switch (touchState->phase)
             {
                 case TouchPhase.Began:
                     DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_OnFingerDown, this, "Touch.onFingerDown");
@@ -188,7 +203,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             Debug.Assert(uniqueId != default, "0 is not a valid ID");
             foreach (var record in m_StateHistory)
             {
-                if (((Touch.ExtraDataPerTouchState*)record.GetUnsafeExtraMemoryPtr())->uniqueId == uniqueId)
+                if (((Touch.ExtraDataPerTouchState*)record.GetUnsafeExtraMemoryPtrUnchecked())->uniqueId == uniqueId)
                     return new Touch(this, record);
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -9,6 +9,8 @@ using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: record velocity on touches? or add method to very easily get the data?
 
+////REVIEW: do we need to keep old touches around on activeTouches like the old UnityEngine touch API?
+
 namespace UnityEngine.InputSystem.EnhancedTouch
 {
     /// <summary>
@@ -78,6 +80,32 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         /// <seealso cref="isInProgress"/>
         /// <seealso cref="TouchControl.phase"/>
         public TouchPhase phase => state.phase;
+
+        /// <summary>
+        /// Whether the touch has begun this frame, i.e. whether <see cref="phase"/> is <see cref="TouchPhase.Began"/>.
+        /// </summary>
+        /// <seealso cref="phase"/>
+        /// <seealso cref="ended"/>
+        /// <seealso cref="inProgress"/>
+        public bool began => phase == TouchPhase.Began;
+
+        /// <summary>
+        /// Whether the touch is currently in progress, i.e. whether <see cref="phase"/> is either
+        /// <see cref="TouchPhase.Moved"/>, <see cref="TouchPhase.Stationary"/>, or <see cref="TouchPhase.Began"/>.
+        /// </summary>
+        /// <seealso cref="phase"/>
+        /// <seealso cref="began"/>
+        /// <seealso cref="ended"/>
+        public bool inProgress => phase == TouchPhase.Moved || phase == TouchPhase.Stationary || phase == TouchPhase.Began;
+
+        /// <summary>
+        /// Whether the touch has ended this frame, i.e. whether <see cref="phase"/> is either
+        /// <see cref="TouchPhase.Ended"/> or <see cref="TouchPhase.Canceled"/>.
+        /// </summary>
+        /// <seealso cref="phase"/>
+        /// <seealso cref="began"/>
+        /// <seealso cref="isInProgress"/>
+        public bool ended => phase == TouchPhase.Ended || phase == TouchPhase.Canceled;
 
         /// <summary>
         /// Unique ID of the touch as (usually) assigned by the platform.
@@ -227,7 +255,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             }
         }
 
-        internal uint updateStepCount => extraData.updateStepCount;
+        internal uint updateStepCount => state.updateStepCount;
         internal uint uniqueId => extraData.uniqueId;
 
         private unsafe ref TouchState state => ref *(TouchState*)m_TouchRecord.GetUnsafeMemoryPtr();
@@ -254,13 +282,55 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         /// All touches that are either on-going as of the current frame or have ended in the current frame.
         /// </summary>
         /// <remarks>
-        /// Note that the fact that ended touches are being kept around until the end of a frame means that this
-        /// array may have more touches than the total number of concurrent touches supported by the system.
+        /// A touch that begins in a frame will always have its phase set to <see cref="TouchPhase.Began"/> even
+        /// if there was also movement (or even an end/cancellation) for the touch in the same frame.
+        ///
+        /// A touch that begins and ends in the same frame will have its <see cref="TouchPhase.Began"/> surface
+        /// in that frame and then another entry with <see cref="TouchPhase.Ended"/> surface in the
+        /// <em>next</em> frame. This logic implies that there can be more active touches than concurrent touches
+        /// supported by the hardware/platform.
+        ///
+        /// A touch that begins and moves in the same frame will have its <see cref="TouchPhase.Began"/> surface
+        /// in that frame and then another entry with <see cref="TouchPhase.Moved"/> and the screen motion
+        /// surface in the <em>next</em> frame <em>except</em> if the touch also ended in the frame (in which
+        /// case <see cref="phase"/> will be <see cref="TouchPhase.Ended"/> instead of <see cref="TouchPhase.Moved"/>).
+        ///
+        /// Note that the touches reported by this API do <em>not</em> necessarily have to match the contents of
+        /// <see href="https://docs.unity3d.com/ScriptReference/Input-touches.html">UnityEngine.Input.touches</see>.
+        /// The reason for this is that the <c>UnityEngine.Input</c> API and the Input System API flush their input
+        /// queues at different points in time and may thus have a different view on available input. In particular,
+        /// the Input System event queue is flushed <em>later</em> in the frame than inputs for <c>UnityEngine.Input</c>
+        /// and may thus have newer inputs available. On Android, for example, touch input is gathered from a separate
+        /// UI thread and fed into the input system via a "background" event queue that can gather input asynchronously.
+        /// Due to this setup, touch events that will reach <c>UnityEngine.Input</c> only in the next frame may have
+        /// already reached the Input System.
+        ///
+        /// <example>
+        /// <code>
+        /// void Awake()
+        /// {
+        ///     // Enable EnhancedTouch.
+        ///     EnhancedTouchSupport.Enable();
+        /// }
+        ///
+        /// void Update()
+        /// {
+        ///     foreach (var touch in Touch.activeTouches)
+        ///         if (touch.began)
+        ///             Debug.Log($"Touch {touch} started this frame");
+        ///         else if (touch.ended)
+        ///             Debug.Log($"Touch {touch} ended this frame");
+        /// }
+        /// </code>
+        /// </example>
         /// </remarks>
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        /// <seealso cref="activeFingers"/>
         public static ReadOnlyArray<Touch> activeTouches
         {
             get
             {
+                EnhancedTouchSupport.CheckEnabled();
                 // We lazily construct the array of active touches.
                 s_PlayerState.UpdateActiveTouches();
                 return new ReadOnlyArray<Touch>(s_PlayerState.activeTouches, 0, s_PlayerState.activeTouchCount);
@@ -268,36 +338,76 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         }
 
         /// <summary>
-        ///
+        /// An array of all possible concurrent touch contacts, i.e. all concurrent touch contacts regardless of whether
+        /// they are currently active or not.
         /// </summary>
         /// <remarks>
+        /// For querying only active fingers, use <see cref="activeFingers"/>.
+        ///
         /// The length of this array will always correspond to the maximum number of concurrent touches supported by the system.
+        /// Note that the actual number of physically supported concurrent touches as determined by the current hardware and
+        /// operating system may be lower than this number.
         /// </remarks>
-        public static ReadOnlyArray<Finger> fingers =>
-            new ReadOnlyArray<Finger>(s_PlayerState.fingers, 0, s_PlayerState.totalFingerCount);
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        /// <seealso cref="activeTouches"/>
+        /// <seealso cref="activeFingers"/>
+        public static ReadOnlyArray<Finger> fingers
+        {
+            get
+            {
+                EnhancedTouchSupport.CheckEnabled();
+                return new ReadOnlyArray<Finger>(s_PlayerState.fingers, 0, s_PlayerState.totalFingerCount);
+            }
+        }
 
+        /// <summary>
+        /// Set of currently active fingers, i.e. touch contacts that currently have an active touch (as defined by <see cref="activeTouches"/>).
+        /// </summary>
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        /// <seealso cref="activeTouches"/>
+        /// <seealso cref="fingers"/>
         public static ReadOnlyArray<Finger> activeFingers
         {
             get
             {
+                EnhancedTouchSupport.CheckEnabled();
                 // We lazily construct the array of active fingers.
                 s_PlayerState.UpdateActiveFingers();
                 return new ReadOnlyArray<Finger>(s_PlayerState.activeFingers, 0, s_PlayerState.activeFingerCount);
             }
         }
 
-        public static IEnumerable<Touchscreen> screens => s_Touchscreens;
+        /// <summary>
+        /// Return the set of <see cref="Touchscreen"/>s on which touch input is monitored.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        public static IEnumerable<Touchscreen> screens
+        {
+            get
+            {
+                EnhancedTouchSupport.CheckEnabled();
+                return s_Touchscreens;
+            }
+        }
 
+        /// <summary>
+        /// Event that is invoked when a finger touches a <see cref="Touchscreen"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        /// <seealso cref="onFingerUp"/>
+        /// <seealso cref="onFingerMove"/>
         public static event Action<Finger> onFingerDown
         {
             add
             {
+                EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 s_OnFingerDown.AppendWithCapacity(value);
             }
             remove
             {
+                EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 var index = s_OnFingerDown.IndexOf(value);
@@ -306,16 +416,24 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             }
         }
 
+        /// <summary>
+        /// Event that is invoked when a finger stops touching a <see cref="Touchscreen"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        /// <seealso cref="onFingerDown"/>
+        /// <seealso cref="onFingerMove"/>
         public static event Action<Finger> onFingerUp
         {
             add
             {
+                EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 s_OnFingerUp.AppendWithCapacity(value);
             }
             remove
             {
+                EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 var index = s_OnFingerUp.IndexOf(value);
@@ -324,16 +442,25 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             }
         }
 
+        /// <summary>
+        /// Event that is invoked when a finger that is in contact with a <see cref="Touchscreen"/> moves
+        /// on the screen.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"><c>EnhancedTouch</c> has not been enabled via <see cref="EnhancedTouchSupport.Enable"/>.</exception>
+        /// <seealso cref="onFingerUp"/>
+        /// <seealso cref="onFingerDown"/>
         public static event Action<Finger> onFingerMove
         {
             add
             {
+                EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 s_OnFingerMove.AppendWithCapacity(value);
             }
             remove
             {
+                EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
                 var index = s_OnFingerMove.IndexOf(value);
@@ -377,7 +504,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             if (!valid)
                 return "<None>";
 
-            return $"{{finger={finger.index} touchId={touchId} phase={phase} position={screenPosition} time={time}}}";
+            return $"{{id={touchId} finger={finger.index} phase={phase} position={screenPosition} delta={delta} time={time}}}";
         }
 
         public bool Equals(Touch other)
@@ -425,7 +552,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             #endif
         }
 
-        //only have this hooked when we actually need it
+        ////TODO: only have this hooked when we actually need it
         internal static void BeginUpdate()
         {
             #if UNITY_EDITOR
@@ -439,7 +566,11 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             #endif
 
             ++s_PlayerState.updateStepCount;
-            s_PlayerState.haveBuiltActiveTouches = false;
+
+            // If we have any touches in activeTouches that are ended or canceled,
+            // we need to clear them in the next frame.
+            if (s_PlayerState.haveActiveTouchesNeedingRefreshNextUpdate)
+                s_PlayerState.haveBuiltActiveTouches = false;
         }
 
         private readonly Finger m_Finger;
@@ -476,6 +607,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             public int totalFingerCount;
             public uint lastId;
             public bool haveBuiltActiveTouches;
+            public bool haveActiveTouchesNeedingRefreshNextUpdate;
 
             // `activeTouches` adds yet another view of input state that is different from "normal" recorded
             // state history. In this view, touches become stationary in the next update and deltas reset
@@ -546,21 +678,36 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 // Clear activeTouches state.
                 if (activeTouchState == null)
                 {
-                    activeTouchState = new InputStateHistory<TouchState>();
-                    activeTouchState.extraMemoryPerRecord = UnsafeUtility.SizeOf<ExtraDataPerTouchState>();
+                    activeTouchState = new InputStateHistory<TouchState>
+                    {
+                        extraMemoryPerRecord = UnsafeUtility.SizeOf<ExtraDataPerTouchState>()
+                    };
                 }
                 else
+                {
                     activeTouchState.Clear();
+                    activeTouchState.m_ControlCount = 0;
+                    activeTouchState.m_Controls.Clear();
+                }
                 activeTouchCount = 0;
+                haveActiveTouchesNeedingRefreshNextUpdate = false;
+                var currentUpdateStepCount = s_PlayerState.updateStepCount;
+
+                ////OPTIMIZE: Handle touchscreens that have no activity more efficiently
+                ////FIXME: This is sensitive to history size; we probably need to ensure that the Begans and Endeds/Canceleds of touches are always available to us
+                ////       (instead of rebuild activeTouches from scratch each time, may be more useful to update it)
 
                 // Go through fingers and for each one, get the touches that were active this update.
                 for (var i = 0; i < totalFingerCount; ++i)
                 {
-                    var finger = fingers[i];
+                    ref var finger = ref fingers[i];
 
-                    // Skip going through the finger's touches if the finger does not have an active touch.
-                    // Avoids doing unnecessary work of sifting through the finger's history.
-                    if (!finger.currentTouch.valid)
+                    // NOTE: Many of the operations here are inlined in order to not perform the same
+                    //       checks/computations repeatedly.
+
+                    var history = finger.m_StateHistory;
+                    var touchRecordCount = history.Count;
+                    if (touchRecordCount == 0)
                         continue;
 
                     // We're walking newest-first through the touch history but want the resulting list of
@@ -572,52 +719,118 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
                     // Go back in time through the touch records on the finger and collect any touch
                     // active in the current frame. Note that this may yield *multiple* touches for the
-                    // finger as there may be touched that have ended in the frame while in the same
+                    // finger as there may be touches that have ended in the frame while in the same
                     // frame, a new touch was started.
-                    var history = finger.m_StateHistory;
-                    var touchRecordCount = history.Count;
                     var currentTouchId = 0;
-                    for (var n = touchRecordCount - 1; n >= 0; --n)
+                    var currentTouchState = default(TouchState*);
+                    var touchRecordIndex = history.UserIndexToRecordIndex(touchRecordCount - 1); // Start with last record.
+                    var touchRecordHeader = history.GetRecordHeaderUnchecked(touchRecordIndex);
+                    var touchRecordSize = history.bytesPerRecord;
+                    var extraMemoryOffset = touchRecordSize - history.extraMemoryPerRecord;
+                    for (var n = 0; n < touchRecordCount; ++n)
                     {
-                        var record = history[n];
-                        var state = *(TouchState*)record.GetUnsafeMemoryPtr();
-                        var extra = (ExtraDataPerTouchState*)record.GetUnsafeExtraMemoryPtr();
+                        if (n != 0)
+                        {
+                            --touchRecordIndex;
+                            if (touchRecordIndex < 0)
+                            {
+                                // We're wrapping around so buffer must be full. Go to last record in buffer.
+                                //touchRecordIndex = history.historyDepth - history.m_HeadIndex - 1;
+                                touchRecordIndex = history.historyDepth - 1;
+                                touchRecordHeader = history.GetRecordHeaderUnchecked(touchRecordIndex);
+                            }
+                            else
+                            {
+                                touchRecordHeader = (InputStateHistory.RecordHeader*)((byte*)touchRecordHeader - touchRecordSize);
+                            }
+                        }
 
                         // Skip if part of an ongoing touch we've already recorded.
-                        if (state.touchId == currentTouchId && !state.phase.IsEndedOrCanceled())
+                        var touchState = (TouchState*)touchRecordHeader->statePtrWithoutControlIndex; // History is tied to a single TouchControl.
+                        var wasUpdatedThisFrame = touchState->updateStepCount == currentUpdateStepCount;
+                        if (touchState->touchId == currentTouchId && !touchState->phase.IsEndedOrCanceled())
+                        {
+                            // If this is the Began record for the touch and that one happened in
+                            // the current frame, we force the touch phase to Began.
+                            if (wasUpdatedThisFrame && touchState->phase == TouchPhase.Began)
+                            {
+                                Debug.Assert(currentTouchState != null, "Must have current touch record at this point");
+
+                                currentTouchState->phase = TouchPhase.Began;
+                                currentTouchState->position = touchState->position;
+                                currentTouchState->delta = default;
+
+                                haveActiveTouchesNeedingRefreshNextUpdate = true;
+                            }
+
+                            // Need to continue here as there may still be Ended touches that need to
+                            // be taken into account (as in, there may actually be multiple active touches
+                            // for the same finger due to how the polling API works).
                             continue;
+                        }
 
                         // If the touch is older than the current frame and it's a touch that has
                         // ended, we don't need to look further back into the history as anything
                         // coming before that will be equally outdated.
-                        var wasUpdatedThisFrame = extra->updateStepCount == updateStepCount;
-                        if (!wasUpdatedThisFrame && state.phase.IsEndedOrCanceled())
-                            break;
+                        if (touchState->phase.IsEndedOrCanceled())
+                        {
+                            // An exception are touches that both began *and* ended in the previous frame.
+                            // For these, we surface the Began in the previous update and the Ended in the
+                            // current frame.
+                            if (!(touchState->beganInSameFrame && touchState->updateStepCount == currentUpdateStepCount - 1) &&
+                                !wasUpdatedThisFrame)
+                                break;
+                        }
 
                         // Make a copy of the touch so that we can modify data like deltas and phase.
-                        var newRecord = activeTouchState.AddRecord(record);
-                        var newTouch = new Touch(finger, newRecord);
+                        // NOTE: Again, not using AddRecord() for speed.
+                        // NOTE: Unlike `history`, `activeTouchState` stores control indices as each active touch
+                        //       will correspond to a different TouchControl.
+                        var touchExtraState = (ExtraDataPerTouchState*)((byte*)touchRecordHeader + extraMemoryOffset);
+                        var newRecordHeader = activeTouchState.AllocateRecord(out var newRecordIndex);
+                        var newRecordState = (TouchState*)newRecordHeader->statePtrWithControlIndex;
+                        var newRecordExtraState = (ExtraDataPerTouchState*)((byte*)newRecordHeader + activeTouchState.bytesPerRecord - UnsafeUtility.SizeOf<ExtraDataPerTouchState>());
+                        newRecordHeader->time = touchRecordHeader->time;
+                        newRecordHeader->controlIndex = ArrayHelpers.AppendWithCapacity(ref activeTouchState.m_Controls,
+                            ref activeTouchState.m_ControlCount, finger.m_StateHistory.controls[0]);
+
+                        UnsafeUtility.MemCpy(newRecordState, touchState, UnsafeUtility.SizeOf<TouchState>());
+                        UnsafeUtility.MemCpy(newRecordExtraState, touchExtraState, UnsafeUtility.SizeOf<ExtraDataPerTouchState>());
 
                         // If the touch hasn't moved this frame, mark it stationary.
-                        if ((state.phase == TouchPhase.Moved || state.phase == TouchPhase.Began) &&
-                            !wasUpdatedThisFrame)
-                            ((TouchState*)newRecord.GetUnsafeMemoryPtr())->phase = TouchPhase.Stationary;
-
-                        // If the touch is hasn't moved or ended this frame, zero out its delta.
-                        if (!((state.phase == TouchPhase.Moved || state.phase == TouchPhase.Ended) &&
-                              wasUpdatedThisFrame))
+                        // EXCEPT: If we are looked at a Moved touch that also began in the same frame and that
+                        //         frame is the one immediately preceding us. In that case, we want to surface the Moved
+                        //         as if it happened this frame.
+                        var phase = touchState->phase;
+                        if ((phase == TouchPhase.Moved || phase == TouchPhase.Began) &&
+                            !wasUpdatedThisFrame && !(phase == TouchPhase.Moved && touchState->beganInSameFrame && touchState->updateStepCount == currentUpdateStepCount - 1))
                         {
-                            ((TouchState*)newRecord.GetUnsafeMemoryPtr())->delta = new Vector2();
+                            newRecordState->phase = TouchPhase.Stationary;
+                            newRecordState->delta = default;
+                        }
+                        // If the touch wasn't updated this frame, zero out its delta.
+                        else if (!wasUpdatedThisFrame && !touchState->beganInSameFrame)
+                        {
+                            newRecordState->delta = default;
                         }
                         else
                         {
                             // We want accumulated deltas only on activeTouches.
-                            ((TouchState*)newRecord.GetUnsafeMemoryPtr())->delta =
-                                ((ExtraDataPerTouchState*)newRecord.GetUnsafeExtraMemoryPtr())->accumulatedDelta;
+                            newRecordState->delta = newRecordExtraState->accumulatedDelta;
                         }
 
+                        var newRecord = new InputStateHistory<TouchState>.Record(activeTouchState, newRecordIndex, newRecordHeader);
+                        var newTouch = new Touch(finger, newRecord);
+
                         ArrayHelpers.InsertAtWithCapacity(ref activeTouches, ref activeTouchCount, insertAt, newTouch);
-                        currentTouchId = state.touchId;
+
+                        currentTouchId = touchState->touchId;
+                        currentTouchState = newRecordState;
+
+                        // For anything but stationary touches on the activeTouches list, we need a subsequent
+                        // update in the next frame.
+                        if (newTouch.phase != TouchPhase.Stationary)
+                            haveActiveTouchesNeedingRefreshNextUpdate = true;
                     }
                 }
 
@@ -628,10 +841,8 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         internal struct ExtraDataPerTouchState
         {
             public Vector2 accumulatedDelta;
-            public uint updateStepCount;
 
-            // We can't guarantee that the platform is not reusing touch IDs.
-            public uint uniqueId;
+            public uint uniqueId; // Unique ID for touch *record* (i.e. multiple TouchStates having the same touchId will still each have a unique ID).
 
             ////TODO
             //public uint tapCount;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -724,7 +724,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                     var currentTouchId = 0;
                     var currentTouchState = default(TouchState*);
                     var touchRecordIndex = history.UserIndexToRecordIndex(touchRecordCount - 1); // Start with last record.
-                    var touchRecordHeader = history.GetRecordHeaderUnchecked(touchRecordIndex);
+                    var touchRecordHeader = history.GetRecordUnchecked(touchRecordIndex);
                     var touchRecordSize = history.bytesPerRecord;
                     var extraMemoryOffset = touchRecordSize - history.extraMemoryPerRecord;
                     for (var n = 0; n < touchRecordCount; ++n)
@@ -737,7 +737,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                                 // We're wrapping around so buffer must be full. Go to last record in buffer.
                                 //touchRecordIndex = history.historyDepth - history.m_HeadIndex - 1;
                                 touchRecordIndex = history.historyDepth - 1;
-                                touchRecordHeader = history.GetRecordHeaderUnchecked(touchRecordIndex);
+                                touchRecordHeader = history.GetRecordUnchecked(touchRecordIndex);
                             }
                             else
                             {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/TouchSimulation.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/TouchSimulation.cs
@@ -93,7 +93,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 throw new ArgumentNullException(nameof(pointer));
 
             // Ignore if not added.
-            var index = ArrayHelpers.IndexOfReference(m_Sources, pointer, m_NumSources);
+            var index = m_Sources.IndexOfReference(pointer, m_NumSources);
             if (index == -1)
                 return;
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -2,6 +2,8 @@ using System;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.Utilities;
 
+////TODO: method to get raw state pointer for device/control
+
 ////REVIEW: allow to restrict state change monitors to specific updates?
 
 namespace UnityEngine.InputSystem.LowLevel
@@ -55,10 +57,11 @@ namespace UnityEngine.InputSystem.LowLevel
 
             // Make sure event is a StateEvent or DeltaStateEvent and has a format matching the device.
             FourCC stateFormat;
-            if (eventPtr.IsA<StateEvent>())
-                stateFormat = StateEvent.From(eventPtr)->stateFormat;
-            else if (eventPtr.IsA<DeltaStateEvent>())
-                stateFormat = DeltaStateEvent.From(eventPtr)->stateFormat;
+            var eventType = eventPtr.type;
+            if (eventType == StateEvent.Type)
+                stateFormat = StateEvent.FromUnchecked(eventPtr)->stateFormat;
+            else if (eventType == DeltaStateEvent.Type)
+                stateFormat = DeltaStateEvent.FromUnchecked(eventPtr)->stateFormat;
             else
             {
                 #if UNITY_EDITOR
@@ -87,7 +90,25 @@ namespace UnityEngine.InputSystem.LowLevel
         /// also performs related tasks such as checking state change monitors, flipping buffers, or making the respective
         /// device current.
         /// </remarks>
-        public static unsafe void Change<TState>(InputControl control, TState state, InputUpdateType updateType = default,
+        public static void Change<TState>(InputControl control, TState state, InputUpdateType updateType = default,
+            InputEventPtr eventPtr = default)
+            where TState : struct
+        {
+            Change(control, ref state, updateType, eventPtr);
+        }
+
+        /// <summary>
+        /// Perform one update of input state.
+        /// </summary>
+        /// <remarks>
+        /// Incorporates the given state and triggers all state change monitors as needed.
+        ///
+        /// Note that input state changes performed with this method will not be visible on remotes as they will bypass
+        /// event processing. It is effectively equivalent to directly writing into input state memory except that it
+        /// also performs related tasks such as checking state change monitors, flipping buffers, or making the respective
+        /// device current.
+        /// </remarks>
+        public static unsafe void Change<TState>(InputControl control, ref TState state, InputUpdateType updateType = default,
             InputEventPtr eventPtr = default)
             where TState : struct
         {

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
@@ -135,7 +135,7 @@ namespace UnityEngine.InputSystem.LowLevel
                         $"Index {index} is out of range for history with {m_RecordCount} entries", nameof(index));
 
                 var recordIndex = UserIndexToRecordIndex(index);
-                return new Record(this, recordIndex, GetRecordHeader(recordIndex));
+                return new Record(this, recordIndex, GetRecord(recordIndex));
             }
             set
             {
@@ -144,7 +144,7 @@ namespace UnityEngine.InputSystem.LowLevel
                         $"Index {index} is out of range for history with {m_RecordCount} entries", nameof(index));
 
                 var recordIndex = UserIndexToRecordIndex(index);
-                new Record(this, recordIndex, GetRecordHeader(recordIndex)).CopyFrom(value);
+                new Record(this, recordIndex, GetRecord(recordIndex)).CopyFrom(value);
             }
         }
 
@@ -337,16 +337,16 @@ namespace UnityEngine.InputSystem.LowLevel
             return (m_HeadIndex + index) % m_HistoryDepth;
         }
 
-        protected internal unsafe RecordHeader* GetRecordHeader(int index)
+        protected internal unsafe RecordHeader* GetRecord(int index)
         {
             if (!m_RecordBuffer.IsCreated)
                 throw new InvalidOperationException("History buffer has been disposed");
             if (index < 0 || index >= m_HistoryDepth)
                 throw new ArgumentOutOfRangeException(nameof(index));
-            return GetRecordHeaderUnchecked(index);
+            return GetRecordUnchecked(index);
         }
 
-        internal unsafe RecordHeader* GetRecordHeaderUnchecked(int index)
+        internal unsafe RecordHeader* GetRecordUnchecked(int index)
         {
             return (RecordHeader*)((byte*)m_RecordBuffer.GetUnsafePtr() + index * bytesPerRecord);
         }
@@ -522,7 +522,7 @@ namespace UnityEngine.InputSystem.LowLevel
             private readonly int m_IndexPlusOne; // Plus one so that default(int) works for us.
             private uint m_Version;
 
-            internal RecordHeader* header => m_Owner.GetRecordHeader(recordIndex);
+            internal RecordHeader* header => m_Owner.GetRecord(recordIndex);
             internal int recordIndex => m_IndexPlusOne - 1;
             internal uint version => m_Version;
 
@@ -569,7 +569,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (userIndex + 1 >= m_Owner.Count)
                         return default;
                     var recordIndex = m_Owner.UserIndexToRecordIndex(userIndex + 1);
-                    return new Record(m_Owner, recordIndex, m_Owner.GetRecordHeader(recordIndex));
+                    return new Record(m_Owner, recordIndex, m_Owner.GetRecord(recordIndex));
                 }
             }
 
@@ -582,7 +582,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (userIndex - 1 < 0)
                         return default;
                     var recordIndex = m_Owner.UserIndexToRecordIndex(userIndex - 1);
-                    return new Record(m_Owner, recordIndex, m_Owner.GetRecordHeader(recordIndex));
+                    return new Record(m_Owner, recordIndex, m_Owner.GetRecord(recordIndex));
                 }
             }
 
@@ -803,7 +803,7 @@ namespace UnityEngine.InputSystem.LowLevel
                         $"Index {index} is out of range for history with {Count} entries", nameof(index));
 
                 var recordIndex = UserIndexToRecordIndex(index);
-                return new Record(this, recordIndex, GetRecordHeader(recordIndex));
+                return new Record(this, recordIndex, GetRecord(recordIndex));
             }
             set
             {
@@ -811,7 +811,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     throw new ArgumentOutOfRangeException(
                         $"Index {index} is out of range for history with {Count} entries", nameof(index));
                 var recordIndex = UserIndexToRecordIndex(index);
-                new Record(this, recordIndex, GetRecordHeader(recordIndex)).CopyFrom(value);
+                new Record(this, recordIndex, GetRecord(recordIndex)).CopyFrom(value);
             }
         }
 
@@ -854,7 +854,7 @@ namespace UnityEngine.InputSystem.LowLevel
             private readonly int m_IndexPlusOne;
             private uint m_Version;
 
-            internal RecordHeader* header => m_Owner.GetRecordHeader(recordIndex);
+            internal RecordHeader* header => m_Owner.GetRecord(recordIndex);
             internal int recordIndex => m_IndexPlusOne - 1;
 
             public bool valid => m_Owner != default && m_IndexPlusOne != default && header->version == m_Version;
@@ -900,7 +900,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (userIndex + 1 >= m_Owner.Count)
                         return default;
                     var recordIndex = m_Owner.UserIndexToRecordIndex(userIndex + 1);
-                    return new Record(m_Owner, recordIndex, m_Owner.GetRecordHeader(recordIndex));
+                    return new Record(m_Owner, recordIndex, m_Owner.GetRecord(recordIndex));
                 }
             }
 
@@ -913,7 +913,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (userIndex - 1 < 0)
                         return default;
                     var recordIndex = m_Owner.UserIndexToRecordIndex(userIndex - 1);
-                    return new Record(m_Owner, recordIndex, m_Owner.GetRecordHeader(recordIndex));
+                    return new Record(m_Owner, recordIndex, m_Owner.GetRecord(recordIndex));
                 }
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ReadOnlyArray.cs
@@ -146,7 +146,7 @@ namespace UnityEngine.InputSystem.Utilities
             {
                 if (m_Index < m_IndexEnd)
                     ++m_Index;
-                return (m_Index != m_IndexEnd);
+                return m_Index != m_IndexEnd;
             }
 
             public void Reset()


### PR DESCRIPTION
Fixes [1230756](https://issuetracker.unity3d.com/issues/input-system-mobile-enhancedtouch-screen-taps-start-with-moved-or-stationary-phase-instead-of-began) ([internal](https://fogbugz.unity3d.com/f/cases/1230756/)).

Also fixes a number of other issues I found in `EnhancedTouch` along the way.

Finally, greatly improves performance of `Touch.activeTouches`. Should be reduced further but it's a step. Saw a consistent reduction of values >1ms to well below 0.5ms. But yeah, still too much. Most prominent thing I got rid of is excessive safety checks by internally relying on public APIs for iterating the data. Now uses internal access that gets rid of all the needless checking.

>__NOTE__: I discovered a bug in our Android backend which ATM sends the first touch with ID=0. The ID is reserved. @todi1856 has a fix pending. The bug manifests itself in EnhancedTouch by the first touch in the game not having a `Began` phase.