### PR TITLE
FIX: Debug assert from composites without controls (case 1244988).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed player build causing `ProjectSettings.asset` to be checked out in Perforce ([case 1254502](https://issuetracker.unity3d.com/issues/projectsettings-dot-asset-is-checked-out-in-perforce-when-building-a-project-with-the-input-system-package-installed)).
 - Fixed player build corrupting preloaded asset list in `PlayerSettings` if it was modified by another build processor.
 - Fixed remoting in Input Debugger not working for devices in the player that are created from generated layouts (such as XR devices).
+- Fixed debug assert in `InputDeviceTester` sample when simultaneously pressing two buttons on gamepad ([case 1244988](https://issuetracker.unity3d.com/issues/input-system-runtime-errors-when-pressing-more-than-one-button-at-the-same-time)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1234,8 +1234,6 @@ namespace UnityEngine.InputSystem
                         var firstControlIndex = binding->controlStartIndex;
                         var compositeIndex = binding->compositeOrCompositeBindingIndex;
 
-                        Debug.Assert(firstControlIndex >= 0 && firstControlIndex < totalControlCount,
-                            "Control start index out of range on composite");
                         Debug.Assert(compositeIndex >= 0 && compositeIndex < totalCompositeCount,
                             "Composite index out of range on composite");
 
@@ -1244,6 +1242,9 @@ namespace UnityEngine.InputSystem
                             ++numActuations;
                         if (magnitude > highestActuationLevel)
                         {
+                            Debug.Assert(firstControlIndex >= 0 && firstControlIndex < totalControlCount,
+                                "Control start index out of range on composite");
+
                             controlWithHighestActuation = firstControlIndex;
                             bindingWithHighestActuation = controlIndexToBindingIndex[firstControlIndex];
                             highestActuationLevel = magnitude;


### PR DESCRIPTION
Fixes [1244988](https://issuetracker.unity3d.com/issues/input-system-runtime-errors-when-pressing-more-than-one-button-at-the-same-time) ([internal](https://fogbugz.unity3d.com/f/cases/1244988/)).

Just a misplaced `Debug.Assert`. No functional impact.