### PR TITLE
Always using standard button names on a generic gamepad

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1043,14 +1043,14 @@ partial class CoreTests
         Assert.That(InputControlPath.ToHumanReadableString("<XRController>{LeftHand}/position"), Is.EqualTo("position [LeftHand XR Controller]"));
         Assert.That(InputControlPath.ToHumanReadableString("*/leftStick"), Is.EqualTo("leftStick [Any]"));
         Assert.That(InputControlPath.ToHumanReadableString("*/{PrimaryMotion}/x"), Is.EqualTo("PrimaryMotion/x [Any]"));
-        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/buttonSouth"), Is.EqualTo(GamepadState.ButtonSouthDisplayName + " [Gamepad]"));
+        Assert.That(InputControlPath.ToHumanReadableString("<Gamepad>/buttonSouth"), Is.EqualTo("Button South [Gamepad]"));
         Assert.That(InputControlPath.ToHumanReadableString("<XInputController>/buttonSouth"), Is.EqualTo("A [Xbox Controller]"));
         Assert.That(InputControlPath.ToHumanReadableString("<Touchscreen>/touch4/tap"), Is.EqualTo("Touch #4/Tap [Touchscreen]"));
 
         // OmitDevice.
         Assert.That(
             InputControlPath.ToHumanReadableString("<Gamepad>/buttonSouth",
-                InputControlPath.HumanReadableStringOptions.OmitDevice), Is.EqualTo(GamepadState.ButtonSouthDisplayName));
+                InputControlPath.HumanReadableStringOptions.OmitDevice), Is.EqualTo("Button South"));
         Assert.That(
             InputControlPath.ToHumanReadableString("*/{PrimaryAction}",
                 InputControlPath.HumanReadableStringOptions.OmitDevice), Is.EqualTo("PrimaryAction"));

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
   * The component has a different GUID from before, so existing setups that use the component from the sample are not broken. To use the built-in component you must explicitly switch over.
 - `InputTestFixture` no longer deletes the `GameObject`s in the current scene in its `TearDown` ([case 1286987](https://issuetracker.unity3d.com/issues/input-system-inputtestfixture-destroys-test-scene)).
   * This was added for the sake of the Input System's own tests but should not have been in the public fixture.
+- Generic `Gamepad` now has platform independent long button names. Previously it used different names if editor targeted PS4/Switch consoles (case 1321676).
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -34,33 +34,13 @@ namespace UnityEngine.InputSystem.LowLevel
     {
         public static FourCC Format => new FourCC('G', 'P', 'A', 'D');
 
-        // On consoles, we use the platform defaults as the gamepad-wide default names.
-        #if UNITY_XBOX_ONE || UNITY_SWITCH
-        internal const string ButtonSouthDisplayName = "A";
-        internal const string ButtonNorthDisplayName = "Y";
-        internal const string ButtonWestDisplayName = "B";
-        internal const string ButtonEastDisplayName = "X";
-
-        internal const string ButtonSouthShortDisplayName = "A";
-        internal const string ButtonNorthShortDisplayName = "Y";
-        internal const string ButtonWestShortDisplayName = "X";
-        internal const string ButtonEastShortDisplayName = "B";
-        #elif UNITY_PS4
-        internal const string ButtonSouthDisplayName = "Cross";
-        internal const string ButtonNorthDisplayName = "Triangle";
-        internal const string ButtonWestDisplayName = "Square";
-        internal const string ButtonEastDisplayName = "Circle";
-
+        // On Sony consoles, we use the platform defaults as the gamepad-wide short default names.
+        #if UNITY_PS4 || UNITY_PS5
         internal const string ButtonSouthShortDisplayName = "Cross";
         internal const string ButtonNorthShortDisplayName = "Triangle";
         internal const string ButtonWestShortDisplayName = "Square";
         internal const string ButtonEastShortDisplayName = "East";
         #else
-        internal const string ButtonSouthDisplayName = "Button South";
-        internal const string ButtonNorthDisplayName = "Button North";
-        internal const string ButtonWestDisplayName = "Button West";
-        internal const string ButtonEastDisplayName = "Button East";
-
         internal const string ButtonSouthShortDisplayName = "A";
         internal const string ButtonNorthShortDisplayName = "Y";
         internal const string ButtonWestShortDisplayName = "X";
@@ -84,10 +64,10 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <seealso cref="Gamepad.rightStickButton"/>
         ////REVIEW: do we want the name to correspond to what's actually on the device?
         [InputControl(name = "dpad", layout = "Dpad", usage = "Hatswitch", displayName = "D-Pad", format = "BIT", sizeInBits = 4, bit = 0)]
-        [InputControl(name = "buttonSouth", layout = "Button", bit = (uint)GamepadButton.South, usages = new[] { "PrimaryAction", "Submit" }, aliases = new[] { "a", "cross" }, displayName = ButtonSouthDisplayName, shortDisplayName = ButtonSouthShortDisplayName)]
-        [InputControl(name = "buttonWest", layout = "Button", bit = (uint)GamepadButton.West, usage = "SecondaryAction", aliases = new[] { "x", "square" }, displayName = ButtonWestDisplayName, shortDisplayName = ButtonWestShortDisplayName)]
-        [InputControl(name = "buttonNorth", layout = "Button", bit = (uint)GamepadButton.North, aliases = new[] { "y", "triangle" }, displayName = ButtonNorthDisplayName, shortDisplayName = ButtonNorthShortDisplayName)]
-        [InputControl(name = "buttonEast", layout = "Button", bit = (uint)GamepadButton.East, usages = new[] { "Back", "Cancel" }, aliases = new[] { "b", "circle" }, displayName = ButtonEastDisplayName, shortDisplayName = ButtonEastShortDisplayName)]
+        [InputControl(name = "buttonSouth", layout = "Button", bit = (uint)GamepadButton.South, usages = new[] { "PrimaryAction", "Submit" }, aliases = new[] { "a", "cross" }, displayName = "Button South", shortDisplayName = ButtonSouthShortDisplayName)]
+        [InputControl(name = "buttonWest", layout = "Button", bit = (uint)GamepadButton.West, usage = "SecondaryAction", aliases = new[] { "x", "square" }, displayName = "Button West", shortDisplayName = ButtonWestShortDisplayName)]
+        [InputControl(name = "buttonNorth", layout = "Button", bit = (uint)GamepadButton.North, aliases = new[] { "y", "triangle" }, displayName = "Button North", shortDisplayName = ButtonNorthShortDisplayName)]
+        [InputControl(name = "buttonEast", layout = "Button", bit = (uint)GamepadButton.East, usages = new[] { "Back", "Cancel" }, aliases = new[] { "b", "circle" }, displayName = "Button East", shortDisplayName = ButtonEastShortDisplayName)]
         ////FIXME: 'Press' naming is inconsistent with 'Button' naming
         [InputControl(name = "leftStickPress", layout = "Button", bit = (uint)GamepadButton.LeftStick, displayName = "Left Stick Press")]
         [InputControl(name = "rightStickPress", layout = "Button", bit = (uint)GamepadButton.RightStick, displayName = "Right Stick Press")]


### PR DESCRIPTION
### Description

If your editor is in Switch or PS4 mode (not Xbox One though ... because it depends on a wrong define) we use platform specific names for generic gamepad buttons, especially for binding popup. This creates a poor UX when you're trying to create a cross platform binding yet see platform dependent button names.

### Changes made

Removed platform specific long button names on generic gamepad.