### PR TITLE
FIX: 'Add Interaction' menu not filtering by value type (case 1272772).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed rebinds triggered by the Enter key causing stuck Enter key states ([case 1271591](https://issuetracker.unity3d.com/issues/input-system-rebind-action-requires-two-inputs-slash-presses-when-using-the-enter-key)).
 - Fixed `Map index on trigger` and `IndexOutOfRangeException` errors when using multiple Interactions on the same Action. ([case 1253034](https://issuetracker.unity3d.com/issues/map-index-on-trigger-and-indexoutofrangeexception-errors-when-using-multiple-interactions-on-the-same-action)).
 - Fixed context menu in action editor not filtering out composites the same way that the `+` icon menu does. This led to, for example, a "2D Vector" composite being shown as an option for a button type action.
+- Fixed "Add Interaction" menu in action editor not filtering out interactions with incompatible value types ([case 1272772](https://issuetracker.unity3d.com/issues/new-input-system-action-gets-called-only-once-when-using-mouse-press-interaction)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -1,4 +1,5 @@
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;
@@ -12,6 +13,7 @@ using UnityEngine.InputSystem.Editor;
 
 namespace UnityEngine.InputSystem.Interactions
 {
+    ////REVIEW: Why is this deriving from IInputInteraction<float>? It goes by actuation just like Hold etc.
     /// <summary>
     /// Interaction that requires multiple taps (press and release within <see cref="tapTime"/>) spaced no more
     /// than <see cref="tapDelay"/> seconds apart. This equates to a chain of <see cref="TapInteraction"/> with
@@ -23,7 +25,7 @@ namespace UnityEngine.InputSystem.Interactions
     /// <see cref="InputActionPhase.Performed"/>) or the multi-tap is aborted by a timeout being hit (in which
     /// case the interaction will trigger <see cref="InputActionPhase.Canceled"/>).
     /// </remarks>
-    [Scripting.Preserve]
+    [Preserve]
     public class MultiTapInteraction : IInputInteraction<float>
     {
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/NameAndParameterListView.cs
@@ -53,8 +53,8 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (m_ExpectedValueType != null)
                 {
                     var valueType = getValueType(rowType);
-                    if (!m_ExpectedValueType.IsAssignableFrom(valueType))
-                        name += " (Ignored)";
+                    if (valueType != null && !m_ExpectedValueType.IsAssignableFrom(valueType))
+                        name += " (Incompatible Value Type)";
                 }
                 m_EditableParametersForEachListItem[i].name = name;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/PropertiesViewBase.cs
@@ -21,7 +21,7 @@ namespace UnityEngine.InputSystem.Editor
             m_InteractionsProperty = bindingOrAction.FindPropertyRelative("m_Interactions");
             m_ProcessorsProperty = bindingOrAction.FindPropertyRelative("m_Processors");
 
-            m_InteractionsList = new InteractionsListView(m_InteractionsProperty, OnInteractionsModified, null);
+            m_InteractionsList = new InteractionsListView(m_InteractionsProperty, OnInteractionsModified, expectedControlLayout);
             UpdateProcessors(expectedControlLayout);
 
             m_OnChange = onChange;


### PR DESCRIPTION
Addresses [1272772](https://issuetracker.unity3d.com/issues/new-input-system-action-gets-called-only-once-when-using-mouse-press-interaction) ([internal](https://fogbugz.unity3d.com/f/cases/1272772/)).

Overall, we need to have a go and improve guidance/visibility provided by the action editor. The bug report here is about a Press interaction on a Vector2 control. Press does what it's meant to do -- and the interaction really does work purely by actuation so works with any type of control -- but the end result is confusing to the user. This needs addressing beyond a simple bugfix.