### PR TITLE
Adding UNITY_INCLUDE_TESTS define constraint to package test assemblies

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -104,6 +104,7 @@ however, it has to be formatted properly to pass verification tests.
   * Puts an upper limit on the number of event bytes processed in a single update.
   * If exceeded, any additional event data will get thrown away and an error will be issued.
   * Set to 5MB by default.
+- Added `UNITY_INCLUDE_TESTS` define constraints to our test assemblies, which is 2019.2+ equivalent to `"optionalUnityReferences": ["TestAssemblies"]`.
 
 ## [1.1.0-preview.3] - 2021-02-04
 

--- a/Packages/com.unity.inputsystem/Tests/IntegrationTests/Unity.InputSystem.IntegrationTests.asmdef
+++ b/Packages/com.unity.inputsystem/Tests/IntegrationTests/Unity.InputSystem.IntegrationTests.asmdef
@@ -13,6 +13,6 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": ["UNITY_INCLUDE_TESTS"],
     "versionDefines": []
 }

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/Unity.InputSystem.TestFramework.asmdef
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/Unity.InputSystem.TestFramework.asmdef
@@ -12,6 +12,6 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": false,
-    "defineConstraints": [],
+    "defineConstraints": ["UNITY_INCLUDE_TESTS"],
     "versionDefines": []
 }


### PR DESCRIPTION
### Description

When doing 1.0.1 and 1.0.2 release I've noticed that API validator was complaining about breaking changes in test assemblies, as they've been added compared to 1.0.0 or something. Package team said that test assemblies must be marked with `UNITY_INCLUDE_TESTS` on 2019.2+ and `"optionalUnityReferences": ["TestAssemblies"]` on 2018.4-2019.1

### Changes made

Added `UNITY_INCLUDE_TESTS`.

### Notes

I expect no functional change to the shipped archives, but just to make another bit of API validator a bit more happier.
