### PR TITLE
[case 1254568] Align memory for input history records

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -3833,9 +3833,6 @@ partial class CoreTests
 
     [Test]
     [Category("Devices")]
-#if UNITY_ANDROID && !UNITY_EDITOR
-    [Ignore("Case 1254562")]
-#endif
     public unsafe void Devices_WhenFocusIsLost_DevicesAreForciblyReset_ExceptThoseMarkedAsReceivingInputInBackground()
     {
         // TrackedDevice is all noisy controls. We need at least one non-noisy control to fully

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -2602,9 +2602,6 @@ partial class CoreTests
 
     [Test]
     [Category("Devices")]
-#if UNITY_ANDROID && !UNITY_EDITOR
-    [Ignore("Case 1254561")]
-#endif
     public void Devices_CanDetectTouchTaps()
     {
         // Give us known tap settings.

--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -1519,9 +1519,6 @@ partial class CoreTests
 
     [Test]
     [Category("Layouts")]
-#if UNITY_ANDROID && !UNITY_EDITOR
-    [Ignore("Case 1254563")]
-#endif
     public void Layouts_CanAddChildControlToExistingControl_UsingStateFromOtherControl()
     {
         InputSystem.RegisterLayout(@"

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -1208,9 +1208,6 @@ partial class CoreTests
 
     [Test]
     [Category("State")]
-#if UNITY_ANDROID && !UNITY_EDITOR
-    [Ignore("Case 1254568")]
-#endif
     public void State_CanRecordHistory_AndGetCallbacksWhenNewStateIsRecorded()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -1249,9 +1249,6 @@ partial class CoreTests
     // onRecordAdded callback.
     [Test]
     [Category("State")]
-#if UNITY_ANDROID && !UNITY_EDITOR
-    [Ignore("Case 1254569")]
-#endif
     public unsafe void State_CanRecordHistory_AndStoreAdditionalCustomDataForEachStateChange()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 
+- Fixed input history on Android mono build by alligning memory of history records
 - Fixed no input being processed when running a `[UnityTest]` over several frames. Before, this required calling `InputSystem.Update` manually.
 - Fixed clicking on help page button in Unity inspector for Input System components not going to relevant manual pages.
 - Fixed a bug that prevented DualShock controllers from working on tvOS. (case 1221223).

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
@@ -33,7 +33,7 @@ namespace UnityEngine.InputSystem.XR
 
         /// <summary>
         /// Constructor for PoseStates.
-        /// 
+        ///
         /// Useful for creating PoseStates locally (not from <see cref="PoseControl"/>).
         /// </summary>
         /// <param name="isTracked">Value to use for <see cref="isTracked"/></param>
@@ -64,7 +64,7 @@ namespace UnityEngine.InputSystem.XR
         /// <summary>
         /// A Flags Enumeration specifying which other fields in the pose state are valid.
         /// </summary>
-        [FieldOffset(4), InputControl( displayName = "Tracking State", layout = "Integer")]
+        [FieldOffset(4), InputControl(displayName = "Tracking State", layout = "Integer")]
         public TrackingState trackingState;
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace UnityEngine.InputSystem.XR
     /// will not work correctly with a different memory layouts. Additional fields may
     /// be appended to the struct but what's there in the struct has to be located
     /// at exactly those memory addresses.
-    /// 
+    ///
     /// For more information on tracking origins see <see cref="UnityEngine.XR.TrackingOriginModeFlags"/>.
     /// </remarks>
     [Preserve, InputControlLayout(stateType = typeof(PoseState))]

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateHistory.cs
@@ -444,11 +444,11 @@ namespace UnityEngine.InputSystem.LowLevel
         internal readonly bool m_AddNewControls;
 
         internal int bytesPerRecord =>
-            m_StateSizeInBytes +
-            m_ExtraMemoryPerRecord +
-            (m_ControlCount == 1 && !m_AddNewControls
-                ? RecordHeader.kSizeWithoutControlIndex
-                : RecordHeader.kSizeWithControlIndex);
+            (m_StateSizeInBytes +
+                m_ExtraMemoryPerRecord +
+                (m_ControlCount == 1 && !m_AddNewControls
+                    ? RecordHeader.kSizeWithoutControlIndex
+                    : RecordHeader.kSizeWithControlIndex)).AlignToMultipleOf(4);
 
         private struct Enumerator : IEnumerator<Record>
         {


### PR DESCRIPTION
Align memory for input history records. Fixes issue where on Android using mono Null ref exception is thrown when trying to write to non-aligned memory