### PR TITLE
Syncing pointer position when allocating a new pointer in ui input module

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1563,43 +1563,47 @@ internal class UITests : CoreTestsFixture
         try
         {
             yield return null;
-            scene.leftChildReceiver.events.Clear();
-
-            var position = scene.From640x480ToScreen(123, 123);
-            InputSystem.QueueStateEvent(mouse, new MouseState
+            for (var attempt = 0; attempt < 3; ++attempt)
             {
-                position = position
-            }.WithButton(MouseButton.Left));
-            InputSystem.Update();
+                scene.leftChildReceiver.events.Clear();
 
-            yield return null;
-
-            Assert.That(scene.uiModule.m_CurrentPointerType, Is.EqualTo(UIPointerType.Touch));
-            Assert.That(scene.uiModule.m_PointerIds.length, Is.EqualTo(1));
-            Assert.That(scene.uiModule.m_PointerTouchControls.length, Is.EqualTo(1));
-            Assert.That(scene.uiModule.m_PointerTouchControls[0], Is.SameAs(Touchscreen.current.touches[0]));
-            Assert.That(scene.leftChildReceiver.events.Select(x => x.type),
-                Is.EquivalentTo(new[]
+                var position = scene.From640x480ToScreen(123, 123);
+                InputSystem.QueueStateEvent(mouse, new MouseState
                 {
-                    EventType.PointerEnter,
-                    #if UNITY_2021_2_OR_NEWER
-                    EventType.PointerMove,
-                    #endif
-                    EventType.PointerDown,
-                    EventType.InitializePotentialDrag
-                }));
-            Assert.That(scene.leftChildReceiver.events,
-                Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.pointerType == UIPointerType.Touch));
-            Assert.That(scene.leftChildReceiver.events,
-                Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.touchId == 1));
-            Assert.That(scene.leftChildReceiver.events,
-                Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.position == position));
+                    position = position
+                }.WithButton(MouseButton.Left));
+                InputSystem.Update();
 
-            // Release the mouse button so the touch ends. TouchSimulation.Disable() will remove
-            // the touchscreen and thus cancel ongoing actions (like Point). This should not result
-            // in exceptions from the input module trying to read data from the already removed touchscreen.
-            Release(mouse.leftButton);
-            yield return null;
+                yield return null;
+
+                Assert.That(scene.uiModule.m_CurrentPointerType, Is.EqualTo(UIPointerType.Touch));
+                Assert.That(scene.uiModule.m_PointerIds.length, Is.EqualTo(1));
+                Assert.That(scene.uiModule.m_PointerTouchControls.length, Is.EqualTo(1));
+                Assert.That(scene.uiModule.m_PointerTouchControls[0], Is.SameAs(Touchscreen.current.touches[0]));
+                Assert.That(scene.leftChildReceiver.events.Select(x => x.type),
+                    Is.EquivalentTo(new[]
+                    {
+                        EventType.PointerEnter,
+#if UNITY_2021_2_OR_NEWER
+                        EventType.PointerMove,
+#endif
+                        EventType.PointerDown,
+                        EventType.InitializePotentialDrag
+                    }));
+                Assert.That(scene.leftChildReceiver.events,
+                    Has.All.Matches(
+                        (UICallbackReceiver.Event evt) => evt.pointerData.pointerType == UIPointerType.Touch));
+                Assert.That(scene.leftChildReceiver.events,
+                    Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.touchId == attempt + 1));
+                Assert.That(scene.leftChildReceiver.events,
+                    Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.position == position));
+
+                // Release the mouse button so the touch ends. TouchSimulation.Disable() will remove
+                // the touchscreen and thus cancel ongoing actions (like Point). This should not result
+                // in exceptions from the input module trying to read data from the already removed touchscreen.
+                Release(mouse.leftButton);
+                yield return null;
+            }
         }
         finally
         {

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1549,6 +1549,7 @@ internal class UITests : CoreTestsFixture
     }
 
     // https://fogbugz.unity3d.com/f/cases/1190150/
+    // https://fogbugz.unity3d.com/f/cases/1311018/
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanUseTouchSimulationWithUI()
@@ -1564,9 +1565,10 @@ internal class UITests : CoreTestsFixture
             yield return null;
             scene.leftChildReceiver.events.Clear();
 
+            var position = scene.From640x480ToScreen(123, 123);
             InputSystem.QueueStateEvent(mouse, new MouseState
             {
-                position = scene.From640x480ToScreen(123, 123)
+                position = position
             }.WithButton(MouseButton.Left));
             InputSystem.Update();
 
@@ -1590,6 +1592,8 @@ internal class UITests : CoreTestsFixture
                 Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.pointerType == UIPointerType.Touch));
             Assert.That(scene.leftChildReceiver.events,
                 Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.touchId == 1));
+            Assert.That(scene.leftChildReceiver.events,
+                Has.All.Matches((UICallbackReceiver.Event evt) => evt.pointerData.position == position));
 
             // Release the mouse button so the touch ends. TouchSimulation.Disable() will remove
             // the touchscreen and thus cancel ongoing actions (like Point). This should not result

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -59,6 +59,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "Scheme Name" label clipped in "Add Control Schema" popup window ([case 1199560]https://issuetracker.unity3d.com/issues/themes-input-system-scheme-name-is-clipped-in-add-control-schema-window-with-inter-default-font)).
 - Fixed `InputSystem.QueueEvent` calls from within `InputAction` callbacks getting dropped entirely ([case 1297339](https://issuetracker.unity3d.com/issues/input-system-ui-button-wont-click-when-simulating-a-mouse-click-with-inputsystem-dot-queueevent)).
 - Fixed `InputSystemUIInputModule` being in invalid state when added from `Awake` to a game object when entering playmode ([case 1323566](https://issuetracker.unity3d.com/issues/input-system-default-ui-actions-do-not-register-when-adding-inputsystemuiinputmodule-at-runtime-to-an-active-game-object)).
+- Fixed `InputSystemUIInputModule` raycasting in invalid position if a new touch was pressed without a prior point event ([case 1311018](https://issuetracker.unity3d.com/issues/ugui-toggle-malfunctions-when-simulated-touch-input-from-mouse-or-pen-is-enabled)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1604,7 +1604,7 @@ namespace UnityEngine.InputSystem.UI
             m_CurrentPointerId = pointerId;
             m_CurrentPointerIndex = index;
             m_CurrentPointerType = pointerType;
-            
+
             if (point != null && point.action != null)
             {
                 var state = m_PointerStates[m_CurrentPointerIndex];

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1540,6 +1540,13 @@ namespace UnityEngine.InputSystem.UI
                 m_CurrentPointerId = pointerId;
                 m_CurrentPointerType = pointerType;
 
+                if (point != null && point.action != null)
+                {
+                    var state = m_PointerStates[m_CurrentPointerIndex];
+                    state.screenPosition = point.action.ReadValue<Vector2>();
+                    m_PointerStates[m_CurrentPointerIndex] = state;
+                }
+
                 return m_CurrentPointerIndex;
             }
 
@@ -1597,6 +1604,13 @@ namespace UnityEngine.InputSystem.UI
             m_CurrentPointerId = pointerId;
             m_CurrentPointerIndex = index;
             m_CurrentPointerType = pointerType;
+            
+            if (point != null && point.action != null)
+            {
+                var state = m_PointerStates[m_CurrentPointerIndex];
+                state.screenPosition = point.action.ReadValue<Vector2>();
+                m_PointerStates[m_CurrentPointerIndex] = state;
+            }
 
             return index;
         }


### PR DESCRIPTION
### Description

If a click event comes from a touch with new id, the gameobject raycast code looks in a wrong position (at default, `(0, 0)`) because we don't sync touch position. This is visible when using simulated touch as it generates new touch id every time.

### Changes made

Added explicit position sync.

### Notes

This change fixes the bug by introducing technical debt, a more proper fix would be to redesign how ui input module deals with data, as currently it's unclear if the data gets synchronized correctly at all, but due lack of time/priorities it's not possible right now.

### Checklist

Before review:

- [X] Changelog entry added.
- [X] Tests added/changed, if applicable.
