### PR TITLE
Adding Lumin Platform to XR

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -37,6 +37,8 @@ however, it has to be formatted properly to pass verification tests.
   * This is to address the problem of mouse input leading to __both__ mouse and touch input happening concurrently. Instead, enabling touch simulation will now effectively __replace__ mouse and pen input with touch input.
   * Devices such `Mouse` and `Pen` will remain in place but will not get updated. Events received for them will be consumed by `TouchSimulation`.
 - Enabled XR device support on Switch.
+- Enabled XR device support on Lumin (Magic Leap).
+- Added ability to force XR Support in a project by defining UNITY_INPUT_FORCE_XR_PLUGIN.
 
 ### Fixed
 
@@ -97,6 +99,7 @@ however, it has to be formatted properly to pass verification tests.
   ```
   - Added support for Step Counter sensors for iOS.
     * You need to enable **Motion Usage** under Input System settings before using the sensor. You can also manually add **Privacy - Motion Usage Description** to your application's Info.plist file.
+  - Add Lumin 
 
 ## [1.1.0-preview.2] - 2020-10-23
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Adding an action to a `InputActionMap` that is part of an `InputActionAsset` now requires all actions in the asset to be disabled ([case 1288335](https://issuetracker.unity3d.com/issues/adding-actions-at-runtime-to-existing-map-from-asset-triggers-assertion-error)).
   * This used to trigger an `Assert` at runtime but now properly throws an `InvalidOperationException`.
+- Enabled XR device support on Magic Leap (Lumin).
 
 ### Fixed
 
@@ -37,7 +38,6 @@ however, it has to be formatted properly to pass verification tests.
   * This is to address the problem of mouse input leading to __both__ mouse and touch input happening concurrently. Instead, enabling touch simulation will now effectively __replace__ mouse and pen input with touch input.
   * Devices such `Mouse` and `Pen` will remain in place but will not get updated. Events received for them will be consumed by `TouchSimulation`.
 - Enabled XR device support on Switch.
-- Enabled XR device support on Lumin (Magic Leap).
 - Added ability to force XR Support in a project by defining UNITY_INPUT_FORCE_XR_PLUGIN.
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,10 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed tooltips not appearing for elements of the Input Actions editor window ([case 1311595](https://issuetracker.unity3d.com/issues/no-tooltips-appear-when-hovering-over-parts-of-input-action-editor-window)).
 
+### Added
+
+- Added ability to force XR Support in a project by defining `UNITY_INPUT_FORCE_XR_PLUGIN`.
+
 ## [1.1.0-preview.3] - 2021-02-04
 
 ### Changed
@@ -38,7 +42,6 @@ however, it has to be formatted properly to pass verification tests.
   * This is to address the problem of mouse input leading to __both__ mouse and touch input happening concurrently. Instead, enabling touch simulation will now effectively __replace__ mouse and pen input with touch input.
   * Devices such `Mouse` and `Pen` will remain in place but will not get updated. Events received for them will be consumed by `TouchSimulation`.
 - Enabled XR device support on Switch.
-- Added ability to force XR Support in a project by defining UNITY_INPUT_FORCE_XR_PLUGIN.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -100,9 +100,8 @@ however, it has to be formatted properly to pass verification tests.
                   Debug.Log($"Button {button} was pressed");
       }
   ```
-  - Added support for Step Counter sensors for iOS.
-    * You need to enable **Motion Usage** under Input System settings before using the sensor. You can also manually add **Privacy - Motion Usage Description** to your application's Info.plist file.
-  - Add Lumin 
+- Added support for Step Counter sensors for iOS.
+  * You need to enable **Motion Usage** under Input System settings before using the sensor. You can also manually add **Privacy - Motion Usage Description** to your application's Info.plist file.
 
 ## [1.1.0-preview.2] - 2020-10-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3166,7 +3166,7 @@ namespace UnityEngine.InputSystem
             Switch.SwitchSupportHID.Initialize();
             #endif
 
-            #if (UNITY_EDITOR || UNITY_STANDALONE || UNITY_ANDROID || UNITY_IOS || UNITY_WSA || UNITY_SWITCH) && UNITY_INPUT_SYSTEM_ENABLE_XR && ENABLE_VR
+            #if (UNITY_EDITOR || UNITY_STANDALONE || UNITY_ANDROID || UNITY_IOS || UNITY_WSA || UNITY_SWITCH || UNITY_LUMIN || UNITY_INPUT_FORCE_XR_PLUGIN) && UNITY_INPUT_SYSTEM_ENABLE_XR && ENABLE_VR
             XR.XRSupport.Initialize();
             #endif
 


### PR DESCRIPTION
Lumin is the Magic Leap device.  
Adding in that platform as a supported XR platform.  
Also adding a secondary define that can be used by project to force enable the XR platform (for NDA and prototype platforms.

Tested on Magic Leap headset.