### PR TITLE
Fixing scheme name label being clipped

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `AxisDeadzoneProcessor` min/max values not being settable to 0 in editor UI ([case 1293744](https://issuetracker.unity3d.com/issues/input-system-input-system-axis-deadzone-minimum-value-fallsback-to-default-value-if-its-set-to-0)).
 - Fixed rebinding not working for any discrete control that was held when the rebinding operation started ([case 1317225](https://issuetracker.unity3d.com/issues/inputsystem-a-key-will-not-be-registered-after-rebinding-if-it-was-pressed-when-the-rebinding-operation-started)).
 - Fixed blurry icons in input debugger, asset editor, input settings ([case 1299595](https://issuetracker.unity3d.com/issues/inputsystem-supported-device-list-dropdown-icons-present-under-project-settings-are-not-user-friendly)).
+- Fixed "Scheme Name" label clipped in "Add Control Schema" popup window ([case 1199560]https://issuetracker.unity3d.com/issues/themes-input-system-scheme-name-is-clipped-in-add-control-schema-window-with-inter-default-font)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorToolbar.cs
@@ -566,7 +566,7 @@ namespace UnityEngine.InputSystem.Editor
             private void DrawNameEditTextField()
             {
                 EditorGUILayout.BeginHorizontal();
-                var labelSize = EditorStyles.label.CalcSize(s_RequirementsLabel);
+                var labelSize = EditorStyles.label.CalcSize(s_ControlSchemeNameLabel);
                 EditorGUILayout.LabelField(s_ControlSchemeNameLabel, GUILayout.Width(labelSize.x));
 
                 GUI.SetNextControlName("ControlSchemeName");


### PR DESCRIPTION
### Description

Wrong string was used to calculate label size in "add control scheme" popup window.

### Changes made

Changed to correct label string.

### Notes

Only did manual testing.

### Checklist

- [X] Changelog entry added.
