### PR TITLE
FIX: Input action property drawer exception

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawer.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem.Editor
             // clear out some properties of the InputAction (id, name, and singleton action bindings) and
             // recreate the tree view.
 
-            if (property == null)
+            if (property?.GetParentProperty() == null || property.GetParentProperty().isArray == false)
                 return false;
 
             var array = property.GetArrayPropertyFromElement();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -102,9 +102,14 @@ namespace UnityEngine.InputSystem.Editor
 
         private static string GetPropertyTitle(SerializedProperty property)
         {
+            var propertyTitleNumeral = string.Empty;
+
+            if (property.GetParentProperty() != null && property.GetParentProperty().isArray)
+                propertyTitleNumeral = $" {property.GetIndexOfArrayElement()}";
+
             return property.type == nameof(InputActionMap) ?
-                $"Input Action Map {property.GetIndexOfArrayElement()}" :
-                $"Input Action {property.GetIndexOfArrayElement()}";
+                $"Input Action Map{propertyTitleNumeral}" :
+                $"Input Action{propertyTitleNumeral}";
         }
 
         private void OnItemDoubleClicked(ActionTreeItemBase item, SerializedProperty property)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionMapDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionMapDrawer.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem.Editor
             // clear out some properties of the InputActionMap (id, name, input actions, and bindings) and
             // recreate the tree view.
 
-            if (property == null)
+            if (property?.GetParentProperty() == null || property.GetParentProperty().isArray == false)
                 return false;
 
             var array = property.GetArrayPropertyFromElement();


### PR DESCRIPTION
### Description

The input action and input action map property drawers would throw an exception when trying to display an item that wasn't in an array.