### PR TITLE
Allowing AxisDeadzoneProcessor min/max to be set to 0 from UI

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -32,6 +32,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `Retrieving array element that was out of bounds` and `SerializedProperty ... has disappeared!` errors when deleting multiple action bindings in the input asset editor ([case 1300506](https://issuetracker.unity3d.com/issues/errors-are-thrown-in-the-console-when-deleting-multiple-bindings)).
 - Fixed `InputUser` no longer sending `InputUserChange.ControlsChanged` when adding a new user after previously, all users were removed.
   * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
+- Fixed `AxisDeadzoneProcessor` min/max values not being settable to 0 in editor UI ([case 1293744](https://issuetracker.unity3d.com/issues/input-system-input-system-axis-deadzone-minimum-value-fallsback-to-default-value-if-its-set-to-0)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -30,11 +30,17 @@ namespace UnityEngine.InputSystem.Processors
         /// <summary>
         /// Lower bound (inclusive) below which input values get clamped. Corresponds to 0 in the normalized range.
         /// </summary>
+        /// <remarks>
+        /// If this is equal to 0 (the default), <see cref="InputSettings.defaultDeadzoneMin"/> is used instead.
+        /// </remarks>
         public float min;
 
         /// <summary>
         /// Upper bound (inclusive) beyond which input values get clamped. Corresponds to 1 in the normalized range.
         /// </summary>
+        /// <remarks>
+        /// If this is equal to 0 (the default), <see cref="InputSettings.defaultDeadzoneMax"/> is used instead.
+        /// </remarks>
         public float max;
 
         private float minOrDefault => min == default ? InputSystem.settings.defaultDeadzoneMin : min;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -202,14 +202,34 @@ namespace UnityEngine.InputSystem.Editor
             {
                 EditorGUILayout.BeginHorizontal();
                 EditorGUI.BeginDisabledGroup(m_UseDefaultValue);
+                
                 var value = m_GetValue();
+
                 if (m_UseDefaultValue)
                     value = m_GetDefaultValue();
+                
+                // If previous value was an epsilon away from default value, it most likely means that value was set by our own code down in this method. 
+                // Revert it back to default to show a nice readable value in UI.
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                if ((value - float.Epsilon) == m_DefaultInitializedValue)
+                    value = m_DefaultInitializedValue;
+
                 ////TODO: use slider rather than float field
                 var newValue = EditorGUILayout.FloatField(m_ValueLabel, value, GUILayout.ExpandWidth(false));
                 if (!m_UseDefaultValue)
-                    m_SetValue(newValue);
+                {
+                    // ReSharper disable once CompareOfFloatsByEqualityOperator
+                    if (newValue == m_DefaultInitializedValue)
+                        // If user sets a value that is equal to default initialized, change value slightly so it doesn't pass potential default checks.
+                        ////TODO: refactor all of this to use tri-state values instead, there is no obvious float value that we can use as default (well maybe NaN),
+                        ////so instead it would be better to have a separate bool to show if value is present or not. 
+                        m_SetValue(newValue + float.Epsilon);
+                    else
+                        m_SetValue(newValue);
+                }
+
                 EditorGUI.EndDisabledGroup();
+                
                 var newUseDefault = GUILayout.Toggle(m_UseDefaultValue, m_ToggleLabel, GUILayout.ExpandWidth(false));
                 if (newUseDefault != m_UseDefaultValue)
                 {
@@ -218,6 +238,7 @@ namespace UnityEngine.InputSystem.Editor
                     else
                         m_SetValue(m_DefaultInitializedValue);
                 }
+
                 m_UseDefaultValue = newUseDefault;
                 EditorGUILayout.EndHorizontal();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -202,13 +202,13 @@ namespace UnityEngine.InputSystem.Editor
             {
                 EditorGUILayout.BeginHorizontal();
                 EditorGUI.BeginDisabledGroup(m_UseDefaultValue);
-                
+
                 var value = m_GetValue();
 
                 if (m_UseDefaultValue)
                     value = m_GetDefaultValue();
-                
-                // If previous value was an epsilon away from default value, it most likely means that value was set by our own code down in this method. 
+
+                // If previous value was an epsilon away from default value, it most likely means that value was set by our own code down in this method.
                 // Revert it back to default to show a nice readable value in UI.
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
                 if ((value - float.Epsilon) == m_DefaultInitializedValue)
@@ -222,14 +222,14 @@ namespace UnityEngine.InputSystem.Editor
                     if (newValue == m_DefaultInitializedValue)
                         // If user sets a value that is equal to default initialized, change value slightly so it doesn't pass potential default checks.
                         ////TODO: refactor all of this to use tri-state values instead, there is no obvious float value that we can use as default (well maybe NaN),
-                        ////so instead it would be better to have a separate bool to show if value is present or not. 
+                        ////so instead it would be better to have a separate bool to show if value is present or not.
                         m_SetValue(newValue + float.Epsilon);
                     else
                         m_SetValue(newValue);
                 }
 
                 EditorGUI.EndDisabledGroup();
-                
+
                 var newUseDefault = GUILayout.Toggle(m_UseDefaultValue, m_ToggleLabel, GUILayout.ExpandWidth(false));
                 if (newUseDefault != m_UseDefaultValue)
                 {


### PR DESCRIPTION
### Description

Currently if one tries to set min/max values to 0 from UI, go to any other UI and go back, they will be set to "default". With default being `0.125` for min, it's very far from 0.

### Changes made

If UI tries to set value to default (in this case being 0), I've add an epsilon instead, so the stored value becomes `1.40129846432481707092e-45` instead.

Also when showing the value in UI, I'm checking if it's `1.40129846432481707092e-45` and converting it back to `0`.

Both are done relative to `m_DefaultInitializedValue`, so while it could work for some other default values but 0, most likely it wouldn't due to float limited precision, e.g. `1.0f` + `1.40129846432481707092e-45` = `1.0f`

### Notes

Prioritized time to resolution instead of fixing design issue. E.g. this is just fixing some of the symptoms of the root cause.

### Checklist

Before review:

- [x] Changelog entry added.
- [x] Docs for new/changed API's.
