### PR TITLE
Ensuring InputManager checks current state of focus on bootstrap

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,7 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Delete key not working in the input actions editor ([case 1282090](https://issuetracker.unity3d.com/issues/input-system-delete-key-doesnt-work-in-the-input-actions-window)).
-- Inputs in game view sometimes not working if running under editor, as we were not checking game view focus state after domain reload.
+- Fixed inputs in game view sometimes not working when running in the editor, as initial focus state could end up being incorrect.
 
 ## [1.1.0-preview.3] - 2021-02-04
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Delete key not working in the input actions editor ([case 1282090](https://issuetracker.unity3d.com/issues/input-system-delete-key-doesnt-work-in-the-input-actions-window)).
+- Inputs in game view sometimes not working if running under editor, as we were not checking game view focus state after domain reload.
 
 ## [1.1.0-preview.3] - 2021-02-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -108,6 +108,12 @@ namespace UnityEngine.InputSystem.LowLevel
         Action<bool> onPlayerFocusChanged { get; set; }
 
         /// <summary>
+        // Is true when the player or game view has focus.
+        /// </summary>
+        /// <seealso cref="Application.isFocused"/>
+        bool isFocused { get; }
+
+        /// <summary>
         /// Set delegate to invoke when system is shutting down.
         /// </summary>
         Action onShutdown { get; set; }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1682,6 +1682,7 @@ namespace UnityEngine.InputSystem
             m_Runtime.onPlayerFocusChanged = OnFocusChanged;
             m_Runtime.onShouldRunUpdate = ShouldRunUpdate;
             m_Runtime.pollingFrequency = pollingFrequency;
+            m_HasFocus = m_Runtime.isFocused;
 
             // We only hook NativeInputSystem.onBeforeUpdate if necessary.
             if (m_BeforeUpdateListeners.length > 0 || m_HaveDevicesWithStateCallbackReceivers)

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -161,6 +161,8 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
+        public bool isFocused => Application.isFocused;
+
         public float pollingFrequency
         {
             get => m_PollingFrequency;

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -319,6 +319,7 @@ namespace UnityEngine.InputSystem
         public Action<int, string> onDeviceDiscovered { get; set; }
         public Action onShutdown { get; set; }
         public Action<bool> onPlayerFocusChanged { get; set; }
+        public bool isFocused => m_HasFocus;
         public float pollingFrequency { get; set; }
         public double currentTime { get; set; }
         public double currentTimeForFixedUpdate { get; set; }


### PR DESCRIPTION
This fixes `EnhancedTouch_SupportsEditorUpdates` sometimes failing on 2021+

Had hard time writing a test to it, because `m_HasFocus` is a private property that is set on bootstrap.
Ideally instead of writing a overspecifying test, I would prefer to remove `m_HasFocus` all together.