### PR TITLE
Fixing deleting multiple bindings

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -1927,6 +1927,57 @@ partial class CoreTests
 
     [Test]
     [Category("Editor")]
+    public void Editor_ActionTree_CanDeleteMultipleBindings()
+    {
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map1 = asset.AddActionMap("map1");
+        var action1 = map1.AddAction("action1");
+        action1.AddBinding("<Gamepad>/leftStick");
+        action1.AddBinding("<Gamepad>/buttonSouth");
+        action1.AddBinding("<Gamepad>/dpad");
+
+        var so = new SerializedObject(asset);
+        var modified = false;
+        var selectionChanged = false;
+        var tree = new InputActionTreeView(so)
+        {
+            onBuildTree = () => InputActionTreeView.BuildFullTree(so),
+            onSerializedObjectModified = () =>
+            {
+                Assert.That(modified, Is.False);
+                modified = true;
+            },
+            onSelectionChanged = () =>
+            {
+                Assert.That(selectionChanged, Is.False);
+                selectionChanged = true;
+            }
+        };
+        tree.Reload();
+        selectionChanged = false;
+        tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[0]"));
+        selectionChanged = false;
+        tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[1]"), true);
+        selectionChanged = false;
+        tree.SelectItem(tree.FindItemByPropertyPath("m_ActionMaps.Array.data[0].m_Bindings.Array.data[2]"), true);
+        selectionChanged = false;
+        tree.DeleteDataOfSelectedItems();
+
+        Assert.That(selectionChanged, Is.True);
+        Assert.That(modified, Is.True);
+        Assert.That(tree.HasSelection, Is.False);
+        Assert.That(tree.rootItem.children, Is.Not.Null);
+        Assert.That(tree.rootItem.children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0], Is.TypeOf<ActionMapTreeItem>());
+        Assert.That(tree.rootItem.children[0].displayName, Is.EqualTo("map1"));
+        Assert.That(tree.rootItem.children[0].children, Is.Not.Null);
+        Assert.That(tree.rootItem.children[0].children, Has.Count.EqualTo(1));
+        Assert.That(tree.rootItem.children[0].children[0].displayName, Is.EqualTo("action1"));
+        Assert.That(tree.rootItem.children[0].children[0].children, Is.Null);
+    }
+
+    [Test]
+    [Category("Editor")]
     public void Editor_ActionTree_CanDeleteComposite()
     {
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed changes to usages of devices in remote player not being reflected in Input Debugger.
 - Fixed exceptions and incorrect values with HIDs using 32-bit fields ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
   * This happened, for example, with vJoy installed.
+- Fixed `Retrieving array element that was out of bounds` and `SerializedProperty ... has disappeared!` errors when deleting multiple action bindings in the input asset editor ([case 1300506](https://issuetracker.unity3d.com/issues/errors-are-thrown-in-the-console-when-deleting-multiple-bindings)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeViewItems.cs
@@ -388,23 +388,32 @@ namespace UnityEngine.InputSystem.Editor
         public string displayPath =>
             !string.IsNullOrEmpty(path) ? InputControlPath.ToHumanReadableString(path) : "<No Binding>";
 
+        private ActionTreeItem actionItem
+        {
+            get
+            {
+                // Find the action we're under.
+                for (var node = parent; node != null; node = node.parent)
+                    if (node is ActionTreeItem item)
+                        return item;
+                return null;
+            }
+        }
+
         public override string expectedControlLayout
         {
             get
             {
-                // Find the action we're under and return its expected control layout.
-                for (var item = parent; item != null; item = item.parent)
-                {
-                    if (item is ActionTreeItem actionItem)
-                        return actionItem.expectedControlLayout;
-                }
-                return string.Empty;
+                var currentActionItem = actionItem;
+                return currentActionItem != null ? currentActionItem.expectedControlLayout : string.Empty;
             }
         }
 
         public override void DeleteData()
         {
-            var bindingsArrayProperty = property.GetParentProperty();
+            var currentActionItem = actionItem;
+            Debug.Assert(currentActionItem != null, "BindingTreeItem should always have a parent action");
+            var bindingsArrayProperty = currentActionItem.bindingsArrayProperty;
             InputActionSerializationHelpers.DeleteBinding(bindingsArrayProperty, guid);
         }
 


### PR DESCRIPTION
### Description

When deleting more than one binding, `BindingTreeItem.property` of existing ones becomes invalid until the tree is recreated. But we made one time copy of them inside `InputActionTreeView.DeleteDataOfSelectedItems` which leads to copies going stale as soon as first item is deleted. When enough items is deleted in one go, `property.GetParentProperty()` starts pointing into completely wrong place, which leads to native errors in `SerializedProperty` code.

### Changes made

When deleting, dynamically discover what action the current binding is bound to.