### PR TITLE
UI scrolling speed kPixelPerLine from 20 to 120

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
   * This used to trigger an `Assert` at runtime but now properly throws an `InvalidOperationException`.
 - The `VirtualMouseInput` component is now part of the Input System assembly. It was previously packaged with the `Gamepad Mouse Cursor` sample.
   * The component has a different GUID from before, so existing setups that use the component from the sample are not broken. To use the built-in component you must explicitly switch over.
+- Changed UI scroll speed from 20 to 120 pixels per line to make UI scrolling speeds more consistent with `Input.mouseScrollDelta`.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1615,7 +1615,10 @@ namespace UnityEngine.InputSystem.UI
             return false;
         }
 
-        internal const float kPixelPerLine = 20;
+        // Due to different input systems at Unity all piping input into UI,
+        // we need to have a consistent scroll speed across the board.
+        // Hence this constant should be equal to Windows WHEEL_DELTA constant.
+        internal const float kPixelPerLine = 120.0f;
 
         private void OnScroll(InputAction.CallbackContext context)
         {


### PR DESCRIPTION
# DONT MERGE YET

### Description

We have a zoo on incompatible scroll scales at Unity:

- `Input.mouseScrollDelta` takes value -1 or 1 based if native mouse scroll delta is `<= -1` or `>= 1`, usually mouse scroll delta is equal to 120 based on historical [WHEEL_DELTA](https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mousehwheel) constant.

- The `Input.GetAxis("Mouse ScrollWheel")` has 0.1f scaling, so it will return -12 / 12 for usual mouse scroll delta of 120

- `EventType.ScrollWheel` `Event.delta` divides by 120 and multiplies by 3, so the resulting delta is -3 / 3 for usual scroll delta of 120.

Now UGUI scroll is driven by `StandaloneInputModule` which is using `Input.mouseScrollDelta`, so it's -1/0/1 per scroll event, regardless of native value.

Our `InputSystemUIInputModule` replacement currently uses scaling of 20, so it's -6/6 per usual scroll delta event of 120. Meaning using our code scroll lists are scrolling 6 times faster.

### Changes made

Adjusting kPixelPerLine from 20 to 120, this will not lead to feature parity due to `Input.mouseScrollDelta` to be utterly broken, but should give a more consistent velocity feel.
