### PR TITLE
FIX: Tap not working when stacked under MultiTap (case 1261462).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,7 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 
 #### Actions
 
-- Fixed not being able to stack a `MultiTap` on top of a `Tap` ([case 1267805](https://issuetracker.unity3d.com/issues/input-system-multi-tap-interaction-doesnt-get-triggered-when-there-are-2-or-more-bindings-in-the-active-control-scheme)).
+- Fixed not being able to stack a `MultiTap` on top of a `Tap` ([case 1261462](https://issuetracker.unity3d.com/issues/multi-tap-and-tap-interactions-in-the-same-action-doesnt-work-properly)).
 
 ## [1.1.0-preview.1] - 2020-08-20
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+#### Actions
+
+- Fixed not being able to stack a `MultiTap` on top of a `Tap` ([case 1267805](https://issuetracker.unity3d.com/issues/input-system-multi-tap-interaction-doesnt-get-triggered-when-there-are-2-or-more-bindings-in-the-active-control-scheme)).
+
 ## [1.1.0-preview.1] - 2020-08-20
 
 >__The minimum version requirement for the Input System package has been moved up to 2019.4 LTS.__

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1493,8 +1493,9 @@ namespace UnityEngine.InputSystem
             interactionStates[interactionIndex].phase = newPhase;
             interactionStates[interactionIndex].triggerControlIndex = trigger.controlIndex;
             interactionStates[interactionIndex].startTime = trigger.startTime;
+            if (newPhase == InputActionPhase.Performed)
+                interactionStates[interactionIndex].performedTime = trigger.time;
 
-            ////REVIEW: If we want to defer triggering of actions, this is the point where we probably need to cut things off
             // See if it affects the phase of an associated action.
             var actionIndex = bindingStates[bindingIndex].actionIndex; // We already had to tap this array and entry in ProcessControlStateChange.
             if (actionIndex != -1)
@@ -1509,7 +1510,8 @@ namespace UnityEngine.InputSystem
                 else if (newPhase == InputActionPhase.Canceled && actionStates[actionIndex].interactionIndex == trigger.interactionIndex)
                 {
                     // We're canceling but maybe there's another interaction ready
-                    // to go into start phase.
+                    // to go into start phase. *Or* there's an interaction that has
+                    // already performed.
 
                     if (!ChangePhaseOfAction(newPhase, ref trigger))
                         return;
@@ -1519,8 +1521,10 @@ namespace UnityEngine.InputSystem
                     for (var i = 0; i < numInteractions; ++i)
                     {
                         var index = interactionStartIndex + i;
-                        if (index != trigger.interactionIndex && interactionStates[index].phase == InputActionPhase.Started)
+                        if (index != trigger.interactionIndex && (interactionStates[index].phase == InputActionPhase.Started ||
+                                                                  interactionStates[index].phase == InputActionPhase.Performed))
                         {
+                            // Trigger start.
                             var startTime = interactionStates[index].startTime;
                             var triggerForInteraction = new TriggerState
                             {
@@ -1533,6 +1537,22 @@ namespace UnityEngine.InputSystem
                             };
                             if (!ChangePhaseOfAction(InputActionPhase.Started, ref triggerForInteraction))
                                 return;
+
+                            // If the interaction has already performed, trigger it now.
+                            if (interactionStates[index].phase == InputActionPhase.Performed)
+                            {
+                                triggerForInteraction = new TriggerState
+                                {
+                                    phase = InputActionPhase.Performed,
+                                    controlIndex = interactionStates[index].triggerControlIndex,
+                                    bindingIndex = trigger.bindingIndex,
+                                    interactionIndex = index,
+                                    time = interactionStates[index].performedTime, // Time when the interaction performed.
+                                    startTime = startTime,
+                                };
+                                if (!ChangePhaseOfAction(InputActionPhase.Performed, ref triggerForInteraction))
+                                    return;
+                            }
                             break;
                         }
                     }
@@ -1564,7 +1584,14 @@ namespace UnityEngine.InputSystem
             // Exception: if it was performed and we're to remain in started state, set the interaction
             //            to started. Note that for that phase transition, there are no callbacks being
             //            triggered (i.e. we don't call 'started' every time after 'performed').
-            if (newPhase == InputActionPhase.Performed && phaseAfterPerformed != InputActionPhase.Waiting)
+            if (newPhase == InputActionPhase.Performed && actionStates[actionIndex].interactionIndex != trigger.interactionIndex)
+            {
+                // We performed but we're not the interaction driving the action. We want to stay performed to make
+                // sure that if the interaction that is currently driving the action cancels, we get to perform
+                // the action. If we go back to waiting here, then the system can't tell that there's another interaction
+                // ready to perform (in fact, that has already performed).
+            }
+            else if (newPhase == InputActionPhase.Performed && phaseAfterPerformed != InputActionPhase.Waiting)
             {
                 interactionStates[interactionIndex].phase = phaseAfterPerformed;
             }
@@ -1572,7 +1599,6 @@ namespace UnityEngine.InputSystem
             {
                 ResetInteractionState(trigger.mapIndex, trigger.bindingIndex, trigger.interactionIndex);
             }
-            ////TODO: reset entire chain
         }
 
         /// <summary>
@@ -2252,13 +2278,14 @@ namespace UnityEngine.InputSystem
         /// Records the current state of a single interaction attached to a binding.
         /// Each interaction keeps track of its own trigger control and phase progression.
         /// </summary>
-        [StructLayout(LayoutKind.Explicit, Size = 12)]
+        [StructLayout(LayoutKind.Explicit, Size = 20)]
         internal struct InteractionState
         {
             [FieldOffset(0)] private ushort m_TriggerControlIndex;
             [FieldOffset(2)] private byte m_Phase;
             [FieldOffset(3)] private byte m_Flags;
             [FieldOffset(4)] private double m_StartTime;
+            [FieldOffset(12)] private double m_PerformedTime;
 
             public int triggerControlIndex
             {
@@ -2276,6 +2303,12 @@ namespace UnityEngine.InputSystem
             {
                 get => m_StartTime;
                 set => m_StartTime = value;
+            }
+
+            public double performedTime
+            {
+                get => m_PerformedTime;
+                set => m_PerformedTime = value;
             }
 
             public bool isTimerRunning


### PR DESCRIPTION
Fixes [1261462](https://issuetracker.unity3d.com/issues/multi-tap-and-tap-interactions-in-the-same-action-doesnt-work-properly) ([internal](https://fogbugz.unity3d.com/f/cases/1261462/)).
