### PR TITLE
Added input action asset validation message to PlayerInputManager and editor

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -75,6 +75,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Enabled XR device support on Magic Leap (Lumin).
 - Added ability to force XR Support in a project by defining `UNITY_INPUT_FORCE_XR_PLUGIN`.
+- Added a warning message to PlayerInputManager editor when the attached input action asset won't work with Join Players When Button Is Pressed behaviour due to missing control scheme device requirements ([case 1265853](https://issuetracker.unity3d.com/issues/input-system-player-prefabs-are-not-instantiated-on-join-action-when-they-have-inputactionasset-assigned-to-them))
 - Added support for [UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) with Unity 2021.1+.
   * UITK is now supported as a UI solution in players. Input support for both [Unity UI](https://docs.unity3d.com/Manual/com.unity.ugui.html) and [UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) is based on the same `InputSystemUIInputModule` code path. More details in the manual.
 - `InputSystemUIInputModule` now has an `xrTrackingOrigin` property. When assigned, this will transform all tracked device positions and rotations from it's local space into Unity's world space ([case 1308480](https://issuetracker.unity3d.com/issues/xr-sdk-tracked-device-raycaster-does-not-work-correctly-with-worldspace-canvas-when-xr-camera-is-offset-from-origin)).

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -75,7 +75,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Enabled XR device support on Magic Leap (Lumin).
 - Added ability to force XR Support in a project by defining `UNITY_INPUT_FORCE_XR_PLUGIN`.
-- Added a warning message to PlayerInputManager editor when the attached input action asset won't work with Join Players When Button Is Pressed behaviour due to missing control scheme device requirements ([case 1265853](https://issuetracker.unity3d.com/issues/input-system-player-prefabs-are-not-instantiated-on-join-action-when-they-have-inputactionasset-assigned-to-them))
+- Added a warning message to PlayerInputManager editor when the attached input action asset won't work with Join Players When Button Is Pressed behaviour due to missing control scheme device requirements ([case 1265853](https://issuetracker.unity3d.com/issues/input-system-player-prefabs-are-not-instantiated-on-join-action-when-they-have-inputactionasset-assigned-to-them)).
 - Added support for [UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) with Unity 2021.1+.
   * UITK is now supported as a UI solution in players. Input support for both [Unity UI](https://docs.unity3d.com/Manual/com.unity.ugui.html) and [UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) is based on the same `InputSystemUIInputModule` code path. More details in the manual.
 - `InputSystemUIInputModule` now has an `xrTrackingOrigin` property. When assigned, this will transform all tracked device positions and rotations from it's local space into Unity's world space ([case 1308480](https://issuetracker.unity3d.com/issues/xr-sdk-tracked-device-raycaster-does-not-work-correctly-with-worldspace-canvas-when-xr-camera-is-offset-from-origin)).

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -1,10 +1,14 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
 using UnityEngine.Events;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 ////REVIEW: should we automatically pool/retain up to maxPlayerCount player instances?
 
@@ -664,6 +668,7 @@ namespace UnityEngine.InputSystem
             return false;
         }
 
+        [Conditional("DEVELOPMENT_BUILD"), Conditional("UNITY_EDITOR")]
         private void ValidateInputActionAsset()
         {
             if (m_PlayerPrefab == null || m_PlayerPrefab.GetComponentInChildren<PlayerInput>() == null)
@@ -682,11 +687,16 @@ namespace UnityEngine.InputSystem
                 isValid = false;
             }
 
-            if (!isValid)
-                Debug.LogWarning("The input action asset in the player prefab assigned to PlayerInputManager has " +
-                    "no control schemes with required devices. The JoinPlayersWhenButtonIsPressed join behavior " +
-                    "will not work unless the expected input devices are listed as requirements in the input " +
-                    "action asset.");
+            if (isValid) return;
+
+            var assetInfo = actions.name;
+#if UNITY_EDITOR
+            assetInfo = AssetDatabase.GetAssetPath(actions);
+#endif
+            Debug.LogWarning($"The input action asset '{assetInfo}' in the player prefab assigned to PlayerInputManager has " +
+                             "no control schemes with required devices. The JoinPlayersWhenButtonIsPressed join behavior " +
+                             "will not work unless the expected input devices are listed as requirements in the input " +
+                             "action asset.", m_PlayerPrefab);
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEngine.Events;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
@@ -272,6 +273,8 @@ namespace UnityEngine.InputSystem
             switch (m_JoinBehavior)
             {
                 case PlayerJoinBehavior.JoinPlayersWhenButtonIsPressed:
+                    ValidateInputActionAsset();
+
                     if (!m_UnpairedDeviceUsedDelegateHooked)
                     {
                         if (m_UnpairedDeviceUsedDelegate == null)
@@ -659,6 +662,31 @@ namespace UnityEngine.InputSystem
                     return true;
 
             return false;
+        }
+
+        private void ValidateInputActionAsset()
+        {
+            if (m_PlayerPrefab == null || m_PlayerPrefab.GetComponentInChildren<PlayerInput>() == null)
+                return;
+
+            var actions = m_PlayerPrefab.GetComponentInChildren<PlayerInput>().actions;
+            if (actions == null)
+                return;
+
+            var isValid = true;
+            foreach (var controlScheme in actions.controlSchemes)
+            {
+                if (controlScheme.deviceRequirements.Count > 0)
+                    break;
+
+                isValid = false;
+            }
+
+            if (!isValid)
+                Debug.LogWarning("The input action asset in the player prefab assigned to PlayerInputManager has " +
+                    "no control schemes with required devices. The JoinPlayersWhenButtonIsPressed join behavior " +
+                    "will not work unless the expected input devices are listed as requirements in the input " +
+                    "action asset.");
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -694,9 +694,9 @@ namespace UnityEngine.InputSystem
             assetInfo = AssetDatabase.GetAssetPath(actions);
 #endif
             Debug.LogWarning($"The input action asset '{assetInfo}' in the player prefab assigned to PlayerInputManager has " +
-                             "no control schemes with required devices. The JoinPlayersWhenButtonIsPressed join behavior " +
-                             "will not work unless the expected input devices are listed as requirements in the input " +
-                             "action asset.", m_PlayerPrefab);
+                "no control schemes with required devices. The JoinPlayersWhenButtonIsPressed join behavior " +
+                "will not work unless the expected input devices are listed as requirements in the input " +
+                "action asset.", m_PlayerPrefab);
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Diagnostics;
-using System.Linq;
 using UnityEngine.Events;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -668,9 +668,9 @@ namespace UnityEngine.InputSystem
             return false;
         }
 
-        [Conditional("DEVELOPMENT_BUILD"), Conditional("UNITY_EDITOR")]
         private void ValidateInputActionAsset()
         {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
             if (m_PlayerPrefab == null || m_PlayerPrefab.GetComponentInChildren<PlayerInput>() == null)
                 return;
 
@@ -697,6 +697,7 @@ namespace UnityEngine.InputSystem
                 "no control schemes with required devices. The JoinPlayersWhenButtonIsPressed join behavior " +
                 "will not work unless the expected input devices are listed as requirements in the input " +
                 "action asset.", m_PlayerPrefab);
+#endif
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
@@ -145,13 +145,13 @@ namespace UnityEngine.InputSystem.Editor
 
             if (playerInput == null)
             {
-                EditorGUILayout.HelpBox("No PlayerInput component found in player prefab", MessageType.Info);
+                EditorGUILayout.HelpBox("No PlayerInput component found in player prefab.", MessageType.Info);
                 return;
             }
 
             if (playerInput.actions == null)
             {
-                EditorGUILayout.HelpBox("PlayerInput component has no input action asset assigned", MessageType.Info);
+                EditorGUILayout.HelpBox("PlayerInput component has no input action asset assigned.", MessageType.Info);
                 return;
             }
 


### PR DESCRIPTION
Fixes [1265853](https://issuetracker.unity3d.com/issues/input-system-player-prefabs-are-not-instantiated-on-join-action-when-they-have-inputactionasset-assigned-to-them) ([Fogbugz](https://fogbugz.unity3d.com/f/cases/1265853/))

## Bug
This was not really a bug. When an input action asset with no required devices on any control scheme is used with PlayerInputManager and Join Players When Button Is Pressed join behavior, the expected outcome of the player joining the game when a button is pressed does not happen. This makes sense, since no input will match against a control scheme with no required devices, but is confusing to the user.

## Fix
Added warning messages to PlayerInputManager editor and debug log to indicate that the attached input action asset has no required devices on any control scheme.