### PR TITLE
FIX: Canceling test run in editor leading to lost state (case 1251724).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed player build causing `ProjectSettings.asset` to be checked out in Perforce ([case 1254502](https://issuetracker.unity3d.com/issues/projectsettings-dot-asset-is-checked-out-in-perforce-when-building-a-project-with-the-input-system-package-installed)).
 - Fixed player build corrupting preloaded asset list in `PlayerSettings` if it was modified by another build processor.
 - Fixed remoting in Input Debugger not working for devices in the player that are created from generated layouts (such as XR devices).
+- Fixed exiting out of play mode in the Unity Editor while a test run is in progress leading to the Input System permanently losing all its state until the editor is restarted ([case 1251724](https://issuetracker.unity3d.com/issues/the-input-system-does-not-get-re-enabled-when-a-playmode-input-test-is-interrupted)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -60,17 +60,20 @@ namespace UnityEngine.InputSystem.Editor
 
             --s_Disabled;
             if (s_Disabled == 0 && s_Instance != null)
+            {
                 s_Instance.InstallHooks();
-
-            ////REVIEW: technically, we'd have to do a refresh here but that'd mean that in the current setup
-            ////        we'd do a refresh after every single test; find a better solution
+                s_Instance.Refresh();
+            }
         }
 
         public static void Disable()
         {
             ++s_Disabled;
             if (s_Disabled == 1 && s_Instance != null)
+            {
                 s_Instance.UninstallHooks();
+                s_Instance.Refresh();
+            }
         }
 
         private void OnDeviceChange(InputDevice device, InputDeviceChange change)


### PR DESCRIPTION
Fixes [1251725](https://issuetracker.unity3d.com/issues/the-input-system-does-not-get-re-enabled-when-a-playmode-input-test-is-interrupted) ([internal](https://fogbugz.unity3d.com/f/cases/1251724/)).

It's more of a workaround. Brought the issue up on [Slack](https://unity.slack.com/archives/C0JHA6J4C/p1602682369266000) as I think ideally the test framework would handle this for us.