### PR TITLE
"Improved" InvokeCallbackSafe method to better guard against concurrent modification

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
@@ -13,10 +13,9 @@ namespace UnityEngine.InputSystem.Utilities
             if (callbacks.length == 0)
                 return;
             Profiler.BeginSample(callbackName);
-            for (var i = 0; i < callbacks.length; ++i)
+            var copy = callbacks.Clone();
+            for (var i = copy.length - 1; i >= 0; --i)
             {
-                var lengthBefore = callbacks.length;
-
                 try
                 {
                     callbacks[i]();
@@ -29,10 +28,6 @@ namespace UnityEngine.InputSystem.Utilities
                         Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
                     Debug.LogException(exception);
                 }
-
-                ////REVIEW: is this enough?
-                if (callbacks.length == lengthBefore - 1)
-                    --i;
             }
             Profiler.EndSample();
         }
@@ -42,10 +37,9 @@ namespace UnityEngine.InputSystem.Utilities
             if (callbacks.length == 0)
                 return;
             Profiler.BeginSample(callbackName);
-            for (var i = 0; i < callbacks.length; ++i)
+            var copy = callbacks.Clone();
+            for (var i = copy.length - 1; i >= 0; --i)
             {
-                var lengthBefore = callbacks.length;
-
                 try
                 {
                     callbacks[i](argument);
@@ -58,10 +52,6 @@ namespace UnityEngine.InputSystem.Utilities
                         Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
                     Debug.LogException(exception);
                 }
-
-                ////REVIEW: is this enough?
-                if (callbacks.length == lengthBefore - 1)
-                    --i;
             }
             Profiler.EndSample();
         }
@@ -71,10 +61,9 @@ namespace UnityEngine.InputSystem.Utilities
             if (callbacks.length == 0)
                 return;
             Profiler.BeginSample(callbackName);
-            for (var i = 0; i < callbacks.length; ++i)
+            var copy = callbacks.Clone();
+            for (var i = copy.length - 1; i >= 0; --i)
             {
-                var lengthBefore = callbacks.length;
-
                 try
                 {
                     callbacks[i](argument1, argument2);
@@ -87,10 +76,6 @@ namespace UnityEngine.InputSystem.Utilities
                         Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
                     Debug.LogException(exception);
                 }
-
-                ////REVIEW: is this enough?
-                if (callbacks.length == lengthBefore - 1)
-                    --i;
             }
             Profiler.EndSample();
         }
@@ -101,10 +86,9 @@ namespace UnityEngine.InputSystem.Utilities
             if (callbacks.length == 0)
                 return true;
             Profiler.BeginSample(callbackName);
-            for (var i = 0; i < callbacks.length; ++i)
+            var copy = callbacks.Clone();
+            for (var i = copy.length - 1; i >= 0; --i)
             {
-                var lengthBefore = callbacks.length;
-
                 try
                 {
                     if (callbacks[i](argument1, argument2))
@@ -118,10 +102,6 @@ namespace UnityEngine.InputSystem.Utilities
                         Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
                     Debug.LogException(exception);
                 }
-
-                ////REVIEW: is this enough?
-                if (callbacks.length == lengthBefore - 1)
-                    --i;
             }
             Profiler.EndSample();
             return false;


### PR DESCRIPTION
Modified all InvokeCallbackSafe methods to Clone the InlineArray of callbacks in order to better guard against removal and addition of new callbacks while still inside the loop.

Currently, when a user registers a new callback, inside another callback, the callback gets executed immediately. I believe this is counter intuitive to what a user might expect. 

For example, when an input action is triggered a game object is enabled. Inside that gameobject OnEnabled is called. Say I want to subscribe to the same input action that triggered this. However, as soon as I subscribe to the input action my method will be executed before even Start is called.

One possible solution could have been to iterate over the callback array backwards, however, this wouldn't account for callbacks being removed and added while still in the loop.

My solution is to use the Clone method of the InlineArray to create a copy of the array we can iterate over to avoid being affected by concurrent modification.