### PR TITLE
CHANGE: Lookup prefers first enabled action (case 1207550).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -4773,6 +4773,52 @@ partial class CoreTests
         }, Is.Not.AllocatingGCMemory());
     }
 
+    // Since we allow looking up by action name without any map qualification, ambiguities result when several
+    // actions are named the same. We choose to not do anything special other than generally preferring an
+    // enabled action over a disabled one. Other than that, we just return the first hit.
+    // https://fogbugz.unity3d.com/f/cases/1207550/
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanLookUpActionInAssetByName_WithMultipleActionsHavingTheSameName()
+    {
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+
+        var map1 = new InputActionMap("map1");
+        var map2 = new InputActionMap("map2");
+        var map3 = new InputActionMap("map3");
+
+        asset.AddActionMap(map1);
+        asset.AddActionMap(map2);
+        asset.AddActionMap(map3);
+
+        var action1 = map1.AddAction("action");
+        var action2 = map2.AddAction("action");
+        var action3 = map3.AddAction("action");
+
+        Assert.That(asset.FindAction("action"), Is.SameAs(action1));
+
+        action2.Enable();
+
+        Assert.That(asset.FindAction("action"), Is.SameAs(action2));
+
+        action3.Enable();
+
+        // No difference. Returns first enabled action.
+        Assert.That(asset.FindAction("action"), Is.SameAs(action2));
+
+        action2.Disable();
+
+        Assert.That(asset.FindAction("action"), Is.SameAs(action3));
+
+        action1.Enable();
+
+        Assert.That(asset.FindAction("action"), Is.SameAs(action1));
+
+        asset.Disable();
+
+        Assert.That(asset.FindAction("action"), Is.SameAs(action1));
+    }
+
     [Test]
     [Category("Actions")]
     public void Actions_CanRemoveActionFromMap()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,7 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 - `InputAction.ReadValue<T>()` now always returns `default<T>` when the action is canceled.
   * This is to make it consistent with `InputAction.CallbackContext.ReadValue<T>()` which already returned `default<T>` when the action was canceled.
   * In general, all APIs that read values will return default values when an action is in a phase other than `Started` or `Performed`.
-- If multiple actions in different action maps but in the same .inputactions asset have the same name, calling `InputActionAsset.FindAction()` with just an action name will now return the first __enabled__ action. If none of the actions are enabled, it will return the first action with a matching as before ([case 1207550](https://issuetracker.unity3d.com/issues/input-system-action-can-only-be-triggered-by-one-of-the-action-maps-when-action-name-is-identical)).
+- If multiple actions in different action maps but in the same .inputactions asset have the same name, calling `InputActionAsset.FindAction()` with just an action name will now return the first __enabled__ action. If none of the actions are enabled, it will return the first action with a matching name as before ([case 1207550](https://issuetracker.unity3d.com/issues/input-system-action-can-only-be-triggered-by-one-of-the-action-maps-when-action-name-is-identical)).
   ```CSharp
   var map1 = new InputActionMap("map1");
   var map2 = new InputActionMap("map2");

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,22 @@ however, it has to be formatted properly to pass verification tests.
 - `InputAction.ReadValue<T>()` now always returns `default<T>` when the action is canceled.
   * This is to make it consistent with `InputAction.CallbackContext.ReadValue<T>()` which already returned `default<T>` when the action was canceled.
   * In general, all APIs that read values will return default values when an action is in a phase other than `Started` or `Performed`.
+- If multiple actions in different action maps but in the same .inputactions asset have the same name, calling `InputActionAsset.FindAction()` with just an action name will now return the first __enabled__ action. If none of the actions are enabled, it will return the first action with a matching as before ([case 1207550](https://issuetracker.unity3d.com/issues/input-system-action-can-only-be-triggered-by-one-of-the-action-maps-when-action-name-is-identical)).
+  ```CSharp
+  var map1 = new InputActionMap("map1");
+  var map2 = new InputActionMap("map2");
+  map1.AddAction("actionWithSameName");
+  map2.AddAction("actionWithSameName");
+  var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+  asset.AddActionMap(map1);
+  asset.AddActionMap(map2);
+  
+  map2["actionWithSameName"].Enable();
+  
+  var action = asset["actionWithSameName"];
+  // Before: "map1/actionWithSameName"
+  // Now: "map2/actionWithSameName"
+  ```
 
 ### Fixed
 


### PR DESCRIPTION
Addresses [1207550](https://issuetracker.unity3d.com/issues/input-system-action-can-only-be-triggered-by-one-of-the-action-maps-when-action-name-is-identical) ([internal](https://fogbugz.unity3d.com/f/cases/1207550/)).

It's a slight tweak to the existing logic. Before, ambiguities in action names were simply ignored entirely. If you did `asset.FindAction("myAction")` it returned the first action called `"myAction"`. If there were multiple, you still always got the first.

With this change, the lookup now treats the first __enabled__ action preferentially. Otherwise, it works as before. Most notably, no exception is thrown and no error is logged when an ambiguity exists.