### PR TITLE
0x5C4 is a valid product id for DualShock ZCT1E under Mac + Bluetooth

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -145,15 +145,17 @@ internal class DualShockTests : InputTestFixture
 
     [Test]
     [Category("Devices")]
-    public void Devices_SupportsDualShockAsHID_WithJustPIDAndVID()
+    [TestCase(0x54C, 0x9CC)]
+    [TestCase(0x54C, 0x5C4)]
+    public void Devices_SupportsDualShockAsHID_WithJustPIDAndVID(int vendorId, int productId)
     {
         var device = InputSystem.AddDevice(new InputDeviceDescription
         {
             interfaceName = "HID",
             capabilities = new HID.HIDDeviceDescriptor
             {
-                vendorId = 0x54C,
-                productId = 0x9CC,
+                vendorId = vendorId,
+                productId = productId,
             }.ToJson()
         });
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed precompiled layouts such as `FastKeyboard` leading to build time regressions with il2cpp (case 1283676).
 - Fixed `InputUser.OnEvent` and `RebindingOperation.OnEvent` exhibiting bad performance profiles and leading to multi-millisecond input update times (case 1253371).
   * In our own measurements, `InputUser.OnEvent` is >9 times faster than before and `RebindingOperation.OnEvent` is ~2.5 times faster.
+- Fixed PS4 controller not recognized on Mac when connected over Bluetooth ([case 1286449](https://issuetracker.unity3d.com/issues/input-system-dualshock-4-zct1e-dualshock-2-v1-devices-are-not-fully-recognised-over-bluetooth)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -32,6 +32,11 @@ namespace UnityEngine.InputSystem.DualShock
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x54C) // Sony Entertainment.
                     .WithCapability("productId", 0x9CC)); // Wireless controller.
+            InputSystem.RegisterLayout<DualShock4GamepadHID>(
+                matches: new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x54C) // Sony Entertainment.
+                    .WithCapability("productId", 0x5C4)); // Wireless controller.
             InputSystem.RegisterPrecompiledLayout<FastDualShock4GamepadHID>(FastDualShock4GamepadHID.metadata);
 
             // Just to make sure, also set up a matcher that goes by strings so that we cover


### PR DESCRIPTION
Fixes 1286449