### PR TITLE
FIX: IndexOutOfRangeException when active device is disconnected, and another activated

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1042,6 +1042,9 @@ namespace UnityEngine.InputSystem.Users
             {
                 ArrayHelpers.EraseSliceWithCapacity(ref s_AllLostDevices, ref s_AllLostDeviceCount,
                     s_AllUserData[userIndex].lostDeviceStartIndex, lostDeviceCount);
+                
+                s_AllUserData[userIndex].lostDeviceCount = 0;
+                s_AllUserData[userIndex].lostDeviceStartIndex = 0;
             }
 
             // Remove account selections that are in progress.
@@ -1322,9 +1325,14 @@ namespace UnityEngine.InputSystem.Users
                             // If we had lost some devices, flush the list. We haven't regained the device
                             // but we're no longer missing devices to play.
                             if (s_AllUserData[userIndex].lostDeviceCount > 0)
+                            {
                                 ArrayHelpers.EraseSliceWithCapacity(ref s_AllLostDevices, ref s_AllLostDeviceCount,
                                     s_AllUserData[userIndex].lostDeviceStartIndex,
                                     s_AllUserData[userIndex].lostDeviceCount);
+                                
+                                s_AllUserData[userIndex].lostDeviceCount = 0;
+                                s_AllUserData[userIndex].lostDeviceStartIndex = 0;
+                            }
 
                             // Control scheme is satisfied with the devices we have available.
                             // If we may have grabbed as of yet unpaired devices, go and pair them to the user.


### PR DESCRIPTION
I was having issues that when disconnecting the active device, and another device is activated, an IndexOutOfRangeException would be spammed.

It seems that every new event, there would be another attempt at ArrayHelpers.EraseSliceWithCapacity on the s_LostDevices as the lostDeviceCount and lostDeviceStartIndex are not reset. Inspiration was taken from the UnpairDevices-method, where they are reset. After resetting them in UpdateControlSchemeMatch, the exception was gone. I also added it to the RemoveUser method for completeness sake.

These are the first few days I'm exploring the system, so by no means do I claim this is a valid fix.