### PR TITLE
FIX: clickCount not incremented correctly (case 1317239).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1789,12 +1789,12 @@ internal class UITests : CoreTestsFixture
         scene.uiModule.point = InputActionReference.Create(actions.UI.Point);
         scene.uiModule.leftClick = InputActionReference.Create(actions.UI.Click);
 
-        Set(mouse.position, scene.From640x480ToScreen(100, 100), queueEventOnly : true);
+        Set(mouse.position, scene.From640x480ToScreen(100, 100), queueEventOnly: true);
 
         yield return null;
 
         scene.ClearEvents();
-        Press(mouse.leftButton, queueEventOnly : true);
+        Press(mouse.leftButton, queueEventOnly: true);
 
         yield return null;
 
@@ -1811,7 +1811,7 @@ internal class UITests : CoreTestsFixture
         );
 
         scene.ClearEvents();
-        Release(mouse.leftButton, queueEventOnly : true);
+        Release(mouse.leftButton, queueEventOnly: true);
 
         yield return null;
 
@@ -1825,7 +1825,7 @@ internal class UITests : CoreTestsFixture
         );
 
         scene.ClearEvents();
-        PressAndRelease(mouse.leftButton, queueEventOnly : true);
+        PressAndRelease(mouse.leftButton, queueEventOnly: true);
 
         yield return null;
 
@@ -1855,7 +1855,7 @@ internal class UITests : CoreTestsFixture
 
         clickTime = runtime.unscaledGameTime;
         scene.ClearEvents();
-        PressAndRelease(mouse.leftButton, queueEventOnly : true);
+        PressAndRelease(mouse.leftButton, queueEventOnly: true);
 
         yield return null;
 
@@ -1885,7 +1885,7 @@ internal class UITests : CoreTestsFixture
 
         clickTime = runtime.unscaledGameTime;
         scene.ClearEvents();
-        Press(mouse.leftButton, queueEventOnly : true);
+        Press(mouse.leftButton, queueEventOnly: true);
 
         yield return null;
 
@@ -1897,7 +1897,7 @@ internal class UITests : CoreTestsFixture
         );
 
         scene.ClearEvents();
-        Release(mouse.leftButton, queueEventOnly : true);
+        Release(mouse.leftButton, queueEventOnly: true);
 
         // Doesn't matter how long we hold the button. If we don't move far enough by the time we release and we still
         // have the same UI element underneath us, it's a click.
@@ -1916,7 +1916,7 @@ internal class UITests : CoreTestsFixture
 
         // However, when more than 0.3s elapses between release and next press, it resets
         // the click sequence.
-        Press(mouse.leftButton, queueEventOnly : true);
+        Press(mouse.leftButton, queueEventOnly: true);
         runtime.unscaledGameTime += 1f;
         yield return null;
 
@@ -1939,7 +1939,7 @@ internal class UITests : CoreTestsFixture
         // Clone left button. If we release the button now, there should not be
         // a click because the object pointed to has changed.
         UnityEngine.Object.Instantiate(scene.leftGameObject, scene.parentReceiver.transform);
-        Release(mouse.leftButton, queueEventOnly : true);
+        Release(mouse.leftButton, queueEventOnly: true);
         scene.ClearEvents();
 
         yield return null;

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -67,6 +67,13 @@ internal class UITests : CoreTestsFixture
             var transform = gameObject.GetComponent<RectTransform>();
             return RectTransformUtility.RectangleContainsScreenPoint(transform, screenPoint, camera, default);
         }
+
+        public void ClearEvents()
+        {
+            parentReceiver.events.Clear();
+            leftChildReceiver.events.Clear();
+            rightChildReceiver.events.Clear();
+        }
     }
 
     [SetUp]
@@ -282,8 +289,8 @@ internal class UITests : CoreTestsFixture
 
         if (isTracked)
         {
-            Set(device, "deviceRotation", trackedOrientation);
-            Set(device, "devicePosition", trackedPosition);
+            Set(device, "deviceRotation", trackedOrientation, queueEventOnly: true);
+            Set(device, "devicePosition", trackedPosition, queueEventOnly: true);
         }
 
         // We need to wait a frame to let the underlying canvas update and properly order the graphics images for raycasting.
@@ -298,23 +305,26 @@ internal class UITests : CoreTestsFixture
         var secondScreenPosition = scene.From640x480ToScreen(100, 200);
         var thirdScreenPosition = scene.From640x480ToScreen(350, 200);
 
+        var clickTime = 0f;
+        var clickCount = 0;
+
         // Move pointer over left child.
         currentTime = 1;
-        runtime.unscaledGameTime = 1;
+        unscaledGameTime = 1;
         if (isTouch)
         {
-            BeginTouch(1, firstScreenPosition);
+            BeginTouch(1, firstScreenPosition, queueEventOnly: true);
         }
         else if (isTracked)
         {
             trackedOrientation = Quaternion.Euler(0, -35, 0);
-            Set(device, "deviceRotation", trackedOrientation);
+            Set(device, "deviceRotation", trackedOrientation, queueEventOnly: true);
         }
         else
         {
-            Set((Vector2Control)pointAction.controls[0], firstScreenPosition);
+            Set((Vector2Control)pointAction.controls[0], firstScreenPosition, queueEventOnly: true);
         }
-        scene.eventSystem.InvokeUpdate();
+        yield return null;
 
         const int kHaveMovementEvents =
 #if UNITY_2021_1_OR_NEWER
@@ -470,8 +480,8 @@ internal class UITests : CoreTestsFixture
             Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.position, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
             Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.delta, Is.EqualTo(Vector2.zero));
             Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.clickTime, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.clickCount, Is.EqualTo(1));
+            Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.clickTime, Is.Zero);
+            Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.clickCount, Is.Zero);
             Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.pointerEnter, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
             Assert.That(scene.leftChildReceiver.events[2 + kHaveMovementEvents].pointerData.pointerPress, Is.SameAs(scene.leftGameObject));
@@ -494,131 +504,76 @@ internal class UITests : CoreTestsFixture
 
             scene.leftChildReceiver.events.Clear();
 
-            PressAndRelease(clickControl);
-            scene.eventSystem.InvokeUpdate();
+            PressAndRelease(clickControl, queueEventOnly: true);
+            yield return null;
 
-            Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(4));
+            clickTime = unscaledGameTime;
+            Assert.That(scene.leftChildReceiver.events,
+                EventSequence(
+                    AllEvents("button", clickButton),
+                    AllEvents("pointerId", pointerId),
+                    AllEvents("touchId", touchId),
+                    AllEvents("device", device),
+                    AllEvents("pointerType", pointerType),
+                    AllEvents("position", firstScreenPosition),
+                    AllEvents("delta", Vector2.zero),
+                    AllEvents("pressPosition", firstScreenPosition),
+                    AllEvents("pointerEnter", scene.leftGameObject),
+                    AllEvents("pointerCurrentRaycast.gameObject", scene.leftGameObject),
+                    AllEvents("pointerCurrentRaycast.screenPosition", firstScreenPosition),
+                    AllEvents("pointerPressRaycast.gameObject", scene.leftGameObject),
+                    AllEvents("pointerPressRaycast.screenPosition", firstScreenPosition),
+                    AllEvents("hovered", new[] { scene.leftGameObject, scene.parentGameObject }),
+                    AllEvents("lastPress", null),
+                    AllEvents("dragging", false),
+                    AllEvents("eligibleForClick", true),
 
-            Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.PointerDown));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.button, Is.EqualTo(clickButton));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.device, Is.SameAs(device));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerType, Is.EqualTo(pointerType));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.touchId, Is.EqualTo(touchId));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.position, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.delta, Is.EqualTo(Vector2.zero));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.clickTime, Is.Zero); // Click detection comes after pointer down event.
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.clickCount, Is.Zero);
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerDrag, Is.Null);
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerPress, Is.Null); // This is set only after the event has been processed.
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.rawPointerPress, Is.Null); // This is set only after the event has been processed.
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.lastPress, Is.Null); // This actually means lastPointerPress, i.e. last value of pointerPress before current.
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.True);
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.eligibleForClick, Is.True);
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerPressRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerPressRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
+                    // PointerDown.
+                    OneEvent("type", EventType.PointerDown),
+                    OneEvent("clickTime", 0f),
+                    OneEvent("clickCount", 0),
+                    OneEvent("pointerDrag", null),
+                    OneEvent("pointerPress", null),
+                    OneEvent("rawPointerPress", null),
+                    OneEvent("useDragThreshold", true),
 
-            Assert.That(scene.leftChildReceiver.events[1].type, Is.EqualTo(EventType.InitializePotentialDrag));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.button, Is.EqualTo(clickButton));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.device, Is.SameAs(device));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerType, Is.EqualTo(pointerType));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.touchId, Is.EqualTo(touchId));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.position, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.delta, Is.EqualTo(Vector2.zero));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.clickTime, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.clickCount, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerEnter, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.Null);
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.eligibleForClick, Is.True);
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerPressRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerPressRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
+                    // InitializePotentialDrag.
+                    OneEvent("type", EventType.InitializePotentialDrag),
+                    OneEvent("clickTime", 0f),
+                    OneEvent("clickCount", 0),
+                    OneEvent("pointerDrag", scene.leftGameObject),
+                    OneEvent("pointerPress", scene.leftGameObject),
+                    OneEvent("rawPointerPress", scene.leftGameObject),
+                    OneEvent("useDragThreshold", false),
 
-            Assert.That(scene.leftChildReceiver.events[2].type, Is.EqualTo(EventType.PointerUp));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.button, Is.EqualTo(clickButton));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.device, Is.SameAs(device));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerType, Is.EqualTo(pointerType));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.touchId, Is.EqualTo(touchId));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.position, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.delta, Is.EqualTo(Vector2.zero));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.clickTime, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.clickCount, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerEnter, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.lastPress, Is.Null);
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.eligibleForClick, Is.True);
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerCurrentRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerPressRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[2].pointerData.pointerPressRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
+                    // PointerUp.
+                    OneEvent("type", EventType.PointerUp),
+                    OneEvent("clickTime", unscaledGameTime),
+                    OneEvent("clickCount", 1),
+                    OneEvent("pointerDrag", scene.leftGameObject),
+                    OneEvent("pointerPress", scene.leftGameObject),
+                    OneEvent("rawPointerPress", scene.leftGameObject),
+                    OneEvent("useDragThreshold", false),
 
-            Assert.That(scene.leftChildReceiver.events[3].type, Is.EqualTo(EventType.PointerClick));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.button, Is.EqualTo(clickButton));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.device, Is.SameAs(device));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerType, Is.EqualTo(pointerType));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.touchId, Is.EqualTo(touchId));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.position, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.delta, Is.EqualTo(Vector2.zero));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.clickTime, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.clickCount, Is.EqualTo(1));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerEnter, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.lastPress, Is.Null);
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.dragging, Is.False);
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.eligibleForClick, Is.True);
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.hovered, Is.EquivalentTo(new[] { scene.leftGameObject, scene.parentGameObject }));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerCurrentRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerPressRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.leftChildReceiver.events[3].pointerData.pointerPressRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
+                    // PointerClick.
+                    OneEvent("type", EventType.PointerClick),
+                    OneEvent("clickTime", clickTime),
+                    OneEvent("clickCount", 1),
+                    OneEvent("pointerDrag", scene.leftGameObject),
+                    OneEvent("pointerPress", scene.leftGameObject),
+                    OneEvent("rawPointerPress", scene.leftGameObject),
+                    OneEvent("useDragThreshold", false)
+                )
+            );
 
             Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
             scene.leftChildReceiver.events.Clear();
 
             // Press again to start drag.
-            runtime.unscaledGameTime = 1.2f; // Advance so we can tell whether this got picked up by click detection (but stay below clickSpeed).
-            Press(clickControl);
-            scene.eventSystem.InvokeUpdate();
+            unscaledGameTime = 1.2f; // Advance so we can tell whether this got picked up by click detection (but stay below clickSpeed).
+            Press(clickControl, queueEventOnly: true);
+            yield return null;
 
             Assert.That(scene.leftChildReceiver.events,
                 EventSequence(
@@ -641,7 +596,7 @@ internal class UITests : CoreTestsFixture
 
                     // PointerDown.
                     OneEvent("type", EventType.PointerDown),
-                    OneEvent("clickTime", 1f),
+                    OneEvent("clickTime", clickTime),
                     OneEvent("clickCount", 1),
                     OneEvent("pointerDrag", null),
                     OneEvent("pointerPress", null), // This is set only after the event has been processed.
@@ -651,8 +606,8 @@ internal class UITests : CoreTestsFixture
 
                     // InitializePotentialDrag.
                     OneEvent("type", EventType.InitializePotentialDrag),
-                    OneEvent("clickTime", 1.2f), // Click detection ran in-between PointerDown and InitializePotentialDrag.
-                    OneEvent("clickCount", 2),
+                    OneEvent("clickTime", clickTime),
+                    OneEvent("clickCount", 1),
                     OneEvent("pointerDrag", scene.leftGameObject),
                     OneEvent("pointerPress", scene.leftGameObject),
                     OneEvent("rawPointerPress", scene.leftGameObject),
@@ -665,25 +620,24 @@ internal class UITests : CoreTestsFixture
         }
 
         scene.leftChildReceiver.events.Clear();
-        var clickCount = isTouch ? 1 : 2;
-        var clickTime = isTouch ? 1f : 1.2f;
+        clickCount = isTouch ? 0 : 1;
 
         // Move. Still over left object.
         runtime.unscaledGameTime = 2;
         if (isTouch)
         {
-            MoveTouch(1, secondScreenPosition);
+            MoveTouch(1, secondScreenPosition, queueEventOnly: true);
         }
         else if (isTracked)
         {
             trackedOrientation = Quaternion.Euler(0, -30, 0);
-            Set(device, "deviceRotation", trackedOrientation);
+            Set(device, "deviceRotation", trackedOrientation, queueEventOnly: true);
         }
         else
         {
-            Set((Vector2Control)pointAction.controls[0], secondScreenPosition);
+            Set((Vector2Control)pointAction.controls[0], secondScreenPosition, queueEventOnly: true);
         }
-        scene.eventSystem.InvokeUpdate();
+        yield return null;
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.True);
 
@@ -776,18 +730,18 @@ internal class UITests : CoreTestsFixture
         runtime.unscaledGameTime = 2.5f;
         if (isTouch)
         {
-            MoveTouch(1, thirdScreenPosition);
+            MoveTouch(1, thirdScreenPosition, queueEventOnly: true);
         }
         else if (isTracked)
         {
             trackedOrientation = Quaternion.Euler(0, 30, 0);
-            Set(device, "deviceRotation", trackedOrientation);
+            Set(device, "deviceRotation", trackedOrientation, queueEventOnly: true);
         }
         else
         {
-            Set((Vector2Control)pointAction.controls[0], thirdScreenPosition);
+            Set((Vector2Control)pointAction.controls[0], thirdScreenPosition, queueEventOnly: true);
         }
-        scene.eventSystem.InvokeUpdate();
+        yield return null;
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.True);
         // Should not have seen pointer enter/exit on parent (we only moved from one of its
@@ -913,10 +867,10 @@ internal class UITests : CoreTestsFixture
 
         // Release.
         if (isTouch)
-            EndTouch(1, thirdScreenPosition);
+            EndTouch(1, thirdScreenPosition, queueEventOnly: true);
         else
-            Release(clickControl);
-        scene.eventSystem.InvokeUpdate();
+            Release(clickControl, queueEventOnly: true);
+        yield return null;
 
         // Left child should have seen pointer up and end drag.
         Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(2));
@@ -1074,8 +1028,8 @@ internal class UITests : CoreTestsFixture
         // Scroll.
         if (scrollAction.controls.Count > 0)
         {
-            Set((Vector2Control)scrollAction.controls[0], Vector2.one);
-            scene.eventSystem.InvokeUpdate();
+            Set((Vector2Control)scrollAction.controls[0], Vector2.one, queueEventOnly: true);
+            yield return null;
 
             Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
             Assert.That(scene.leftChildReceiver.events, Is.Empty);
@@ -1807,6 +1761,180 @@ internal class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event eventRecord) => eventRecord.pointerData.clickCount == 0));
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1317239/
+    [UnityTest]
+    [Category("UI")]
+    public IEnumerator UI_CanDetectClicks_WithSuccessiveClicksReflectedInClickCount()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+        var scene = CreateTestUI();
+        var actions = new DefaultInputActions();
+        scene.uiModule.point = InputActionReference.Create(actions.UI.Point);
+        scene.uiModule.leftClick = InputActionReference.Create(actions.UI.Click);
+
+        Set(mouse.position, scene.From640x480ToScreen(100, 100), queueEventOnly: true);
+
+        yield return null;
+
+        scene.ClearEvents();
+        Press(mouse.leftButton, queueEventOnly: true);
+
+        yield return null;
+
+        // No click yet.
+        // NOTE: This is different from StandaloneInputModule which immediately ups
+        //       clickCount on press. However, until we release we don't know yet whether
+        //       we actually have a click or a drag (or neither).
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                AllEvents("clickCount", 0),
+                AllEvents("clickTime", 0f),
+                AllEvents("lastPress", null)
+            )
+        );
+
+        scene.ClearEvents();
+        Release(mouse.leftButton, queueEventOnly: true);
+
+        yield return null;
+
+        var clickTime = runtime.unscaledGameTime;
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                AllEvents("clickCount", 1),
+                AllEvents("clickTime", clickTime),
+                AllEvents("lastPress", null)
+            )
+        );
+
+        scene.ClearEvents();
+        PressAndRelease(mouse.leftButton, queueEventOnly: true);
+
+        yield return null;
+
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                // PointerDown.
+                OneEvent("type", EventType.PointerDown),
+                OneEvent("clickCount", 1),
+                OneEvent("clickTime", clickTime),
+
+                // InitializePotentialDrag.
+                OneEvent("type", EventType.InitializePotentialDrag),
+                OneEvent("clickCount", 1),
+                OneEvent("clickTime", clickTime),
+
+                // PointerUp.
+                OneEvent("type", EventType.PointerUp),
+                OneEvent("clickCount", 2),
+                OneEvent("clickTime", runtime.unscaledGameTime),
+
+                // PointerClick.
+                OneEvent("type", EventType.PointerClick),
+                OneEvent("clickCount", 2),
+                OneEvent("clickTime", runtime.unscaledGameTime)
+            )
+        );
+
+        clickTime = runtime.unscaledGameTime;
+        scene.ClearEvents();
+        PressAndRelease(mouse.leftButton, queueEventOnly: true);
+
+        yield return null;
+
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                // PointerDown.
+                OneEvent("type", EventType.PointerDown),
+                OneEvent("clickCount", 2),
+                OneEvent("clickTime", clickTime),
+
+                // InitializePotentialDrag.
+                OneEvent("type", EventType.InitializePotentialDrag),
+                OneEvent("clickCount", 2),
+                OneEvent("clickTime", clickTime),
+
+                // PointerUp.
+                OneEvent("type", EventType.PointerUp),
+                OneEvent("clickCount", 3),
+                OneEvent("clickTime", runtime.unscaledGameTime),
+
+                // PointerClick.
+                OneEvent("type", EventType.PointerClick),
+                OneEvent("clickCount", 3),
+                OneEvent("clickTime", runtime.unscaledGameTime)
+            )
+        );
+
+        clickTime = runtime.unscaledGameTime;
+        scene.ClearEvents();
+        Press(mouse.leftButton, queueEventOnly: true);
+
+        yield return null;
+
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                AllEvents("clickCount", 3),
+                AllEvents("clickTime", clickTime)
+            )
+        );
+
+        scene.ClearEvents();
+        Release(mouse.leftButton, queueEventOnly: true);
+
+        // Doesn't matter how long we hold the button. If we don't move far enough by the time we release and we still
+        // have the same UI element underneath us, it's a click.
+        runtime.unscaledGameTime += 1f;
+        yield return null;
+
+        clickTime = runtime.unscaledGameTime;
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                AllEvents("clickCount", 4),
+                AllEvents("clickTime", clickTime)
+            )
+        );
+
+        scene.ClearEvents();
+
+        // However, when more than 0.3s elapses between release and next press, it resets
+        // the click sequence.
+        Press(mouse.leftButton, queueEventOnly: true);
+        runtime.unscaledGameTime += 1f;
+        yield return null;
+
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                // On button down, we still see the state from the previous click (we don't
+                // know yet whether we clicked on the same object).
+                OneEvent("type", EventType.PointerDown),
+                OneEvent("clickCount", 4),
+                OneEvent("clickTime", clickTime),
+
+                // Before InitializePotentialDrag, we reset.
+                OneEvent("type", EventType.InitializePotentialDrag),
+                OneEvent("clickCount", 0),
+                OneEvent("clickTime", 0f)
+            )
+        );
+        clickTime = runtime.unscaledGameTime;
+
+        // Clone left button. If we release the button now, there should not be
+        // a click because the object pointed to has changed.
+        UnityEngine.Object.Instantiate(scene.leftGameObject, scene.parentReceiver.transform);
+        Release(mouse.leftButton, queueEventOnly: true);
+        scene.ClearEvents();
+
+        yield return null;
+
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                AllEvents("clickCount", 0),
+                AllEvents("clickTime", 0f)
+            )
+        );
+    }
+
     [UnityTest]
     [Category("UI")]
     [Ignore("TODO")]
@@ -2091,10 +2219,6 @@ internal class UITests : CoreTestsFixture
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
-        // Get rid of deadzones to simplify test.
-        InputSystem.settings.defaultDeadzoneMax = 1;
-        InputSystem.settings.defaultDeadzoneMin = 0;
-
         var scene = CreateTestUI();
 
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -2119,8 +2243,7 @@ internal class UITests : CoreTestsFixture
         // Left object should have been selected as part of enabling the event system and module.
         // This is key to having navigation work.
         Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.leftGameObject));
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Select));
+        Assert.That(scene.leftChildReceiver.events, EventSequence(OneEvent("type", EventType.Select)));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
@@ -2129,10 +2252,11 @@ internal class UITests : CoreTestsFixture
         Set(gamepad.leftStick, new Vector2(1, 0.5f));
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveDir, Is.EqualTo(MoveDirection.Right));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveVector, Is.EqualTo(new Vector2(1, 0.5f).normalized).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                OneEvent("type", EventType.Move),
+                OneEvent("moveDir", MoveDirection.Right),
+                OneEvent("moveVector", gamepad.leftStick.ReadValue())));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
@@ -2141,10 +2265,11 @@ internal class UITests : CoreTestsFixture
         Set(gamepad.leftStick, new Vector2(-1, 0.5f));
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveDir, Is.EqualTo(MoveDirection.Left));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveVector, Is.EqualTo(new Vector2(-1, 0.5f).normalized).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                OneEvent("type", EventType.Move),
+                OneEvent("moveDir", MoveDirection.Left),
+                OneEvent("moveVector", gamepad.leftStick.ReadValue())));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
@@ -2153,10 +2278,11 @@ internal class UITests : CoreTestsFixture
         Set(gamepad.leftStick, new Vector2(-0.5f, 1));
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveDir, Is.EqualTo(MoveDirection.Up));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveVector, Is.EqualTo(new Vector2(-0.5f, 1).normalized).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                OneEvent("type", EventType.Move),
+                OneEvent("moveDir", MoveDirection.Up),
+                OneEvent("moveVector", gamepad.leftStick.ReadValue())));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
@@ -2165,36 +2291,38 @@ internal class UITests : CoreTestsFixture
         Set(gamepad.leftStick, new Vector2(0.5f, -1));
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveDir, Is.EqualTo(MoveDirection.Down));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveVector, Is.EqualTo(new Vector2(0.5f, -1).normalized).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                OneEvent("type", EventType.Move),
+                OneEvent("moveDir", MoveDirection.Down),
+                OneEvent("moveVector", gamepad.leftStick.ReadValue())));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
 
         // Check repeat delay. Wait enough to cross both delay and subsequent repeat. We should
         // still only get one repeat event.
-        runtime.unscaledGameTime = 1.21f;
+        unscaledGameTime += 1.21f;
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveDir, Is.EqualTo(MoveDirection.Down));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveVector, Is.EqualTo(new Vector2(0.5f, -1).normalized).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                OneEvent("type", EventType.Move),
+                OneEvent("moveDir", MoveDirection.Down),
+                OneEvent("moveVector", gamepad.leftStick.ReadValue())));
 
         scene.leftChildReceiver.events.Clear();
 
         // Check repeat rate. Same here; doesn't matter how much time we pass as long as we cross
         // the repeat rate threshold.
-        runtime.unscaledGameTime = 2;
+        unscaledGameTime += 2;
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Move));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveDir, Is.EqualTo(MoveDirection.Down));
-        Assert.That(scene.leftChildReceiver.events[0].axisData.moveVector, Is.EqualTo(new Vector2(0.5f, -1).normalized).Using(Vector2EqualityComparer.Instance));
-        Assert.That(scene.rightChildReceiver.events, Is.Empty);
+        Assert.That(scene.leftChildReceiver.events,
+            EventSequence(
+                OneEvent("type", EventType.Move),
+                OneEvent("moveDir", MoveDirection.Down),
+                OneEvent("moveVector", gamepad.leftStick.ReadValue())));
 
         scene.leftChildReceiver.events.Clear();
 
@@ -2202,8 +2330,7 @@ internal class UITests : CoreTestsFixture
         PressAndRelease(gamepad.buttonSouth);
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Submit));
+        Assert.That(scene.leftChildReceiver.events, EventSequence(OneEvent("type", EventType.Submit)));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
@@ -2212,8 +2339,7 @@ internal class UITests : CoreTestsFixture
         PressAndRelease(gamepad.buttonEast);
         scene.eventSystem.InvokeUpdate();
 
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-        Assert.That(scene.leftChildReceiver.events[0].type, Is.EqualTo(EventType.Cancel));
+        Assert.That(scene.leftChildReceiver.events, EventSequence(OneEvent("type", EventType.Cancel)));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
@@ -3007,7 +3133,7 @@ internal class UITests : CoreTestsFixture
 
         private static AxisEventData CloneAxisEventData(AxisEventData eventData)
         {
-            return new AxisEventData(EventSystem.current)
+            return new ExtendedAxisEventData(EventSystem.current)
             {
                 moveVector = eventData.moveVector,
                 moveDir = eventData.moveDir
@@ -3127,7 +3253,7 @@ internal class UITests : CoreTestsFixture
                         // Sadly, "hovered" is a field.
                         var field = eventObject.GetType().GetField(propertyName, BindingFlags.Instance | BindingFlags.Public);
                         if (field == null)
-                            throw new Exception($"Could not find '{propertyName}' on {eventObject}");
+                            throw new Exception($"Could not find '{propertyName}' field or property on {eventObject}");
                         eventPropertyValue = field.GetValue(eventObject);
                         eventPropertyType = field.FieldType;
                     }
@@ -3171,7 +3297,8 @@ internal class UITests : CoreTestsFixture
                     result = value == null || eventPropertyValue == null ? ReferenceEquals(eventPropertyValue, value) : eventPropertyValue.Equals(value);
 
                 if (!result)
-                    Debug.Log($"Expected '{propertyPath}' to be '{value}' but got '{eventPropertyValue}' instead!");
+                    Debug.Log(
+                        $"Expected '{propertyPath}' to be '{value}' ({value?.GetType().GetNiceTypeName()}) but got '{eventPropertyValue}' ({eventPropertyValue?.GetType().GetNiceTypeName()}) instead!");
                 return result;
             }
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -32,6 +32,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `Retrieving array element that was out of bounds` and `SerializedProperty ... has disappeared!` errors when deleting multiple action bindings in the input asset editor ([case 1300506](https://issuetracker.unity3d.com/issues/errors-are-thrown-in-the-console-when-deleting-multiple-bindings)).
 - Fixed `InputUser` no longer sending `InputUserChange.ControlsChanged` when adding a new user after previously, all users were removed.
   * Fix contributed by [Sven Herrmann](https://github.com/SvenRH) in [1292](https://github.com/Unity-Technologies/InputSystem/pull/1292).
+- Fixed `clickCount` not being incremented correctly by `InputSystemUIInputModule` for successive mouse clicks ([case 1317239](https://issuetracker.unity3d.com/issues/eventdata-dot-clickcount-doesnt-increase-when-clicking-repeatedly-in-the-new-input-system)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedAxisEventData.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedAxisEventData.cs
@@ -1,0 +1,21 @@
+#if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
+using UnityEngine.EventSystems;
+
+namespace UnityEngine.InputSystem.UI
+{
+    // AxisEventData has no ToString. But that's the only thing we add so keeping
+    // it internal.
+    internal class ExtendedAxisEventData : AxisEventData
+    {
+        public ExtendedAxisEventData(EventSystem eventSystem)
+            : base(eventSystem)
+        {
+        }
+
+        public override string ToString()
+        {
+            return $"MoveDir: {moveDir}\nMoveVector: {moveVector}";
+        }
+    }
+}
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedAxisEventData.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedAxisEventData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 408bd3b4ce254207beaa4e0779763fd6
+timeCreated: 1617961863

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
@@ -80,12 +80,14 @@ namespace UnityEngine.InputSystem.UI
         {
             var stringBuilder = new StringBuilder();
             stringBuilder.Append(base.ToString());
-            stringBuilder.AppendLine("<b>button</b>: " + button); // Defined in PointerEventData but PointerEventData.ToString() does not include it.
-            stringBuilder.AppendLine("<b>device</b>: " + device);
-            stringBuilder.AppendLine("<b>pointerType</b>: " + pointerType);
-            stringBuilder.AppendLine("<b>touchId</b>: " + touchId);
-            stringBuilder.AppendLine("<b>trackedDevicePosition</b>: " + trackedDevicePosition);
-            stringBuilder.AppendLine("<b>trackedDeviceOrientation</b>: " + trackedDeviceOrientation);
+            stringBuilder.AppendLine("button: " + button); // Defined in PointerEventData but PointerEventData.ToString() does not include it.
+            stringBuilder.AppendLine("clickTime: " + clickTime); // Same here.
+            stringBuilder.AppendLine("clickCount: " + clickCount); // Same here.
+            stringBuilder.AppendLine("device: " + device);
+            stringBuilder.AppendLine("pointerType: " + pointerType);
+            stringBuilder.AppendLine("touchId: " + touchId);
+            stringBuilder.AppendLine("trackedDevicePosition: " + trackedDevicePosition);
+            stringBuilder.AppendLine("trackedDeviceOrientation: " + trackedDeviceOrientation);
             return stringBuilder.ToString();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/PointerModel.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/PointerModel.cs
@@ -198,6 +198,7 @@ namespace UnityEngine.InputSystem.UI
         {
             private bool m_IsPressed;
             private PointerEventData.FramePressState m_FramePressState;
+            private float m_PressTime;
 
             public bool isPressed
             {
@@ -218,27 +219,40 @@ namespace UnityEngine.InputSystem.UI
                 }
             }
 
+            public float pressTime
+            {
+                get => m_PressTime;
+                set => m_PressTime = value;
+            }
+
+            public bool clickedOnSameGameObject
+            {
+                get => m_ClickedOnSameGameObject;
+                set => m_ClickedOnSameGameObject = value;
+            }
+
             public bool wasPressedThisFrame => m_FramePressState == PointerEventData.FramePressState.Pressed ||
             m_FramePressState == PointerEventData.FramePressState.PressedAndReleased;
             public bool wasReleasedThisFrame => m_FramePressState == PointerEventData.FramePressState.Released ||
             m_FramePressState == PointerEventData.FramePressState.PressedAndReleased;
 
-            private RaycastResult pressRaycast;
-            private GameObject pressObject;
-            private GameObject rawPressObject;
-            private GameObject lastPressObject;
-            private GameObject dragObject;
-            private Vector2 pressPosition;
-            private float clickTime; // On Time.unscaledTime timeline, NOT input event time.
-            private int clickCount;
-            private bool dragging;
+            private RaycastResult m_PressRaycast;
+            private GameObject m_PressObject;
+            private GameObject m_RawPressObject;
+            private GameObject m_LastPressObject;
+            private GameObject m_DragObject;
+            private Vector2 m_PressPosition;
+            private float m_ClickTime; // On Time.unscaledTime timeline, NOT input event time.
+            private int m_ClickCount;
+            private bool m_Dragging;
+            private bool m_ClickedOnSameGameObject;
 
             public void CopyPressStateTo(PointerEventData eventData)
             {
-                eventData.pointerPressRaycast = pressRaycast;
-                eventData.pressPosition = pressPosition;
-                eventData.clickCount = clickCount;
-                eventData.clickTime = clickTime;
+                eventData.pointerPressRaycast = m_PressRaycast;
+                eventData.pressPosition = m_PressPosition;
+                eventData.clickCount = m_ClickCount;
+                eventData.clickTime = m_ClickTime;
                 // We can't set lastPress directly. Old input module uses three different event instances, one for each
                 // button. We share one instance and just switch press states. Set pointerPress twice to get the lastPress
                 // we need.
@@ -246,24 +260,24 @@ namespace UnityEngine.InputSystem.UI
                 // NOTE: This does *NOT* quite work as stated in the docs. pointerPress is nulled out on button release which
                 //       will set lastPress as a side-effect. This means that lastPress will only be non-null while no press is
                 //       going on and will *NOT* refer to the last pressed object when a new object has been pressed on.
-                eventData.pointerPress = lastPressObject;
-                eventData.pointerPress = pressObject;
-                eventData.rawPointerPress = rawPressObject;
-                eventData.pointerDrag = dragObject;
-                eventData.dragging = dragging;
+                eventData.pointerPress = m_LastPressObject;
+                eventData.pointerPress = m_PressObject;
+                eventData.rawPointerPress = m_RawPressObject;
+                eventData.pointerDrag = m_DragObject;
+                eventData.dragging = m_Dragging;
             }
 
             public void CopyPressStateFrom(PointerEventData eventData)
             {
-                pressRaycast = eventData.pointerPressRaycast;
-                pressObject = eventData.pointerPress;
-                rawPressObject = eventData.rawPointerPress;
-                lastPressObject = eventData.lastPress;
-                pressPosition = eventData.pressPosition;
-                clickTime = eventData.clickTime;
-                clickCount = eventData.clickCount;
-                dragObject = eventData.pointerDrag;
-                dragging = eventData.dragging;
+                m_PressRaycast = eventData.pointerPressRaycast;
+                m_PressObject = eventData.pointerPress;
+                m_RawPressObject = eventData.rawPointerPress;
+                m_LastPressObject = eventData.lastPress;
+                m_PressPosition = eventData.pressPosition;
+                m_ClickTime = eventData.clickTime;
+                m_ClickCount = eventData.clickCount;
+                m_DragObject = eventData.pointerDrag;
+                m_Dragging = eventData.dragging;
             }
 
             public void OnEndFrame()

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeHelpers.cs
@@ -47,7 +47,7 @@ namespace UnityEngine.InputSystem.Utilities
             return null;
         }
 
-        public static string GetNiceTypeName(Type type)
+        public static string GetNiceTypeName(this Type type)
         {
             if (type.IsPrimitive)
             {

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -359,6 +359,8 @@ namespace UnityEngine.InputSystem
                 duration: duration, value: value);
         }
 
+        ////REVIEW: Should we determine queueEventOnly automatically from whether we're in a UnityTest?
+
         // ReSharper disable once MemberCanBeProtected.Global
         public void Press(ButtonControl button, double time = -1, double timeOffset = 0, bool queueEventOnly = false)
         {
@@ -650,6 +652,16 @@ namespace UnityEngine.InputSystem
             {
                 runtime.currentTime = value;
                 runtime.dontAdvanceTimeNextDynamicUpdate = true;
+            }
+        }
+
+        internal float unscaledGameTime
+        {
+            get => runtime.unscaledGameTime;
+            set
+            {
+                runtime.unscaledGameTime = value;
+                runtime.dontAdvanceUnscaledGameTimeNextDynamicUpdate = true;
             }
         }
 

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -47,6 +47,12 @@ namespace UnityEngine.InputSystem
 
             lock (m_Lock)
             {
+                if (type == InputUpdateType.Dynamic && !dontAdvanceUnscaledGameTimeNextDynamicUpdate)
+                {
+                    unscaledGameTime += 1 / 30f;
+                    dontAdvanceUnscaledGameTimeNextDynamicUpdate = false;
+                }
+
                 if (m_NewDeviceDiscoveries != null && m_NewDeviceDiscoveries.Count > 0)
                 {
                     if (onDeviceDiscovered != null)
@@ -60,7 +66,10 @@ namespace UnityEngine.InputSystem
                 // Advance time *after* onBeforeUpdate so that events generated from onBeforeUpdate
                 // don't get bumped into the following update.
                 if (type == InputUpdateType.Dynamic && !dontAdvanceTimeNextDynamicUpdate)
+                {
                     currentTime += advanceTimeEachDynamicUpdate;
+                    dontAdvanceTimeNextDynamicUpdate = false;
+                }
 
                 if (onUpdate != null)
                 {
@@ -81,8 +90,6 @@ namespace UnityEngine.InputSystem
                     m_EventCount = 0;
                     m_EventWritePosition = 0;
                 }
-
-                dontAdvanceTimeNextDynamicUpdate = false;
             }
         }
 
@@ -324,6 +331,7 @@ namespace UnityEngine.InputSystem
         public double currentTime { get; set; }
         public double currentTimeForFixedUpdate { get; set; }
         public float unscaledGameTime { get; set; } = 1;
+        public bool dontAdvanceUnscaledGameTimeNextDynamicUpdate { get; set; }
 
         public double advanceTimeEachDynamicUpdate { get; set; } = 1.0 / 60;
 


### PR DESCRIPTION
### Description

Fixes [1317239](https://issuetracker.unity3d.com/issues/eventdata-dot-clickcount-doesnt-increase-when-clicking-repeatedly-in-the-new-input-system) ([internal](https://fogbugz.unity3d.com/f/cases/1317239/)).

### Changes made

Main problem was that the code before ran the `newPressed == lastPress` check before looking for the `OnPointerClick` handler (in the mistaken believe it would actually *invoke* the handler). This meant that if there was no `OnPointerDown` handler and only an `OnPointerClick` handler, click detection wouldn't work.

Other than this, I moved the click count around so that `clickCount` and `clickTime` are now actually tied to `OnPointerClick`. Meaning, you only get a click if the press-release sequence actually does form a click.

Some other minor massaging.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
