### PR TITLE
DOCS: Details about Switch Pro support on desktop (case 1190216).

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -135,3 +135,7 @@ On other platforms Unity, uses derived classes to represent Xbox controllers:
 ## Switch
 
 The Input System support Switch Pro controllers on desktop computers via the [`SwitchProControllerHID`](../api/UnityEngine.InputSystem.Switch.SwitchProControllerHID.html) class, which implements basic gamepad functionality.
+
+>__Note__: This support does not currently work for Switch Pro controllers connected via wired USB. Instead, the Switch Pro controller *must* be connected via Bluetooth. This is due to the controller using a prioprietary communication protocol on top of HID which does not allow treating the controller like any other HID.
+
+>__Note__: Switch Joy-Cons are not currently supported on desktop.

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -28,7 +28,7 @@ Support for the following Devices doesn't require specialized support of particu
 |Xbox 360 (4)|Yes|Yes (3)|Yes|Yes|No|No|No|Yes|No|No|Sometimes (2)|
 |Xbox One|Yes (1)|Yes (3)|Yes (1)|Yes|Yes (1)|Yes (6)|Yes (6)|Yes|No|No|Sometimes (2)|
 |PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
-|Switch|Yes|Yes|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
+|Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
 |MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
 
 >__Notes__:
@@ -39,6 +39,7 @@ Support for the following Devices doesn't require specialized support of particu
 >5. Unity doesn't support the gyro or accelerometer on PS4 controllers on platforms other than the PlayStation 4 console. Unity also doesn't support the DualShock 4 USB Wireless Adaptor.
 >6. Unity supports Made for iOS (Mfi) certified controllers on iOS. Xbox One and PS4 controllers are only supported on iOS 13 or higher.
 >7. Consoles are supported using separate packages. You need to install these packages in your Project to enable console support.
+>8. Switch Joy-Cons are not currently supported on Windows and Mac. Also, Switch Pro controllers are supported only when connected via Bluetooth but not when connected via wired USB.
 
 ### WebGL
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -112,6 +112,9 @@ namespace UnityEngine.InputSystem.Switch
     /// <summary>
     /// A Nintendo Switch Pro controller connected to a desktop mac/windows PC using the HID interface.
     /// </summary>
+    /// <remarks>
+    /// This controller currently only works when connected via Bluetooth but not when connected over USB.
+    /// </remarks>
     [InputControlLayout(stateType = typeof(SwitchProControllerHIDInputState), displayName = "Switch Pro Controller")]
     [Scripting.Preserve]
     public class SwitchProControllerHID : Gamepad


### PR DESCRIPTION
Switch Pro support via USB is more involved due to how the controller works. From all we've found, the HID descriptor and default state of the device is useless with the device expecting custom HID output commands to set it up properly. Added as an internal feature request (ISX-451).

Added some text to the docs to this end.