### PR TITLE
FIX: InputUser.pairedDevices getting corrupted (case 1327628).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UserTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UserTests.cs
@@ -1177,6 +1177,33 @@ internal class UserTests : CoreTestsFixture
         Assert.That(user.pairedDevices, Is.EquivalentTo(new[] { gamepad }));
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1327628/
+    [Test]
+    [Category("Users")]
+    public void Users_WhenAddingDevicesToUsers_PairedDevicesOfExistingUsersAreUnaffected()
+    {
+        var user1 = InputUser.CreateUserWithoutPairedDevices();
+
+        var user1pad1 = InputSystem.AddDevice<Gamepad>("user1pad1");
+        var user1pad2 = InputSystem.AddDevice<Gamepad>("user1pad2");
+
+        InputUser.PerformPairingWithDevice(user1pad1, user1);
+        InputUser.PerformPairingWithDevice(user1pad2, user1);
+
+        var user2pad = InputSystem.AddDevice<Gamepad>("user2pad");
+        var user2 = InputUser.PerformPairingWithDevice(user2pad);
+
+        var user3pad = InputSystem.AddDevice<Gamepad>("user3pad");
+        var user3 = InputUser.PerformPairingWithDevice(user3pad);
+
+        var user1pad3 = InputSystem.AddDevice<Gamepad>("user1pad3");
+        InputUser.PerformPairingWithDevice(user1pad3, user1);
+
+        Assert.That(user1.pairedDevices, Is.EquivalentTo(new[] { user1pad1, user1pad2, user1pad3 }));
+        Assert.That(user2.pairedDevices, Is.EquivalentTo(new[] { user2pad }));
+        Assert.That(user3.pairedDevices, Is.EquivalentTo(new[] { user3pad }));
+    }
+
     [Test]
     [Category("Users")]
     [Ignore("TODO")]

--- a/Assets/Tests/InputSystem/Utilities/ArrayHelperTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ArrayHelperTests.cs
@@ -12,14 +12,32 @@ internal class ArrayHelperTests
         var array1 = new[] {1, 2, 3, 4, 5, 6, 7, 8};
         var array2 = new[] {1, 2, 3, 4, 5, 6, 7, 8};
         var array3 = new[] {1, 2, 3, 4, 5, 6, 7, 8};
+        var array4 = new[] {1, 2, 3, 4, 5, 6, 7, 8};
+        var array5 = new[] {1, 2, 3, 4};
+        var array6 = new[] {1, 2, 3, 4};
+        var array7 = new[] {1, 2, 3, 4};
+        var array8 = new[] {1, 2, 3, 4};
+        var array9 = new[] {1, 2, 3, 4};
 
         ArrayHelpers.MoveSlice(array1, 1, 6, 2);
         ArrayHelpers.MoveSlice(array2, 6, 1, 2);
         ArrayHelpers.MoveSlice(array3, 0, 5, 3);
+        ArrayHelpers.MoveSlice(array4, 4, 2, 2);
+        ArrayHelpers.MoveSlice(array5, 0, 2, 2);
+        ArrayHelpers.MoveSlice(array6, 2, 1, 2);
+        ArrayHelpers.MoveSlice(array7, 3, 0, 1);
+        ArrayHelpers.MoveSlice(array8, 1, 0, 3);
+        ArrayHelpers.MoveSlice(array9, 0, 1, 3);
 
-        Assert.That(array1, Is.EquivalentTo(new[] {1, 4, 5, 6, 7, 8, 2, 3}));
-        Assert.That(array2, Is.EquivalentTo(new[] {1, 7, 8, 2, 3, 4, 5, 6}));
-        Assert.That(array3, Is.EquivalentTo(new[] {4, 5, 6, 7, 8, 1, 2, 3}));
+        Assert.That(array1, Is.EqualTo(new[] {1, 4, 5, 6, 7, 8, 2, 3}));
+        Assert.That(array2, Is.EqualTo(new[] {1, 7, 8, 2, 3, 4, 5, 6}));
+        Assert.That(array3, Is.EqualTo(new[] {4, 5, 6, 7, 8, 1, 2, 3}));
+        Assert.That(array4, Is.EqualTo(new[] {1, 2, 5, 6, 3, 4, 7, 8}));
+        Assert.That(array5, Is.EqualTo(new[] {3, 4, 1, 2}));
+        Assert.That(array6, Is.EqualTo(new[] {1, 3, 4, 2}));
+        Assert.That(array7, Is.EqualTo(new[] {4, 1, 2, 3}));
+        Assert.That(array8, Is.EqualTo(new[] {2, 3, 4, 1}));
+        Assert.That(array9, Is.EqualTo(new[] {4, 1, 2, 3}));
     }
 
     [Test]
@@ -38,9 +56,9 @@ internal class ArrayHelperTests
         ArrayHelpers.EraseAtWithCapacity(array2, ref array2Length, 7);
         ArrayHelpers.EraseAtWithCapacity(array3, ref array3Length, 0);
 
-        Assert.That(array1, Is.EquivalentTo(new[] {1, 2, 4, 5, 0, 0, 0, 0}));
-        Assert.That(array2, Is.EquivalentTo(new[] {1, 2, 3, 4, 5, 6, 7, 0}));
-        Assert.That(array3, Is.EquivalentTo(new[] {2, 3, 4, 0, 0, 0, 0, 0}));
+        Assert.That(array1, Is.EqualTo(new[] {1, 2, 4, 5, 0, 0, 0, 0}));
+        Assert.That(array2, Is.EqualTo(new[] {1, 2, 3, 4, 5, 6, 7, 0}));
+        Assert.That(array3, Is.EqualTo(new[] {2, 3, 4, 0, 0, 0, 0, 0}));
 
         Assert.That(array1Length, Is.EqualTo(4));
         Assert.That(array2Length, Is.EqualTo(7));
@@ -66,9 +84,9 @@ internal class ArrayHelperTests
             ArrayHelpers.EraseAtWithCapacity(array3, ref array3Length, 0);
 
             // For NativeArray, we don't clear memory.
-            Assert.That(array1, Is.EquivalentTo(new[] {1, 2, 4, 5, 5, 0, 0, 0}));
-            Assert.That(array2, Is.EquivalentTo(new[] {1, 2, 3, 4, 5, 6, 7, 8}));
-            Assert.That(array3, Is.EquivalentTo(new[] {2, 3, 4, 4, 0, 0, 0, 0}));
+            Assert.That(array1, Is.EqualTo(new[] {1, 2, 4, 5, 5, 0, 0, 0}));
+            Assert.That(array2, Is.EqualTo(new[] {1, 2, 3, 4, 5, 6, 7, 8}));
+            Assert.That(array3, Is.EqualTo(new[] {2, 3, 4, 4, 0, 0, 0, 0}));
 
             Assert.That(array1Length, Is.EqualTo(4));
             Assert.That(array2Length, Is.EqualTo(7));

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unpublished]
+
+### Fixed
+
+- Fixed pairing devices to existing `InputUser`s potentially corrupting list of paired devices from other `InputUser`s ([case 1327628](https://issuetracker.unity3d.com/issues/input-system-devices-are-reassigned-to-the-wrong-users-after-adding-a-new-device)).
+
 ## [1.1.0-pre.4] - 2021-05-04
 
 ### Changed

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
-## [Unpublished]
+## [Unreleased]
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
@@ -667,28 +667,6 @@ namespace UnityEngine.InputSystem.Utilities
         }
 
         /// <summary>
-        /// Swap the contents of two potentially overlapping slices within the array.
-        /// </summary>
-        /// <param name="array"></param>
-        /// <param name="sourceIndex"></param>
-        /// <param name="destinationIndex"></param>
-        /// <param name="count"></param>
-        /// <typeparam name="TValue"></typeparam>
-        public static void SwapSlice<TValue>(TValue[] array, int sourceIndex, int destinationIndex, int count)
-        {
-            if (sourceIndex < destinationIndex)
-            {
-                for (var i = 0; i < count; ++i)
-                    Swap(ref array[sourceIndex + count - i - 1], ref array[destinationIndex + count - i - 1]);
-            }
-            else
-            {
-                for (var i = 0; i < count; ++i)
-                    Swap(ref array[sourceIndex + i], ref array[destinationIndex + i]);
-            }
-        }
-
-        /// <summary>
         /// Move a slice in the array to a different place without allocating a temporary array.
         /// </summary>
         /// <param name="array"></param>
@@ -706,28 +684,65 @@ namespace UnityEngine.InputSystem.Utilities
             if (count <= 0 || sourceIndex == destinationIndex)
                 return;
 
-            // Make sure we're moving from lower part of array to higher part so we only
-            // have to deal with that scenario.
-            if (sourceIndex > destinationIndex)
-                Swap(ref sourceIndex, ref destinationIndex);
+            // Determine the number of elements in the window.
+            int elementCount;
+            if (destinationIndex > sourceIndex)
+                elementCount = destinationIndex + count - sourceIndex;
+            else
+                elementCount = sourceIndex + count - destinationIndex;
 
-            while (destinationIndex != sourceIndex)
+            // If the source and target slice are right next to each other, just go
+            // and swap out the elements in both slices.
+            if (elementCount == count * 2)
             {
-                // Swap source and destination slice. Afterwards, the source slice is the right, final
-                // place but the destination slice may not be.
-                SwapSlice(array, sourceIndex, destinationIndex, count);
+                for (var i = 0; i < count; ++i)
+                    Swap(ref array[sourceIndex + i], ref array[destinationIndex + i]);
+            }
+            else
+            {
+                // There's elements in-between the two slices.
+                //
+                // The easiest way to picture this operation is as a rotation of the elements within
+                // the window given by sourceIndex, destination, and count. Within that window, we are
+                // simply treating it as a wrap-around buffer and then sliding the elements clockwise
+                // or counter-clockwise (depending on whether we move up or down, respectively) through
+                // the window.
+                //
+                // Unfortunately, we can't just memcopy the slices within that window as we have to
+                // have a temporary copy in place in order to preserve element values. So instead, we
+                // go and swap elements one by one, something that doesn't require anything other than
+                // a single value temporary copy.
 
-                // Slide destination window down.
-                if (destinationIndex - sourceIndex >= count * 2)
+                // Determine the number of swaps we need to achieve the desired order. Swaps
+                // operate in pairs so it's one less than the number of elements in the range.
+                var swapCount = elementCount - 1;
+
+                // We simply take sourceIndex as fixed and do all swaps from there until all
+                // the elements in the window are in the right order. Each swap will put one
+                // element in its final place.
+                var dst = destinationIndex;
+                for (var i = 0; i < swapCount; ++i)
                 {
-                    // Slide down one whole window of count elements.
-                    destinationIndex -= count;
-                }
-                else
-                {
-                    ////TODO: this can be improved by using halving instead and only doing the final step as a single element slide
-                    // Slide down by one element.
-                    --destinationIndex;
+                    // Swap source into its destination place. This puts the current sourceIndex
+                    // element in its final place.
+                    Swap(ref array[dst], ref array[sourceIndex]);
+
+                    // Find out where the element that we now swapped into sourceIndex should
+                    // actually go.
+                    if (destinationIndex > sourceIndex)
+                    {
+                        // Rotating clockwise.
+                        dst -= count;
+                        if (dst < sourceIndex)
+                            dst = destinationIndex + count - Math.Abs(sourceIndex - dst); // Wrap around.
+                    }
+                    else
+                    {
+                        // Rotating counter-clockwise.
+                        dst += count;
+                        if (dst >= sourceIndex + count)
+                            dst = destinationIndex + (dst - (sourceIndex + count)); // Wrap around.
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description

Fixes [1327628](https://issuetracker.unity3d.com/issues/input-system-devices-are-reassigned-to-the-wrong-users-after-adding-a-new-device) ([internal](https://fogbugz.unity3d.com/f/cases/1327628/)).

Pairing and unpairing devices from `InputUser`s had the potential for corrupting lists of `InputUser.pairedDevices` on users due to a nonsensical implementation of `ArrayHelpers.MoveSlice` (which slides a window of elements around in an array without requiring a temporary memory allocation).

### Changes made

Replaced the implementation of `ArrayHelpers.MoveSlice` entirely with one that recognizes that if it isn't an absolutely straightforward swapping of two array regions, then it is a simple rotation of elements within a window into the array.

Could be there's a good and proper algorithm for this that I'm ignorant of and that my Google fu failed to turn up. Had to turn this around in my head a couple times until I came up with the current solution. No proof that it's correct.

### Notes

I noticed that the existing tests in `ArrayHelperTests` were wrongly using `Is.EquivalentTo` (ignores element ordering) when they really should be using `Is.EqualTo`. Fixed that. Means that the existing test for `MoveSlice` was bogus.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
