### PR TITLE
FIX: right/leftTriggerButton on PS3/4 HID not being synthetic (case 1293734).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -64,6 +64,13 @@ internal class DualShockTests : InputTestFixture
         Assert.That(gamepad.leftStickButton.isPressed);
         Assert.That(gamepad.rightStickButton.isPressed);
 
+        ////REVIEW: Should we just kill these buttons? Do they provide any value?
+        // PS controller adds buttons for the left and right trigger. Make sure these are marked as
+        // synthetic so they don't get picked up as double input.
+        // https://fogbugz.unity3d.com/f/cases/1293734
+        Assert.That(gamepad["leftTriggerButton"].synthetic, Is.True);
+        Assert.That(gamepad["rightTriggerButton"].synthetic, Is.True);
+
         return gamepad;
         // Sensors not (yet?) supported. Needs figuring out how to interpret the HID data.
     }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed inputs in game view sometimes not working when running in the editor, as initial focus state could end up being incorrect.
 - Fixed bad performance in Input Debugger with high-frequency devices (e.g. 1+ KHz gaming mice). Before, high event volumes led to excessive refreshes of debugger data.
 - Fixed compile error on tvOS due to step counter support for iOS added in `1.1.0-preview.3`.
+- Fixed PS4- and PS3-specific `rightTriggerButton` and `leftTriggerButton` controls not being marked as synthetic and thus conflicting with `rightTrigger` and `leftTrigger` input ([case 1293734](https://issuetracker.unity3d.com/issues/input-system-when-binding-gamepad-controls-triggerbutton-gets-bound-instead-of-triggeraxis)).
+  * This manifested itself, for example, when using interactive rebinding and seeing `rightTriggerButton` getting picked instead of the expected `rightTrigger` control.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -51,8 +51,8 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         [FieldOffset(5)] public byte buttons1;
         [InputControl(name = "leftShoulder", bit = 0)]
         [InputControl(name = "rightShoulder", bit = 1)]
-        [InputControl(name = "leftTriggerButton", layout = "Button", bit = 2)]
-        [InputControl(name = "rightTriggerButton", layout = "Button", bit = 3)]
+        [InputControl(name = "leftTriggerButton", layout = "Button", bit = 2, synthetic = true)]
+        [InputControl(name = "rightTriggerButton", layout = "Button", bit = 3, synthetic = true)]
         [InputControl(name = "select", displayName = "Share", bit = 4)]
         [InputControl(name = "start", displayName = "Options", bit = 5)]
         [InputControl(name = "leftStickPress", bit = 6)]
@@ -92,8 +92,8 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         [InputControl(name = "dpad/down", bit = 6)]
         [InputControl(name = "dpad/left", bit = 7)]
         [FieldOffset(2)] public byte buttons1;
-        [InputControl(name = "leftTriggerButton", layout = "Button", bit = 0)]
-        [InputControl(name = "rightTriggerButton", layout = "Button", bit = 1)]
+        [InputControl(name = "leftTriggerButton", layout = "Button", bit = 0, synthetic = true)]
+        [InputControl(name = "rightTriggerButton", layout = "Button", bit = 1, synthetic = true)]
         [InputControl(name = "leftShoulder", bit = 2)]
         [InputControl(name = "rightShoulder", bit = 3)]
         [InputControl(name = "buttonNorth", displayName = "Triangle", bit = 4)]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
@@ -458,6 +458,7 @@ namespace UnityEngine.InputSystem.DualShock
                 .WithName("leftTriggerButton")
                 .WithDisplayName("leftTriggerButton")
                 .WithLayout(kButtonLayout)
+                .IsSynthetic(true)
                 .IsButton(true)
                 .WithStateBlock(new InputStateBlock
                 {
@@ -480,6 +481,7 @@ namespace UnityEngine.InputSystem.DualShock
                 .WithName("rightTriggerButton")
                 .WithDisplayName("rightTriggerButton")
                 .WithLayout(kButtonLayout)
+                .IsSynthetic(true)
                 .IsButton(true)
                 .WithStateBlock(new InputStateBlock
                 {


### PR DESCRIPTION
Fixes [1293734](https://issuetracker.unity3d.com/issues/input-system-when-binding-gamepad-controls-triggerbutton-gets-bound-instead-of-triggeraxis) ([internal](https://fogbugz.unity3d.com/f/cases/1293734)).

# Bug

The PS4 and PS3 controller both have the left and right triggers exposed as two controls each: a 8 byte version and a 1 bit version. We currently expose the latter as `leftTriggerButton` (as opposed to `leftTrigger`) and `rightTriggerButton` (as opposed to `rightTrigger`).

In 1.0, these additional controls are not marked as `synthetic`. This means that the input system will pick up input in parallel from both controls and consider them separately. This leads to rebinding, for example, taking `leftTriggerButton` over `leftTrigger` because it is actuated more (e.g. when `leftTrigger` is at 0.6, `leftTriggerButton` is already at 1).

# Fix

`leftTriggerButton` and `rightTriggerButton` are now marked as `synthetic`. This will automatically mark their input as synthesized input and put them low in the priority list in rebinds.

# Notes

This likely is also a problem in the PS4/5 input system package. Needs to be checked.