### PR TITLE
FIX: Memory corruption in InputEventTrace (case 1262496).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -1763,6 +1763,8 @@ partial class CoreTests
 
         using (var trace = new InputActionTrace())
         {
+            Assert.That(trace.buffer.capacityInBytes, Is.Zero);
+
             action.performed += trace.RecordAction;
 
             var state = new GamepadState {leftStick = new Vector2(0.123f, 0.234f)};
@@ -1772,6 +1774,7 @@ partial class CoreTests
             InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.W), 0.0987);
             InputSystem.Update();
 
+            Assert.That(trace.buffer.capacityInBytes, Is.EqualTo(2048)); // Default capacity increment.
             Assert.That(trace.count, Is.EqualTo(3));
 
             var events = trace.ToArray();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -32,6 +32,8 @@ however, it has to be formatted properly to pass verification tests.
 - Improved performance of `Touch.activeTouches` (most notably, a lot of time was spent in endlessly repetitive safety checks).
 - Fixed `EnhancedTouch` APIs not indicating that they need to be enabled with `EnhancedTouchSupport.Enable()`.
   - The APIs now throw `InvalidOperationException` when used without being enabled.
+- Fixed memory corruption in `InputEventTrace.AllocateEvent` ([case 1262496](https://issuetracker.unity3d.com/issues/input-system-crash-with-various-stack-traces-when-using-inputactiontrace-dot-subscribetoall))
+  * Manifested itself, for example, as crashes when using `InputActionTrace.SubscribeToAll`.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
@@ -151,25 +151,25 @@ namespace UnityEngine.InputSystem.LowLevel
             var alignedSizeInBytes = sizeInBytes.AlignToMultipleOf(InputEvent.kAlignment);
 
             // See if we need to enlarge our buffer.
+            var necessaryCapacity = m_SizeInBytes + alignedSizeInBytes;
             var currentCapacity = capacityInBytes;
-            if (currentCapacity < alignedSizeInBytes)
+            if (currentCapacity < necessaryCapacity)
             {
                 // Yes, so reallocate.
-                var newCapacity = Math.Max(currentCapacity + capacityIncrementInBytes,
-                    currentCapacity + alignedSizeInBytes);
-                var newSize = this.sizeInBytes + newCapacity;
-                if (newSize > int.MaxValue)
+
+                var newCapacity = necessaryCapacity.AlignToMultipleOf(capacityIncrementInBytes);
+                if (newCapacity > int.MaxValue)
                     throw new NotImplementedException("NativeArray long support");
                 var newBuffer =
-                    new NativeArray<byte>((int)newSize, Allocator.Persistent, NativeArrayOptions.ClearMemory);
+                    new NativeArray<byte>((int)newCapacity, Allocator.Persistent, NativeArrayOptions.ClearMemory);
 
                 if (m_Buffer.IsCreated)
+                {
                     UnsafeUtility.MemCpy(newBuffer.GetUnsafePtr(), m_Buffer.GetUnsafeReadOnlyPtr(), this.sizeInBytes);
-                else
-                    m_SizeInBytes = 0;
+                    if (m_WeOwnTheBuffer)
+                        m_Buffer.Dispose();
+                }
 
-                if (m_WeOwnTheBuffer)
-                    m_Buffer.Dispose();
                 m_Buffer = newBuffer;
                 m_WeOwnTheBuffer = true;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
@@ -13,6 +13,15 @@ namespace UnityEngine.InputSystem.Utilities
             return number + alignment - remainder;
         }
 
+        public static long AlignToMultipleOf(this long number, long alignment)
+        {
+            var remainder = number % alignment;
+            if (remainder == 0)
+                return number;
+
+            return number + alignment - remainder;
+        }
+
         public static uint AlignToMultipleOf(this uint number, uint alignment)
         {
             var remainder = number % alignment;


### PR DESCRIPTION
Fixes [1262496](https://issuetracker.unity3d.com/issues/input-system-crash-with-various-stack-traces-when-using-inputactiontrace-dot-subscribetoall) ([internal](https://fogbugz.unity3d.com/f/cases/1262496/)).

Was a stupid thing where I changed the meaning of `capacity` to be in line with how it is used elsewhere in .NET but then didn't correctly update all the code that depended on the previous meaning.