### PR TITLE
FIX: InputUser stopping to send ControlsChanged notification.

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UserTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UserTests.cs
@@ -1023,6 +1023,39 @@ internal class UserTests : InputTestFixture
         Assert.That(receivedChange, Is.EqualTo(InputUserChange.ControlsChanged));
         Assert.That(receivedUser, Is.EqualTo(user));
         Assert.That(receivedDevice, Is.Null);
+
+        receivedChange = null;
+        receivedUser = null;
+        receivedDevice = null;
+
+        // Remove user and then add new one.
+        var oldUser = user;
+        user.UnpairDevicesAndRemoveUser();
+
+        Assert.That(receivedChange, Is.EqualTo(InputUserChange.ControlsChanged));
+        Assert.That(receivedUser, Is.EqualTo(oldUser));
+        Assert.That(receivedDevice, Is.Null);
+
+        receivedChange = null;
+        receivedUser = null;
+        receivedDevice = null;
+
+        user = InputUser.PerformPairingWithDevice(gamepad1);
+        user.AssociateActionsWithUser(actions);
+
+        Assert.That(receivedChange, Is.EqualTo(InputUserChange.ControlsChanged));
+        Assert.That(receivedUser, Is.EqualTo(user));
+        Assert.That(receivedDevice, Is.Null);
+
+        receivedChange = null;
+        receivedUser = null;
+        receivedDevice = null;
+
+        action.ApplyBindingOverride("<Gamepad>/leftTrigger");
+
+        Assert.That(receivedChange, Is.EqualTo(InputUserChange.ControlsChanged));
+        Assert.That(receivedUser, Is.EqualTo(user));
+        Assert.That(receivedDevice, Is.Null);
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -27,6 +27,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed exceptions and incorrect values with HIDs using 32-bit fields ([case 1189859](https://issuetracker.unity3d.com/issues/inputsystem-error-when-vjoy-is-installed)).
   * This happened, for example, with vJoy installed.
 - Fixed `Retrieving array element that was out of bounds` and `SerializedProperty ... has disappeared!` errors when deleting multiple action bindings in the input asset editor ([case 1300506](https://issuetracker.unity3d.com/issues/errors-are-thrown-in-the-console-when-deleting-multiple-bindings)).
+- Fixed `InputUser` no longer sending `InputUserChange.ControlsChanged` when adding a new user after previously, all users were removed.
+  * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Unity.Collections;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
@@ -475,6 +476,15 @@ namespace UnityEngine.InputSystem.Users
                     UnhookFromDeviceStateChange();
                 s_ListenForUnpairedDeviceActivity = value;
             }
+        }
+
+        public override string ToString()
+        {
+            if (!valid)
+                return $"<Invalid> (id: {m_Id})";
+
+            var deviceList = string.Join(",", pairedDevices);
+            return $"User #{index} (id: {m_Id}, devices: {deviceList}, actions: {actions})";
         }
 
         /// <summary>
@@ -1943,7 +1953,7 @@ namespace UnityEngine.InputSystem.Users
             if (!s_OnActionChangeHooked)
                 return;
             InputSystem.onActionChange -= OnActionChange;
-            s_OnActionChangeHooked = true;
+            s_OnActionChangeHooked = false;
         }
 
         private static void HookIntoDeviceChange()


### PR DESCRIPTION
User-contributed fix (#1292).

# Bug

When the last user was removed, `InputUser` would unhook itself from `InputSystem.onActionChange` in a way that meant it would never subscribe again. In turn, no more `InputUserChange.ControlsChanged` notifications would be sent in the future.

# Fix

Set `s_OnActionChangeHooked` properly.