### PR TITLE
Support of 32 bit fields, improving float precision and fixing vJoy

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -1676,9 +1676,9 @@ partial class CoreTests
     [TestCase(InputStateBlock.kFormatBit, 5, 16, 0b1101010101010101u, 0b1101010101010101)]
     [TestCase(InputStateBlock.kFormatSBit, 15, 16, 0b1101010101010101u, 0b1101010101010101 + short.MinValue)]
     [TestCase(InputStateBlock.kFormatBit, 16, 31, 0x7fffffffu, int.MaxValue)]
-    [TestCase(InputStateBlock.kFormatSBit, 24, 31, 0x7fffffffu, -1073741825)] // integer overflow, fix me?
+    [TestCase(InputStateBlock.kFormatSBit, 24, 31, 0x7fffffffu, 1073741823)] // excess-K
     [TestCase(InputStateBlock.kFormatBit, 16, 32, uint.MaxValue, -1)]
-    [TestCase(InputStateBlock.kFormatSBit, 24, 32, uint.MaxValue, -1)] // integer overflow, fix me?
+    [TestCase(InputStateBlock.kFormatSBit, 24, 32, uint.MaxValue, int.MaxValue)] // excess-K
     // primitive types
     [TestCase(InputStateBlock.kFormatInt, 32, 32, 0u, 0, 0.0f)]
     [TestCase(InputStateBlock.kFormatInt, 64, 32, 1231231231u, 1231231231, 0.573336720466613769531f)]

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -1664,7 +1664,7 @@ partial class CoreTests
     }
 
     #endif
-    
+
     [Test]
     [Category("State")]
     // single bit
@@ -1728,19 +1728,19 @@ partial class CoreTests
                     continue;
                 var bytePosition = (i + bitOffset) / 8;
                 var bitPosition = (i + bitOffset) % 8;
-                dataRead[bytePosition] &= (byte) ~(1UL << bitPosition);
+                dataRead[bytePosition] &= (byte)~(1UL << bitPosition);
             }
 
             // prepare write array
             for (var i = 0; i < bufferSize; ++i)
-                dataWrite[i] = (byte) ~dataRead[i];
+                dataWrite[i] = (byte)~dataRead[i];
 
             var block = new InputStateBlock
             {
                 format = new FourCC(format),
-                byteOffset = (uint) (bitOffset / 8),
-                bitOffset = (uint) (bitOffset % 8),
-                sizeInBits = (uint) bitSize
+                byteOffset = (uint)(bitOffset / 8),
+                bitOffset = (uint)(bitOffset % 8),
+                sizeInBits = (uint)bitSize
             };
 
             var testWrittenBinaryData = false;
@@ -1773,7 +1773,7 @@ partial class CoreTests
                     if (expectedFloatValue.HasValue)
                     {
                         var expectedDoubleValue = (double)expectedFloatValue;
-                        
+
                         // While this test should be able to test precise floats, we do some computations with hard to predict precision.
                         // Hence leaving some precision slack for now.
                         testWrittenBinaryData = expectedDoubleValue == -1.0f || expectedDoubleValue == 0.0f || expectedDoubleValue == 1.0f;
@@ -1794,8 +1794,8 @@ partial class CoreTests
             {
                 var bytePosition = i / 8;
                 var bitPosition = i % 8;
-                var readBit = (dataRead[bytePosition] & (byte) (1UL << bitPosition)) != 0 ? 1 : 0;
-                var writeBit = (dataWrite[bytePosition] & (byte) (1UL << bitPosition)) != 0 ? 1 : 0;
+                var readBit = (dataRead[bytePosition] & (byte)(1UL << bitPosition)) != 0 ? 1 : 0;
+                var writeBit = (dataWrite[bytePosition] & (byte)(1UL << bitPosition)) != 0 ? 1 : 0;
                 validWrite &= (i >= bitOffset && i < bitOffset + bitSize)
                     ? readBit == writeBit
                     : readBit != writeBit;
@@ -1806,13 +1806,13 @@ partial class CoreTests
                 var sb = new StringBuilder();
                 sb.Append($"Offset {bitOffset} size {bitSize} in bits, read, write, xor:\n");
                 for (var i = 0; i < bufferSize * 8; ++i)
-                    sb.Append((dataRead[i / 8] & (byte) (1UL << (i % 8))) != 0 ? '1' : '0');
+                    sb.Append((dataRead[i / 8] & (byte)(1UL << (i % 8))) != 0 ? '1' : '0');
                 sb.Append("\n");
                 for (var i = 0; i < bufferSize * 8; ++i)
-                    sb.Append((dataWrite[i / 8] & (byte) (1UL << (i % 8))) != 0 ? '1' : '0');
+                    sb.Append((dataWrite[i / 8] & (byte)(1UL << (i % 8))) != 0 ? '1' : '0');
                 sb.Append("\n");
                 for (var i = 0; i < bufferSize * 8; ++i)
-                    sb.Append(((dataRead[i / 8] ^ dataWrite[i / 8]) & (byte) (1UL << (i % 8))) != 0 ? '1' : '0');
+                    sb.Append(((dataRead[i / 8] ^ dataWrite[i / 8]) & (byte)(1UL << (i % 8))) != 0 ? '1' : '0');
                 throw new AssertionException($"Written data is not matching expected data: {sb}");
             }
         }

--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -1705,7 +1705,7 @@ partial class CoreTests
     [TestCase(InputStateBlock.kFormatFloat, 64, 32, 0x3f800000u, null, 1.0f)]
     [TestCase(InputStateBlock.kFormatFloat, 64, 32, 0xbf800000u, null, -1.0f)]
     [TestCase(InputStateBlock.kFormatDouble, 64, 64, 0x0u, null, 0.0f)]
-    public unsafe void State_InputStateBlock_ReadWrite(int format, int bitOffset, int bitSize, uint bitValue, int? expectedIntValue = null, float? expectedFloatValue = null)
+    public unsafe void State_CanReadAndWriteBitFormat(int format, int bitOffset, int bitSize, uint bitValue, int? expectedIntValue = null, float? expectedFloatValue = null)
     {
         const int bufferSize = 16; // make buffer a bit larger to have guard bits
         if (bitOffset + bitSize > bufferSize * 8)

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -489,12 +489,13 @@ internal class HIDTests : InputTestFixture
     struct SimpleAxisState : IInputStateTypeInfo
     {
         [FieldOffset(0)] public byte reportId;
-        [FieldOffset(1)] public ushort x;
-        [FieldOffset(3)] public short y;
+        [FieldOffset(1)] public ushort rz;
+        [FieldOffset(3)] public short vz;
         [FieldOffset(5)] public byte rx;
         [FieldOffset(6)] public sbyte ry;
         [FieldOffset(7)] public ushort vx;
         [FieldOffset(9)] public short vy;
+        [FieldOffset(11)] public int x;
 
         public FourCC format => new FourCC('H', 'I', 'D');
     }
@@ -535,6 +536,8 @@ internal class HIDTests : InputTestFixture
                 .AddElement(HID.GenericDesktop.Vx, 16).WithLogicalMinMax(0, 10000)
                 // 16bit [-10000..10000]
                 .AddElement(HID.GenericDesktop.Vy, 16).WithLogicalMinMax(-10000, 10000)
+                // 32bit [int min..int max]
+                .AddElement(HID.GenericDesktop.X, 32).WithLogicalMinMax(int.MinValue, int.MaxValue)
                 .Finish();
 
         runtime.ReportNewInputDevice(
@@ -553,12 +556,13 @@ internal class HIDTests : InputTestFixture
         InputSystem.QueueStateEvent(device, new SimpleAxisState
         {
             reportId = 1,
-            x = ushort.MinValue,
-            y = short.MinValue,
+            rz = ushort.MinValue,
+            vz = short.MinValue,
             rx = byte.MinValue,
             ry = sbyte.MinValue,
             vx = 0,
             vy = -10000,
+            x = int.MinValue
         });
         InputSystem.Update();
 
@@ -568,17 +572,19 @@ internal class HIDTests : InputTestFixture
         Assert.That(device["Ry"].ReadValueAsObject(), Is.EqualTo(1).Within(0.0001)); // Inverted
         Assert.That(device["Vx"].ReadValueAsObject(), Is.EqualTo(-1).Within(0.0001));
         Assert.That(device["Vy"].ReadValueAsObject(), Is.EqualTo(1).Within(0.0001)); // Inverted
+        Assert.That(device["X"].ReadValueAsObject(), Is.EqualTo(-1).Within(0.0001));
 
         // Test upper bound.
         InputSystem.QueueStateEvent(device, new SimpleAxisState
         {
             reportId = 1,
-            x = ushort.MaxValue,
-            y = short.MaxValue,
+            rz = ushort.MaxValue,
+            vz = short.MaxValue,
             rx = byte.MaxValue,
             ry = sbyte.MaxValue,
             vx = 10000,
             vy = 10000,
+            x = int.MaxValue
         });
         InputSystem.Update();
 
@@ -588,17 +594,19 @@ internal class HIDTests : InputTestFixture
         Assert.That(device["Ry"].ReadValueAsObject(), Is.EqualTo(-1).Within(0.0001)); // Inverted
         Assert.That(device["Vx"].ReadValueAsObject(), Is.EqualTo(1).Within(0.0001));
         Assert.That(device["Vy"].ReadValueAsObject(), Is.EqualTo(-1).Within(0.0001)); // Inverted
+        Assert.That(device["X"].ReadValueAsObject(), Is.EqualTo(1).Within(0.0001));
 
         // Test center.
         InputSystem.QueueStateEvent(device, new SimpleAxisState
         {
             reportId = 1,
-            x = ushort.MaxValue / 2,
-            y = 0,
+            rz = ushort.MaxValue / 2,
+            vz = 0,
             rx = byte.MaxValue / 2,
             ry = 0,
             vx = 10000 / 2,
             vy = 0,
+            x = 0
         });
         InputSystem.Update();
 
@@ -609,6 +617,7 @@ internal class HIDTests : InputTestFixture
         Assert.That(device["Ry"].ReadValueAsObject(), Is.EqualTo(0).Within(0.004));
         Assert.That(device["Vx"].ReadValueAsObject(), Is.EqualTo(0).Within(0.0001));
         Assert.That(device["Vy"].ReadValueAsObject(), Is.EqualTo(0).Within(0.0001));
+        Assert.That(device["X"].ReadValueAsObject(), Is.EqualTo(0).Within(0.0001));
     }
 
     // https://github.com/Unity-Technologies/InputSystem/issues/134

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR || UNITY_STANDALONE_LINUX
 using NUnit.Framework;
 using System.Runtime.InteropServices;
+using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.InputSystem.Linux;
@@ -226,6 +227,7 @@ internal class LinuxTests : InputTestFixture
 
         public TestSDLJoystick WithButton(SDLButtonUsage usage, bool value = true)
         {
+            Debug.Assert((int)SDLButtonUsage.Count <= 32);
             var bitMask = 1 << ((int)usage - 1);
 
             if (value)

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -227,7 +227,8 @@ internal class LinuxTests : InputTestFixture
 
         public TestSDLJoystick WithButton(SDLButtonUsage usage, bool value = true)
         {
-            Debug.Assert((int)SDLButtonUsage.Count <= 32, $"Expected SDLButtonUsage.Count <= 32, so we fit into the 32 bit wide bitmask, but found SDLButtonUsage.Count == {(int)SDLButtonUsage.Count}");
+            // checking <= here because Count equals to largest button value + 1, so the actual value will be < 32 
+            Debug.Assert((int)SDLButtonUsage.Count <= 32, $"Expected SDLButtonUsage.Count <= 32, so we fit into the 32 bit wide bitmask");
             var bitMask = 1U << ((int)usage - 1);
 
             if (value)

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -227,7 +227,7 @@ internal class LinuxTests : InputTestFixture
 
         public TestSDLJoystick WithButton(SDLButtonUsage usage, bool value = true)
         {
-            // checking <= here because Count equals to largest button value + 1, so the actual value will be < 32 
+            // checking <= here because Count equals to largest button value + 1, so the actual value will be < 32
             Debug.Assert((int)SDLButtonUsage.Count <= 32, $"Expected SDLButtonUsage.Count <= 32, so we fit into the 32 bit wide bitmask");
             var bitMask = 1U << ((int)usage - 1);
 

--- a/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/LinuxTests.cs
@@ -217,7 +217,7 @@ internal class LinuxTests : InputTestFixture
     [StructLayout(LayoutKind.Explicit)]
     private struct TestSDLJoystick : IInputStateTypeInfo
     {
-        [FieldOffset(0)] public int buttons;
+        [FieldOffset(0)] public uint buttons;
         [FieldOffset(4)] public int xAxis;
         [FieldOffset(8)] public int yAxis;
         [FieldOffset(12)] public int rotateZAxis;
@@ -227,8 +227,8 @@ internal class LinuxTests : InputTestFixture
 
         public TestSDLJoystick WithButton(SDLButtonUsage usage, bool value = true)
         {
-            Debug.Assert((int)SDLButtonUsage.Count <= 32);
-            var bitMask = 1 << ((int)usage - 1);
+            Debug.Assert((int)SDLButtonUsage.Count <= 32, $"Expected SDLButtonUsage.Count <= 32, so we fit into the 32 bit wide bitmask, but found SDLButtonUsage.Count == {(int)SDLButtonUsage.Count}");
+            var bitMask = 1U << ((int)usage - 1);
 
             if (value)
                 buttons |= bitMask;

--- a/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs
@@ -1,0 +1,85 @@
+﻿using NUnit.Framework;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using UnityEngine;
+using UnityEngine.InputSystem.Utilities;
+
+internal class NumberHelpersTests
+{
+    [Test]
+    [Category("Utilities")]
+    // out of boundary tests
+    [TestCase(-1, 0, 1, 0.0f)]
+    [TestCase(2, 0, 1, 1.0f)]
+    // [0, 1]
+    [TestCase(0, 0, 1, 0.0f)]
+    [TestCase(1, 0, 1, 1.0f)]
+    // [-128, 127]
+    [TestCase(-128, sbyte.MinValue, sbyte.MaxValue, 0.0f)]
+    [TestCase(0, sbyte.MinValue, sbyte.MaxValue, 0.501960813999176025391f)]
+    [TestCase(127, sbyte.MinValue, sbyte.MaxValue, 1.0f)]
+    // [0, 255]
+    [TestCase(0, byte.MinValue, byte.MaxValue, 0.0f)]
+    [TestCase(128, byte.MinValue, byte.MaxValue, 0.501960813999176025391f)]
+    [TestCase(255, byte.MinValue, byte.MaxValue, 1.0f)]
+    // [-32768, 32767]
+    [TestCase(-32768, short.MinValue, short.MaxValue, 0.0f)]
+    [TestCase(0, short.MinValue, short.MaxValue, 0.50000762939453125f)]
+    [TestCase(32767, short.MinValue, short.MaxValue, 1.0f)]
+    // [0, 65535]
+    [TestCase(0, ushort.MinValue, ushort.MaxValue, 0.0f)]
+    [TestCase(32767, ushort.MinValue, ushort.MaxValue, 0.49999237060546875f)]
+    [TestCase(65535, ushort.MinValue, ushort.MaxValue, 1.0f)]
+    // [-2147483648, 2147483647]
+    [TestCase(-2147483648, int.MinValue, int.MaxValue, 0.0f)]
+    [TestCase(0, int.MinValue, int.MaxValue, 0.5f)]
+    [TestCase(2147483647, int.MinValue, int.MaxValue, 1.0f)]
+    public void Utilities_NumberHelpers_CanConvertIntToNormalizedFloatAndBack(int value, int minValue, int maxValue, float expected)
+    {
+        var result = NumberHelpers.IntToNormalizedFloat(value, minValue, maxValue);
+        Assert.That(result, Is.EqualTo(expected).Within(float.Epsilon));
+
+        var integer = NumberHelpers.NormalizedFloatToInt(result, minValue, maxValue);
+        Assert.That(integer, Is.EqualTo(Mathf.Clamp(value, minValue, maxValue)));
+    }
+    
+    [Test]
+    [Category("Utilities")]
+    // out of boundary tests
+    [TestCase(0U, 1U, 2U, 0.0f)]
+    [TestCase(3U, 1U, 2U, 1.0f)]
+    // [10, 30]
+    [TestCase(10U, 10U, 30U, 0.0f)]
+    [TestCase(25U, 10U, 30U, 0.75f)]
+    [TestCase(30U, 10U, 30U, 1.0f)]
+    // [0, 255]
+    [TestCase(0U, byte.MinValue, byte.MaxValue, 0.0f)]
+    [TestCase(128U, byte.MinValue, byte.MaxValue, 0.501960813999176025391f)]
+    [TestCase(255U, byte.MinValue, byte.MaxValue, 1.0f)]
+    // [0, 65535]
+    [TestCase(0U, ushort.MinValue, ushort.MaxValue, 0.0f)]
+    [TestCase(32767U, ushort.MinValue, ushort.MaxValue, 0.49999237060546875f)]
+    [TestCase(65535U, ushort.MinValue, ushort.MaxValue, 1.0f)]
+    // [0, 4294967295]
+    [TestCase(0U, uint.MinValue, uint.MaxValue, 0.0f)]
+    [TestCase(2147483647U, uint.MinValue, uint.MaxValue, 0.5f)]
+    [TestCase(4294967295U, uint.MinValue, uint.MaxValue, 1.0f)]
+    public void Utilities_NumberHelpers_CanConvertUIntToNormalizedFloatAndBack(uint value, uint minValue, uint maxValue, float expected)
+    {
+        var result = NumberHelpers.UIntToNormalizedFloat(value, minValue, maxValue);
+        Assert.That(result, Is.EqualTo(expected).Within(float.Epsilon));
+        
+        var integer = NumberHelpers.NormalizedFloatToUInt(result, minValue, maxValue);
+        Assert.That(integer, Is.EqualTo(Clamp(value, minValue, maxValue)));
+    }
+
+    // Mathf.Clamp is not overloaded for uint's, Math.Clamp is only available in .NET core 2.0+ / .NET 5
+    private static uint Clamp(uint value, uint min, uint max)
+    {
+        if (value < min)
+            value = min;
+        else if (value > max)
+            value = max;
+        return value;
+    }
+}

--- a/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs
@@ -1,7 +1,11 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
+using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 
 internal class NumberHelpersTests

--- a/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text;
 using NUnit.Framework;
@@ -46,7 +46,7 @@ internal class NumberHelpersTests
         var integer = NumberHelpers.NormalizedFloatToInt(result, minValue, maxValue);
         Assert.That(integer, Is.EqualTo(Mathf.Clamp(value, minValue, maxValue)));
     }
-    
+
     [Test]
     [Category("Utilities")]
     // out of boundary tests
@@ -72,7 +72,7 @@ internal class NumberHelpersTests
     {
         var result = NumberHelpers.UIntToNormalizedFloat(value, minValue, maxValue);
         Assert.That(result, Is.EqualTo(expected).Within(float.Epsilon));
-        
+
         var integer = NumberHelpers.NormalizedFloatToUInt(result, minValue, maxValue);
         Assert.That(integer, Is.EqualTo(Clamp(value, minValue, maxValue)));
     }

--- a/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs.meta
+++ b/Assets/Tests/InputSystem/Utilities/NumberHelpersTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 649e07386e9f42f59cd7e55796b1a1b1
+timeCreated: 1611237180

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,6 +23,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed compile error on tvOS due to step counter support for iOS added in `1.1.0-preview.3`.
 - Fixed PS4- and PS3-specific `rightTriggerButton` and `leftTriggerButton` controls not being marked as synthetic and thus conflicting with `rightTrigger` and `leftTrigger` input ([case 1293734](https://issuetracker.unity3d.com/issues/input-system-when-binding-gamepad-controls-triggerbutton-gets-bound-instead-of-triggeraxis)).
   * This manifested itself, for example, when using interactive rebinding and seeing `rightTriggerButton` getting picked instead of the expected `rightTrigger` control.
+- Fixing HID fallback correctly supporting fields with `reportSizeInBits` of 32 bits, which is also reported by vJoy device driver ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
 
 #### Actions
 
@@ -69,7 +70,6 @@ however, it has to be formatted properly to pass verification tests.
   * Regression introduced in 1.1-preview.2.
 - Fixed `Touch.activeTouches` having incorrect touch phases after calling `EnhancedTouch.Disable()` and then `EnhancedTouch.Enable()` ([case 1286865](https://issuetracker.unity3d.com/issues/new-input-system-began-moved-and-ended-touch-phases-are-not-reported-when-a-second-scene-is-loaded)).
 - Fixed compile errors related to XR/AR on console platforms.
-- Fixing HID fallback correctly supporting fields with `reportSizeInBits` of 32 bits, which is also reported by vJoy device driver ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -69,6 +69,7 @@ however, it has to be formatted properly to pass verification tests.
   * Regression introduced in 1.1-preview.2.
 - Fixed `Touch.activeTouches` having incorrect touch phases after calling `EnhancedTouch.Disable()` and then `EnhancedTouch.Enable()` ([case 1286865](https://issuetracker.unity3d.com/issues/new-input-system-began-moved-and-ended-touch-phases-are-not-reported-when-a-second-scene-is-loaded)).
 - Fixed compile errors related to XR/AR on console platforms.
+- Fixing HID fallback correctly supporting fields with `reportSizeInBits` of 32 bits, which is also reported by vJoy device driver ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,7 +23,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed compile error on tvOS due to step counter support for iOS added in `1.1.0-preview.3`.
 - Fixed PS4- and PS3-specific `rightTriggerButton` and `leftTriggerButton` controls not being marked as synthetic and thus conflicting with `rightTrigger` and `leftTrigger` input ([case 1293734](https://issuetracker.unity3d.com/issues/input-system-when-binding-gamepad-controls-triggerbutton-gets-bound-instead-of-triggeraxis)).
   * This manifested itself, for example, when using interactive rebinding and seeing `rightTriggerButton` getting picked instead of the expected `rightTrigger` control.
-- Fixing HID fallback correctly supporting fields with `reportSizeInBits` of 32 bits, which is also reported by vJoy device driver ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
+- Fixed exceptions and incorrect values with HIDs using 32-bit fields ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
+  * This happened, for example, with vJoy installed.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.InputSystem
         public BindingState* bindingStates => memory.bindingStates;
         public InteractionState* interactionStates => memory.interactionStates;
         public int* controlIndexToBindingIndex => memory.controlIndexToBindingIndex;
-        public int* enabledControls => memory.enabledControls;
+        public uint* enabledControls => (uint*)memory.enabledControls;
 
         public bool isProcessingControlStateChange => m_InProcessControlStateChange;
 
@@ -779,19 +779,19 @@ namespace UnityEngine.InputSystem
         private bool IsControlEnabled(int controlIndex)
         {
             var intIndex = controlIndex / 32;
-            var intMask = 1 << (controlIndex % 32);
-            return (enabledControls[intIndex] & intMask) != 0;
+            var mask = 1U << (controlIndex % 32);
+            return (enabledControls[intIndex] & mask) != 0;
         }
 
         private void SetControlEnabled(int controlIndex, bool state)
         {
             var intIndex = controlIndex / 32;
-            var intMask = 1 << (controlIndex % 32);
+            var mask = 1U << (controlIndex % 32);
 
             if (state)
-                enabledControls[intIndex] |= intMask;
+                enabledControls[intIndex] |= mask;
             else
-                enabledControls[intIndex] &= ~intMask;
+                enabledControls[intIndex] &= ~mask;
         }
 
         private void HookOnBeforeUpdate()

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
@@ -57,7 +57,8 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            var intValue = MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
+            ////REVIEW: seems like all signed data in state buffers is in excess-K format, do we have any that is in two's complement format?
+            var intValue = MemoryHelpers.ReadTwosComplementMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
 
             var value = 0.0f;
             if (minValue > maxValue)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
@@ -57,7 +57,7 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            var intValue = MemoryHelpers.ReadIntFromMultipleBits(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
+            var intValue = MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
 
             var value = 0.0f;
             if (minValue > maxValue)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
@@ -57,7 +57,7 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            ////REVIEW: seems like all signed data in state buffers is in excess-K format, do we have any that is in two's complement format?
+            // Note that all signed data in state buffers is in excess-K format. 
             var intValue = MemoryHelpers.ReadTwosComplementMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
 
             var value = 0.0f;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DiscreteButtonControl.cs
@@ -57,7 +57,7 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            // Note that all signed data in state buffers is in excess-K format. 
+            // Note that all signed data in state buffers is in excess-K format.
             var intValue = MemoryHelpers.ReadTwosComplementMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
 
             var value = 0.0f;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
@@ -34,7 +34,7 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            var intValue = MemoryHelpers.ReadIntFromMultipleBits(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
+            var intValue = MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
             var phaseValue = (TouchPhase)intValue;
 
             var value = 0.0f;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
@@ -34,7 +34,8 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            var intValue = MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
+            ////REVIEW: seems like all signed data in state buffers is in excess-K format, do we have any that is in two's complement format?
+            var intValue = MemoryHelpers.ReadTwosComplementMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
             var phaseValue = (TouchPhase)intValue;
 
             var value = 0.0f;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
@@ -34,9 +34,8 @@ namespace UnityEngine.InputSystem.Controls
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
-            ////REVIEW: seems like all signed data in state buffers is in excess-K format, do we have any that is in two's complement format?
-            var intValue = MemoryHelpers.ReadTwosComplementMultipleBitsAsInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
-            var phaseValue = (TouchPhase)intValue;
+            var uintValue = MemoryHelpers.ReadMultipleBitsAsUInt(valuePtr, m_StateBlock.bitOffset, m_StateBlock.sizeInBits);
+            var phaseValue = (TouchPhase)uintValue;
 
             var value = 0.0f;
             if (phaseValue == TouchPhase.Began || phaseValue == TouchPhase.Stationary ||

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -158,7 +158,8 @@ namespace UnityEngine.InputSystem.LowLevel
 
             foreach (var button in buttons)
             {
-                var bit = (uint)1 << (int)button;
+                Debug.Assert((int)button < 32);
+                var bit = 1U << (int)button;
                 this.buttons |= bit;
             }
         }
@@ -172,7 +173,8 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <returns>GamepadState with a modified <see cref="buttons"/> mask.</returns>
         public GamepadState WithButton(GamepadButton button, bool value = true)
         {
-            var bit = (uint)1 << (int)button;
+            Debug.Assert((int)button < 32);
+            var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;
             else

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -158,7 +158,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
             foreach (var button in buttons)
             {
-                Debug.Assert((int)button < 32);
+                Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
                 var bit = 1U << (int)button;
                 this.buttons |= bit;
             }
@@ -173,7 +173,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <returns>GamepadState with a modified <see cref="buttons"/> mask.</returns>
         public GamepadState WithButton(GamepadButton button, bool value = true)
         {
-            Debug.Assert((int)button < 32);
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
             var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -158,7 +158,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
             foreach (var button in buttons)
             {
-                Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
+                Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask");
                 var bit = 1U << (int)button;
                 this.buttons |= bit;
             }
@@ -173,7 +173,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <returns>GamepadState with a modified <see cref="buttons"/> mask.</returns>
         public GamepadState WithButton(GamepadButton button, bool value = true)
         {
-            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask");
             var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -603,18 +603,21 @@ namespace UnityEngine.InputSystem
 
         internal static uint EncodeStateOffsetToControlMapEntry(uint controlIndex, uint stateOffsetInBits, uint stateSizeInBits)
         {
-            Debug.Assert(controlIndex < (1 << kControlIndexBits), "Control index beyond what is supported");
-            Debug.Assert(stateOffsetInBits < (1 << kStateOffsetBits), "State offset beyond what is supported");
-            Debug.Assert(stateSizeInBits < (1 << kStateSizeBits), "State size beyond what is supported");
+            Debug.Assert(kControlIndexBits < 32);
+            Debug.Assert(kStateOffsetBits < 32);
+            Debug.Assert(kStateSizeBits < 32);
+            Debug.Assert(controlIndex < (1U << kControlIndexBits), "Control index beyond what is supported");
+            Debug.Assert(stateOffsetInBits < (1U << kStateOffsetBits), "State offset beyond what is supported");
+            Debug.Assert(stateSizeInBits < (1U << kStateSizeBits), "State size beyond what is supported");
             return stateOffsetInBits << (kControlIndexBits + kStateSizeBits) | stateSizeInBits << kControlIndexBits | controlIndex;
         }
 
         internal static void DecodeStateOffsetToControlMapEntry(uint entry, out uint controlIndex,
             out uint stateOffset, out uint stateSize)
         {
-            controlIndex = entry & (1 << kControlIndexBits) - 1;
+            controlIndex = entry & (1U << kControlIndexBits) - 1;
             stateOffset = entry >> (kControlIndexBits + kStateSizeBits);
-            stateSize = (entry >> kControlIndexBits) & (((1 << (kControlIndexBits + kStateSizeBits)) - 1) >> kControlIndexBits);
+            stateSize = (entry >> kControlIndexBits) & (((1U << (kControlIndexBits + kStateSizeBits)) - 1) >> kControlIndexBits);
         }
 
         // NOTE: We don't store processors in a combined array the same way we do for

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -603,9 +603,9 @@ namespace UnityEngine.InputSystem
 
         internal static uint EncodeStateOffsetToControlMapEntry(uint controlIndex, uint stateOffsetInBits, uint stateSizeInBits)
         {
-            Debug.Assert(kControlIndexBits < 32);
-            Debug.Assert(kStateOffsetBits < 32);
-            Debug.Assert(kStateSizeBits < 32);
+            Debug.Assert(kControlIndexBits < 32, $"Expected kControlIndexBits < 32, so we fit into the 32 bit wide bitmask, but found kControlIndexBits == {kControlIndexBits}");
+            Debug.Assert(kStateOffsetBits < 32, $"Expected kStateOffsetBits < 32, so we fit into the 32 bit wide bitmask, but found kStateOffsetBits == {kStateOffsetBits}");
+            Debug.Assert(kStateSizeBits < 32, $"Expected kStateSizeBits < 32, so we fit into the 32 bit wide bitmask, but found kStateSizeBits == {kStateSizeBits}");
             Debug.Assert(controlIndex < (1U << kControlIndexBits), "Control index beyond what is supported");
             Debug.Assert(stateOffsetInBits < (1U << kStateOffsetBits), "State offset beyond what is supported");
             Debug.Assert(stateSizeInBits < (1U << kStateSizeBits), "State size beyond what is supported");

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -603,9 +603,9 @@ namespace UnityEngine.InputSystem
 
         internal static uint EncodeStateOffsetToControlMapEntry(uint controlIndex, uint stateOffsetInBits, uint stateSizeInBits)
         {
-            Debug.Assert(kControlIndexBits < 32, $"Expected kControlIndexBits < 32, so we fit into the 32 bit wide bitmask, but found kControlIndexBits == {kControlIndexBits}");
-            Debug.Assert(kStateOffsetBits < 32, $"Expected kStateOffsetBits < 32, so we fit into the 32 bit wide bitmask, but found kStateOffsetBits == {kStateOffsetBits}");
-            Debug.Assert(kStateSizeBits < 32, $"Expected kStateSizeBits < 32, so we fit into the 32 bit wide bitmask, but found kStateSizeBits == {kStateSizeBits}");
+            Debug.Assert(kControlIndexBits < 32, $"Expected kControlIndexBits < 32, so we fit into the 32 bit wide bitmask");
+            Debug.Assert(kStateOffsetBits < 32, $"Expected kStateOffsetBits < 32, so we fit into the 32 bit wide bitmask");
+            Debug.Assert(kStateSizeBits < 32, $"Expected kStateSizeBits < 32, so we fit into the 32 bit wide bitmask");
             Debug.Assert(controlIndex < (1U << kControlIndexBits), "Control index beyond what is supported");
             Debug.Assert(stateOffsetInBits < (1U << kStateOffsetBits), "State offset beyond what is supported");
             Debug.Assert(stateSizeInBits < (1U << kStateSizeBits), "State size beyond what is supported");

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
@@ -868,8 +868,8 @@ namespace UnityEngine.InputSystem.Layouts
             if (m_StateOffsetToControlMap == null)
                 m_StateOffsetToControlMap = new List<uint>();
 
-            if (m_Device.allControls.Count > (1 << InputDevice.kControlIndexBits))
-                throw new NotSupportedException($"Device '{m_Device}' exceeds maximum supported control count of {1 << InputDevice.kControlIndexBits} (has {m_Device.allControls.Count} controls)");
+            if (m_Device.allControls.Count > (1U << InputDevice.kControlIndexBits))
+                throw new NotSupportedException($"Device '{m_Device}' exceeds maximum supported control count of {1U << InputDevice.kControlIndexBits} (has {m_Device.allControls.Count} controls)");
 
             // Device is not in m_ChildrenForEachControl so use index -1.
             FinalizeControlHierarchyRecursive(m_Device, -1, m_Device.m_ChildrenForEachControl);
@@ -880,10 +880,10 @@ namespace UnityEngine.InputSystem.Layouts
             // Make sure we're staying within limits on state offsets and sizes.
             if (control.m_ChildCount == 0)
             {
-                if (control.m_StateBlock.effectiveBitOffset >= (1 << InputDevice.kStateOffsetBits))
-                    throw new NotSupportedException($"Control '{control}' exceeds maximum supported state bit offset of {(1 << InputDevice.kStateOffsetBits) - 1} (bit offset {control.stateBlock.effectiveBitOffset})");
-                if (control.m_StateBlock.sizeInBits >= (1 << InputDevice.kStateSizeBits))
-                    throw new NotSupportedException($"Control '{control}' exceeds maximum supported state bit size of {(1 << InputDevice.kStateSizeBits) - 1} (bit offset {control.stateBlock.sizeInBits})");
+                if (control.m_StateBlock.effectiveBitOffset >= (1U << InputDevice.kStateOffsetBits))
+                    throw new NotSupportedException($"Control '{control}' exceeds maximum supported state bit offset of {(1U << InputDevice.kStateOffsetBits) - 1} (bit offset {control.stateBlock.effectiveBitOffset})");
+                if (control.m_StateBlock.sizeInBits >= (1U << InputDevice.kStateSizeBits))
+                    throw new NotSupportedException($"Control '{control}' exceeds maximum supported state bit size of {(1U << InputDevice.kStateSizeBits) - 1} (bit offset {control.stateBlock.sizeInBits})");
             }
 
             // Add all leaf controls to state offset mapping.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -102,7 +102,8 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <seealso cref="buttons"/>
         public MouseState WithButton(MouseButton button, bool state = true)
         {
-            var bit = 1 << (int)button;
+            Debug.Assert((int)button < 16);
+            var bit = 1U << (int)button;
             if (state)
                 buttons |= (ushort)bit;
             else

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -102,7 +102,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <seealso cref="buttons"/>
         public MouseState WithButton(MouseButton button, bool state = true)
         {
-            Debug.Assert((int)button < 16);
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
             var bit = 1U << (int)button;
             if (state)
                 buttons |= (ushort)bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -102,7 +102,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <seealso cref="buttons"/>
         public MouseState WithButton(MouseButton button, bool state = true)
         {
-            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask");
             var bit = 1U << (int)button;
             if (state)
                 buttons |= (ushort)bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -110,10 +110,12 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <returns>Same PenState with an updated <see cref="buttons"/> mask.</returns>
         public PenState WithButton(PenButton button, bool state = true)
         {
+            Debug.Assert((int)button < 16);
+            var bit = 1U << (int)button;
             if (state)
-                buttons |= (ushort)(1 << (int)button);
+                buttons |= (ushort)bit;
             else
-                buttons &= (ushort)~(1 << (int)button);
+                buttons &= (ushort)~bit;
             return this;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <returns>Same PenState with an updated <see cref="buttons"/> mask.</returns>
         public PenState WithButton(PenButton button, bool state = true)
         {
-            Debug.Assert((int)button < 16);
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
             var bit = 1U << (int)button;
             if (state)
                 buttons |= (ushort)bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <returns>Same PenState with an updated <see cref="buttons"/> mask.</returns>
         public PenState WithButton(PenButton button, bool state = true)
         {
-            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask");
             var bit = 1U << (int)button;
             if (state)
                 buttons |= (ushort)bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -58,9 +58,9 @@ namespace UnityEngine.InputSystem.Android.LowLevel
             fixed(uint* buttonsPtr = buttons)
             {
                 if (value)
-                    buttonsPtr[(int)code / 32] |= (uint)1 << ((int)code % 32);
+                    buttonsPtr[(int)code / 32] |= 1U << ((int)code % 32);
                 else
-                    buttonsPtr[(int)code / 32] &= ~((uint)1 << ((int)code % 32));
+                    buttonsPtr[(int)code / 32] &= ~(1U << ((int)code % 32));
             }
             return this;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -542,7 +542,7 @@ namespace UnityEngine.InputSystem.HID
             {
                 get
                 {
-                    var maxValue = (1 << reportSizeInBits) - 1;
+                    var maxValue = (1UL << reportSizeInBits) - 1;
                     if (isSigned)
                         return logicalMin / (float)((maxValue + 1) / 2);
                     return logicalMin / (float)maxValue;
@@ -553,7 +553,7 @@ namespace UnityEngine.InputSystem.HID
             {
                 get
                 {
-                    var maxValue = (1 << reportSizeInBits) - 1;
+                    var maxValue = (1UL << reportSizeInBits) - 1;
                     if (isSigned)
                         return logicalMax / (float)((maxValue + 1) / 2);
                     return logicalMax / (float)maxValue;
@@ -673,17 +673,11 @@ namespace UnityEngine.InputSystem.HID
                 switch (reportSizeInBits)
                 {
                     case 8:
-                        if (isSigned)
-                            return InputStateBlock.FormatSByte;
-                        return InputStateBlock.FormatByte;
+                        return isSigned ? InputStateBlock.FormatSByte : InputStateBlock.FormatByte;
                     case 16:
-                        if (isSigned)
-                            return InputStateBlock.FormatShort;
-                        return InputStateBlock.FormatUShort;
+                        return isSigned ? InputStateBlock.FormatShort : InputStateBlock.FormatUShort;
                     case 32:
-                        if (isSigned)
-                            return InputStateBlock.FormatInt;
-                        return InputStateBlock.FormatUInt;
+                        return isSigned ? InputStateBlock.FormatInt : InputStateBlock.FormatUInt;
                     default:
                         // Generic bitfield value.
                         return InputStateBlock.FormatBit;
@@ -796,15 +790,14 @@ namespace UnityEngine.InputSystem.HID
                                     // logical min and max but in range with respect to what we can store
                                     // in the bits we have.
 
-                                    // Test lower bound.
-                                    var minMinusOne = logicalMin - 1;
-                                    if (minMinusOne >= 0)
-                                        return new PrimitiveValue(minMinusOne);
+                                    // Test lower bound, we can store >= 0.
+                                    if (logicalMin >= 1)
+                                        return new PrimitiveValue(logicalMin - 1);
 
-                                    // Test upper bound.
-                                    var maxPlusOne = logicalMax + 1;
-                                    if (maxPlusOne <= (1 << reportSizeInBits) - 1)
-                                        return new PrimitiveValue(maxPlusOne);
+                                    // Test upper bound, we can store <= maxValue.
+                                    var maxValue = (1UL << reportSizeInBits) - 1;
+                                    if ((ulong)logicalMax < maxValue)
+                                        return new PrimitiveValue(logicalMax + 1);
                                 }
                                 break;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -542,10 +542,18 @@ namespace UnityEngine.InputSystem.HID
             {
                 get
                 {
-                    var maxValue = (1UL << reportSizeInBits) - 1;
                     if (isSigned)
-                        return logicalMin / (float)((maxValue + 1) / 2);
-                    return logicalMin / (float)maxValue;
+                    {
+                        var minValue = (int)-(long)(1UL << (reportSizeInBits - 1));
+                        var maxValue = (int) ((1UL << (reportSizeInBits - 1)) - 1);
+                        return NumberHelpers.IntToNormalizedFloat(logicalMin, minValue, maxValue) * 2.0f - 1.0f;
+                    }
+                    else
+                    {
+                        Debug.Assert(logicalMin >= 0);
+                        var maxValue = (uint) ((1UL << reportSizeInBits) - 1);
+                        return NumberHelpers.UIntToNormalizedFloat((uint)logicalMin, 0, maxValue);
+                    }
                 }
             }
 
@@ -553,10 +561,18 @@ namespace UnityEngine.InputSystem.HID
             {
                 get
                 {
-                    var maxValue = (1UL << reportSizeInBits) - 1;
                     if (isSigned)
-                        return logicalMax / (float)((maxValue + 1) / 2);
-                    return logicalMax / (float)maxValue;
+                    {
+                        var minValue = (int)-(long)(1UL << (reportSizeInBits - 1));
+                        var maxValue = (int) ((1UL << (reportSizeInBits - 1)) - 1);
+                        return NumberHelpers.IntToNormalizedFloat(logicalMax, minValue, maxValue) * 2.0f - 1.0f;
+                    }
+                    else
+                    {
+                        Debug.Assert(logicalMax >= 0);
+                        var maxValue = (uint) ((1UL << reportSizeInBits) - 1);
+                        return NumberHelpers.UIntToNormalizedFloat((uint)logicalMax, 0, maxValue);
+                    }
                 }
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -550,7 +550,7 @@ namespace UnityEngine.InputSystem.HID
                     }
                     else
                     {
-                        Debug.Assert(logicalMin >= 0, $"Expected logicalMin to be unsigned, but logicalMin == {logicalMin}");
+                        Debug.Assert(logicalMin >= 0, $"Expected logicalMin to be unsigned");
                         var maxValue = (uint)((1UL << reportSizeInBits) - 1);
                         return NumberHelpers.UIntToNormalizedFloat((uint)logicalMin, 0, maxValue);
                     }
@@ -569,7 +569,7 @@ namespace UnityEngine.InputSystem.HID
                     }
                     else
                     {
-                        Debug.Assert(logicalMax >= 0, $"Expected logicalMax to be unsigned, but logicalMax == {logicalMax}");
+                        Debug.Assert(logicalMax >= 0, $"Expected logicalMax to be unsigned");
                         var maxValue = (uint)((1UL << reportSizeInBits) - 1);
                         return NumberHelpers.UIntToNormalizedFloat((uint)logicalMax, 0, maxValue);
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -550,7 +550,7 @@ namespace UnityEngine.InputSystem.HID
                     }
                     else
                     {
-                        Debug.Assert(logicalMin >= 0);
+                        Debug.Assert(logicalMin >= 0, $"Expected logicalMin to be unsigned, but logicalMin == {logicalMin}");
                         var maxValue = (uint)((1UL << reportSizeInBits) - 1);
                         return NumberHelpers.UIntToNormalizedFloat((uint)logicalMin, 0, maxValue);
                     }
@@ -569,7 +569,7 @@ namespace UnityEngine.InputSystem.HID
                     }
                     else
                     {
-                        Debug.Assert(logicalMax >= 0);
+                        Debug.Assert(logicalMax >= 0, $"Expected logicalMax to be unsigned, but logicalMax == {logicalMax}");
                         var maxValue = (uint)((1UL << reportSizeInBits) - 1);
                         return NumberHelpers.UIntToNormalizedFloat((uint)logicalMax, 0, maxValue);
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -545,13 +545,13 @@ namespace UnityEngine.InputSystem.HID
                     if (isSigned)
                     {
                         var minValue = (int)-(long)(1UL << (reportSizeInBits - 1));
-                        var maxValue = (int) ((1UL << (reportSizeInBits - 1)) - 1);
+                        var maxValue = (int)((1UL << (reportSizeInBits - 1)) - 1);
                         return NumberHelpers.IntToNormalizedFloat(logicalMin, minValue, maxValue) * 2.0f - 1.0f;
                     }
                     else
                     {
                         Debug.Assert(logicalMin >= 0);
-                        var maxValue = (uint) ((1UL << reportSizeInBits) - 1);
+                        var maxValue = (uint)((1UL << reportSizeInBits) - 1);
                         return NumberHelpers.UIntToNormalizedFloat((uint)logicalMin, 0, maxValue);
                     }
                 }
@@ -564,13 +564,13 @@ namespace UnityEngine.InputSystem.HID
                     if (isSigned)
                     {
                         var minValue = (int)-(long)(1UL << (reportSizeInBits - 1));
-                        var maxValue = (int) ((1UL << (reportSizeInBits - 1)) - 1);
+                        var maxValue = (int)((1UL << (reportSizeInBits - 1)) - 1);
                         return NumberHelpers.IntToNormalizedFloat(logicalMax, minValue, maxValue) * 2.0f - 1.0f;
                     }
                     else
                     {
                         Debug.Assert(logicalMax >= 0);
-                        var maxValue = (uint) ((1UL << reportSizeInBits) - 1);
+                        var maxValue = (uint)((1UL << reportSizeInBits) - 1);
                         return NumberHelpers.UIntToNormalizedFloat((uint)logicalMax, 0, maxValue);
                     }
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -60,9 +60,9 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         [FieldOffset(8)] public ushort rightStickX;
         [FieldOffset(10)] public ushort rightStickY;
 
-        public float leftTrigger => ((buttons & (1 << (int)Button.ZL)) != 0) ? 1f : 0f;
+        public float leftTrigger => ((buttons & (1U << (int)Button.ZL)) != 0) ? 1f : 0f;
 
-        public float rightTrigger => ((buttons & (1 << (int)Button.ZR)) != 0) ? 1f : 0f;
+        public float rightTrigger => ((buttons & (1U << (int)Button.ZR)) != 0) ? 1f : 0f;
 
         public enum Button
         {
@@ -89,7 +89,8 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
 
         public SwitchProControllerHIDInputState WithButton(Button button, bool value = true)
         {
-            var bit = (uint)1 << (int)button;
+            Debug.Assert((int)button < 32);
+            var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;
             else

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -89,7 +89,7 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
 
         public SwitchProControllerHIDInputState WithButton(Button button, bool value = true)
         {
-            Debug.Assert((int)button < 32);
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
             var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -89,7 +89,7 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
 
         public SwitchProControllerHIDInputState WithButton(Button button, bool value = true)
         {
-            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask");
             var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -79,7 +79,8 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerWindowsState WithButton(Button button)
         {
-            buttons |= (ushort)((uint)1 << (int)button);
+            Debug.Assert((int)button < 16);
+            buttons |= (ushort)(1U << (int)button);
             return this;
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -79,7 +79,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerWindowsState WithButton(Button button)
         {
-            Debug.Assert((int)button < 16);
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
             buttons |= (ushort)(1U << (int)button);
             return this;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputControllerWindows.cs
@@ -79,7 +79,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerWindowsState WithButton(Button button)
         {
-            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask");
             buttons |= (ushort)(1U << (int)button);
             return this;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -97,7 +97,8 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerOSXState WithButton(Button button)
         {
-            buttons |= (ushort)((uint)1 << (int)button);
+            Debug.Assert((int)button < 16);
+            buttons |= (ushort)(1U << (int)button);
             return this;
         }
     }
@@ -174,7 +175,8 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerWirelessOSXState WithButton(Button button)
         {
-            buttons |= (uint)1 << (int)button;
+            Debug.Assert((int)button < 32);
+            buttons |= 1U << (int)button;
             return this;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -97,7 +97,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerOSXState WithButton(Button button)
         {
-            Debug.Assert((int)button < 16);
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
             buttons |= (ushort)(1U << (int)button);
             return this;
         }
@@ -175,7 +175,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerWirelessOSXState WithButton(Button button)
         {
-            Debug.Assert((int)button < 32);
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
             buttons |= 1U << (int)button;
             return this;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -97,7 +97,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerOSXState WithButton(Button button)
         {
-            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 16, $"Expected button < 16, so we fit into the 16 bit wide bitmask");
             buttons |= (ushort)(1U << (int)button);
             return this;
         }
@@ -175,7 +175,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public XInputControllerWirelessOSXState WithButton(Button button)
         {
-            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask");
             buttons |= 1U << (int)button;
             return this;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -79,10 +79,12 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
         {
             buttonValues[(int)button] = rawValue;
 
+            Debug.Assert((int)button < 32);
+            var bit = 1U << (int) button;
             if (value)
-                buttons |= (uint)1 << (int)button;
+                buttons |= bit;
             else
-                buttons &= ~(uint)1 << (int)button;
+                buttons &= ~bit;
 
             return this;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -80,7 +80,7 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
             buttonValues[(int)button] = rawValue;
 
             Debug.Assert((int)button < 32);
-            var bit = 1U << (int) button;
+            var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;
             else

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -79,7 +79,7 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
         {
             buttonValues[(int)button] = rawValue;
 
-            Debug.Assert((int)button < 32);
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
             var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -79,7 +79,7 @@ namespace UnityEngine.InputSystem.iOS.LowLevel
         {
             buttonValues[(int)button] = rawValue;
 
-            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask, but found button == {(int)button}");
+            Debug.Assert((int)button < 32, $"Expected button < 32, so we fit into the 32 bit wide bitmask");
             var bit = 1U << (int)button;
             if (value)
                 buttons |= bit;

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -51,7 +51,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatBit = new FourCC('B', 'I', 'T');
-        private const int kFormatBit = 'B' << 24 | 'I' << 16 | 'T' << 8 | ' ';
+        internal const int kFormatBit = 'B' << 24 | 'I' << 16 | 'T' << 8 | ' ';
 
         /// <summary>
         /// Format code for a variable-width bitfield representing a signed value, i.e. the
@@ -60,77 +60,77 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatSBit = new FourCC('S', 'B', 'I', 'T');
-        private const int kFormatSBit = 'S' << 24 | 'B' << 16 | 'I' << 8 | 'T';
+        internal const int kFormatSBit = 'S' << 24 | 'B' << 16 | 'I' << 8 | 'T';
 
         /// <summary>
         /// Format code for a 32-bit signed integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatInt = new FourCC('I', 'N', 'T');
-        private const int kFormatInt = 'I' << 24 | 'N' << 16 | 'T' << 8 | ' ';
+        internal const int kFormatInt = 'I' << 24 | 'N' << 16 | 'T' << 8 | ' ';
 
         /// <summary>
         /// Format code for a 32-bit unsigned integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatUInt = new FourCC('U', 'I', 'N', 'T');
-        private const int kFormatUInt = 'U' << 24 | 'I' << 16 | 'N' << 8 | 'T';
+        internal const int kFormatUInt = 'U' << 24 | 'I' << 16 | 'N' << 8 | 'T';
 
         /// <summary>
         /// Format code for a 16-bit signed integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatShort = new FourCC('S', 'H', 'R', 'T');
-        private const int kFormatShort = 'S' << 24 | 'H' << 16 | 'R' << 8 | 'T';
+        internal const int kFormatShort = 'S' << 24 | 'H' << 16 | 'R' << 8 | 'T';
 
         /// <summary>
         /// Format code for a 16-bit unsigned integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatUShort = new FourCC('U', 'S', 'H', 'T');
-        private const int kFormatUShort = 'U' << 24 | 'S' << 16 | 'H' << 8 | 'T';
+        internal const int kFormatUShort = 'U' << 24 | 'S' << 16 | 'H' << 8 | 'T';
 
         /// <summary>
         /// Format code for an 8-bit unsigned integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatByte = new FourCC('B', 'Y', 'T', 'E');
-        private const int kFormatByte = 'B' << 24 | 'Y' << 16 | 'T' << 8 | 'E';
+        internal const int kFormatByte = 'B' << 24 | 'Y' << 16 | 'T' << 8 | 'E';
 
         /// <summary>
         /// Format code for an 8-bit signed integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatSByte = new FourCC('S', 'B', 'Y', 'T');
-        private const int kFormatSByte = 'S' << 24 | 'B' << 16 | 'Y' << 8 | 'T';
+        internal const int kFormatSByte = 'S' << 24 | 'B' << 16 | 'Y' << 8 | 'T';
 
         /// <summary>
         /// Format code for a 64-bit signed integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatLong = new FourCC('L', 'N', 'G');
-        private const int kFormatLong = 'L' << 24 | 'N' << 16 | 'G' << 8 | ' ';
+        internal const int kFormatLong = 'L' << 24 | 'N' << 16 | 'G' << 8 | ' ';
 
         /// <summary>
         /// Format code for a 64-bit unsigned integer value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatULong = new FourCC('U', 'L', 'N', 'G');
-        private const int kFormatULong = 'U' << 24 | 'L' << 16 | 'N' << 8 | 'G';
+        internal const int kFormatULong = 'U' << 24 | 'L' << 16 | 'N' << 8 | 'G';
 
         /// <summary>
         /// Format code for a 32-bit floating-point value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatFloat = new FourCC('F', 'L', 'T');
-        private const int kFormatFloat = 'F' << 24 | 'L' << 16 | 'T' << 8 | ' ';
+        internal const int kFormatFloat = 'F' << 24 | 'L' << 16 | 'T' << 8 | ' ';
 
         /// <summary>
         /// Format code for a 64-bit floating-point value.
         /// </summary>
         /// <seealso cref="format"/>
         public static readonly FourCC FormatDouble = new FourCC('D', 'B', 'L');
-        private const int kFormatDouble = 'D' << 24 | 'B' << 16 | 'L' << 8 | ' ';
+        internal const int kFormatDouble = 'D' << 24 | 'B' << 16 | 'L' << 8 | ' ';
 
         ////REVIEW: are these really useful?
         public static readonly FourCC FormatVector2 = new FourCC('V', 'E', 'C', '2');
@@ -250,13 +250,13 @@ namespace UnityEngine.InputSystem.LowLevel
                 case kFormatBit:
                     if (sizeInBits == 1)
                         return MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1 : 0;
-                    return MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
+                    return MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, bitOffset, sizeInBits);
                 case kFormatSBit:
                 {
                     if (sizeInBits == 1)
                         return MemoryHelpers.ReadSingleBit(valuePtr, bitOffset) ? 1 : -1;
-                    var halfMax = (1 << (int)sizeInBits) / 2; // TODO fix me!
-                    var unsignedValue = MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
+                    var halfMax = (int)(1UL << (int)sizeInBits) / 2; // TODO fix me!
+                    var unsignedValue = MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, bitOffset, sizeInBits);
                     return unsignedValue - halfMax;
                 }
                 case kFormatInt:
@@ -305,7 +305,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits == 1)
                         MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value != 0);
                     else
-                        MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value);
+                        MemoryHelpers.WriteIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value);
                     break;
                 case kFormatSBit:
                     if (sizeInBits == 1)
@@ -313,7 +313,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     else
                     {
                         var halfMax = (1 << (int) sizeInBits) / 2; // TODO fix me!
-                        MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value + halfMax);
+                        MemoryHelpers.WriteIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value + halfMax);
                     }
                     break;
                 case kFormatInt:
@@ -372,7 +372,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits > 32)
                         throw new NotImplementedException("Cannot yet convert unaligned multi-bit fields greater than 32 bits to floats");
                     
-                    var uintValue = (uint)MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
+                    var uintValue = (uint)MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, bitOffset, sizeInBits);
                     var maxValue = (uint)((1UL << (int)sizeInBits) - 1); // TODO fix me!
                     var value = NumberHelpers.UIntToNormalizedFloat(uintValue, 0, maxValue);
                     if (fmt == kFormatSBit)
@@ -433,7 +433,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     {
                         var maxValue = (1 << (int) sizeInBits) - 1; // TODO fix me!
                         var intValue = (int) (value * maxValue);
-                        MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, intValue);
+                        MemoryHelpers.WriteIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, intValue);
                     }
                     break;
                 case kFormatInt:
@@ -559,7 +559,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits > 32)
                         throw new NotImplementedException("Cannot yet convert unaligned multi-bit fields greater than 32 bits to floats");
                     
-                    var uintValue = (uint)MemoryHelpers.ReadIntFromMultipleBits(valuePtr, bitOffset, sizeInBits);
+                    var uintValue = (uint)MemoryHelpers.ReadMultipleBitsAsInt(valuePtr, bitOffset, sizeInBits);
                     var maxValue = (uint)((1UL << (int)sizeInBits) - 1); // TODO fix me!
                     var value = NumberHelpers.UIntToNormalizedFloat(uintValue, 0, maxValue);
                     if (fmt == kFormatSBit)
@@ -623,10 +623,20 @@ namespace UnityEngine.InputSystem.LowLevel
                     {
                         var maxValue = (1 << (int) sizeInBits) - 1;
                         var intValue = (int) (value * maxValue);
-                        MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, intValue);
+                        MemoryHelpers.WriteIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, intValue);
                     }
                     break;
                 }
+                case kFormatInt:
+                    Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");
+                    Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
+                    *(int*) valuePtr = NumberHelpers.NormalizedFloatToInt((float)value * 0.5f + 0.5f, int.MinValue, int.MaxValue);
+                    break;
+                case kFormatUInt:
+                    Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=16");
+                    Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
+                    *(uint*) valuePtr = NumberHelpers.NormalizedFloatToUInt((float)value, uint.MinValue, uint.MaxValue);
+                    break;
                 case kFormatShort:
                     Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
@@ -659,8 +669,6 @@ namespace UnityEngine.InputSystem.LowLevel
                     break;
                 // Not supported:
                 // - kFormatSBit
-                // - kFormatInt
-                // - kFormatUInt
                 // - kFormatLong
                 // - kFormatULong
                 // - kFormatFloat
@@ -687,7 +695,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits == 1)
                         MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value.ToBoolean());
                     else
-                        MemoryHelpers.WriteIntFromMultipleBits(valuePtr, bitOffset, sizeInBits, value.ToInt32());
+                        MemoryHelpers.WriteIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value.ToInt32());
                     break;
                 }
                 case kFormatInt:

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -421,22 +421,22 @@ namespace UnityEngine.InputSystem.LowLevel
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
-                    *(int*) valuePtr = (int)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, int.MinValue, int.MaxValue);
+                    *(int*)valuePtr = (int)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, int.MinValue, int.MaxValue);
                     break;
                 case kFormatUInt:
                     Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
-                    *(uint*) valuePtr = NumberHelpers.NormalizedFloatToUInt(value, uint.MinValue, uint.MaxValue);
+                    *(uint*)valuePtr = NumberHelpers.NormalizedFloatToUInt(value, uint.MinValue, uint.MaxValue);
                     break;
                 case kFormatShort:
                     Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "SHRT state must be byte-aligned");
-                    *(short*) valuePtr = (short)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, short.MinValue, short.MaxValue);
+                    *(short*)valuePtr = (short)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, short.MinValue, short.MaxValue);
                     break;
                 case kFormatUShort:
                     Debug.Assert(sizeInBits == 16, "USHT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "USHT state must be byte-aligned");
-                    *(ushort*) valuePtr = (ushort)NumberHelpers.NormalizedFloatToUInt(value, ushort.MinValue, ushort.MaxValue);
+                    *(ushort*)valuePtr = (ushort)NumberHelpers.NormalizedFloatToUInt(value, ushort.MinValue, ushort.MaxValue);
                     break;
                 case kFormatByte:
                     Debug.Assert(sizeInBits == 8, "BYTE state must have sizeInBits=8");
@@ -446,7 +446,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 case kFormatSByte:
                     Debug.Assert(sizeInBits == 8, "SBYT state must have sizeInBits=8");
                     Debug.Assert(bitOffset == 0, "SBYT state must be byte-aligned");
-                    *(sbyte*) valuePtr = (sbyte)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, sbyte.MinValue, sbyte.MaxValue);
+                    *(sbyte*)valuePtr = (sbyte)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, sbyte.MinValue, sbyte.MaxValue);
                     break;
                 case kFormatFloat:
                     Debug.Assert(sizeInBits == 32, "FLT state must have sizeInBits=32");
@@ -476,7 +476,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits == 1)
                         return value >= 0.5f;
                     ////FIXME: is this supposed to be int or uint?
-                    return (int)NumberHelpers.NormalizedFloatToUInt(value, 0, (uint) ((1UL << (int) sizeInBits) - 1));
+                    return (int)NumberHelpers.NormalizedFloatToUInt(value, 0, (uint)((1UL << (int)sizeInBits) - 1));
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=32");
                     Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
@@ -599,12 +599,12 @@ namespace UnityEngine.InputSystem.LowLevel
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
-                    *(int*) valuePtr = NumberHelpers.NormalizedFloatToInt((float)value * 0.5f + 0.5f, int.MinValue, int.MaxValue);
+                    *(int*)valuePtr = NumberHelpers.NormalizedFloatToInt((float)value * 0.5f + 0.5f, int.MinValue, int.MaxValue);
                     break;
                 case kFormatUInt:
                     Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
-                    *(uint*) valuePtr = NumberHelpers.NormalizedFloatToUInt((float)value, uint.MinValue, uint.MaxValue);
+                    *(uint*)valuePtr = NumberHelpers.NormalizedFloatToUInt((float)value, uint.MinValue, uint.MaxValue);
                     break;
                 case kFormatShort:
                     Debug.Assert(sizeInBits == 16, "SHRT state must have sizeInBits=16");

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -416,7 +416,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits == 1)
                         MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value >= 0.5f);
                     else
-                        MemoryHelpers.WriteNormalizedUintAsMultipleBits(valuePtr, bitOffset, sizeInBits, value);
+                        MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value);
                     break;
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");
@@ -594,7 +594,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     if (sizeInBits == 1)
                         MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value >= 0.5f);
                     else
-                        MemoryHelpers.WriteNormalizedUintAsMultipleBits(valuePtr, bitOffset, sizeInBits, (float)value);
+                        MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, (float)value);
                     break;
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DynamicBitfield.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DynamicBitfield.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(bitIndex >= 0);
             Debug.Assert(bitIndex < length);
 
-            array[bitIndex / 64] |= (ulong)1 << (bitIndex % 64);
+            array[bitIndex / 64] |= 1UL << (bitIndex % 64);
         }
 
         public bool TestBit(int bitIndex)
@@ -40,7 +40,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(bitIndex >= 0);
             Debug.Assert(bitIndex < length);
 
-            return (array[bitIndex / 64] & ((ulong)1 << (bitIndex % 64))) != 0;
+            return (array[bitIndex / 64] & (1UL << (bitIndex % 64))) != 0;
         }
 
         public void ClearBit(int bitIndex)
@@ -48,7 +48,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(bitIndex >= 0);
             Debug.Assert(bitIndex < length);
 
-            array[bitIndex / 64] &= ~((ulong)1 << (bitIndex % 64));
+            array[bitIndex / 64] &= ~(1UL << (bitIndex % 64));
         }
 
         private static int BitCountToULongCount(int bitCount)

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -366,7 +366,7 @@ namespace UnityEngine.InputSystem.Utilities
             }
         }
 
-        public static int ReadIntFromMultipleBits(void* ptr, uint bitOffset, uint bitCount)
+        public static int ReadMultipleBitsAsInt(void* ptr, uint bitOffset, uint bitCount)
         {
             if (ptr == null)
                 throw new ArgumentNullException(nameof(ptr));
@@ -412,7 +412,7 @@ namespace UnityEngine.InputSystem.Utilities
             throw new NotImplementedException("Reading int straddling int boundary");
         }
 
-        public static void WriteIntFromMultipleBits(void* ptr, uint bitOffset, uint bitCount, int value)
+        public static void WriteIntAsMultipleBits(void* ptr, uint bitOffset, uint bitCount, int value)
         {
             if (ptr == null)
                 throw new ArgumentNullException(nameof(ptr));

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -370,7 +370,7 @@ namespace UnityEngine.InputSystem.Utilities
         {
             if (ptr == null)
                 throw new ArgumentNullException(nameof(ptr));
-            if (bitCount >= sizeof(int) * 8)
+            if (bitCount > sizeof(int) * 8)
                 throw new ArgumentException("Trying to read more than 32 bits as int", nameof(bitCount));
 
             // Shift the pointer up on larger bitmasks and retry.
@@ -416,7 +416,7 @@ namespace UnityEngine.InputSystem.Utilities
         {
             if (ptr == null)
                 throw new ArgumentNullException(nameof(ptr));
-            if (bitCount >= sizeof(int) * 8)
+            if (bitCount > sizeof(int) * 8)
                 throw new ArgumentException("Trying to write more than 32 bits as int", nameof(bitCount));
 
             // Bits out of byte.

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -55,64 +55,19 @@ namespace UnityEngine.InputSystem.Utilities
 
         public static void WriteSingleBit(void* ptr, uint bitOffset, bool value)
         {
-            if (bitOffset < 8)
-            {
-                if (value)
-                    *(byte*)ptr |= (byte)(1 << (int)bitOffset);
-                else
-                    *(byte*)ptr &= (byte)~(1 << (int)bitOffset);
-            }
-            else if (bitOffset < 32)
-            {
-                if (value)
-                    *(int*)ptr |= 1 << (int)bitOffset;
-                else
-                    *(int*)ptr &= ~(1 << (int)bitOffset);
-            }
+            var byteOffset = bitOffset >> 3;
+            bitOffset &= 7;
+            if (value)
+                *((byte*)ptr + byteOffset) |= (byte)(1U << (int)bitOffset);
             else
-            {
-                var byteOffset = bitOffset / 8;
-                bitOffset %= 8;
-
-                if (value)
-                    *((byte*)ptr + byteOffset) |= (byte)(1 << (int)bitOffset);
-                else
-                    *((byte*)ptr + byteOffset) &= (byte)~(1 << (int)bitOffset);
-            }
+                *((byte*)ptr + byteOffset) &= (byte)~(1U << (int)bitOffset);
         }
 
         public static bool ReadSingleBit(void* ptr, uint bitOffset)
         {
-            ////TODO: currently this is not actually enforced...
-            // The layout code makes sure that bitfields are either 8bit or multiples
-            // of 32bits. So we always safely read either a byte or int. Handling
-            // the 8bit and 32bit case directly will lead to nicely aligned memory
-            // accesses if the state has been laid out that way.
-
-            int bits;
-
-            if (bitOffset < 8)
-            {
-                bits = *(byte*)ptr;
-            }
-            else if (bitOffset < 32)
-            {
-                bits = *(int*)ptr;
-            }
-            else
-            {
-                // Long bitfield. Compute an offset to the byte we need and fetch
-                // only that byte. Adjust the bit offset to be for that byte.
-                // On this path, we may end up doing memory accesses that the CPU
-                // doesn't like much.
-
-                var byteOffset = bitOffset / 8;
-                bitOffset %= 8;
-
-                bits = *((byte*)ptr + byteOffset);
-            }
-
-            return (bits & (1 << (int)bitOffset)) != 0;
+            var byteOffset = bitOffset >> 3;
+            bitOffset &= 7;
+            return (*((byte*)ptr + byteOffset) & (1U << (int)bitOffset)) != 0;
         }
 
         public static void MemCpyBitRegion(void* destination, void* source, uint bitOffset, uint bitCount)

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -393,7 +393,7 @@ namespace UnityEngine.InputSystem.Utilities
             {
                 var byteValue = (byte)value;
                 byteValue <<= (int)bitOffset;
-                var mask = ~((0xFF >> (8 - (int)bitCount)) << (int)bitOffset);
+                var mask = ~((0xFFU >> (8 - (int)bitCount)) << (int)bitOffset);
                 *(byte*)ptr = (byte)((*(byte*)ptr & mask) | byteValue);
                 return;
             }
@@ -403,7 +403,7 @@ namespace UnityEngine.InputSystem.Utilities
             {
                 var ushortValue = (ushort)value;
                 ushortValue <<= (int)bitOffset;
-                var mask = ~((0xFFFF >> (16 - (int)bitCount)) << (int)bitOffset);
+                var mask = ~((0xFFFFU >> (16 - (int)bitCount)) << (int)bitOffset);
                 *(ushort*)ptr = (ushort)((*(ushort*)ptr & mask) | ushortValue);
                 return;
             }
@@ -413,7 +413,7 @@ namespace UnityEngine.InputSystem.Utilities
             {
                 var uintValue = (uint)value;
                 uintValue <<= (int)bitOffset;
-                var mask = ~((0xFFFFFFFF >> (32 - (int)bitCount)) << (int)bitOffset);
+                var mask = ~((0xFFFFFFFFU >> (32 - (int)bitCount)) << (int)bitOffset);
                 *(uint*)ptr = (*(uint*)ptr & mask) | uintValue;
                 return;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -434,7 +434,7 @@ namespace UnityEngine.InputSystem.Utilities
             // int is already represented as two's complement
             return (int)ReadMultipleBitsAsUInt(ptr, bitOffset, bitCount);
         }
-        
+
         /// <summary>
         /// Writes bits memory region as two's complement integer, up to and including 32 bits, least-significant bit first (LSB).
         /// </summary>
@@ -445,9 +445,9 @@ namespace UnityEngine.InputSystem.Utilities
         public static void WriteIntAsTwosComplementMultipleBits(void* ptr, uint bitOffset, uint bitCount, int value)
         {
             // int is already represented as two's complement, so write as-is
-            WriteUIntAsMultipleBits(ptr, bitOffset, bitCount, (uint) value);
+            WriteUIntAsMultipleBits(ptr, bitOffset, bitCount, (uint)value);
         }
-        
+
         /// <summary>
         /// Reads bits memory region as excess-K integer where K is set to (2^bitCount)/2, up to and including 32 bits, least-significant bit first (LSB).
         /// For example reading 0 as 8 bits will result in -128. Reading 0xff as 8 bits will result in 127.
@@ -463,7 +463,7 @@ namespace UnityEngine.InputSystem.Utilities
             var halfMax = (long)((1UL << (int)bitCount) / 2);
             return (int)(value - halfMax);
         }
-        
+
         /// <summary>
         /// Writes bits memory region as excess-K integer where K is set to (2^bitCount)/2, up to and including 32 bits, least-significant bit first (LSB).
         /// </summary>
@@ -493,7 +493,7 @@ namespace UnityEngine.InputSystem.Utilities
             var maxValue = (uint)((1UL << (int)bitCount) - 1);
             return NumberHelpers.UIntToNormalizedFloat(uintValue, 0, maxValue);
         }
-        
+
         /// <summary>
         /// Writes bits memory region as normalized unsigned integer, up to and including 32 bits, least-significant bit first (LSB).
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MemoryHelpers.cs
@@ -501,7 +501,7 @@ namespace UnityEngine.InputSystem.Utilities
         /// <param name="bitOffset">Offset in bits from the pointer to the start of the unsigned integer.</param>
         /// <param name="bitCount">Number of bits to read.</param>
         /// <param name="value">Normalized value to write.</param>
-        public static void WriteNormalizedUintAsMultipleBits(void* ptr, uint bitOffset, uint bitCount, float value)
+        public static void WriteNormalizedUIntAsMultipleBits(void* ptr, uint bitOffset, uint bitCount, float value)
         {
             var maxValue = (uint)((1UL << (int)bitCount) - 1);
             var uintValue = NumberHelpers.NormalizedFloatToUInt(value, 0, maxValue);

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace UnityEngine.InputSystem.Utilities
 {
     internal static class NumberHelpers
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int AlignToMultipleOf(this int number, int alignment)
         {
             var remainder = number % alignment;
@@ -13,6 +15,7 @@ namespace UnityEngine.InputSystem.Utilities
             return number + alignment - remainder;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static long AlignToMultipleOf(this long number, long alignment)
         {
             var remainder = number % alignment;
@@ -22,6 +25,7 @@ namespace UnityEngine.InputSystem.Utilities
             return number + alignment - remainder;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint AlignToMultipleOf(this uint number, uint alignment)
         {
             var remainder = number % alignment;
@@ -31,9 +35,50 @@ namespace UnityEngine.InputSystem.Utilities
             return number + alignment - remainder;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool Approximately(double a, double b)
         {
             return Math.Abs(b - a) <  Math.Max(1E-06 * Math.Max(Math.Abs(a), Math.Abs(b)), double.Epsilon * 8);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float IntToNormalizedFloat(int value, int minValue, int maxValue)
+        {
+            if (value <= minValue)
+                return 0.0f;
+            if (value >= maxValue)
+                return 1.0f;
+            return (float)(((double)value - minValue) / ((double)maxValue - minValue));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int NormalizedFloatToInt(float value, int intMinValue, int intMaxValue)
+        {
+            if (value <= 0.0f)
+                return intMinValue;
+            if (value >= 1.0f)
+                return intMaxValue;
+            return (int)(value * ((double) intMaxValue - intMinValue) + intMinValue);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float UIntToNormalizedFloat(uint value, uint minValue, uint maxValue)
+        {
+            if (value <= minValue)
+                return 0.0f;
+            if (value >= maxValue)
+                return 1.0f;
+            return (float)(((double)value - minValue) / ((double)maxValue - minValue));
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint NormalizedFloatToUInt(float value, uint uintMinValue, uint uintMaxValue)
+        {
+            if (value <= 0.0f)
+                return uintMinValue;
+            if (value >= 1.0f)
+                return uintMaxValue;
+            return (uint)(value * ((double) uintMaxValue - uintMinValue) + uintMinValue);
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
@@ -58,7 +58,7 @@ namespace UnityEngine.InputSystem.Utilities
                 return intMinValue;
             if (value >= 1.0f)
                 return intMaxValue;
-            return (int)(value * ((double) intMaxValue - intMinValue) + intMinValue);
+            return (int)(value * ((double)intMaxValue - intMinValue) + intMinValue);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -70,7 +70,7 @@ namespace UnityEngine.InputSystem.Utilities
                 return 1.0f;
             return (float)(((double)value - minValue) / ((double)maxValue - minValue));
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint NormalizedFloatToUInt(float value, uint uintMinValue, uint uintMaxValue)
         {
@@ -78,7 +78,7 @@ namespace UnityEngine.InputSystem.Utilities
                 return uintMinValue;
             if (value >= 1.0f)
                 return uintMaxValue;
-            return (uint)(value * ((double) uintMaxValue - uintMinValue) + uintMinValue);
+            return (uint)(value * ((double)uintMaxValue - uintMinValue) + uintMinValue);
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/NumberHelpers.cs
@@ -48,6 +48,8 @@ namespace UnityEngine.InputSystem.Utilities
                 return 0.0f;
             if (value >= maxValue)
                 return 1.0f;
+            // using double here because int.MaxValue is not representable in floats
+            // as int.MaxValue = 2147483647 will become 2147483648.0 when casted to a float
             return (float)(((double)value - minValue) / ((double)maxValue - minValue));
         }
 
@@ -68,6 +70,7 @@ namespace UnityEngine.InputSystem.Utilities
                 return 0.0f;
             if (value >= maxValue)
                 return 1.0f;
+            // using double here because uint.MaxValue is not representable in floats
             return (float)(((double)value - minValue) / ((double)maxValue - minValue));
         }
 


### PR DESCRIPTION
When HID contains 32 bit fields for axes, a few int based expressions start to overflow, hence why `PrimitiveValue` was getting NaN and Inf when vJoy was installed.

- Refactored all the code to use unsigned (logical) shifts.
- Tuned state readers to correctly parse edge/limit values, both signed and unsigned
- Exposed semantics of two's complement and excess-K numbers.

Verified with vJoy feeder that we're getting the data.