### PR TITLE
FIX: GetBindingDisplyString() doubling up output for composite bindings (case 1321175).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -5984,6 +5984,20 @@ partial class CoreTests
         Assert.That(action.GetBindingDisplayString(8), Is.EqualTo("Left Shift|Right Shift+A"));
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1321175/
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenGettingDisplayTextForBindingsOnAction_EmptyBindingsOnComposites_ArePrintedAsSpaces()
+    {
+        var action = new InputAction();
+
+        action.AddCompositeBinding("2DVector")
+            .With("Up", "<Keyboard>/upArrow")
+            .With("Down", "");
+
+        Assert.That(action.GetBindingDisplayString(), Is.EqualTo("Up Arrow/ / / "));
+    }
+
     ////TODO: this will need to take localization into account (though this is part of a broader integration that also affects other features of the input system)
     [Test]
     [Category("Actions")]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,11 +13,12 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed pairing devices to existing `InputUser`s potentially corrupting list of paired devices from other `InputUser`s ([case 1327628](https://issuetracker.unity3d.com/issues/input-system-devices-are-reassigned-to-the-wrong-users-after-adding-a-new-device)).
-- Fixed StackOverflowException caused by calling InputSystem.Update from inside an input action callback ([case 1316000](https://issuetracker.unity3d.com/issues/crash-when-adding-inputsystem-dot-update-to-inputsystem-command-handler-to-force-processing-an-event-and-sending-input)).
+- Fixed `StackOverflowException` caused by calling `InputSystem.Update` from inside an input action callback such as `InputAction.performed` ([case 1316000](https://issuetracker.unity3d.com/issues/crash-when-adding-inputsystem-dot-update-to-inputsystem-command-handler-to-force-processing-an-event-and-sending-input)).
 
 #### Actions
 
 - Fixed binding paths being misaligned in UI when switching to text mode editing ([case 1200107](https://issuetracker.unity3d.com/issues/input-system-path-input-field-text-is-clipping-under-binding-in-the-properties-section)).
+- Fixed calling `GetBindingDisplayString()` on an `InputAction` with a composite binding leading to doubled up output ([case 1321175](https://issuetracker.unity3d.com/issues/macos-input-system-getbindingdisplaystring-returns-empty-strings-for-some-mappings)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -301,6 +301,8 @@ namespace UnityEngine.InputSystem
             var bindings = action.bindings;
             for (var i = 0; i < bindings.Count; ++i)
             {
+                if (bindings[i].isPartOfComposite)
+                    continue;
                 if (!bindingMask.Matches(bindings[i]))
                     continue;
 
@@ -432,7 +434,12 @@ namespace UnityEngine.InputSystem
                 // Get the display string for each part.
                 var partStrings = new string[partCount];
                 for (var i = 0; i < partCount; ++i)
-                    partStrings[i] = action.GetBindingDisplayString(firstPartIndex + i, options);
+                {
+                    var partString = action.GetBindingDisplayString(firstPartIndex + i, options);
+                    if (string.IsNullOrEmpty(partString))
+                        partString = " ";
+                    partStrings[i] = partString;
+                }
 
                 // Put the parts together based on the display format string for
                 // the composite.
@@ -459,6 +466,9 @@ namespace UnityEngine.InputSystem
                             else
                                 result = partStrings[i];
                         }
+
+                        if (string.IsNullOrEmpty(result))
+                            result = " ";
 
                         return result;
                     });


### PR DESCRIPTION
Fixes [1321175](https://issuetracker.unity3d.com/issues/macos-input-system-getbindingdisplaystring-returns-empty-strings-for-some-mappings) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1321175/)).

### Description

`GetBindingDisplayString()` simply iterated over the bindings in an `InputAction` and included any one that matches the mask. That doesn't work for composites as the composite is printed as a whole.

### Changes made

Changed it to skip part bindings.

Also, made empty parts get printed as a single space instead of as an empty string. I.e. "Up/Down/ / " instead of "Up/Down//".

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
