### PR TITLE
Remove stale data from package.json

### DIFF
--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -3,12 +3,7 @@
 	"displayName": "Input System",
 	"version": "1.1.0-preview.2",
 	"unity": "2019.4",
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/Unity-Technologies/InputSystem.git",
-		"revision": "9ceb1563f669e33fe7b8562e36375caa59bb6f1b"
-	},
-  	"description": "A new input system which can be used as a more extensible and customizable alternative to Unity's classic input system in UnityEngine.Input.",
+	"description": "A new input system which can be used as a more extensible and customizable alternative to Unity's classic input system in UnityEngine.Input.",
 	"keywords": [
 		"input",
 		"events",


### PR DESCRIPTION
This part of the package.json is always filled by upm-ci, so no need for us to keep track of it.