### PR TITLE
FIX: Drag thresholds in UI deactivated by Sliders (case 1275834).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -374,7 +374,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.leftChildReceiver.events[2].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[2].pointerData.lastPress, Is.Null);
             Assert.That(scene.leftChildReceiver.events[2].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.leftChildReceiver.events[2].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.leftChildReceiver.events[2].pointerData.eligibleForClick, Is.True);
             Assert.That(scene.leftChildReceiver.events[2].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
             Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -441,7 +441,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.Null);
             Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.leftChildReceiver.events[1].pointerData.eligibleForClick, Is.True);
             Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
             Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -469,7 +469,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.leftChildReceiver.events[2].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[2].pointerData.lastPress, Is.Null);
             Assert.That(scene.leftChildReceiver.events[2].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.leftChildReceiver.events[2].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.leftChildReceiver.events[2].pointerData.eligibleForClick, Is.True);
             Assert.That(scene.leftChildReceiver.events[2].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
             Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -497,7 +497,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.leftChildReceiver.events[3].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[3].pointerData.lastPress, Is.Null);
             Assert.That(scene.leftChildReceiver.events[3].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.leftChildReceiver.events[3].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.leftChildReceiver.events[3].pointerData.eligibleForClick, Is.True);
             Assert.That(scene.leftChildReceiver.events[3].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
             Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -563,7 +563,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.Null); // See PointerModel.ButtonState.CopyPressStateTo.
             Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.leftChildReceiver.events[1].pointerData.eligibleForClick, Is.True);
             Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
             Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -619,7 +619,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.leftChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.lastPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[0].pointerData.dragging, Is.False);
-        Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.leftChildReceiver.events[0].pointerData.eligibleForClick, Is.True);
         Assert.That(scene.leftChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -646,7 +646,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.True);
-        Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.leftChildReceiver.events[1].pointerData.eligibleForClick, Is.True);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
@@ -691,7 +691,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.leftChildReceiver.events[0].pointerData.position, Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.delta, Is.EqualTo(thirdScreenPosition - secondScreenPosition).Using(Vector2EqualityComparer.Instance));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(scene.leftGameObject));
-        Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.leftChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject })); // Updated from pointer enter.
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
@@ -741,7 +741,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.True);
-        Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.screenPosition,
@@ -757,7 +757,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.rightChildReceiver.events[0].pointerData.position, Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
         Assert.That(scene.rightChildReceiver.events[0].pointerData.delta, Is.EqualTo(thirdScreenPosition - secondScreenPosition).Using(Vector2EqualityComparer.Instance));
         Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(scene.rightGameObject));
-        Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.rightChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.parentGameObject })); // Right GO gets added after.
         Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
@@ -816,7 +816,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.leftChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.lastPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[0].pointerData.dragging, Is.True);
-        Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.leftChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(isTouch ? Enumerable.Empty<GameObject>() : new[] { scene.rightGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
@@ -839,7 +839,7 @@ internal class UITests : InputTestFixture
         Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.SameAs(scene.leftGameObject)); // Remembers last pointerPress.
         Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.True);
-        Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.True);
+        Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
         Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(isTouch ? Enumerable.Empty<GameObject>() : new[] { scene.rightGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.screenPosition,
@@ -868,7 +868,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.rightChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.lastPress, Is.Null);
             Assert.That(scene.rightChildReceiver.events[0].pointerData.dragging, Is.True);
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.rightChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
@@ -893,7 +893,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.parentReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.parentReceiver.events[0].pointerData.lastPress, Is.Null);
             Assert.That(scene.parentReceiver.events[0].pointerData.dragging, Is.True);
-            Assert.That(scene.parentReceiver.events[0].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.parentReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             ////REVIEW: This behavior is inconsistent between "normal" pointer-enter/exit sequences but is consistent with what StandaloneInputModule does.
             ////        However, it seems wrong that on one path, GOs are removed one-by-one from `hovered` as the callbacks step through the hierarchy, whereas
             ////        on the other path, the list stays unmodified until the end and is then cleared en-bloc.
@@ -920,7 +920,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.rightChildReceiver.events[1].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.rightChildReceiver.events[1].pointerData.lastPress, Is.Null); // See PointerModel.ButtonState.CopyPressStateTo.
             Assert.That(scene.rightChildReceiver.events[1].pointerData.dragging, Is.True);
-            Assert.That(scene.rightChildReceiver.events[1].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.rightChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.rightChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(Enumerable.Empty<GameObject>()));
             Assert.That(scene.rightChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
             Assert.That(scene.rightChildReceiver.events[1].pointerData.pointerCurrentRaycast.screenPosition,
@@ -951,7 +951,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.rightChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.lastPress, Is.Null); // See PointerModel.ButtonState.CopyPressStateTo.
             Assert.That(scene.rightChildReceiver.events[0].pointerData.dragging, Is.True);
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.rightChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
@@ -986,7 +986,7 @@ internal class UITests : InputTestFixture
             Assert.That(scene.rightChildReceiver.events[0].pointerData.rawPointerPress, Is.Null);
             Assert.That(scene.rightChildReceiver.events[0].pointerData.lastPress, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.dragging, Is.False);
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
+            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
             Assert.That(scene.rightChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
             Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
@@ -2477,6 +2477,12 @@ internal class UITests : InputTestFixture
 
         public void OnInitializePotentialDrag(PointerEventData eventData)
         {
+            // Slider sets useDragThreshold to false. Simulate this happening in response to InitializePotentialDrag
+            // to ensure InputSystemUIInputModule handles that correctly.
+            // https://fogbugz.unity3d.com/f/cases/1275834/
+            Assert.That(eventData.useDragThreshold, Is.True); // Module should have initialized to true.
+            eventData.useDragThreshold = false;
+
             events.Add(new Event(EventType.InitializePotentialDrag, ClonePointerEventData(eventData)));
         }
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed player build causing `ProjectSettings.asset` to be checked out in Perforce ([case 1254502](https://issuetracker.unity3d.com/issues/projectsettings-dot-asset-is-checked-out-in-perforce-when-building-a-project-with-the-input-system-package-installed)).
 - Fixed player build corrupting preloaded asset list in `PlayerSettings` if it was modified by another build processor.
 - Fixed remoting in Input Debugger not working for devices in the player that are created from generated layouts (such as XR devices).
+- Fixed use of UI `Slider` causing drag thresholds to no longer work ([case 1275834](https://issuetracker.unity3d.com/issues/inputsystem-drag-threshold-value-is-ignored-for-scroll-view-after-interacting-with-a-slider-slash-scroll-bar)).
 
 #### Actions
 
@@ -70,7 +71,6 @@ however, it has to be formatted properly to pass verification tests.
   * `Vector3Composite`: Works the same way `Vector2Composite` does. Adds a `forward` and `backward` binding in addition to `up`, `down`, `left`, and `right`.
 
 ## [1.1.0-preview.1] - 2020-08-20
->>>>>>> develop
 
 >__The minimum version requirement for the Input System package has been moved up to 2019.4 LTS.__
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
@@ -239,8 +239,21 @@ namespace UnityEngine.InputSystem.Editor
         public override GUIStyle colorTagStyle => Styles.greenRect;
         public bool isSingletonAction => actionMapProperty == null;
 
-        public override string expectedControlLayout =>
-            property.FindPropertyRelative("m_ExpectedControlType").stringValue;
+        public override string expectedControlLayout
+        {
+            get
+            {
+                var expectedControlType = property.FindPropertyRelative("m_ExpectedControlType").stringValue;
+                if (!string.IsNullOrEmpty(expectedControlType))
+                    return expectedControlType;
+
+                var type = property.FindPropertyRelative("m_Type").intValue;
+                if (type == (int)InputActionType.Button)
+                    return "Button";
+
+                return null;
+            }
+        }
 
         public SerializedProperty bindingsArrayProperty => isSingletonAction
         ? property.FindPropertyRelative("m_SingletonActionBindings")

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -348,6 +348,7 @@ namespace UnityEngine.InputSystem.UI
                 eventData.pressPosition = eventData.position;
                 eventData.pointerPressRaycast = eventData.pointerCurrentRaycast;
                 eventData.eligibleForClick = true;
+                eventData.useDragThreshold = true;
 
                 var selectHandler = ExecuteEvents.GetEventHandler<ISelectHandler>(currentOverGo);
 


### PR DESCRIPTION
Fixes [1275834](https://issuetracker.unity3d.com/issues/inputsystem-drag-threshold-value-is-ignored-for-scroll-view-after-interacting-with-a-slider-slash-scroll-bar) ([internal](https://fogbugz.unity3d.com/f/cases/1275834/)).