### PR TITLE
Add gamepad layout for SteelSeries Nimbus+ on Mac OSX

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -29,7 +29,7 @@ Support for the following Devices doesn't require specialized support of particu
 |Xbox One|Yes (1)|Yes (3)|Yes (1)|Yes|Yes (1)|Yes (6)|Yes (6)|Yes|No|No|Sometimes (2)|
 |PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
 |Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
-|MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
+|MFi (such as SteelSeries)|No|Sometimes (9)|No|No|No|Yes|Yes|No|No|No|No|
 
 >__Notes__:
 >1. The trigger motors on the Xbox One controller are only supported on UWP and Xbox.
@@ -40,6 +40,7 @@ Support for the following Devices doesn't require specialized support of particu
 >6. Unity supports Made for iOS (Mfi) certified controllers on iOS. Xbox One and PS4 controllers are only supported on iOS 13 or higher.
 >7. Consoles are supported using separate packages. You need to install these packages in your Project to enable console support.
 >8. Switch Joy-Cons are not currently supported on Windows and Mac. Also, Switch Pro controllers are supported only when connected via Bluetooth but not when connected via wired USB.
+>9. SteelSeries Nimbus+ supported.
 
 ### WebGL
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3226,6 +3226,10 @@ namespace UnityEngine.InputSystem
             iOS.iOSSupport.Initialize();
             #endif
 
+            #if UNITY_EDITOR || UNITY_STANDALONE_OSX
+            OSX.OSXSupport.Initialize();
+            #endif
+
             #if UNITY_EDITOR || UNITY_WEBGL
             WebGL.WebGLSupport.Initialize();
             #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2c926fe78180c34180fd3100f7b0c5b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
@@ -1,0 +1,75 @@
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX
+using System.Runtime.InteropServices;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
+using UnityEngine.InputSystem.OSX.LowLevel;
+
+namespace UnityEngine.InputSystem.OSX.LowLevel
+{
+    /// <summary>
+    /// Structure of HID input reports for SteelSeries Nimbus+ controllers.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 8)]
+    internal struct NimbusControllerHIDInputState : IInputStateTypeInfo {
+        [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "SBYT", parameters = "")]
+        [InputControl(name = "leftStick/left", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [InputControl(name = "leftStick/right", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "leftStick/y", offset = 1, format = "SBYT", parameters = "")]
+        [InputControl(name = "leftStick/up", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "leftStick/down", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [FieldOffset(0)] public sbyte leftStickX;
+        [FieldOffset(1)] public sbyte leftStickY;
+
+        [InputControl(name = "rightStick", layout = "Stick", format = "VC2B")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "SBYT")]
+        [InputControl(name = "rightStick/left", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [InputControl(name = "rightStick/right", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "rightStick/y", offset = 1, format = "SBYT")]
+        [InputControl(name = "rightStick/up", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "rightStick/down", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [FieldOffset(2)] public sbyte rightStickX;
+        [FieldOffset(3)] public sbyte rightStickY;
+
+        [InputControl(name = "leftTrigger", format = "BYTE")]
+        [FieldOffset(4)] public byte leftTrigger;
+        [InputControl(name = "rightTrigger", format = "BYTE")]
+        [FieldOffset(5)] public byte rightTrigger;
+
+        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4)]
+        [InputControl(name = "dpad/up", format = "BIT", bit = 0)]
+        [InputControl(name = "dpad/right", format = "BIT", bit = 1)]
+        [InputControl(name = "dpad/down", format = "BIT",  bit = 2)]
+        [InputControl(name = "dpad/left", format = "BIT", bit = 3)]
+        [InputControl(name = "buttonSouth", displayName = "A", bit = 4)]
+        [InputControl(name = "buttonEast", displayName = "B", bit = 5)]
+        [InputControl(name = "buttonWest", displayName = "X", bit = 6)]
+        [InputControl(name = "buttonNorth", displayName = "Y", bit = 7)]
+        [FieldOffset(6)] public byte buttons1;
+        [InputControl(name = "leftShoulder", bit = 0)]
+        [InputControl(name = "rightShoulder", bit = 1)]
+        [InputControl(name = "leftStickPress", bit = 2)]
+        [InputControl(name = "rightStickPress", bit = 3)]
+        [InputControl(name = "menuButton", layout = "Button", bit = 4)]
+        [InputControl(name = "select", bit = 5)]
+        [InputControl(name = "start", bit = 6)]
+        [FieldOffset(7)] public byte buttons2;
+
+        public FourCC format => new FourCC('H', 'I', 'D');
+    }
+}
+
+namespace UnityEngine.InputSystem.OSX
+{
+    /// <summary>
+    /// Steel Series Nimbus+ uses iOSGameController MFI when on iOS but
+    /// is just a standard HID on osx.
+    /// </summary>
+    [InputControlLayout(stateType = typeof(NimbusControllerHIDInputState), displayName = "nimbus+ Gamepad")]
+    [Scripting.Preserve]
+    public class NimbusGameController : Gamepad
+    {
+    }
+}
+#endif // UNITY_EDITOR || UNITY_STANDALONE_OSX

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82428183c712ff946b78934dc45fe458
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
@@ -1,0 +1,21 @@
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX
+using UnityEngine.InputSystem.Layouts;
+
+namespace UnityEngine.InputSystem.OSX
+{
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class OSXSupport
+    {
+        public static void Initialize()
+        {
+            InputSystem.RegisterLayout<NimbusGameController>(
+                matches: new InputDeviceMatcher()
+                    .WithProduct("Nimbus+"));
+        }
+    }
+}
+#endif // UNITY_EDITOR || UNITY_STANDALONE_OSX

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 22142a0a0bd4def44bcdfc88848ffd00
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

Add support for SteelSeries Nimbus+ on Mac OSX by adding gamepad layout

### Changes made

New OSXSupport plugin made that initializes layout for input from SteelSeries Nimbus+ gamepad.
