### PR TITLE
Fixing 1217379

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
   * The component has a different GUID from before, so existing setups that use the component from the sample are not broken. To use the built-in component you must explicitly switch over.
 - `InputTestFixture` no longer deletes the `GameObject`s in the current scene in its `TearDown` ([case 1286987](https://issuetracker.unity3d.com/issues/input-system-inputtestfixture-destroys-test-scene)).
   * This was added for the sake of the Input System's own tests but should not have been in the public fixture.
+- When creating a new control scheme with a name `All Control Schemes`, `All Control Schemes1` will be created to avoid confusion with implicit `All Control Schemes` scheme ([case 1217379](https://issuetracker.unity3d.com/issues/control-scheme-cannot-be-selected-when-it-is-named-all-control-schemes)).
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
@@ -321,7 +321,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private string MakeUniqueControlSchemeName(string name)
         {
-            return StringHelpers.MakeUniqueName(name, m_ControlSchemes, x => x.name);
+            return StringHelpers.MakeUniqueName(name, m_ControlSchemes.Select(x => x.name).Append("All Control Schemes"), x => x);
         }
 
         private static string DeviceRequirementToDisplayString(InputControlScheme.DeviceRequirement requirement)


### PR DESCRIPTION
### Description

Unity GenericMenu by default collapses duplicates (see [allowDuplicateNames](https://docs.unity3d.com/2019.4/Documentation/ScriptReference/GenericMenu-allowDuplicateNames.html) ). So when user adds a new control scheme with a name "All Control Schemes" first it doesn't show up because we hide duplicates, second even if we show duplicates it is not selectable because we implicitly add `All Control Schemes` element first, but it goes to the same `OnControlSchemeSelected` callback as all real schemes.

### Changes made

Added "All Control Schemes" to the list of existing names when trying to select a new name for a scheme.

### Checklist

- [X] Changelog entry added.
