### PR TITLE
FIX: No OnPointerExit events without moving pointer (case 1232705).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -32,6 +32,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `Retrieving array element that was out of bounds` and `SerializedProperty ... has disappeared!` errors when deleting multiple action bindings in the input asset editor ([case 1300506](https://issuetracker.unity3d.com/issues/errors-are-thrown-in-the-console-when-deleting-multiple-bindings)).
 - Fixed `InputUser` no longer sending `InputUserChange.ControlsChanged` when adding a new user after previously, all users were removed.
   * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
+- Fixed no `OnPointerExit` received when changing UI state without moving pointer ([case 1232705](https://issuetracker.unity3d.com/issues/input-system-onpointerexit-is-not-triggered-when-a-ui-element-interrupts-a-mouse-hover)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -196,9 +196,6 @@ namespace UnityEngine.InputSystem.UI
         // Mouse, pen, touch, and tracked device pointer input all go through here.
         private void ProcessPointer(ref PointerModel state)
         {
-            if (!state.changedThisFrame)
-                return;
-
             var eventData = state.eventData;
 
             // Sync position.
@@ -242,6 +239,14 @@ namespace UnityEngine.InputSystem.UI
             state.leftButton.CopyPressStateTo(eventData);
 
             ProcessPointerMovement(ref state, eventData);
+
+            // We always need to process move-related events in order to get PointerEnter and Exit events
+            // when we change UI state (e.g. show/hide objects) without moving the pointer. This unfortunately
+            // also means that we will invariably raycast on every update.
+            // However, after that, early out at this point when there's no changes to the pointer state.
+            if (!state.changedThisFrame)
+                return;
+
             ProcessPointerButton(ref state.leftButton, eventData);
             ProcessPointerButtonDrag(ref state.leftButton, eventData);
             ProcessPointerScroll(ref state, eventData);


### PR DESCRIPTION
Fixes [1232705](https://issuetracker.unity3d.com/issues/input-system-onpointerexit-is-not-triggered-when-a-ui-element-interrupts-a-mouse-hover) ([internal](https://fogbugz.unity3d.com/f/cases/1232705/)).

# Bug

When changing UI state (such as showing new UI elements or hiding existing ones) without moving the pointer, no pointer exit events were being sent from `InputSystemUIInputModule`. This behavior is different from `StandaloneInputModule`.

# Fix

In `ProcessPointer` we earlied out when there was no input changes on a pointer. Instead, now we *always* raycast and send enter and exit events if the raycast target changes.

Would be nice to only raycast when the UI state *or* pointer state changed but we don't have a good way ATM to detect the former.