### PR TITLE
CHANGE: Add event processing limits

### DIFF
--- a/Assets/TestScript.cs.meta
+++ b/Assets/TestScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8bdffba4e0da6594990af2512d66d077
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -2076,33 +2076,32 @@ partial class CoreTests
     [Category("Events")]
     public void Events_MaximumQueuedEventsDuringEventProcessingIsLimited()
     {
-	    // Default setting is 1000.
-	    Assert.That(InputSystem.settings.maxQueuedEventsPerUpdate, Is.EqualTo(1000));
+        // Default setting is 1000.
+        Assert.That(InputSystem.settings.maxQueuedEventsPerUpdate, Is.EqualTo(1000));
 
-	    InputSystem.settings.maxQueuedEventsPerUpdate = 20;
+        InputSystem.settings.maxQueuedEventsPerUpdate = 20;
 
         var mouse = InputSystem.AddDevice<Mouse>();
 
         var callbackCount = 0;
         var action = new InputAction(type: InputActionType.Value, binding: "<mouse>/position");
-	    action.performed +=
-		    _ =>
-		    {
-                if(callbackCount > InputSystem.settings.maxQueuedEventsPerUpdate)
-                    Assert.Fail("Maximum queued event count exceeded");
+        action.performed +=
+            _ =>
+        {
+            if (callbackCount > InputSystem.settings.maxQueuedEventsPerUpdate)
+                Assert.Fail("Maximum queued event count exceeded");
 
-                callbackCount++;
-                Set(mouse.position, Random.insideUnitCircle * 100, queueEventOnly: true);
-            };
-	    action.Enable();
+            callbackCount++;
+            Set(mouse.position, Random.insideUnitCircle * 100, queueEventOnly: true);
+        };
+        action.Enable();
 
         Set(mouse.position, Random.insideUnitCircle * 100);
 
         LogAssert.Expect(LogType.Error, $"Maximum number of queued events exceeded. Set the '{nameof(InputSettings.maxQueuedEventsPerUpdate)}' setting to a higher value if you " +
-                                        $"need to queue more events than this. Current limit is '{InputSystem.settings.maxQueuedEventsPerUpdate}'.");
-		Assert.That(callbackCount - 1, Is.EqualTo(InputSystem.settings.maxQueuedEventsPerUpdate));
+            $"need to queue more events than this. Current limit is '{InputSystem.settings.maxQueuedEventsPerUpdate}'.");
+        Assert.That(callbackCount - 1, Is.EqualTo(InputSystem.settings.maxQueuedEventsPerUpdate));
     }
-
 
     ////TODO: test thread-safe QueueEvent
 }

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -20,6 +20,7 @@ using UnityEngine.TestTools;
 using UnityEngine.TestTools.Constraints;
 using UnityEngine.TestTools.Utils;
 using Is = UnityEngine.TestTools.Constraints.Is;
+using Random = UnityEngine.Random;
 using TouchPhase = UnityEngine.InputSystem.TouchPhase;
 
 #pragma warning disable CS0649
@@ -1991,7 +1992,6 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    [Ignore("Not implemented yet. Fix as part of https://jira.unity3d.com/browse/ISX-557.")]
     public void Events_MaximumEventLoadPerUpdateIsLimited()
     {
         // Default setting is 5MB.
@@ -2009,7 +2009,7 @@ partial class CoreTests
         InputSystem.onEvent += (eventPtr, device) => ++ eventCount;
 
         LogAssert.Expect(LogType.Error, "Exceeded budget for maximum input event throughput per InputSystem.Update(). Discarding remaining events. "
-            + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to raise the limit.");
+            + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to remove the limit.");
 
         InputSystem.Update();
 
@@ -2041,6 +2041,10 @@ partial class CoreTests
         var keyboard = InputSystem.AddDevice<Keyboard>();
 
         var numMouseEventsQueued = InputTestRuntime.kDefaultEventBufferSize / StateEvent.GetEventSizeWithPayload<MouseState>() + 1;
+
+        // allow all these events
+        InputSystem.settings.maxQueuedEventsPerUpdate = numMouseEventsQueued;
+
         var numMouseEventsReceived = 0;
         InputSystem.onEvent +=
             (eventPtr, device) =>
@@ -2067,6 +2071,38 @@ partial class CoreTests
         Assert.That(mouse.position.ReadValue(), Is.EqualTo(new Vector2(123, 234)));
         Assert.That(numMouseEventsReceived, Is.EqualTo(numMouseEventsQueued));
     }
+
+    [Test]
+    [Category("Events")]
+    public void Events_MaximumQueuedEventsDuringEventProcessingIsLimited()
+    {
+	    // Default setting is 1000.
+	    Assert.That(InputSystem.settings.maxQueuedEventsPerUpdate, Is.EqualTo(1000));
+
+	    InputSystem.settings.maxQueuedEventsPerUpdate = 20;
+
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        var callbackCount = 0;
+        var action = new InputAction(type: InputActionType.Value, binding: "<mouse>/position");
+	    action.performed +=
+		    _ =>
+		    {
+                if(callbackCount > InputSystem.settings.maxQueuedEventsPerUpdate)
+                    Assert.Fail("Maximum queued event count exceeded");
+
+                callbackCount++;
+                Set(mouse.position, Random.insideUnitCircle * 100, queueEventOnly: true);
+            };
+	    action.Enable();
+
+        Set(mouse.position, Random.insideUnitCircle * 100);
+
+        LogAssert.Expect(LogType.Error, $"Maximum number of queued events exceeded. Set the '{nameof(InputSettings.maxQueuedEventsPerUpdate)}' setting to a higher value if you " +
+                                        $"need to queue more events than this. Current limit is '{InputSystem.settings.maxQueuedEventsPerUpdate}'.");
+		Assert.That(callbackCount - 1, Is.EqualTo(InputSystem.settings.maxQueuedEventsPerUpdate));
+    }
+
 
     ////TODO: test thread-safe QueueEvent
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -105,6 +105,8 @@ however, it has to be formatted properly to pass verification tests.
   * Puts an upper limit on the number of event bytes processed in a single update.
   * If exceeded, any additional event data will get thrown away and an error will be issued.
   * Set to 5MB by default.
+- Added a new API-only setting called `InputSystem.settings.maxQueuedEventsPerUpdate`.
+  * This limits the number of events that can be queued during event processing using the `InputSystem.QueueEvent` method. This guards against infinite loops in the case where an action callback queues an event that causes the same action callback to be called again.
 - Added `InputSystemUIInputModule.AssignDefaultActions` to assign default actions when creating ui module in runtime.
 
 ## [1.1.0-preview.3] - 2021-02-04

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -114,6 +114,8 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.PropertyField(m_DefaultHoldTime, m_DefaultHoldTimeContent);
                 EditorGUILayout.PropertyField(m_TapRadius, m_TapRadiusContent);
                 EditorGUILayout.PropertyField(m_MultiTapDelayTime, m_MultiTapDelayTimeContent);
+                EditorGUILayout.PropertyField(m_MaxQueuedEventsPerUpdate, m_MaxQueuedEventsPerUpdateContent);
+                EditorGUILayout.PropertyField(m_MaxEventBytesPerUpdate, m_MaxEventBytesPerUpdateContent);
 
                 EditorGUILayout.Space();
                 EditorGUILayout.Separator();
@@ -244,6 +246,8 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTime = m_SettingsObject.FindProperty("m_DefaultHoldTime");
             m_TapRadius = m_SettingsObject.FindProperty("m_TapRadius");
             m_MultiTapDelayTime = m_SettingsObject.FindProperty("m_MultiTapDelayTime");
+            m_MaxQueuedEventsPerUpdate = m_SettingsObject.FindProperty(nameof(m_MaxQueuedEventsPerUpdate));
+            m_MaxEventBytesPerUpdate = m_SettingsObject.FindProperty(nameof(m_MaxEventBytesPerUpdate));
 
             m_UpdateModeContent = new GUIContent("Update Mode", "When should the Input System be updated?");
             m_FilterNoiseOnCurrentContent = new GUIContent("Filter Noise on current", "If enabled, input from noisy controls will not cause a device to become '.current'.");
@@ -257,6 +261,8 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTimeContent = new GUIContent("Default Hold Time", "Default duration to be used for Hold interactions.");
             m_TapRadiusContent = new GUIContent("Tap Radius", "Maximum distance between two finger taps on a touch screen device allowed for the system to consider this a tap of the same touch (as opposed to a new touch).");
             m_MultiTapDelayTimeContent = new GUIContent("MultiTap Delay Time", "Default delay to be allowed between taps for MultiTap interactions. Also used by by touch devices to count multi taps.");
+            m_MaxQueuedEventsPerUpdateContent = new GUIContent("Max Queued Events", "Maximum number of events that can be queued during event processing.");
+            m_MaxEventBytesPerUpdateContent = new GUIContent("Max Event Bytes", "Maximum byte count of input events that will be processed in one update.");
 
             // Initialize ReorderableList for list of supported devices.
             var supportedDevicesProperty = m_SettingsObject.FindProperty("m_SupportedDevices");
@@ -357,6 +363,8 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private SerializedProperty m_DefaultHoldTime;
         [NonSerialized] private SerializedProperty m_TapRadius;
         [NonSerialized] private SerializedProperty m_MultiTapDelayTime;
+        [NonSerialized] private SerializedProperty m_MaxQueuedEventsPerUpdate;
+        [NonSerialized] private SerializedProperty m_MaxEventBytesPerUpdate;
 
         [NonSerialized] private ReorderableList m_SupportedDevices;
         [NonSerialized] private string[] m_AvailableInputSettingsAssets;
@@ -378,6 +386,8 @@ namespace UnityEngine.InputSystem.Editor
         GUIContent m_DefaultHoldTimeContent;
         GUIContent m_TapRadiusContent;
         GUIContent m_MultiTapDelayTimeContent;
+        GUIContent m_MaxQueuedEventsPerUpdateContent;
+        GUIContent m_MaxEventBytesPerUpdateContent;
 
         [NonSerialized] private InputSettingsiOSProvider m_iOSProvider;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -114,8 +114,6 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.PropertyField(m_DefaultHoldTime, m_DefaultHoldTimeContent);
                 EditorGUILayout.PropertyField(m_TapRadius, m_TapRadiusContent);
                 EditorGUILayout.PropertyField(m_MultiTapDelayTime, m_MultiTapDelayTimeContent);
-                EditorGUILayout.PropertyField(m_MaxQueuedEventsPerUpdate, m_MaxQueuedEventsPerUpdateContent);
-                EditorGUILayout.PropertyField(m_MaxEventBytesPerUpdate, m_MaxEventBytesPerUpdateContent);
 
                 EditorGUILayout.Space();
                 EditorGUILayout.Separator();
@@ -246,8 +244,6 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTime = m_SettingsObject.FindProperty("m_DefaultHoldTime");
             m_TapRadius = m_SettingsObject.FindProperty("m_TapRadius");
             m_MultiTapDelayTime = m_SettingsObject.FindProperty("m_MultiTapDelayTime");
-            m_MaxQueuedEventsPerUpdate = m_SettingsObject.FindProperty(nameof(m_MaxQueuedEventsPerUpdate));
-            m_MaxEventBytesPerUpdate = m_SettingsObject.FindProperty(nameof(m_MaxEventBytesPerUpdate));
 
             m_UpdateModeContent = new GUIContent("Update Mode", "When should the Input System be updated?");
             m_FilterNoiseOnCurrentContent = new GUIContent("Filter Noise on current", "If enabled, input from noisy controls will not cause a device to become '.current'.");
@@ -261,8 +257,6 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTimeContent = new GUIContent("Default Hold Time", "Default duration to be used for Hold interactions.");
             m_TapRadiusContent = new GUIContent("Tap Radius", "Maximum distance between two finger taps on a touch screen device allowed for the system to consider this a tap of the same touch (as opposed to a new touch).");
             m_MultiTapDelayTimeContent = new GUIContent("MultiTap Delay Time", "Default delay to be allowed between taps for MultiTap interactions. Also used by by touch devices to count multi taps.");
-            m_MaxQueuedEventsPerUpdateContent = new GUIContent("Max Queued Events", "Maximum number of events that can be queued during event processing.");
-            m_MaxEventBytesPerUpdateContent = new GUIContent("Max Event Bytes", "Maximum byte count of input events that will be processed in one update.");
 
             // Initialize ReorderableList for list of supported devices.
             var supportedDevicesProperty = m_SettingsObject.FindProperty("m_SupportedDevices");
@@ -363,8 +357,6 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private SerializedProperty m_DefaultHoldTime;
         [NonSerialized] private SerializedProperty m_TapRadius;
         [NonSerialized] private SerializedProperty m_MultiTapDelayTime;
-        [NonSerialized] private SerializedProperty m_MaxQueuedEventsPerUpdate;
-        [NonSerialized] private SerializedProperty m_MaxEventBytesPerUpdate;
 
         [NonSerialized] private ReorderableList m_SupportedDevices;
         [NonSerialized] private string[] m_AvailableInputSettingsAssets;
@@ -386,8 +378,6 @@ namespace UnityEngine.InputSystem.Editor
         GUIContent m_DefaultHoldTimeContent;
         GUIContent m_TapRadiusContent;
         GUIContent m_MultiTapDelayTimeContent;
-        GUIContent m_MaxQueuedEventsPerUpdateContent;
-        GUIContent m_MaxEventBytesPerUpdateContent;
 
         [NonSerialized] private InputSettingsiOSProvider m_iOSProvider;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventStream.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventStream.cs
@@ -72,13 +72,13 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public void Write(InputEvent* eventPtr)
         {
-	        if (m_AppendBuffer.eventCount >= m_MaxAppendedEvents)
-	        {
+            if (m_AppendBuffer.eventCount >= m_MaxAppendedEvents)
+            {
                 Debug.LogError($"Maximum number of queued events exceeded. Set the '{nameof(InputSettings.maxQueuedEventsPerUpdate)}' " +
-                               $"setting to a higher value if you need to queue more events than this. " +
-                               $"Current limit is '{m_MaxAppendedEvents}'.");
-		        return;
-	        }
+                    $"setting to a higher value if you need to queue more events than this. " +
+                    $"Current limit is '{m_MaxAppendedEvents}'.");
+                return;
+            }
 
             var wasAlreadyCreated = m_AppendBuffer.data.IsCreated;
             var oldBufferPtr = (byte*)m_AppendBuffer.bufferPtr.data;

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2634,13 +2634,13 @@ namespace UnityEngine.InputSystem
             // Handle events.
             while (m_InputEventStream.remainingEventCount > 0)
             {
-	            if (m_Settings.maxEventBytesPerUpdate > 0 &&
-	                totalEventBytesProcessed >= m_Settings.maxEventBytesPerUpdate)
-	            {
-		            Debug.LogError("Exceeded budget for maximum input event throughput per InputSystem.Update(). Discarding remaining events. "
-					             + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to remove the limit.");
-		            break;
-	            }
+                if (m_Settings.maxEventBytesPerUpdate > 0 &&
+                    totalEventBytesProcessed >= m_Settings.maxEventBytesPerUpdate)
+                {
+                    Debug.LogError("Exceeded budget for maximum input event throughput per InputSystem.Update(). Discarding remaining events. "
+                        + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to remove the limit.");
+                    break;
+                }
 
                 InputDevice device = null;
                 var currentEventReadPtr = m_InputEventStream.currentEventPtr;

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2628,11 +2628,20 @@ namespace UnityEngine.InputSystem
             var processingStartTime = Stopwatch.GetTimestamp();
             var totalEventLag = 0.0;
 
-            m_InputEventStream = new InputEventStream(ref eventBuffer);
+            m_InputEventStream = new InputEventStream(ref eventBuffer, m_Settings.maxQueuedEventsPerUpdate);
+            var totalEventBytesProcessed = 0U;
 
             // Handle events.
             while (m_InputEventStream.remainingEventCount > 0)
             {
+	            if (m_Settings.maxEventBytesPerUpdate > 0 &&
+	                totalEventBytesProcessed >= m_Settings.maxEventBytesPerUpdate)
+	            {
+		            Debug.LogError("Exceeded budget for maximum input event throughput per InputSystem.Update(). Discarding remaining events. "
+					             + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to remove the limit.");
+		            break;
+	            }
+
                 InputDevice device = null;
                 var currentEventReadPtr = m_InputEventStream.currentEventPtr;
 
@@ -2782,6 +2791,8 @@ namespace UnityEngine.InputSystem
 
                             haveChangedStateOtherThanNoise = UpdateState(device, eventPtr, updateType);
                         }
+
+                        totalEventBytesProcessed += eventPtr.sizeInBytes;
 
                         // Update timestamp on device.
                         // NOTE: We do this here and not in UpdateState() so that InputState.Change() will *NOT* change timestamps.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -460,15 +460,15 @@ namespace UnityEngine.InputSystem
         /// </summary>
         public int maxQueuedEventsPerUpdate
         {
-	        get => m_MaxQueuedEventsPerUpdate;
-	        set
-	        {
-		        if (m_MaxQueuedEventsPerUpdate == value)
-			        return;
+            get => m_MaxQueuedEventsPerUpdate;
+            set
+            {
+                if (m_MaxQueuedEventsPerUpdate == value)
+                    return;
 
-		        m_MaxQueuedEventsPerUpdate = value;
+                m_MaxQueuedEventsPerUpdate = value;
                 OnChange();
-	        }
+            }
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -417,9 +417,8 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <remarks>
         /// This setting establishes a bound on the amount of input event data processed in a single
-        /// update and thus limits throughput allowed for input. This both prevents long stalls from
-        /// leading to long delays in input processing and prevents deadlocks when events themselves
-        /// lead to additional events being queued.
+        /// update and thus limits throughput allowed for input. This prevents long stalls from
+        /// leading to long delays in input processing.
         ///
         /// When the limit is exceeded, all events remaining in the buffer are thrown away (the
         /// <see cref="InputEventBuffer"/> is reset) and an error is logged. After that, the current
@@ -441,6 +440,35 @@ namespace UnityEngine.InputSystem
                 m_MaxEventBytesPerUpdate = value;
                 OnChange();
             }
+        }
+
+        /// <summary>
+        /// Upper limit on the number of <see cref="InputEvent"/>s that can be queued within one
+        /// <see cref="InputSystem.Update"/>.
+        /// <remarks>
+        /// This settings establishes an upper limit on the number of events that can be queued
+        /// using <see cref="InputSystem.QueueEvent"/> during a single update. This prevents infinite
+        /// loops where an action callback queues an event that causes the action callback to
+        /// be called again which queues an event...
+        ///
+        /// Note that this limit only applies while the input system is updating. There is no limit
+        /// on the number of events that can be queued outside of this time, but those will be queued
+        /// into the next frame where the <see cref="maxEventBytesPerUpdate"/> setting will apply.
+        ///
+        /// The default value is 1000.
+        /// </remarks>
+        /// </summary>
+        public int maxQueuedEventsPerUpdate
+        {
+	        get => m_MaxQueuedEventsPerUpdate;
+	        set
+	        {
+		        if (m_MaxQueuedEventsPerUpdate == value)
+			        return;
+
+		        m_MaxQueuedEventsPerUpdate = value;
+                OnChange();
+	        }
         }
 
         /// <summary>
@@ -496,7 +524,8 @@ namespace UnityEngine.InputSystem
         [Tooltip("Determine when Unity processes events. By default, accumulated input events are flushed out before each fixed update and "
             + "before each dynamic update. This setting can be used to restrict event processing to only where the application needs it.")]
         [SerializeField] private UpdateMode m_UpdateMode = UpdateMode.ProcessEventsInDynamicUpdate;
-        [SerializeField] private int m_MaxEventBytesPerUpdate = 5 * 1014 * 1024;
+        [SerializeField] private int m_MaxEventBytesPerUpdate = 5 * 1024 * 1024;
+        [SerializeField] private int m_MaxQueuedEventsPerUpdate = 1000;
 
         [SerializeField] private bool m_CompensateForScreenOrientation = true;
         [SerializeField] private bool m_FilterNoiseOnCurrent = false;


### PR DESCRIPTION
### Description

Added InputSettings.maxQueuedEventsPerUpdate setting to limit the number of events that can be queue during event processing. Also hooked up the logic for the InputSettings.maxEventBytesPerUpdate setting.

### Checklist

Before review:

- [x] Changelog entry added.
- [x] Tests added/changed, if applicable.
- [x] Docs for new/changed API's.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:

