### PR TITLE
Setting default input actions asset in InputSystemUIInputModule (fixes 1323566)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -160,23 +160,6 @@ internal class UITests : CoreTestsFixture
         return objects;
     }
 
-    private static void AssignDefaultActions(ref TestObjects setup)
-    {
-        var defaultActions = new DefaultInputActions();
-
-        setup.uiModule.actionsAsset = defaultActions.asset;
-        setup.uiModule.cancel = InputActionReference.Create(defaultActions.UI.Cancel);
-        setup.uiModule.submit = InputActionReference.Create(defaultActions.UI.Submit);
-        setup.uiModule.move = InputActionReference.Create(defaultActions.UI.Navigate);
-        setup.uiModule.leftClick = InputActionReference.Create(defaultActions.UI.Click);
-        setup.uiModule.rightClick = InputActionReference.Create(defaultActions.UI.RightClick);
-        setup.uiModule.middleClick = InputActionReference.Create(defaultActions.UI.MiddleClick);
-        setup.uiModule.point = InputActionReference.Create(defaultActions.UI.Point);
-        setup.uiModule.scrollWheel = InputActionReference.Create(defaultActions.UI.ScrollWheel);
-
-        defaultActions.Enable();
-    }
-
     // Comprehensive test for general pointer input behaviors.
     // NOTE: The behavior we test for here is slightly *DIFFERENT* than what you get with StandaloneInputModule. The reason is that
     //       StandaloneInputModule has both lots of inconsistencies between touch and mouse input (example: touch press handling goes
@@ -1573,7 +1556,7 @@ internal class UITests : CoreTestsFixture
         var mouse = InputSystem.AddDevice<Mouse>();
 
         var scene = CreateTestUI();
-        AssignDefaultActions(ref scene);
+        scene.uiModule.AssignDefaultActions();
         TouchSimulation.Enable();
 
         try

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -58,6 +58,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed reference to `.inputactions` of `Player Prefab` referenced by `PlayerInputManager` being destroyed on going into play mode, if the player prefab was a nested prefab ([case 1319756](https://issuetracker.unity3d.com/issues/playerinput-component-loses-its-reference-to-an-inputactionasset)).
 - Fixed "Scheme Name" label clipped in "Add Control Schema" popup window ([case 1199560]https://issuetracker.unity3d.com/issues/themes-input-system-scheme-name-is-clipped-in-add-control-schema-window-with-inter-default-font)).
 - Fixed `InputSystem.QueueEvent` calls from within `InputAction` callbacks getting dropped entirely ([case 1297339](https://issuetracker.unity3d.com/issues/input-system-ui-button-wont-click-when-simulating-a-mouse-click-with-inputsystem-dot-queueevent)).
+- Fixed `InputSystemUIInputModule` being in invalid state when added from `Awake` to a game object when entering playmode ([case 1323566](https://issuetracker.unity3d.com/issues/input-system-default-ui-actions-do-not-register-when-adding-inputsystemuiinputmodule-at-runtime-to-an-active-game-object)).
 
 #### Actions
 
@@ -104,6 +105,7 @@ however, it has to be formatted properly to pass verification tests.
   * Puts an upper limit on the number of event bytes processed in a single update.
   * If exceeded, any additional event data will get thrown away and an error will be issued.
   * Set to 5MB by default.
+- Added `InputSystemUIInputModule.AssignDefaultActions` to assign default actions when creating ui module in runtime.
 
 ## [1.1.0-preview.3] - 2021-02-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -6,6 +6,9 @@ using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.Serialization;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 ////FIXME: The UI is currently not reacting to pointers until they are moved after the UI module has been enabled. What needs to
 ////       happen is that point, trackedDevicePosition, and trackedDeviceOrientation have initial state checks. However, for touch,
@@ -1197,12 +1200,46 @@ namespace UnityEngine.InputSystem.UI
             set => SwapAction(ref m_TrackedDevicePositionAction, value, m_ActionsHooked, m_OnTrackedDevicePositionDelegate);
         }
 
+        /// <summary>
+        /// Assigns default input actions asset and input actions, similar to how defaults are assigned when creating UI module in editor.
+        /// Useful for creating <see cref="InputSystemUIInputModule"/> at runtime.
+        /// </summary>
+        public void AssignDefaultActions()
+        {
+            var defaultActions = new DefaultInputActions();
+            actionsAsset = defaultActions.asset;
+            cancel = InputActionReference.Create(defaultActions.UI.Cancel);
+            submit = InputActionReference.Create(defaultActions.UI.Submit);
+            move = InputActionReference.Create(defaultActions.UI.Navigate);
+            leftClick = InputActionReference.Create(defaultActions.UI.Click);
+            rightClick = InputActionReference.Create(defaultActions.UI.RightClick);
+            middleClick = InputActionReference.Create(defaultActions.UI.MiddleClick);
+            point = InputActionReference.Create(defaultActions.UI.Point);
+            scrollWheel = InputActionReference.Create(defaultActions.UI.ScrollWheel);
+
+            defaultActions.Enable();
+        }
+
         [Obsolete("'trackedDeviceSelect' has been obsoleted; use 'leftClick' instead.", true)]
         public InputActionReference trackedDeviceSelect
         {
             get => throw new InvalidOperationException();
             set => throw new InvalidOperationException();
         }
+
+#if UNITY_EDITOR
+        protected override void Reset()
+        {
+            base.Reset();
+
+            var asset = (InputActionAsset)AssetDatabase.LoadAssetAtPath(
+                UnityEngine.InputSystem.Editor.PlayerInputEditor.kDefaultInputActionsAssetPath,
+                typeof(InputActionAsset));
+            // Setting default asset and actions when creating via inspector
+            Editor.InputSystemUIInputModuleEditor.ReassignActions(this, asset);
+        }
+
+#endif
 
         protected override void Awake()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs.meta
@@ -3,31 +3,7 @@ guid: 01614664b831546d2ae94a42149d80ac
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
-  defaultReferences:
-  - m_ActionsAsset: {fileID: -944628639613478452, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_PointAction: {fileID: 1054132383583890850, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_MoveAction: {fileID: 3710738434707379630, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_SubmitAction: {fileID: 2064916234097673511, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_CancelAction: {fileID: -1967631576421560919, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_LeftClickAction: {fileID: 8056856818456041789, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_MiddleClickAction: {fileID: 3279352641294131588, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_RightClickAction: {fileID: 3837173908680883260, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_ScrollWheelAction: {fileID: 4502412055082496612, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_TrackedDevicePositionAction: {fileID: 4754684134866288074, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_TrackedDeviceOrientationAction: {fileID: 1025543830046995696, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
-  - m_TrackedDeviceSelectAction: {fileID: 2559092417903258184, guid: ca9f5fa95ffab41fb9a615ab714db018,
-      type: 3}
+  defaultReferences: []
   executionOrder: 0
   icon: {fileID: 2800000, guid: 3028dc075ba8c584d9bc7d1e0255e038, type: 3}
   userData: 


### PR DESCRIPTION
### Description

When adding ui module with `AddComponent<InputSystemUIInputModule>` in `Awake` of some script present in the scene, deserialization of default references of ui module happens after `OnEnable` is called. Which makes `InputSystemUIInputModule` not work correctly, e.g. setting `module.actionsAsset = defaultReference` would be a no-op even if module went through `Awake`/`OnEnable` with `m_ActionsAsset` being `null`

### Changes made

- Setting default asset from `Reset()` instead of relying on script file settings in inspector.
- Added `AssignDefaultActions` for convenience of the user, otherwise they would need to set all actions manually from script.

### Notes

This is not possible to test from unit test. The behavior is only reproducible when pressing play button in editor, as part of entering playmode we load the scene and call `Awake` on everything, but editor is not in play loop yet, hence why setting default refences is still enabled at that point. Unit tests run in play mode instead.

### Checklist

- [X] Changelog entry added.
