### PR TITLE
FIX: Bad max values for float controls stored as multi bitfields (case 1223436).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -470,8 +470,9 @@ partial class CoreTests
         {
             ++receivedCalls;
             float value;
-            Assert.IsTrue(gamepad.leftTrigger.ReadValueFromEvent(eventPtr, out value));
+            Assert.That(gamepad.leftTrigger.ReadValueFromEvent(eventPtr, out value), Is.True);
             Assert.That(value, Is.EqualTo(0.234f).Within(0.00001));
+            Assert.That(gamepad.leftTrigger.ReadValueFromEventAsObject(eventPtr), Is.EqualTo(0.234f).Within(0.00001));
         };
 
         InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.234f});
@@ -700,10 +701,7 @@ partial class CoreTests
             this.dpad = dpad;
         }
 
-        public FourCC format
-        {
-            get { return new FourCC('C', 'U', 'S', 'T'); }
-        }
+        public FourCC format => new FourCC('C', 'U', 'S', 'T');
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -313,6 +313,60 @@ partial class CoreTests
 
     [Test]
     [Category("State")]
+    [TestCase("Axis")]
+    [TestCase("Double")]
+    public void State_CanStoreControlAsMultiBitfield(string controlType)
+    {
+        var json = @"
+        {
+            ""name"" : ""TestDevice"",
+            ""controls"" : [
+                {
+                    ""name"" : ""max"",
+                    ""layout"" : ""__CONTROLTYPE__"",
+                    ""format"" : ""BIT"",
+                    ""offset"" : 0,
+                    ""sizeInBits"" : 7,
+                    ""defaultState"" : 127
+                },
+                {
+                    ""name"" : ""min"",
+                    ""layout"" : ""__CONTROLTYPE__"",
+                    ""format"" : ""BIT"",
+                    ""offset"" : 1,
+                    ""bit"" : 0,
+                    ""sizeInBits"" : 7,
+                    ""defaultState"" : 0
+                },
+                {
+                    ""name"" : ""mid"",
+                    ""layout"" : ""__CONTROLTYPE__"",
+                    ""format"" : ""BIT"",
+                    ""offset"" : 2,
+                    ""sizeInBits"" : 7,
+                    ""defaultState"" : 63
+                }
+            ]
+        }".Replace("__CONTROLTYPE__", controlType);
+
+        InputSystem.RegisterLayout(json);
+        var device = InputSystem.AddDevice("TestDevice");
+
+        var min = device["min"];
+        var max = device["max"];
+        var mid = device["mid"];
+
+        var minValue = min.ReadValueAsObject();
+        var maxValue = max.ReadValueAsObject();
+        var midValue = mid.ReadValueAsObject();
+
+        Assert.That(minValue, Is.EqualTo(0).Within(0.00001));
+        Assert.That(maxValue, Is.EqualTo(1).Within(0.00001));
+        Assert.That(midValue, Is.EqualTo(0.5).Within(1 / 128f)); // Precision dictated by number of bits we have available.
+    }
+
+    [Test]
+    [Category("State")]
     public void State_AppendsControlsWithoutForcedOffsetToEndOfState()
     {
         var json = @"

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed player build causing `ProjectSettings.asset` to be checked out in Perforce ([case 1254502](https://issuetracker.unity3d.com/issues/projectsettings-dot-asset-is-checked-out-in-perforce-when-building-a-project-with-the-input-system-package-installed)).
 - Fixed player build corrupting preloaded asset list in `PlayerSettings` if it was modified by another build processor.
 - Fixed remoting in Input Debugger not working for devices in the player that are created from generated layouts (such as XR devices).
+- Fixed max values for `Axis` and `Double` controls stored as multi-bit fields being off by one ([case 1223436](https://issuetracker.unity3d.com/issues/value-equal-to-1-is-not-returned-by-the-input-system-when-reading-a-multi-bit-control)).
+  * Fix contributed by [jamre](https://github.com/jamre) in [962](https://github.com/Unity-Technologies/InputSystem/pull/962). Thank you!
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -220,6 +220,27 @@ namespace UnityEngine.InputSystem
             return true;
         }
 
+        /// <summary>
+        /// Read the value of <paramref name="control"/> from the given <paramref name="inputEvent"/> without having to
+        /// know the specific value type of the control.
+        /// </summary>
+        /// <param name="control">Control to read the value for.</param>
+        /// <param name="inputEvent">An <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> to read the value from.</param>
+        /// <returns>The current value for the control or <c>null</c> if the control's value is not included
+        /// in the event.</returns>
+        /// <seealso cref="InputControl.ReadValueFromStateAsObject"/>
+        public static unsafe object ReadValueFromEventAsObject(this InputControl control, InputEventPtr inputEvent)
+        {
+            if (control == null)
+                throw new ArgumentNullException(nameof(control));
+
+            var statePtr = control.GetStatePtrFromStateEvent(inputEvent);
+            if (statePtr == null)
+                return control.ReadDefaultValueAsObject();
+
+            return control.ReadValueFromStateAsObject(statePtr);
+        }
+
         public static TValue ReadUnprocessedValueFromEvent<TValue>(this InputControl<TValue> control, InputEventPtr eventPtr)
             where TValue : struct
         {

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -372,8 +372,8 @@ namespace UnityEngine.InputSystem.LowLevel
                 }
                 else if (sizeInBits <= 31)
                 {
-                    var maxValue = (float)(1 << (int)sizeInBits);
-                    var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
+                    var maxValue = (float)((1 << (int)sizeInBits) - 1);
+                    var rawValue = (float)MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
                     if (format == FormatSBit)
                     {
                         var unclampedValue = (rawValue / maxValue) * 2.0f - 1.0f;
@@ -596,8 +596,8 @@ namespace UnityEngine.InputSystem.LowLevel
                 }
                 else if (sizeInBits != 31)
                 {
-                    var maxValue = (float)(1 << (int)sizeInBits);
-                    var rawValue = (float)(MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits));
+                    var maxValue = (float)((1 << (int)sizeInBits) - 1);
+                    var rawValue = (float)MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
                     if (format == FormatSBit)
                     {
                         var unclampedValue = (((rawValue / maxValue) * 2.0f) - 1.0f);


### PR DESCRIPTION
Fixes [1223436](https://issuetracker.unity3d.com/issues/value-equal-to-1-is-not-returned-by-the-input-system-when-reading-a-multi-bit-control) ([internal](https://fogbugz.unity3d.com/f/cases/1223436/)).

Incorporates fix supplied by [jamre](https://github.com/jamre) in #962.