### PR TITLE
FIX: Misaligned binding paths when in text mode (case 1200107).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,10 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed pairing devices to existing `InputUser`s potentially corrupting list of paired devices from other `InputUser`s ([case 1327628](https://issuetracker.unity3d.com/issues/input-system-devices-are-reassigned-to-the-wrong-users-after-adding-a-new-device)).
 
+#### Actions
+
+- Fixed binding paths being misaligned in UI when switching to text mode editing ([case 1200107](https://issuetracker.unity3d.com/issues/input-system-path-input-field-text-is-clipping-under-binding-in-the-properties-section)).
+
 ## [1.1.0-pre.4] - 2021-05-04
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -118,8 +118,6 @@ namespace UnityEngine.InputSystem.Editor
                 bindingTextRect.x -= 15;
                 bindingTextRect.width += 15;
 
-                bindingTextRect.height -= 2;
-                bindingTextRect.y += 1;
                 EditorGUI.BeginChangeCheck();
                 path = EditorGUI.DelayedTextField(bindingTextRect, path);
                 if (EditorGUI.EndChangeCheck())


### PR DESCRIPTION
### Description

Fixes minor cosmetic [issue](https://issuetracker.unity3d.com/issues/input-system-path-input-field-text-is-clipping-under-binding-in-the-properties-section) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1200107/)).

### Changes made

Removed the vertical offset. Checked in both 2019.4 and 2020.3 and looks proper. Assume it was added in a phase where the editor UI was seeing some temporary regressions.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
