### PR TITLE
FIX: Tooltips not appearing in action editor (case 1311595).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,10 @@ however, it has to be formatted properly to pass verification tests.
 
 - Delete key not working in the input actions editor ([case 1282090](https://issuetracker.unity3d.com/issues/input-system-delete-key-doesnt-work-in-the-input-actions-window)).
 
+#### Actions
+
+- Fixed tooltips not appearing for elements of the Input Actions editor window ([case 1311595](https://issuetracker.unity3d.com/issues/no-tooltips-appear-when-hovering-over-parts-of-input-action-editor-window)).
+
 ## [1.1.0-preview.3] - 2021-02-04
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1355,9 +1355,21 @@ namespace UnityEngine.InputSystem
         [Tooltip("Human readable name of the action. Must be unique within its action map (case is ignored). Can be changed "
             + "without breaking references to the action.")]
         [SerializeField] internal string m_Name;
+        [Tooltip("Determines how the action triggers.\n"
+            + "\n"
+            + "A Value action will start and perform when a control moves from its default value and then "
+            + "perform on every value change. It will cancel when controls go back to default value. Also, when enabled, a Value "
+            + "action will respond right away to a control's current value.\n"
+            + "\n"
+            + "A Button action will start when a button is pressed and perform when the press threshold (see 'Default Button Press Point' in settings) "
+            + "is reached. It will cancel when the button is going below the release threshold (see 'Button Release Threshold' in settings). Also, "
+            + "if a button is already pressed when the action is enabled, the button has to be released first.\n"
+            + "\n"
+            + "A Pass-Through action will not explicitly start and will never cancel. Instead, for every value change on any bound control, "
+            + "the action will perform.")]
         [SerializeField] internal InputActionType m_Type;
         [FormerlySerializedAs("m_ExpectedControlLayout")]
-        [Tooltip("Type of control expected by the action (e.g. \"Button\" or \"Stick\"). This will limit the controls shown "
+        [Tooltip("The type of control expected by the action (e.g. \"Button\" or \"Stick\"). This will limit the controls shown "
             + "when setting up bindings in the UI and will also limit which controls can be bound interactively to the action.")]
         [SerializeField] internal string m_ExpectedControlType;
         [Tooltip("Unique ID of the action (GUID). Used to reference the action from bindings such that actions can be renamed "

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
@@ -425,6 +425,9 @@ namespace UnityEngine.InputSystem
 
         [SerializeField] private string m_Name;
         [SerializeField] internal string m_Id;
+        [Tooltip("Path of the control to bind to. Matched at runtime to controls from InputDevices present at the time.\n\nCan either be "
+            + "graphically from the control picker dropdown UI or edited manually in text mode by clicking the 'T' button. Internally, both "
+            + "method result in control path strings that look like, for example, \"<Gamepad>/buttonSouth\".")]
         [SerializeField] private string m_Path;
         [SerializeField] private string m_Interactions;
         [SerializeField] private string m_Processors;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
@@ -427,7 +427,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] internal string m_Id;
         [Tooltip("Path of the control to bind to. Matched at runtime to controls from InputDevices present at the time.\n\nCan either be "
             + "graphically from the control picker dropdown UI or edited manually in text mode by clicking the 'T' button. Internally, both "
-            + "method result in control path strings that look like, for example, \"<Gamepad>/buttonSouth\".")]
+            + "methods result in control path strings that look like, for example, \"<Gamepad>/buttonSouth\".")]
         [SerializeField] private string m_Path;
         [SerializeField] private string m_Interactions;
         [SerializeField] private string m_Processors;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -355,7 +355,8 @@ namespace UnityEngine.InputSystem.Editor
                 onSelectionChanged = OnActionTreeSelectionChanged,
                 onSerializedObjectModified = ApplyAndReloadTrees,
                 drawMinusButton = false,
-                title = "Actions",
+                title = ("Actions", "A list of InputActions in the InputActionMap selected in the left pane. Also, for each InputAction, the list "
+                    + "of bindings that determine the controls that can trigger the action.\n\nThe name of each action must be unique within its InputActionMap."),
             };
 
             // Create tree in left pane showing action maps.
@@ -367,7 +368,8 @@ namespace UnityEngine.InputSystem.Editor
                 onSerializedObjectModified = ApplyAndReloadTrees,
                 onHandleAddNewAction = m_ActionsTree.AddNewAction,
                 drawMinusButton = false,
-                title = "Action Maps",
+                title = ("Action Maps", "A list of InputActionMaps in the asset. Each map can be enabled and disabled separately at runtime and holds "
+                    + "its own collection of InputActions which are listed in the middle pane (along with their InputBindings).")
             };
             m_ActionMapsTree.Reload();
             m_ActionMapsTree.ExpandAll();
@@ -691,16 +693,23 @@ namespace UnityEngine.InputSystem.Editor
 
             EditorGUI.LabelField(rect, GUIContent.none, InputActionTreeView.Styles.backgroundWithBorder);
             var headerRect = new Rect(rect.x + 1, rect.y + 1, rect.width - 2, rect.height - 2);
-            EditorGUI.LabelField(headerRect, "Properties", InputActionTreeView.Styles.columnHeaderLabel);
 
             if (m_BindingPropertyView != null)
             {
+                if (m_BindingPropertiesTitle == null)
+                    m_BindingPropertiesTitle = new GUIContent("Binding Properties", "The properties for the InputBinding selected in the "
+                        + "'Actions' pane on the left.");
+                EditorGUI.LabelField(headerRect, m_BindingPropertiesTitle, InputActionTreeView.Styles.columnHeaderLabel);
                 m_PropertiesScroll = EditorGUILayout.BeginScrollView(m_PropertiesScroll);
                 m_BindingPropertyView.OnGUI();
                 EditorGUILayout.EndScrollView();
             }
             else if (m_ActionPropertyView != null)
             {
+                if (m_ActionPropertiesTitle == null)
+                    m_ActionPropertiesTitle = new GUIContent("Action Properties", "The properties for the InputAction selected in the "
+                        + "'Actions' pane on the left.");
+                EditorGUI.LabelField(headerRect, m_ActionPropertiesTitle, InputActionTreeView.Styles.columnHeaderLabel);
                 m_PropertiesScroll = EditorGUILayout.BeginScrollView(m_PropertiesScroll);
                 m_ActionPropertyView.OnGUI();
                 EditorGUILayout.EndScrollView();
@@ -787,6 +796,8 @@ namespace UnityEngine.InputSystem.Editor
         [SerializeField] private InputActionEditorToolbar m_Toolbar;
         [SerializeField] private GUIContent m_DirtyTitle;
         [SerializeField] private GUIContent m_Title;
+        [NonSerialized] private GUIContent m_ActionPropertiesTitle;
+        [NonSerialized] private GUIContent m_BindingPropertiesTitle;
 
         private InputBindingPropertiesView m_BindingPropertyView;
         private InputActionPropertiesView m_ActionPropertyView;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
@@ -32,9 +32,9 @@ namespace UnityEngine.InputSystem.Editor
                 m_SelectedControlType = 0;
 
             if (s_ControlTypeLabel == null)
-                s_ControlTypeLabel = EditorGUIUtility.TrTextContent("Control Type", m_ExpectedControlTypeProperty.tooltip);
+                s_ControlTypeLabel = EditorGUIUtility.TrTextContent("Control Type", m_ExpectedControlTypeProperty.GetTooltip());
             if (s_ActionTypeLabel == null)
-                s_ActionTypeLabel = EditorGUIUtility.TrTextContent("Action Type", m_ActionTypeProperty.tooltip);
+                s_ActionTypeLabel = EditorGUIUtility.TrTextContent("Action Type", m_ActionTypeProperty.GetTooltip());
         }
 
         protected override void DrawGeneralProperties()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -1346,10 +1346,11 @@ namespace UnityEngine.InputSystem.Editor
         public float foldoutOffset { get; set; }
 
         public Action<SerializedProperty> onHandleAddNewAction { get; set; }
-        public string title
+
+        public (string, string) title
         {
-            get => m_Title?.text;
-            set => m_Title = new GUIContent(value);
+            get => (m_Title?.text, m_Title?.tooltip);
+            set => m_Title = new GUIContent(value.Item1, value.Item2);
         }
 
         public new float totalHeight

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -34,7 +34,7 @@ namespace UnityEngine.InputSystem.Editor
             this.pathProperty = pathProperty;
             this.onModified = onModified;
             m_PickerState = pickerState ?? new InputControlPickerState();
-            m_PathLabel = label ?? new GUIContent(pathProperty.displayName, pathProperty.tooltip);
+            m_PathLabel = label ?? new GUIContent(pathProperty.displayName, pathProperty.GetTooltip());
         }
 
         public void Dispose()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/EditorHelpers.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Reflection;
 using UnityEditor;
-using UnityEditor.VersionControl;
 
 namespace UnityEngine.InputSystem.Editor
 {
@@ -10,6 +9,24 @@ namespace UnityEngine.InputSystem.Editor
     {
         public static Action<string> SetSystemCopyBufferContents = s => EditorGUIUtility.systemCopyBuffer = s;
         public static Func<string> GetSystemCopyBufferContents = () => EditorGUIUtility.systemCopyBuffer;
+
+        // SerializedProperty.tooltip *should* give us the tooltip as per [Tooltip] attribute. Alas, for some
+        // reason, it's not happening.
+        public static string GetTooltip(this SerializedProperty property)
+        {
+            if (!string.IsNullOrEmpty(property.tooltip))
+                return property.tooltip;
+
+            var field = property.GetField();
+            if (field != null)
+            {
+                var tooltipAttribute = field.GetCustomAttribute<TooltipAttribute>();
+                if (tooltipAttribute != null)
+                    return tooltipAttribute.tooltip;
+            }
+
+            return string.Empty;
+        }
 
         public static void RestartEditorAndRecompileScripts(bool dryRun = false)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -45,7 +45,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     onBuildTree = () => BuildTree(property),
                     onDoubleClick = OnItemDoubleClicked,
-                    title = property.displayName,
+                    title = (property.displayName, property.GetTooltip()),
                     // With the tree in the inspector, the foldouts are drawn too far to the left. I don't
                     // really know where this is coming from. This works around it by adding an arbitrary offset...
                     foldoutOffset = 14,

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -133,7 +133,7 @@ namespace UnityEngine.InputSystem.Editor
             #if UNITY_INPUT_SYSTEM_ENABLE_UI
             // UI config section.
             if (m_UIPropertyText == null)
-                m_UIPropertyText = EditorGUIUtility.TrTextContent("UI Input Module", m_UIInputModuleProperty.tooltip);
+                m_UIPropertyText = EditorGUIUtility.TrTextContent("UI Input Module", m_UIInputModuleProperty.GetTooltip());
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_UIInputModuleProperty, m_UIPropertyText);
             if (EditorGUI.EndChangeCheck())
@@ -153,7 +153,7 @@ namespace UnityEngine.InputSystem.Editor
 
             // Camera section.
             if (m_CameraPropertyText == null)
-                m_CameraPropertyText = EditorGUIUtility.TrTextContent("Camera", m_CameraProperty.tooltip);
+                m_CameraPropertyText = EditorGUIUtility.TrTextContent("Camera", m_CameraProperty.GetTooltip());
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_CameraProperty, m_CameraPropertyText);
             if (EditorGUI.EndChangeCheck())

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
@@ -108,7 +108,7 @@ namespace UnityEngine.InputSystem.Editor
             // Enabled-by-default.
             var allowJoiningProperty = serializedObject.FindProperty("m_AllowJoining");
             if (m_AllowingJoiningLabel == null)
-                m_AllowingJoiningLabel = new GUIContent("Joining Enabled By Default", allowJoiningProperty.tooltip);
+                m_AllowingJoiningLabel = new GUIContent("Joining Enabled By Default", allowJoiningProperty.GetTooltip());
             EditorGUILayout.PropertyField(allowJoiningProperty, m_AllowingJoiningLabel);
 
             // Max player count.
@@ -135,7 +135,7 @@ namespace UnityEngine.InputSystem.Editor
             // Split-screen toggle.
             var splitScreenProperty = serializedObject.FindProperty("m_SplitScreen");
             if (m_SplitScreenLabel == null)
-                m_SplitScreenLabel = new GUIContent("Enable Split-Screen", splitScreenProperty.tooltip);
+                m_SplitScreenLabel = new GUIContent("Enable Split-Screen", splitScreenProperty.GetTooltip());
             EditorGUILayout.PropertyField(splitScreenProperty, m_SplitScreenLabel);
             if (!splitScreenProperty.boolValue)
                 return;
@@ -146,7 +146,7 @@ namespace UnityEngine.InputSystem.Editor
             var maintainAspectRatioProperty = serializedObject.FindProperty("m_MaintainAspectRatioInSplitScreen");
             if (m_MaintainAspectRatioLabel == null)
                 m_MaintainAspectRatioLabel =
-                    new GUIContent("Maintain Aspect Ratio", maintainAspectRatioProperty.tooltip);
+                    new GUIContent("Maintain Aspect Ratio", maintainAspectRatioProperty.GetTooltip());
             EditorGUILayout.PropertyField(maintainAspectRatioProperty, m_MaintainAspectRatioLabel);
 
             // Fixed-number toggle.
@@ -174,7 +174,7 @@ namespace UnityEngine.InputSystem.Editor
             // Split-screen area.
             var splitScreenAreaProperty = serializedObject.FindProperty("m_SplitScreenRect");
             if (m_SplitScreenAreaLabel == null)
-                m_SplitScreenAreaLabel = new GUIContent("Screen Rectangle", splitScreenAreaProperty.tooltip);
+                m_SplitScreenAreaLabel = new GUIContent("Screen Rectangle", splitScreenAreaProperty.GetTooltip());
             EditorGUILayout.PropertyField(splitScreenAreaProperty, m_SplitScreenAreaLabel);
 
             --EditorGUI.indentLevel;


### PR DESCRIPTION
Fixes [1311595](https://issuetracker.unity3d.com/issues/no-tooltips-appear-when-hovering-over-parts-of-input-action-editor-window) ([internal](https://fogbugz.unity3d.com/f/cases/1311595/)).