### PR TITLE
Making keyboard display names consistent

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1073,7 +1073,7 @@ partial class CoreTests
         // Pretend 'a' key is mapped to 'q' in current keyboard layout.
         SetKeyInfo(Key.A, "q");
 
-        Assert.That(InputControlPath.ToHumanReadableString("<Keyboard>/a", control: Keyboard.current), Is.EqualTo("q [Keyboard]"));
+        Assert.That(InputControlPath.ToHumanReadableString("<Keyboard>/a", control: Keyboard.current), Is.EqualTo("Q [Keyboard]"));
     }
 
     [Preserve]

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -2253,7 +2253,7 @@ partial class CoreTests
                         if (keyNameCommand->scanOrKeyCode == (int)Key.A)
                         {
                             scanCode = 0x01;
-                            name = currentLayoutName == "default" ? "m" : "q";
+                            name = currentLayoutName == "default" ? "M" : "RIGHT CTRL";
                         }
 
                         keyNameCommand->scanOrKeyCode = scanCode;
@@ -2267,16 +2267,16 @@ partial class CoreTests
                 });
         }
 
-        Assert.That(keyboard.aKey.displayName, Is.EqualTo("m"));
-        Assert.That(keyboard.bKey.displayName, Is.EqualTo("other"));
+        Assert.That(keyboard.aKey.displayName, Is.EqualTo("M"));
+        Assert.That(keyboard.bKey.displayName, Is.EqualTo("Other"));
 
         // Change layout.
         currentLayoutName = "other";
         InputSystem.QueueConfigChangeEvent(keyboard);
         InputSystem.Update();
 
-        Assert.That(keyboard.aKey.displayName, Is.EqualTo("q"));
-        Assert.That(keyboard.bKey.displayName, Is.EqualTo("other"));
+        Assert.That(keyboard.aKey.displayName, Is.EqualTo("Right Ctrl"));
+        Assert.That(keyboard.bKey.displayName, Is.EqualTo("Other"));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
   * This was added for the sake of the Input System's own tests but should not have been in the public fixture.
 - Generic `Gamepad` now has platform independent long button names. Previously it used different names if editor targeted PS4/Switch consoles (case 1321676).
 - When creating a new control scheme with a name `All Control Schemes`, `All Control Schemes1` will be created to avoid confusion with implicit `All Control Schemes` scheme ([case 1217379](https://issuetracker.unity3d.com/issues/control-scheme-cannot-be-selected-when-it-is-named-all-control-schemes)).
+- Display names of keyboard buttons are now passed through `ToLower` and `ToTitleCase` to enforce consistent casing between different platforms and keyboard layouts ([case 1254705](https://issuetracker.unity3d.com/issues/the-display-names-for-keyboard-keys-in-the-input-debugger-do-not-match-those-defined-in-input-system-package)).
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
@@ -69,7 +69,7 @@ namespace UnityEngine.InputSystem.Controls
                     displayName = rawKeyName;
                     return;
                 }
-                
+
                 displayName = textInfo.ToTitleCase(keyNameLowerCase);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
@@ -53,11 +53,24 @@ namespace UnityEngine.InputSystem.Controls
                 m_ScanCode = command.scanOrKeyCode;
 
                 var rawKeyName = command.ReadKeyName();
-                var textInfo = CultureInfo.CurrentCulture.TextInfo;
+                if (string.IsNullOrEmpty(rawKeyName))
+                {
+                    displayName = rawKeyName;
+                    return;
+                }
+
+                var textInfo = CultureInfo.InvariantCulture.TextInfo;
                 // We need to lower case first because ToTitleCase preserves upper casing.
                 // For example on Swedish Windows layout right shift display name is "HÖGER SKIFT".
                 // Just passing it to ToTitleCase won't change anything. But passing "höger skift" will return "Höger Skift".
-                displayName = textInfo.ToTitleCase(textInfo.ToLower(rawKeyName));
+                var keyNameLowerCase = textInfo.ToLower(rawKeyName);
+                if (string.IsNullOrEmpty(keyNameLowerCase))
+                {
+                    displayName = rawKeyName;
+                    return;
+                }
+                
+                displayName = textInfo.ToTitleCase(keyNameLowerCase);
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.Scripting;
 
@@ -50,7 +51,13 @@ namespace UnityEngine.InputSystem.Controls
             if (device.ExecuteCommand(ref command) > 0)
             {
                 m_ScanCode = command.scanOrKeyCode;
-                displayName = command.ReadKeyName();
+
+                var rawKeyName = command.ReadKeyName();
+                var textInfo = CultureInfo.CurrentCulture.TextInfo;
+                // We need to lower case first because ToTitleCase preserves upper casing.
+                // For example on Swedish Windows layout right shift display name is "HÖGER SKIFT".
+                // Just passing it to ToTitleCase won't change anything. But passing "höger skift" will return "Höger Skift".
+                displayName = textInfo.ToTitleCase(textInfo.ToLower(rawKeyName));
             }
         }
 


### PR DESCRIPTION
### Description

Platforms don't have any consistency to keyboard key names, it can be all upper case, all lower case, title case. And can even change between keyboard layouts on the same platform. For example Swedish Windows have key names in all upper case.

### Changes made

Enforced title case (even on all upper case) names.

### Checklist

Before review:

- [X] Changelog entry added.
- [X] Tests added/changed, if applicable.
