### PR TITLE
Moving CI to 2020.2

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,6 +1,6 @@
 editors:
   - version: 2019.4
-  - version: 2020.1
+  - version: 2020.2
   - version: trunk
 platforms:
   - name: win


### PR DESCRIPTION
No more 2020.1 unity releases are planned, so at this is not possible to fix anything in 2020.1 backend. We can re-add a sparse 2020.1 set (1-2 platforms) later on just to make sure it doesn't regress.

PS. I guess if this going in, we need to change which jobs are required