### PR TITLE
Properly selecting dropdown items when going up through hierarchy

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -58,6 +58,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed reference to `.inputactions` of `Player Prefab` referenced by `PlayerInputManager` being destroyed on going into play mode, if the player prefab was a nested prefab ([case 1319756](https://issuetracker.unity3d.com/issues/playerinput-component-loses-its-reference-to-an-inputactionasset)).
 - Fixed "Scheme Name" label clipped in "Add Control Schema" popup window ([case 1199560]https://issuetracker.unity3d.com/issues/themes-input-system-scheme-name-is-clipped-in-add-control-schema-window-with-inter-default-font)).
 - Fixed `InputSystem.QueueEvent` calls from within `InputAction` callbacks getting dropped entirely ([case 1297339](https://issuetracker.unity3d.com/issues/input-system-ui-button-wont-click-when-simulating-a-mouse-click-with-inputsystem-dot-queueevent)).
+- Fixed binding path selection windows not remembering navigation state when going up through hierarchy ([case 1254981](https://issuetracker.unity3d.com/issues/action-binding-path-selection-windows-doesnt-remember-navigation-state)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownItem.cs
@@ -26,6 +26,11 @@ namespace UnityEngine.InputSystem.Editor
             m_Children.Add(child);
         }
 
+        public int GetIndexOfChild(AdvancedDropdownItem child)
+        {
+            return m_Children.IndexOf(child);
+        }
+
         static readonly AdvancedDropdownItem k_SeparatorItem = new SeparatorDropdownItem();
 
         public AdvancedDropdownItem(string name)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownState.cs
@@ -94,6 +94,11 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
+        internal void ClearSelectionOnItem(AdvancedDropdownItem item)
+        {
+            GetStateForItem(item).selectedIndex = -1;
+        }
+
         internal int GetSelectedIndex(AdvancedDropdownItem item)
         {
             return GetStateForItem(item).selectedIndex;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownWindow.cs
@@ -518,7 +518,17 @@ namespace UnityEngine.InputSystem.Editor
             else
                 m_NewAnimTarget = -1;
             m_AnimationTree = m_CurrentlyRenderedTree;
-            m_CurrentlyRenderedTree = m_ViewsStack.Pop();
+            var parentItem = m_ViewsStack.Pop();
+
+            m_State.ClearSelectionOnItem(m_CurrentlyRenderedTree);
+
+            if (parentItem != null)
+            {
+                var suggestedIndex = parentItem.GetIndexOfChild(m_CurrentlyRenderedTree);
+                m_State.SetSelectionOnItem(parentItem, suggestedIndex);
+            }
+
+            m_CurrentlyRenderedTree = parentItem;
         }
 
         private void GoToChild()


### PR DESCRIPTION
### Description

In input action editor when selecting binding path via dropdown window, when clicking on items in the window, closing window by clicking away/pressing escape, and then opening window again, it remembers the state where it was last in. That is helpful so you don't need to traverse the hierarchy again. But when clicking up through hierarchy (going to parent), the state was not updated, so closing/opening the window was resulting in the wrong section.

### Changes made

Correctly selecting right items when going up through hierarchy.

### Notes

Doesn't seem like we have any tests in this region, so this fix was manually tested.

### Checklist

Before review:

- [X] Changelog entry added.
