### PR TITLE
FIX: Can't rebind to a key that was pressed when the rebinding operation started (case 1317225)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -625,6 +625,35 @@ internal partial class CoreTests
         }
     }
 
+    // Tests that controls with discrete actuations successfully rebind when the control is already
+    // actuated when rebinding begins.
+    // https://fogbugz.unity3d.com/f/cases/1317225/
+    [Test]
+    [Category("Actions")]
+    public void Actions_InteractiveRebinding_WhenDiscreteControlAlreadyPressed_RebindWorksOnNextActuation()
+    {
+        var action = new InputAction(binding: "<Keyboard>/n");
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        Press(keyboard.spaceKey);
+
+        using (var rebind = new InputActionRebindingExtensions.RebindingOperation()
+                   .WithAction(action)
+                   .WithMatchingEventsBeingSuppressed()
+                   .Start())
+        {
+            Release(keyboard.spaceKey);
+
+            Assert.That(rebind.completed, Is.False);
+            Assert.That(rebind.candidates, Is.Empty);
+
+            Press(keyboard.spaceKey);
+
+            Assert.That(rebind.completed, Is.True);
+            Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Keyboard>/space"));
+        }
+    }
+
     [Test]
     [Category("Actions")]
     public void Actions_InteractiveRebinding_CanGetActuationMagnitudeOfCandidateControls()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -32,6 +32,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `Retrieving array element that was out of bounds` and `SerializedProperty ... has disappeared!` errors when deleting multiple action bindings in the input asset editor ([case 1300506](https://issuetracker.unity3d.com/issues/errors-are-thrown-in-the-console-when-deleting-multiple-bindings)).
 - Fixed `InputUser` no longer sending `InputUserChange.ControlsChanged` when adding a new user after previously, all users were removed.
   * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
+- Fixed rebinding not working for any discrete control that was held when the rebinding operation started ([case 1317225](https://issuetracker.unity3d.com/issues/inputsystem-a-key-will-not-be-registered-after-rebinding-if-it-was-pressed-when-the-rebinding-operation-started)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1329,6 +1329,12 @@ namespace UnityEngine.InputSystem
                             m_CurrentControl = m_AllControls[controlIndex];
                         }
 
+                        if ((m_Flags & Enumerate.IncludeNoisyControls) == 0 && m_CurrentControl.noisy)
+                        {
+                            m_CurrentControl = null;
+                            continue;
+                        }
+
                         if ((m_Flags & Enumerate.IncludeSyntheticControls) == 0)
                         {
                             var controlHasSharedState = (m_CurrentControl.m_ControlFlags &

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -1285,7 +1285,7 @@ namespace UnityEngine.InputSystem
                 {
                     // Check for direct match.
                     var layoutMatches = Substring.Compare(layout, control.layout,
-                        StringComparison.InvariantCultureIgnoreCase) == 0;
+                        StringComparison.OrdinalIgnoreCase) == 0;
                     if (!layoutMatches)
                     {
                         // No direct match but base layout may match.
@@ -1293,7 +1293,7 @@ namespace UnityEngine.InputSystem
                         while (InputControlLayout.s_Layouts.baseLayoutTable.TryGetValue(baseLayout, out baseLayout) && !layoutMatches)
                         {
                             layoutMatches = Substring.Compare(layout, baseLayout.ToString(),
-                                StringComparison.InvariantCultureIgnoreCase) == 0;
+                                StringComparison.OrdinalIgnoreCase) == 0;
                         }
                     }
 
@@ -1311,7 +1311,7 @@ namespace UnityEngine.InputSystem
                             var controlUsages = control.usages;
                             var haveUsageMatch = false;
                             for (var ci = 0; ci < controlUsages.Count; ++ci)
-                                if (Substring.Compare(controlUsages[ci].ToString(), usages[i], StringComparison.InvariantCultureIgnoreCase) == 0)
+                                if (Substring.Compare(controlUsages[ci].ToString(), usages[i], StringComparison.OrdinalIgnoreCase) == 0)
                                 {
                                     haveUsageMatch = true;
                                     break;
@@ -1327,7 +1327,7 @@ namespace UnityEngine.InputSystem
                 if (!name.isEmpty && !isWildcard)
                 {
                     ////FIXME: unlike the matching path we have in MatchControlsRecursive, this does not take aliases into account
-                    if (Substring.Compare(control.name, name, StringComparison.InvariantCultureIgnoreCase) != 0)
+                    if (Substring.Compare(control.name, name, StringComparison.OrdinalIgnoreCase) != 0)
                         return false;
                 }
 
@@ -1335,7 +1335,7 @@ namespace UnityEngine.InputSystem
                 if (!displayName.isEmpty)
                 {
                     if (Substring.Compare(control.displayName, displayName,
-                        StringComparison.InvariantCultureIgnoreCase) != 0)
+                        StringComparison.OrdinalIgnoreCase) != 0)
                         return false;
                 }
 


### PR DESCRIPTION
### Description

Fixes an issue where it is impossible to bind a control to an action if that control is pressed when a rebind operation begins. This was caused by the rebinding logic using the flag IgnoreControlsInCurrentState when iterating over controls which would prevent any actuated control from ever being considered during rebinding.

### Changes made

* Removed the IgnoreControlsInCurrentState flag when iterating over controls in the RebindingOperation.OnEvent method. This affects performance because all controls in the current device will now be checked, so changed the starting actuation code to use a dictionary rather than arrays and linear search, and optimized path part matching by changing from InvariantCulture to Ordinal string comparisons.
* Made a small change to starting actuation logic so once the pressed key is released, the next time it is pressed it will be chosen as the binding, rather than having to be released, pressed and released, then pressed again.
* This change broke the skip noisy controls path in InputEventControlCollection, which only works when also ignoring controls in current state, so added some extra code there to compensate.
