### PR TITLE
FIX: Composites failing initial state check (case 1274977).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -519,7 +519,7 @@ partial class CoreTests
         var keyboard = InputSystem.AddDevice<Keyboard>();
 
         var map = new InputActionMap();
-        
+
         var action = map.AddAction("action", type: InputActionType.Value);
         action.AddCompositeBinding("2DVector")
             .With("Up", "<Keyboard>/w")
@@ -528,30 +528,30 @@ partial class CoreTests
             .With("Right", "<Keyboard>/d");
 
         Press(keyboard.dKey);
-        
+
         map.Enable();
         InputSystem.Update();
 
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
-        
+
         map.Disable();
         InputSystem.Update();
-        
+
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
-        
+
         map.Enable();
         InputSystem.Update();
-        
+
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
-        
+
         map.Disable();
         InputSystem.Update();
-        
+
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
-        
+
         map.Enable();
         InputSystem.Update();
-        
+
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -508,6 +508,53 @@ partial class CoreTests
         }
     }
 
+    // Composites have logic to ignore control state changes coming from the same event. We had a bug where
+    // this threw off initial value checks for actions as we made up a fake event. Specifically test
+    // for this here.
+    // https://fogbugz.unity3d.com/f/cases/1274977/
+    [Test]
+    [Category("Actions")]
+    public void Actions_ValueActionsReactToCurrentStateOfControlWhenEnabled_WithCompositeBinding()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        var map = new InputActionMap();
+        
+        var action = map.AddAction("action", type: InputActionType.Value);
+        action.AddCompositeBinding("2DVector")
+            .With("Up", "<Keyboard>/w")
+            .With("Down", "<Keyboard>/s")
+            .With("Left", "<Keyboard>/a")
+            .With("Right", "<Keyboard>/d");
+
+        Press(keyboard.dKey);
+        
+        map.Enable();
+        InputSystem.Update();
+
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
+        
+        map.Disable();
+        InputSystem.Update();
+        
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+        
+        map.Enable();
+        InputSystem.Update();
+        
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
+        
+        map.Disable();
+        InputSystem.Update();
+        
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero).Using(Vector2EqualityComparer.Instance));
+        
+        map.Enable();
+        InputSystem.Update();
+        
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.right).Using(Vector2EqualityComparer.Instance));
+    }
+
     // Value actions perform an initial state check when enabled. These state checks are performed
     // from InputSystem.onBeforeUpdate. However, if we enable an action as part of event processing,
     // we will react to the state of a control right away and should then not ALSO perform an

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed rebinds triggered by the Enter key causing stuck Enter key states ([case 1271591](https://issuetracker.unity3d.com/issues/input-system-rebind-action-requires-two-inputs-slash-presses-when-using-the-enter-key)).
 - Fixed `Map index on trigger` and `IndexOutOfRangeException` errors when using multiple Interactions on the same Action. ([case 1253034](https://issuetracker.unity3d.com/issues/map-index-on-trigger-and-indexoutofrangeexception-errors-when-using-multiple-interactions-on-the-same-action)).
 - Fixed context menu in action editor not filtering out composites the same way that the `+` icon menu does. This led to, for example, a "2D Vector" composite being shown as an option for a button type action.
+- Fixed initial state checks for composite bindings failing if performed repeatedly. For example, doing a `ReadValue<Vector2>` for a WASD binding would return an incorrect value after disabling the the map twice while no input from the keyboard was received ([case 1274977](https://issuetracker.unity3d.com/issues/input-system-cannot-read-vector2-values-after-inputactionset-has-been-disabled-and-enabled-twice)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -728,7 +728,7 @@ namespace UnityEngine.InputSystem
                 var mapControlAndBindingIndex = ToCombinedMapAndControlAndBindingIndex(mapIndex, controlIndex, bindingIndex);
                 var bindingStatePtr = &bindingStates[bindingIndex];
                 if (bindingStatePtr->wantsInitialStateCheck)
-                    bindingStatePtr->initialStateCheckPending = true;
+                    SetInitialStateCheckPending(bindingStatePtr, true);
                 manager.AddStateChangeMonitor(controls[controlIndex], this, mapControlAndBindingIndex);
 
                 SetControlEnabled(controlIndex, true);
@@ -753,10 +753,26 @@ namespace UnityEngine.InputSystem
                 var mapControlAndBindingIndex = ToCombinedMapAndControlAndBindingIndex(mapIndex, controlIndex, bindingIndex);
                 var bindingStatePtr = &bindingStates[bindingIndex];
                 if (bindingStatePtr->wantsInitialStateCheck)
-                    bindingStatePtr->initialStateCheckPending = false;
+                    SetInitialStateCheckPending(bindingStatePtr, false);
                 manager.RemoveStateChangeMonitor(controls[controlIndex], this, mapControlAndBindingIndex);
 
                 SetControlEnabled(controlIndex, false);
+            }
+        }
+
+        private void SetInitialStateCheckPending(BindingState* bindingStatePtr, bool value)
+        {
+            if (bindingStatePtr->isPartOfComposite)
+            {
+                // For composites, we always flag the composite itself as wanting an initial state check. This
+                // way, we don't have to worry about triggering the composite multiple times when several of its
+                // controls are actuated.
+                var compositeIndex = bindingStatePtr->compositeOrCompositeBindingIndex;
+                bindingStates[compositeIndex].initialStateCheckPending = value;
+            }
+            else
+            {
+                bindingStatePtr->initialStateCheckPending = value;
             }
         }
 
@@ -815,11 +831,6 @@ namespace UnityEngine.InputSystem
 
             Profiler.BeginSample("InitialActionStateCheck");
 
-            // The composite logic relies on the event ID to determine whether a composite binding should trigger again
-            // when already triggered. Make up a fake event with just an ID.
-            var inputEvent = new InputEvent {eventId = 1234};
-            var eventPtr = new InputEventPtr(&inputEvent);
-
             // Use current time as time of control state change.
             var time = InputRuntime.s_Instance.currentTime;
 
@@ -830,22 +841,39 @@ namespace UnityEngine.InputSystem
             // that the control just got actuated.
             for (var bindingIndex = 0; bindingIndex < totalBindingCount; ++bindingIndex)
             {
-                if (!bindingStates[bindingIndex].initialStateCheckPending)
+                var bindingStatePtr = &bindingStates[bindingIndex];
+                if (!bindingStatePtr->initialStateCheckPending)
                     continue;
 
+                Debug.Assert(!bindingStatePtr->isPartOfComposite, "Initial state check flag must be set on composite, not on its parts");
                 bindingStates[bindingIndex].initialStateCheckPending = false;
 
-                var mapIndex = bindingStates[bindingIndex].mapIndex;
-                var controlStartIndex = bindingStates[bindingIndex].controlStartIndex;
-                var controlCount = bindingStates[bindingIndex].controlCount;
+                var mapIndex = bindingStatePtr->mapIndex;
+                var controlStartIndex = bindingStatePtr->controlStartIndex;
+                var controlCount = bindingStatePtr->controlCount;
 
+                var isComposite = bindingStatePtr->isComposite;
                 for (var n = 0; n < controlCount; ++n)
                 {
                     var controlIndex = controlStartIndex + n;
                     var control = controls[controlIndex];
 
                     if (!control.CheckStateIsAtDefault())
-                        ProcessControlStateChange(mapIndex, controlIndex, bindingIndex, time, eventPtr);
+                    {
+                        // For composites, the binding index we have at this point is for the composite binding, not for the part
+                        // binding that contributes the control we're looking at. Adjust for that.
+                        if (isComposite)
+                            bindingIndex = controlIndexToBindingIndex[controlIndex];
+                        
+                        ProcessControlStateChange(mapIndex, controlIndex, bindingIndex, time, default);
+                        
+                        // For composites, any one actuated control will lead to the composite being
+                        // processed as a whole so we can stop here. This also ensure that we are
+                        // not triggering the composite repeatedly if there are multiple actuated
+                        // controls bound to its parts.
+                        if (isComposite)
+                            break;
+                    }
                 }
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -862,11 +862,12 @@ namespace UnityEngine.InputSystem
                     {
                         // For composites, the binding index we have at this point is for the composite binding, not for the part
                         // binding that contributes the control we're looking at. Adjust for that.
+                        var bindingIndexForControl = bindingIndex;
                         if (isComposite)
-                            bindingIndex = controlIndexToBindingIndex[controlIndex];
-                        
-                        ProcessControlStateChange(mapIndex, controlIndex, bindingIndex, time, default);
-                        
+                            bindingIndexForControl = controlIndexToBindingIndex[controlIndex];
+
+                        ProcessControlStateChange(mapIndex, controlIndex, bindingIndexForControl, time, default);
+
                         // For composites, any one actuated control will lead to the composite being
                         // processed as a whole so we can stop here. This also ensure that we are
                         // not triggering the composite repeatedly if there are multiple actuated

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -846,7 +846,7 @@ namespace UnityEngine.InputSystem
                     continue;
 
                 Debug.Assert(!bindingStatePtr->isPartOfComposite, "Initial state check flag must be set on composite, not on its parts");
-                bindingStates[bindingIndex].initialStateCheckPending = false;
+                bindingStatePtr->initialStateCheckPending = false;
 
                 var mapIndex = bindingStatePtr->mapIndex;
                 var controlStartIndex = bindingStatePtr->controlStartIndex;


### PR DESCRIPTION
Fixes [1274977](https://issuetracker.unity3d.com/issues/input-system-cannot-read-vector2-values-after-inputactionset-has-been-disabled-and-enabled-twice) ([internal](https://fogbugz.unity3d.com/f/cases/1274977/)).