### PR TITLE
FIX: UI stops working when multiple scenes with event systems are additively loaded and unloaded

### DIFF
--- a/Assets/Tests/InputSystem/Assets/UIInputModuleTestScene.unity
+++ b/Assets/Tests/InputSystem/Assets/UIInputModuleTestScene.unity
@@ -1,0 +1,209 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &2050849869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2050849872}
+  - component: {fileID: 2050849871}
+  - component: {fileID: 2050849870}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2050849870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2050849869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01614664b831546d2ae94a42149d80ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MoveRepeatDelay: 0.5
+  m_MoveRepeatRate: 0.1
+  m_XRTrackingOrigin: {fileID: 0}
+  m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_PointAction: {fileID: 1054132383583890850, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MoveAction: {fileID: 3710738434707379630, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_SubmitAction: {fileID: 2064916234097673511, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_CancelAction: {fileID: -1967631576421560919, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_LeftClickAction: {fileID: 8056856818456041789, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_MiddleClickAction: {fileID: 3279352641294131588, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_RightClickAction: {fileID: 3837173908680883260, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_ScrollWheelAction: {fileID: 4502412055082496612, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: ca9f5fa95ffab41fb9a615ab714db018,
+    type: 3}
+  m_DeselectOnBackgroundClick: 1
+  m_PointerBehavior: 0
+--- !u!114 &2050849871
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2050849869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &2050849872
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2050849869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Tests/InputSystem/Assets/UIInputModuleTestScene.unity.meta
+++ b/Assets/Tests/InputSystem/Assets/UIInputModuleTestScene.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: baa5134b94cf0174c8f3452fc4aec251
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
-using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
@@ -26,6 +25,7 @@ using MouseButton = UnityEngine.InputSystem.LowLevel.MouseButton;
 
 #if UNITY_EDITOR
 using UnityEditor;
+using UnityEditor.SceneManagement;
 #endif
 
 #if UNITY_2021_2_OR_NEWER

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
 using NUnit.Framework.Constraints;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
@@ -2480,6 +2481,90 @@ internal class UITests : CoreTestsFixture
 
     [UnityTest]
     [Category("UI")]
+    public IEnumerator UI_WhenMultipleInputModulesExist_ActionsAreNotDisabledUntilTheLastInputModuleIsDisabled()
+    {
+        var firstScene = UITestScene.LoadScene();
+        yield return null;
+
+        var secondScene = UITestScene.LoadScene();
+        yield return null;
+
+        var unloadOperation = SceneManager.UnloadSceneAsync(firstScene.Scene);
+        yield return new WaitUntil(() => unloadOperation.isDone);
+
+        var pointAction = secondScene.InputModule.point.action;
+        Assert.That(pointAction.enabled, Is.True);
+
+        unloadOperation = SceneManager.UnloadSceneAsync(secondScene.Scene);
+        yield return new WaitUntil(() => unloadOperation.isDone);
+
+        Assert.That(pointAction.enabled, Is.False);
+    }
+
+    [Test]
+    [Category("UI")]
+    public void UI_WhenDisablingInputModule_ActionsAreNotDisabledIfTheyWereNotEnabledByTheInputModule()
+    {
+        var eventSystemGO = new GameObject();
+        eventSystemGO.AddComponent<EventSystem>();
+        var inputModule = eventSystemGO.AddComponent<InputSystemUIInputModule>();
+
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = asset.AddActionMap("map");
+        var pointAction = map.AddAction("point", type: InputActionType.PassThrough, binding: "<Mouse>/position");
+
+        map.Enable();
+
+        inputModule.point = InputActionReference.Create(pointAction);
+
+        GameObject.DestroyImmediate(eventSystemGO);
+
+        Assert.That(pointAction.enabled, Is.True);
+    }
+
+    [UnityTest]
+    [Category("UI")]
+    public IEnumerator UI_WhenAssigningInputModuleAction_PreviousOwnedActionsAreDisabled()
+    {
+        var scene = UITestScene.LoadScene();
+        yield return null;
+
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = asset.AddActionMap("map");
+        var pointAction = map.AddAction("point", type: InputActionType.PassThrough, binding: "<Mouse>/position");
+
+        map.Enable();
+
+        var inputModule = scene.InputModule;
+        var previousAction = inputModule.point.action;
+        inputModule.point = InputActionReference.Create(pointAction);
+
+        Assert.That(previousAction.enabled, Is.False);
+    }
+
+    [UnityTest]
+    [Category("UI")]
+    public IEnumerator UI_WhenAssigningInputModuleAction_ExternalActionsAreNotDisabled()
+    {
+        var scene = UITestScene.LoadScene();
+        yield return null;
+
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = asset.AddActionMap("map");
+        var pointAction = map.AddAction("point", type: InputActionType.PassThrough, binding: "<Mouse>/position");
+        var scrollAction = map.AddAction("scroll", type: InputActionType.PassThrough, binding: "<Mouse>/scroll/x");
+
+        map.Enable();
+
+        var inputModule = scene.InputModule;
+        inputModule.point = InputActionReference.Create(pointAction);
+        inputModule.point = InputActionReference.Create(scrollAction);
+
+        Assert.That(pointAction.enabled, Is.True);
+    }
+
+    [UnityTest]
+    [Category("UI")]
     [Ignore("TODO")]
     public IEnumerator TODO_UI_WhenEnabled_InitialPointerPositionIsPickedUp()
     {
@@ -3349,5 +3434,24 @@ internal class UITests : CoreTestsFixture
 
             return new ConstraintResult(this, actual, true);
         }
+    }
+
+    private class UITestScene
+    {
+        private UITestScene(Scene scene)
+        {
+            Scene = scene;
+        }
+
+        public static UITestScene LoadScene(LoadSceneMode loadSceneMode = LoadSceneMode.Additive)
+        {
+            var scene = EditorSceneManager.LoadSceneInPlayMode(s_TestScenePath, new LoadSceneParameters(loadSceneMode));
+            return new UITestScene(scene);
+        }
+
+        public Scene Scene { get; }
+        public InputSystemUIInputModule InputModule => Scene.GetRootGameObjects()[0].GetComponent<InputSystemUIInputModule>();
+
+        private static string s_TestScenePath = "Assets/Tests/InputSystem/Assets/UIInputModuleTestScene.unity";
     }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -48,7 +48,7 @@ however, it has to be formatted properly to pass verification tests.
   * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
 - Fixed `AxisDeadzoneProcessor` min/max values not being settable to 0 in editor UI ([case 1293744](https://issuetracker.unity3d.com/issues/input-system-input-system-axis-deadzone-minimum-value-fallsback-to-default-value-if-its-set-to-0)).
 - Fixed blurry icons in input debugger, asset editor, input settings ([case 1299595](https://issuetracker.unity3d.com/issues/inputsystem-supported-device-list-dropdown-icons-present-under-project-settings-are-not-user-friendly)).
-- Fixed UI not working after additively loading scenes with additional InputSystemUIInputModule modules ([case 1251720](https://issuetracker.unity3d.com/issues/input-system-buttons-cannot-be-pressed-after-additively-loading-scenes-with-additional-event-systems))
+- Fixed UI not working after additively loading scenes with additional InputSystemUIInputModule modules ([case 1251720](https://issuetracker.unity3d.com/issues/input-system-buttons-cannot-be-pressed-after-additively-loading-scenes-with-additional-event-systems)).
 - Fixed no `OnPointerExit` received when changing UI state without moving pointer ([case 1232705](https://issuetracker.unity3d.com/issues/input-system-onpointerexit-is-not-triggered-when-a-ui-element-interrupts-a-mouse-hover)).
 
 #### Actions

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -48,6 +48,7 @@ however, it has to be formatted properly to pass verification tests.
   * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
 - Fixed `AxisDeadzoneProcessor` min/max values not being settable to 0 in editor UI ([case 1293744](https://issuetracker.unity3d.com/issues/input-system-input-system-axis-deadzone-minimum-value-fallsback-to-default-value-if-its-set-to-0)).
 - Fixed blurry icons in input debugger, asset editor, input settings ([case 1299595](https://issuetracker.unity3d.com/issues/inputsystem-supported-device-list-dropdown-icons-present-under-project-settings-are-not-user-friendly)).
+- Fixed UI not working after additively loading scenes with additional InputSystemUIInputModule modules ([case 1251720](https://issuetracker.unity3d.com/issues/input-system-buttons-cannot-be-pressed-after-additively-loading-scenes-with-additional-event-systems))
 - Fixed no `OnPointerExit` received when changing UI state without moving pointer ([case 1232705](https://issuetracker.unity3d.com/issues/input-system-onpointerexit-is-not-triggered-when-a-ui-element-interrupts-a-mouse-hover)).
 
 #### Actions

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1,5 +1,6 @@
 #if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
 using System;
+using System.Collections.Generic;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
@@ -719,6 +720,7 @@ namespace UnityEngine.InputSystem.UI
             var oldActionNull = property?.action == null;
             var oldActionEnabled = property?.action != null && property.action.enabled;
 
+            DisableInputAction(property);
             property = newValue;
 
             #if DEBUG
@@ -743,7 +745,7 @@ namespace UnityEngine.InputSystem.UI
             }
 
             if (isActiveAndEnabled && newValue?.action != null && (oldActionEnabled || oldActionNull))
-                newValue.action.Enable();
+                EnableInputAction(property);
         }
 
         #if DEBUG
@@ -1256,38 +1258,66 @@ namespace UnityEngine.InputSystem.UI
 
         private void EnableAllActions()
         {
-            if (!IsAnyActionEnabled())
-            {
-                m_PointAction?.action?.Enable();
-                m_LeftClickAction?.action?.Enable();
-                m_RightClickAction?.action?.Enable();
-                m_MiddleClickAction?.action?.Enable();
-                m_MoveAction?.action?.Enable();
-                m_SubmitAction?.action?.Enable();
-                m_CancelAction?.action?.Enable();
-                m_ScrollWheelAction?.action?.Enable();
-                m_TrackedDeviceOrientationAction?.action?.Enable();
-                m_TrackedDevicePositionAction?.action?.Enable();
-                m_OwnsEnabledState = true;
-            }
+            EnableInputAction(m_PointAction);
+            EnableInputAction(m_LeftClickAction);
+            EnableInputAction(m_RightClickAction);
+            EnableInputAction(m_MiddleClickAction);
+            EnableInputAction(m_MoveAction);
+            EnableInputAction(m_SubmitAction);
+            EnableInputAction(m_CancelAction);
+            EnableInputAction(m_ScrollWheelAction);
+            EnableInputAction(m_TrackedDeviceOrientationAction);
+            EnableInputAction(m_TrackedDevicePositionAction);
         }
 
         private void DisableAllActions()
         {
-            if (m_OwnsEnabledState)
+            DisableInputAction(m_PointAction);
+            DisableInputAction(m_LeftClickAction);
+            DisableInputAction(m_RightClickAction);
+            DisableInputAction(m_MiddleClickAction);
+            DisableInputAction(m_MoveAction);
+            DisableInputAction(m_SubmitAction);
+            DisableInputAction(m_CancelAction);
+            DisableInputAction(m_ScrollWheelAction);
+            DisableInputAction(m_TrackedDeviceOrientationAction);
+            DisableInputAction(m_TrackedDevicePositionAction);
+        }
+
+        private void EnableInputAction(InputActionReference inputActionReference)
+        {
+            if (inputActionReference == null ||
+                inputActionReference.m_ActionId == null ||
+                inputActionReference.action == null)
+                return;
+
+            if (s_InputActionReferenceCounts.TryGetValue(inputActionReference.m_ActionId, out var referenceState))
             {
-                m_OwnsEnabledState = false;
-                m_PointAction?.action?.Disable();
-                m_LeftClickAction?.action?.Disable();
-                m_RightClickAction?.action?.Disable();
-                m_MiddleClickAction?.action?.Disable();
-                m_MoveAction?.action?.Disable();
-                m_SubmitAction?.action?.Disable();
-                m_CancelAction?.action?.Disable();
-                m_ScrollWheelAction?.action?.Disable();
-                m_TrackedDeviceOrientationAction?.action?.Disable();
-                m_TrackedDevicePositionAction?.action?.Disable();
+                referenceState.refCount++;
+                s_InputActionReferenceCounts[inputActionReference.m_ActionId] = referenceState;
             }
+            else
+            {
+                // if the action is already enabled but its reference count is zero then it was enabled by
+                // something outside the input module and the input module should never disable it.
+                referenceState = new InputActionReferenceState {refCount = 1, enabledByInputModule = !inputActionReference.action.enabled};
+                s_InputActionReferenceCounts.Add(inputActionReference.m_ActionId, referenceState);
+            }
+
+            inputActionReference.action.Enable();
+        }
+
+        private void DisableInputAction(InputActionReference inputActionReference)
+        {
+            if (!s_InputActionReferenceCounts.TryGetValue(inputActionReference?.m_ActionId ?? string.Empty,
+                out var referenceState))
+                return;
+
+            if (referenceState.refCount - 1 == 0 && referenceState.enabledByInputModule)
+                inputActionReference?.action?.Disable();
+
+            referenceState.refCount--;
+            s_InputActionReferenceCounts[inputActionReference.m_ActionId] = referenceState;
         }
 
         private int GetPointerStateIndexFor(int pointerOrTouchId)
@@ -1919,7 +1949,14 @@ namespace UnityEngine.InputSystem.UI
         [SerializeField] private bool m_DeselectOnBackgroundClick = true;
         [SerializeField] private UIPointerBehavior m_PointerBehavior = UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack;
 
-        private bool m_OwnsEnabledState;
+        private static Dictionary<string, InputActionReferenceState> s_InputActionReferenceCounts = new Dictionary<string, InputActionReferenceState>();
+
+        private struct InputActionReferenceState
+        {
+            public int refCount;
+            public bool enabledByInputModule;
+        }
+
         private bool m_ActionsHooked;
         private bool m_NeedToPurgeStalePointers;
 


### PR DESCRIPTION
### Description

Load a scene that contains an InputSystemUIInputModule that uses the default actions setup. Then additively load a second scene that also has an InputSystemUIInputModule with the default setup and unload the first scene. The first InputSystemUIInputModule will be destroyed and disable all of the input actions that the second input module is still using.

### Changes made

Added an InputAction reference counting solution to InputSystemUIInputModule where any time an InputSystemUIInputModule enables an action, it increments a reference for that action. When an InputSystemUIInputModule is destroyed, it will only disable input actions that have no more references. 

### Notes

The InputSystemUIInputModule used to have the concept of ownership of input actions to try and prevent this problem but it would fail for the case where the module was destroyed after another one had been created because ownership couldn't float between them. This might have been a reasonable fix for the issue here, but it would not have handled the case where an input action of the input module was assigned to after the module was enabled.

### Checklist

Before review:

- [x] Changelog entry added.
- [x] Tests added
