### PR TITLE
Supporting kFormatSBit in float operations in InputStateBlock

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_State.cs
+++ b/Assets/Tests/InputSystem/CoreTests_State.cs
@@ -1670,15 +1670,15 @@ partial class CoreTests
     // single bit
     [TestCase(InputStateBlock.kFormatBit, 5, 1, 0u, 0, 0.0f)]
     [TestCase(InputStateBlock.kFormatBit, 10, 1, 1u, 1, 1.0f)]
-    [TestCase(InputStateBlock.kFormatSBit, 15, 1, 0u, -1, null)]
-    [TestCase(InputStateBlock.kFormatSBit, 25, 1, 1u, 1, null)]
-    // multiple bits
-    [TestCase(InputStateBlock.kFormatBit, 5, 16, 0b1101010101010101u, 0b1101010101010101)]
-    [TestCase(InputStateBlock.kFormatSBit, 15, 16, 0b1101010101010101u, 0b1101010101010101 + short.MinValue)]
-    [TestCase(InputStateBlock.kFormatBit, 16, 31, 0x7fffffffu, int.MaxValue)]
-    [TestCase(InputStateBlock.kFormatSBit, 24, 31, 0x7fffffffu, 1073741823)] // excess-K
-    [TestCase(InputStateBlock.kFormatBit, 16, 32, uint.MaxValue, -1)]
-    [TestCase(InputStateBlock.kFormatSBit, 24, 32, uint.MaxValue, int.MaxValue)] // excess-K
+    [TestCase(InputStateBlock.kFormatSBit, 15, 1, 0u, -1, -1.0f)]
+    [TestCase(InputStateBlock.kFormatSBit, 25, 1, 1u, 1, 1.0f)]
+    // multiple bits/
+    [TestCase(InputStateBlock.kFormatBit, 5, 16, 0b1101010101010101u, 0b1101010101010101, 0.8333282470703125f)]
+    [TestCase(InputStateBlock.kFormatSBit, 15, 16, 0b1101010101010101u, 0b1101010101010101 + short.MinValue, 0.666656494140625f)]
+    [TestCase(InputStateBlock.kFormatBit, 16, 31, 0x7fffffffu, int.MaxValue, 1.0f)]
+    [TestCase(InputStateBlock.kFormatSBit, 24, 31, 0x7fffffffu, 1073741823, 1.0f)] // excess-K
+    [TestCase(InputStateBlock.kFormatBit, 16, 32, uint.MaxValue, -1, 1.0f)]
+    [TestCase(InputStateBlock.kFormatSBit, 24, 32, uint.MaxValue, int.MaxValue, 1.0f)] // excess-K
     // primitive types
     [TestCase(InputStateBlock.kFormatInt, 32, 32, 0u, 0, 0.0f)]
     [TestCase(InputStateBlock.kFormatInt, 64, 32, 1231231231u, 1231231231, 0.573336720466613769531f)]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -57,6 +57,7 @@ however, it has to be formatted properly to pass verification tests.
   * UITK is now supported as a UI solution in players. Input support for both [Unity UI](https://docs.unity3d.com/Manual/com.unity.ugui.html) and [UI Toolkit](https://docs.unity3d.com/Manual/UIElements.html) is based on the same `InputSystemUIInputModule` code path. More details in the manual.
 - `InputSystemUIInputModule` now has an `xrTrackingOrigin` property. When assigned, this will transform all tracked device positions and rotations from it's local space into Unity's world space ([case 1308480](https://issuetracker.unity3d.com/issues/xr-sdk-tracked-device-raycaster-does-not-work-correctly-with-worldspace-canvas-when-xr-camera-is-offset-from-origin)).
 - Added `InputSystemUIInputModule.GetLastRaycastResult`. This returns the most recent raycast result and can be used to draw ray visualizations or get information on the most recent UI object hit.
+- Added `InputStateBlock` support for `kFormatSBit` when working with floats ([case 1258003](https://issuetracker.unity3d.com/issues/hid-exceptions-are-thrown-when-launching-a-project-while-analog-keyboard-is-connected-to-the-machine)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -486,8 +486,8 @@ namespace UnityEngine.InputSystem.LowLevel
                 {
                     if (sizeInBits == 1)
                         return value >= 0.0f;
-                    var minValue = (int) -(long) (1UL << ((int)sizeInBits - 1));
-                    var maxValue = (int) ((1UL << ((int)sizeInBits - 1)) - 1);
+                    var minValue = (int)-(long)(1UL << ((int)sizeInBits - 1));
+                    var maxValue = (int)((1UL << ((int)sizeInBits - 1)) - 1);
                     return NumberHelpers.NormalizedFloatToInt(value, minValue, maxValue);
                 }
                 case kFormatInt:

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -418,13 +418,19 @@ namespace UnityEngine.InputSystem.LowLevel
                     else
                         MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value);
                     break;
+                case kFormatSBit:
+                    if (sizeInBits == 1)
+                        MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value >= 0.0f);
+                    else
+                        MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value * 0.5f + 0.5f);
+                    break;
                 case kFormatInt:
-                    Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");
+                    Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=32");
                     Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
                     *(int*)valuePtr = (int)NumberHelpers.NormalizedFloatToInt(value * 0.5f + 0.5f, int.MinValue, int.MaxValue);
                     break;
                 case kFormatUInt:
-                    Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=16");
+                    Debug.Assert(sizeInBits == 32, "UINT state must have sizeInBits=32");
                     Debug.Assert(bitOffset == 0, "UINT state must be byte-aligned");
                     *(uint*)valuePtr = NumberHelpers.NormalizedFloatToUInt(value, uint.MinValue, uint.MaxValue);
                     break;
@@ -459,7 +465,6 @@ namespace UnityEngine.InputSystem.LowLevel
                     *(double*)valuePtr = value;
                     break;
                 // Not supported:
-                // - kFormatSBit
                 // - kFormatLong
                 // - kFormatULong
                 default:
@@ -477,6 +482,14 @@ namespace UnityEngine.InputSystem.LowLevel
                         return value >= 0.5f;
                     ////FIXME: is this supposed to be int or uint?
                     return (int)NumberHelpers.NormalizedFloatToUInt(value, 0, (uint)((1UL << (int)sizeInBits) - 1));
+                case kFormatSBit:
+                {
+                    if (sizeInBits == 1)
+                        return value >= 0.0f;
+                    var minValue = (int) -(long) (1UL << ((int)sizeInBits - 1));
+                    var maxValue = (int) ((1UL << ((int)sizeInBits - 1)) - 1);
+                    return NumberHelpers.NormalizedFloatToInt(value, minValue, maxValue);
+                }
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=32");
                     Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
@@ -510,7 +523,6 @@ namespace UnityEngine.InputSystem.LowLevel
                     Debug.Assert(bitOffset == 0, "DBL state must be byte-aligned");
                     return value;
                 // Not supported:
-                // - kFormatSBit
                 // - kFormatLong
                 // - kFormatULong
                 default:
@@ -596,6 +608,12 @@ namespace UnityEngine.InputSystem.LowLevel
                     else
                         MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, (float)value);
                     break;
+                case kFormatSBit:
+                    if (sizeInBits == 1)
+                        MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value >= 0.0f);
+                    else
+                        MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, (float)value * 0.5f + 0.5f);
+                    break;
                 case kFormatInt:
                     Debug.Assert(sizeInBits == 32, "INT state must have sizeInBits=16");
                     Debug.Assert(bitOffset == 0, "INT state must be byte-aligned");
@@ -637,7 +655,6 @@ namespace UnityEngine.InputSystem.LowLevel
                     *(double*)valuePtr = value;
                     break;
                 // Not supported:
-                // - kFormatSBit
                 // - kFormatLong
                 // - kFormatULong
                 // - kFormatFloat


### PR DESCRIPTION
### Description

Currently input state block will throw exceptions if trying to read/write/convert_to_primitive_value floats when format is SBIT/kFormatSBit. This seems to be observed in [case 1258003](https://issuetracker.unity3d.com/issues/hid-exceptions-are-thrown-when-launching-a-project-while-analog-keyboard-is-connected-to-the-machine).

### Changes made

Adding support for SBIT. Fixing tests.

### Notes

I don't have the device, so while tests for InputStateBlock are passing, I can't be confident that it's 100% resolves the issue.

### Checklist

Before review:

- [X] Changelog entry added.
- [X] Tests added/changed, if applicable.
