### PR TITLE
Fixing touch updateStepCount invalid state after being disabled/enabled.

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -797,6 +797,41 @@ internal class EnhancedTouchTests : InputTestFixture
             new Tuple<string, Finger>("Up", Touch.fingers[1])
         }));
     }
+    
+    [Test]
+    [Category("EnhancedTouch")]
+    public void EnhancedTouch_TouchWorksAfterDisableEnable()
+    {
+        BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Began));
+
+        MoveTouch(1, new Vector2(0.234f, 0.345f), queueEventOnly: true);
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Moved));
+
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Stationary));
+        
+        EnhancedTouchSupport.Disable();
+        EnhancedTouchSupport.Enable();
+
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Stationary));
+
+        MoveTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Moved));
+
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Stationary));
+    }
 
     [Test]
     [Category("EnhancedTouch")]

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -798,9 +798,10 @@ internal class EnhancedTouchTests : InputTestFixture
         }));
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1286865/
     [Test]
     [Category("EnhancedTouch")]
-    public void EnhancedTouch_TouchWorksAfterDisableEnable()
+    public void EnhancedTouch_CanBeDisabledAndReenabled()
     {
         BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
         InputSystem.Update();

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -797,7 +797,7 @@ internal class EnhancedTouchTests : InputTestFixture
             new Tuple<string, Finger>("Up", Touch.fingers[1])
         }));
     }
-    
+
     [Test]
     [Category("EnhancedTouch")]
     public void EnhancedTouch_TouchWorksAfterDisableEnable()
@@ -815,7 +815,7 @@ internal class EnhancedTouchTests : InputTestFixture
         InputSystem.Update();
         Assert.That(Touch.activeTouches.Count, Is.EqualTo(1));
         Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Stationary));
-        
+
         EnhancedTouchSupport.Disable();
         EnhancedTouchSupport.Enable();
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
   * In our own measurements, `InputUser.OnEvent` is >9 times faster than before and `RebindingOperation.OnEvent` is ~2.5 times faster.
 - Fixed PS4 controller not recognized on Mac when connected over Bluetooth ([case 1286449](https://issuetracker.unity3d.com/issues/input-system-dualshock-4-zct1e-dualshock-2-v1-devices-are-not-fully-recognised-over-bluetooth)).
 - Fixed restart prompt after package installation not appearing on Unity 2020.2+ ([case 1292513](https://issuetracker.unity3d.com/issues/input-system-after-package-install-the-update-slash-switch-and-restart-prompt-does-not-appear)).
+- Fixed incorrect touch phases reported when enhanced is re-enabled ([case 1286865](https://issuetracker.unity3d.com/issues/new-input-system-began-moved-and-ended-touch-phases-are-not-reported-when-a-second-scene-is-loaded)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,7 +24,7 @@ however, it has to be formatted properly to pass verification tests.
   * In our own measurements, `InputUser.OnEvent` is >9 times faster than before and `RebindingOperation.OnEvent` is ~2.5 times faster.
 - Fixed PS4 controller not recognized on Mac when connected over Bluetooth ([case 1286449](https://issuetracker.unity3d.com/issues/input-system-dualshock-4-zct1e-dualshock-2-v1-devices-are-not-fully-recognised-over-bluetooth)).
 - Fixed restart prompt after package installation not appearing on Unity 2020.2+ ([case 1292513](https://issuetracker.unity3d.com/issues/input-system-after-package-install-the-update-slash-switch-and-restart-prompt-does-not-appear)).
-- Fixed incorrect touch phases reported when enhanced is re-enabled ([case 1286865](https://issuetracker.unity3d.com/issues/new-input-system-began-moved-and-ended-touch-phases-are-not-reported-when-a-second-scene-is-loaded)).
+- Fixed `Touch.activeTouches` having incorrect touch phases after calling `EnhancedTouch.Disable()` and then `EnhancedTouch.Enable()` ([case 1286865](https://issuetracker.unity3d.com/issues/new-input-system-began-moved-and-ended-touch-phases-are-not-reported-when-a-second-scene-is-loaded)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2257,14 +2257,7 @@ namespace UnityEngine.InputSystem
 
             InputStateBuffers.SwitchTo(m_StateBuffers, updateType);
 
-            InputUpdate.s_LastUpdateType = updateType;
-            if (updateType == InputUpdateType.Dynamic || updateType == InputUpdateType.Manual || updateType == InputUpdateType.Fixed)
-            {
-                // We want to update step counts to be correct in OnNextUpdate() and onBeforeUpdate callbacks.
-                // We use a boolean flag to tell OnUpdate() that we've already incremented the count.
-                ++InputUpdate.s_UpdateStepCount;
-                InputUpdate.s_HaveUpdatedStepCount = true;
-            }
+            InputUpdate.OnBeforeUpdate(updateType);
 
             // For devices that have state callbacks, tell them we're carrying state over
             // into the next frame.
@@ -2586,20 +2579,9 @@ namespace UnityEngine.InputSystem
             // Store current time offset.
             InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup = m_Runtime.currentTimeOffsetToRealtimeSinceStartup;
 
-            InputUpdate.s_LastUpdateType = updateType;
             InputStateBuffers.SwitchTo(m_StateBuffers, updateType);
 
-            var isBeforeRenderUpdate = false;
-            if (updateType == InputUpdateType.Dynamic || updateType == InputUpdateType.Manual || updateType == InputUpdateType.Fixed)
-            {
-                if (!InputUpdate.s_HaveUpdatedStepCount)
-                    ++InputUpdate.s_UpdateStepCount;
-                InputUpdate.s_HaveUpdatedStepCount = false;
-            }
-            else if (updateType == InputUpdateType.BeforeRender)
-            {
-                isBeforeRenderUpdate = true;
-            }
+            InputUpdate.OnUpdate(updateType);
 
             // See if we're supposed to only take events up to a certain time.
             // NOTE: We do not require the events in the queue to be sorted. Instead, we will walk over
@@ -2650,7 +2632,7 @@ namespace UnityEngine.InputSystem
 
                 // In before render updates, we only take state events and only those for devices
                 // that have before render updates enabled.
-                if (isBeforeRenderUpdate)
+                if (updateType == InputUpdateType.BeforeRender)
                 {
                     while (remainingEventCount > 0)
                     {

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -71,13 +71,11 @@ namespace UnityEngine.InputSystem.LowLevel
 
     internal static class InputUpdate
     {
+        public static uint s_UpdateStepCount; // read only, but kept as a variable for performance reasons
         public static InputUpdateType s_LastUpdateType;
         public static UpdateStepCount s_PlayerUpdateStepCount;
         #if UNITY_EDITOR
         public static UpdateStepCount s_EditorUpdateStepCount;
-        public static uint s_UpdateStepCount => s_LastUpdateType == InputUpdateType.Editor ? s_EditorUpdateStepCount.value : s_PlayerUpdateStepCount.value;
-        #else
-        public static uint s_UpdateStepCount => s_PlayerUpdateStepCount.value;
         #endif
         public static uint s_LastUpdateRetainedEventBytes;
         public static uint s_LastUpdateRetainedEventCount;
@@ -125,10 +123,12 @@ namespace UnityEngine.InputSystem.LowLevel
                 case InputUpdateType.Manual:
                 case InputUpdateType.Fixed:
                     s_PlayerUpdateStepCount.OnBeforeUpdate();
+                    s_UpdateStepCount = s_PlayerUpdateStepCount.value;
                     break;
                 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
                     s_EditorUpdateStepCount.OnBeforeUpdate();
+                    s_UpdateStepCount = s_EditorUpdateStepCount.value;
                     break;
                 #endif
             }
@@ -143,10 +143,12 @@ namespace UnityEngine.InputSystem.LowLevel
                 case InputUpdateType.Manual:
                 case InputUpdateType.Fixed:
                     s_PlayerUpdateStepCount.OnUpdate();
+                    s_UpdateStepCount = s_PlayerUpdateStepCount.value;
                     break;
                 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
                     s_EditorUpdateStepCount.OnUpdate();
+                    s_UpdateStepCount = s_EditorUpdateStepCount.value;
                     break;
                 #endif
             }
@@ -175,6 +177,20 @@ namespace UnityEngine.InputSystem.LowLevel
             #if UNITY_EDITOR
             s_EditorUpdateStepCount = state.editorUpdateStepCount;
             #endif
+
+            switch (s_LastUpdateType)
+            {
+                case InputUpdateType.Dynamic:
+                case InputUpdateType.Manual:
+                case InputUpdateType.Fixed:
+                    s_UpdateStepCount = s_PlayerUpdateStepCount.value;
+                    break;
+                #if UNITY_EDITOR
+                case InputUpdateType.Editor:
+                    s_UpdateStepCount = s_EditorUpdateStepCount.value;
+                    break;
+                #endif
+            }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -190,6 +190,10 @@ namespace UnityEngine.InputSystem.LowLevel
                     s_UpdateStepCount = s_EditorUpdateStepCount.value;
                     break;
                 #endif
+                default:
+                    // if there was no previous update type, reset the counter
+                    s_UpdateStepCount = 0;
+                    break;
             }
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -85,21 +85,22 @@ namespace UnityEngine.InputSystem.LowLevel
         [Serializable]
         public struct UpdateStepCount
         {
-            public bool wasUpdated;
-            public uint value;
+            private bool m_WasUpdated;
+
+            public uint value { get; private set; }
 
             public void OnBeforeUpdate()
             {
-                wasUpdated = true;
+                m_WasUpdated = true;
                 value++;
             }
 
             public void OnUpdate()
             {
                 // only increment if OnBeforeUpdate was not called
-                if (!wasUpdated)
+                if (!m_WasUpdated)
                     value++;
-                wasUpdated = false;
+                m_WasUpdated = false;
             }
         };
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
@@ -124,8 +124,10 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         private static void SetUpState()
         {
             Touch.s_PlayerState.updateMask = InputUpdateType.Dynamic | InputUpdateType.Manual;
+            Touch.s_PlayerState.updateStepCount = InputUpdate.s_UpdateStepCount;
             #if UNITY_EDITOR
             Touch.s_EditorState.updateMask = InputUpdateType.Editor;
+            Touch.s_EditorState.updateStepCount = InputUpdate.s_UpdateStepCount;
             #endif
 
             s_UpdateMode = InputSystem.settings.updateMode;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
@@ -124,10 +124,8 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         private static void SetUpState()
         {
             Touch.s_PlayerState.updateMask = InputUpdateType.Dynamic | InputUpdateType.Manual;
-            Touch.s_PlayerState.updateStepCount = InputUpdate.s_PlayerUpdateStepCount.value;
             #if UNITY_EDITOR
             Touch.s_EditorState.updateMask = InputUpdateType.Editor;
-            Touch.s_EditorState.updateStepCount = InputUpdate.s_EditorUpdateStepCount.value;
             #endif
 
             s_UpdateMode = InputSystem.settings.updateMode;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
@@ -124,10 +124,10 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         private static void SetUpState()
         {
             Touch.s_PlayerState.updateMask = InputUpdateType.Dynamic | InputUpdateType.Manual;
-            Touch.s_PlayerState.updateStepCount = InputUpdate.s_UpdateStepCount;
+            Touch.s_PlayerState.updateStepCount = InputUpdate.s_PlayerUpdateStepCount.value;
             #if UNITY_EDITOR
             Touch.s_EditorState.updateMask = InputUpdateType.Editor;
-            Touch.s_EditorState.updateStepCount = InputUpdate.s_UpdateStepCount;
+            Touch.s_EditorState.updateStepCount = InputUpdate.s_EditorUpdateStepCount.value;
             #endif
 
             s_UpdateMode = InputSystem.settings.updateMode;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -125,7 +125,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             };
             m_StateHistory.StartRecording();
 
-            // if touch is already in progress, record the current state
+            // record the current state if touch is already in progress
             if (screen.touches[index].isInProgress)
                 m_StateHistory.RecordStateChange(screen.touches[index], screen.touches[index].ReadValue());
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -124,6 +124,10 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 updateMask = updateMask,
             };
             m_StateHistory.StartRecording();
+
+            // if touch is already in progress, record the current state
+            if (screen.touches[index].isInProgress)
+                m_StateHistory.RecordStateChange(screen.touches[index], screen.touches[index].ReadValue());
         }
 
         private static unsafe bool ShouldRecordTouch(InputControl control, double time, InputEventPtr eventPtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -91,7 +91,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 if (touch.isInProgress)
                     return touch;
                 // Ended touches stay current in the frame they ended in.
-                if (touch.updateStepCount == Touch.s_PlayerState.updateStepCount)
+                if (touch.updateStepCount == InputUpdate.s_UpdateStepCount)
                     return touch;
                 return default;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -565,8 +565,6 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             }
             #endif
 
-            ++s_PlayerState.updateStepCount;
-
             // If we have any touches in activeTouches that are ended or canceled,
             // we need to clear them in the next frame.
             if (s_PlayerState.haveActiveTouchesNeedingRefreshNextUpdate)
@@ -598,7 +596,6 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         internal struct FingerAndTouchState
         {
             public InputUpdateType updateMask;
-            public uint updateStepCount;
             public Finger[] fingers;
             public Finger[] activeFingers;
             public Touch[] activeTouches;
@@ -691,7 +688,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 }
                 activeTouchCount = 0;
                 haveActiveTouchesNeedingRefreshNextUpdate = false;
-                var currentUpdateStepCount = s_PlayerState.updateStepCount;
+                var currentUpdateStepCount = InputUpdate.s_UpdateStepCount;
 
                 ////OPTIMIZE: Handle touchscreens that have no activity more efficiently
                 ////FIXME: This is sensitive to history size; we probably need to ensure that the Begans and Endeds/Canceleds of touches are always available to us


### PR DESCRIPTION
Potential fix for https://fogbugz.unity3d.com/f/cases/1286865/
Needs to be validated that it is correct.

Analysis:
During debug I found that touch `updateStepCount` was a lot higher than `currentUpdateStepCount`, hence the following check was failing:
![image](https://user-images.githubusercontent.com/1333661/100462453-9833f100-30ca-11eb-9788-d210bed1c4c1.png)
From that I concluded that `s_PlayerState.updateStepCount` must have been reset somehow, and yes indeed during scene reload it is reset.