### PR TITLE
Fixing Keyboard.current becoming null after OnScreenButton is disabled/destroyed

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4196,4 +4196,20 @@ partial class CoreTests
         InputSystem.RemoveDevice(keyboard2);
         Assert.That(Keyboard.current, Is.EqualTo(keyboard1));
     }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_RemovingDevice_MakesNextDeviceOfTypeCurrent()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+        Press(mouse.leftButton);
+        Assert.That(Pointer.current, Is.EqualTo(mouse));
+
+        var pointer = InputSystem.AddDevice<Pointer>();
+        Move(pointer.position, Vector2.right);
+        Assert.That(Pointer.current, Is.EqualTo(pointer));
+
+        InputSystem.RemoveDevice(pointer);
+        Assert.That(Pointer.current, Is.EqualTo(mouse));
+    }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4180,4 +4180,20 @@ partial class CoreTests
         keyboard.SetIMECursorPosition(Vector2.one);
         Assert.That(commandWasSent, Is.True);
     }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_RemovingKeyboardMakesNextKeyboardCurrent()
+    {
+        var keyboard1 = InputSystem.AddDevice<Keyboard>();
+        Press(keyboard1.spaceKey);
+        Assert.That(Keyboard.current, Is.EqualTo(keyboard1));
+
+        var keyboard2 = InputSystem.AddDevice<Keyboard>();
+        Press(keyboard2.spaceKey);
+        Assert.That(Keyboard.current, Is.EqualTo(keyboard2));
+
+        InputSystem.RemoveDevice(keyboard2);
+        Assert.That(Keyboard.current, Is.EqualTo(keyboard1));
+    }
 }

--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -263,6 +263,27 @@ internal class OnScreenTests : CoreTestsFixture
         Assert.That(Gamepad.all[0].buttonSouth.isPressed, Is.False);
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1305016/
+    [Test]
+    [Category("Devices")]
+    public void Devices_CanUseKeyboardCurrentAfterDisablingOnScreenButton()
+    {
+        var systemKeyboard = InputSystem.AddDevice<Keyboard>();
+
+        Assert.That(Keyboard.current, Is.EqualTo(systemKeyboard));
+
+        var gameObject = new GameObject();
+        var button = gameObject.AddComponent<OnScreenButton>();
+        button.controlPath = "<Keyboard>/a";
+
+        Assert.That(Keyboard.current, Is.Not.EqualTo(systemKeyboard));
+        Assert.That(Keyboard.current, Is.Not.Null);
+
+        gameObject.SetActive(false);
+
+        Assert.That(Keyboard.current, Is.EqualTo(systemKeyboard));
+    }
+
     private class TestEventSystem : EventSystem
     {
         public new void OnApplicationFocus(bool hasFocus)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -60,6 +60,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `InputSystem.QueueEvent` calls from within `InputAction` callbacks getting dropped entirely ([case 1297339](https://issuetracker.unity3d.com/issues/input-system-ui-button-wont-click-when-simulating-a-mouse-click-with-inputsystem-dot-queueevent)).
 - Fixed `InputSystemUIInputModule` being in invalid state when added from `Awake` to a game object when entering playmode ([case 1323566](https://issuetracker.unity3d.com/issues/input-system-default-ui-actions-do-not-register-when-adding-inputsystemuiinputmodule-at-runtime-to-an-active-game-object)).
 - Fixed binding path selection windows not remembering navigation state when going up through hierarchy ([case 1254981](https://issuetracker.unity3d.com/issues/action-binding-path-selection-windows-doesnt-remember-navigation-state)).
+- Fixed `Keyboard.current` becoming `null` after `OnScreenButton` is disabled or destroyed ([case 1305016](https://issuetracker.unity3d.com/issues/inputsystem-keyboard-dot-current-becomes-null-after-onscreenbutton-is-destroyed)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1303,6 +1303,9 @@ namespace UnityEngine.InputSystem
             // Let listeners know.
             for (var i = 0; i < m_DeviceChangeListeners.length; ++i)
                 m_DeviceChangeListeners[i](device, InputDeviceChange.Removed);
+
+            // Try setting next device of same type as current
+            InputSystem.GetDevice(device.GetType())?.MakeCurrent();
         }
 
         public void FlushDisconnectedDevices()

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1574,7 +1574,7 @@ namespace UnityEngine.InputSystem
             var lastUpdateTime = -1.0;
             foreach (var device in devices)
             {
-                if (device.GetType() != type)
+                if (!type.IsInstanceOfType(device))
                     continue;
 
                 if (result == null || device.m_LastUpdateTimeInternal > lastUpdateTime)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1562,12 +1562,28 @@ namespace UnityEngine.InputSystem
             return s_Manager.TryGetDevice(nameOrLayout);
         }
 
+        ////REVIEW: this API seems inconsistent with GetDevice(string); both have very different meaning yet very similar signatures
+        /// <summary>
+        /// Return the most recently used device that is assignable to the given type <typeparamref name="TDevice"/>.
+        /// Returns null if no such device currently exists.
+        /// </summary>
+        /// <typeparam name="TDevice">Type of device to look for.</typeparam>
+        /// <returns>The device that is assignable to the given type or null.</returns>
+        /// <seealso cref="GetDevice(Type)"/>
         public static TDevice GetDevice<TDevice>()
             where TDevice : InputDevice
         {
             return (TDevice)GetDevice(typeof(TDevice));
         }
 
+        ////REVIEW: this API seems inconsistent with GetDevice(string); both have very different meaning yet very similar signatures
+        /// <summary>
+        /// Return the most recently used device that is assignable to the given type <param name="type"/>.
+        /// Returns null if no such device currently exists.
+        /// </summary>
+        /// <param name="type">Type of the device</param>
+        /// <returns>The device that is assignable to the given type or null.</returns>
+        /// <seealso cref="GetDevice&lt;TDevice&gt;()"/>
         public static InputDevice GetDevice(Type type)
         {
             InputDevice result = null;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1565,17 +1565,21 @@ namespace UnityEngine.InputSystem
         public static TDevice GetDevice<TDevice>()
             where TDevice : InputDevice
         {
-            TDevice result = null;
+            return (TDevice)GetDevice(typeof(TDevice));
+        }
+
+        public static InputDevice GetDevice(Type type)
+        {
+            InputDevice result = null;
             var lastUpdateTime = -1.0;
             foreach (var device in devices)
             {
-                var deviceOfType = device as TDevice;
-                if (deviceOfType == null)
+                if (device.GetType() != type)
                     continue;
 
-                if (result == null || deviceOfType.m_LastUpdateTimeInternal > lastUpdateTime)
+                if (result == null || device.m_LastUpdateTimeInternal > lastUpdateTime)
                 {
-                    result = deviceOfType;
+                    result = device;
                     lastUpdateTime = result.m_LastUpdateTimeInternal;
                 }
             }


### PR DESCRIPTION
### Description

When `OnScreenButton` is disabled, it removes it's own virtual device, which triggers method `Keyboard.OnRemoved` which sets `Keyboard.current` static variable to `null`. [We have a bug](https://issuetracker.unity3d.com/issues/inputsystem-keyboard-dot-current-becomes-null-after-onscreenbutton-is-destroyed) complaining that it's suboptimal. Given keyboard is of a more fundamental device, it makes sense to set current to already known device without waiting for it's input.

### Changes made

If any Keyboard-derived device is removed, set first known Keyboard-derived device as current.

### Notes

This change fixes the bug by introducing technical debt, a more proper fix would be to redesign whole `.current` concept, but due lack of time/priorities it's not possible right now.

### Checklist

Before review:

- [X] Changelog entry added.
- [X] Tests added/changed, if applicable.
