### PR TITLE
CHANGE: Register controls using static type references

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,6 +23,10 @@ however, it has to be formatted properly to pass verification tests.
 
 - Added `InputSystem.runUpdatesInEditMode` to enable processing of non-editor updates without entering playmode (only available for XR).
 
+### Changed
+
+- Changes to control and device layout registration resulting in minor performance increase and slightly lower memory consumption during device creation.
+
 ## [1.1.0-pre.4] - 2021-05-04
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -148,6 +148,11 @@ namespace UnityEngine.InputSystem.Controls
             return new Vector2(-left + right, up - down);
         }
 
+        public static InputControlLayout CreateLayout(string name)
+        {
+            return CreateDefaultLayout<DpadControl>(name);
+        }
+
         internal enum ButtonBits
         {
             Up,

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -148,7 +148,7 @@ namespace UnityEngine.InputSystem.Controls
             return new Vector2(-left + right, up - down);
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             return CreateDefaultLayout<DpadControl>(name);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -958,6 +958,24 @@ namespace UnityEngine.InputSystem
         }
 
         #endif
+
+        internal static InputControlLayout CreateDefaultLayout<TControl>(string name, string displayName = null)
+            where TControl : InputControl
+        {
+            var layout = new InputControlLayout(name, typeof(TControl), displayName);
+            layout.BuildChildControlsFrom<TControl>();
+            return layout;
+        }
+
+        internal static InputControlLayout CreateDefaultLayoutFromStateType<TControl, TStateType>(string name,
+            FourCC format, string displayName = null)
+            where TControl : InputControl
+        {
+            var layout = new InputControlLayout(name, typeof(TControl), displayName);
+            layout.BuildChildControlsFrom<TStateType>();
+            layout.SetStateFormat(format);
+            return layout;
+        }
     }
 
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -924,12 +924,12 @@ namespace UnityEngine.InputSystem.Layouts
             return layout;
         }
 
-        public void BuildChildControlsFrom<T>()
+        internal void BuildChildControlsFrom<T>()
         {
             m_Controls = GetControlItems(typeof(T), name).ToArray();
         }
 
-        public void SetStateFormat(FourCC format)
+        internal void SetStateFormat(FourCC format)
         {
             m_StateFormat = format;
         }
@@ -2134,7 +2134,7 @@ namespace UnityEngine.InputSystem.Layouts
         /// Creates an <see cref="InputControlLayout"/> instance from a provided function or by using the
         /// reflection path if no function is passed.
         /// </summary>
-        public class LayoutConstructor
+        internal class LayoutConstructor
         {
             public LayoutConstructor(Type type, Func<string, InputControlLayout> func = null)
             {
@@ -2144,7 +2144,7 @@ namespace UnityEngine.InputSystem.Layouts
 
             public Type controlType { get; }
 
-            public InputControlLayout CreateLayout(string name)
+            internal InputControlLayout CreateLayout(string name)
             {
                 if (m_Func != null)
                     return m_Func.Invoke(name);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
@@ -233,5 +233,10 @@ namespace UnityEngine.InputSystem.Controls
             var valuePtr = (TouchState*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
             UnsafeUtility.MemCpy(valuePtr, UnsafeUtility.AddressOf(ref value), UnsafeUtility.SizeOf<TouchState>());
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            return CreateDefaultLayoutFromStateType<TouchControl, TouchState>(name, TouchState.Format);
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
@@ -234,7 +234,7 @@ namespace UnityEngine.InputSystem.Controls
             UnsafeUtility.MemCpy(valuePtr, UnsafeUtility.AddressOf(ref value), UnsafeUtility.SizeOf<TouchState>());
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             return CreateDefaultLayoutFromStateType<TouchControl, TouchState>(name, TouchState.Format);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPhaseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPhaseControl.cs
@@ -45,5 +45,13 @@ namespace UnityEngine.InputSystem.Controls
             var valuePtr = (byte*)statePtr + (int)m_StateBlock.byteOffset;
             *(TouchPhase*)valuePtr = value;
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            return new InputControlLayout(name, typeof(TouchPhaseControl))
+            {
+                hideInUI = true
+            };
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPhaseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPhaseControl.cs
@@ -46,7 +46,7 @@ namespace UnityEngine.InputSystem.Controls
             *(TouchPhase*)valuePtr = value;
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             return new InputControlLayout(name, typeof(TouchPhaseControl))
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
@@ -49,5 +49,13 @@ namespace UnityEngine.InputSystem.Controls
         {
             throw new NotSupportedException();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            return new InputControlLayout(name, typeof(TouchPressControl))
+            {
+                hideInUI = true
+            };
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchPressControl.cs
@@ -50,7 +50,7 @@ namespace UnityEngine.InputSystem.Controls
             throw new NotSupportedException();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             return new InputControlLayout(name, typeof(TouchPressControl))
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -713,6 +713,13 @@ namespace UnityEngine.InputSystem
             m_Rumble.SetMotorSpeeds(this, lowFrequency, highFrequency);
         }
 
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Gamepad, GamepadState>(name, GamepadState.Format);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
+
         private DualMotorRumble m_Rumble;
 
         private static int s_GamepadCount;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -713,7 +713,7 @@ namespace UnityEngine.InputSystem
             m_Rumble.SetMotorSpeeds(this, lowFrequency, highFrequency);
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Gamepad, GamepadState>(name, GamepadState.Format);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
@@ -185,5 +185,12 @@ namespace UnityEngine.InputSystem
 
         private static int s_JoystickCount;
         private static Joystick[] s_Joysticks;
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Joystick, JoystickState>(name, JoystickState.kFormat);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Joystick.cs
@@ -186,7 +186,7 @@ namespace UnityEngine.InputSystem
         private static int s_JoystickCount;
         private static Joystick[] s_Joysticks;
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Joystick, JoystickState>(name, JoystickState.kFormat);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
@@ -2204,7 +2204,7 @@ namespace UnityEngine.InputSystem
         private KeyControl[] m_Keys;
         private InlinedArray<Action<IMECompositionString>> m_ImeCompositionListeners;
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Keyboard, KeyboardState>(name, KeyboardState.Format);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
@@ -2204,6 +2204,13 @@ namespace UnityEngine.InputSystem
         private KeyControl[] m_Keys;
         private InlinedArray<Action<IMECompositionString>> m_ImeCompositionListeners;
 
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Keyboard, KeyboardState>(name, KeyboardState.Format);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
+
         /// <summary>
         /// Raw array of key controls on the keyboard.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -319,5 +319,12 @@ namespace UnityEngine.InputSystem
         {
             OnStateEvent(eventPtr);
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Mouse, MouseState>(name, MouseState.Format);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -320,7 +320,7 @@ namespace UnityEngine.InputSystem
             OnStateEvent(eventPtr);
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Mouse, MouseState>(name, MouseState.Format);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -383,7 +383,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Pen, PenState>(name, PenState.Format);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -382,5 +382,12 @@ namespace UnityEngine.InputSystem
             twist = GetChildControl<AxisControl>("twist");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Pen, PenState>(name, PenState.Format);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -250,7 +250,7 @@ namespace UnityEngine.InputSystem
             return false;
         }
 
-        public static InputControlLayout CreatePointerLayout(string name)
+        internal static InputControlLayout CreatePointerLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Pointer, PointerState>(name, PointerState.kFormat);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -249,5 +249,12 @@ namespace UnityEngine.InputSystem
         {
             return false;
         }
+
+        public static InputControlLayout CreatePointerLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Pointer, PointerState>(name, PointerState.kFormat);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
@@ -123,7 +123,7 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        public static InputControlLayout CreateSensorLayout(string name)
+        internal static InputControlLayout CreateSensorLayout(string name)
         {
             var layout = CreateDefaultLayout<Sensor>(name);
             layout.isGenericTypeOfDevice = true;
@@ -198,7 +198,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Accelerometer, AccelerometerState>(name, AccelerometerState.kFormat);
             return layout;
@@ -245,7 +245,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Gyroscope, GyroscopeState>(name, GyroscopeState.kFormat);
             return layout;
@@ -293,7 +293,7 @@ namespace UnityEngine.InputSystem
                 current = null;
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<GravitySensor, GravityState>(name, GravityState.kFormat, "Gravity");
             return layout;
@@ -342,7 +342,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<AttitudeSensor, AttitudeState>(name, AttitudeState.kFormat, "Attitude");
             return layout;
@@ -391,7 +391,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<LinearAccelerationSensor, LinearAccelerationState>(name,
                 LinearAccelerationState.kFormat, "Linear Acceleration");
@@ -444,7 +444,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<MagneticFieldSensor>(name, "Magnetic Field");
             return layout;
@@ -492,7 +492,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<Accelerometer>(name, "Light");
             return layout;
@@ -540,7 +540,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<PressureSensor>(name, "Pressure");
             return layout;
@@ -591,7 +591,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<ProximitySensor>(name, "Proximity");
             return layout;
@@ -639,7 +639,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<HumiditySensor>(name, "Humidity");
             return layout;
@@ -687,7 +687,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<AmbientTemperatureSensor>(name, "Ambient Temperature");
             return layout;
@@ -738,7 +738,7 @@ namespace UnityEngine.InputSystem
             base.FinishSetup();
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<StepCounter>(name, "Step Counter");
             return layout;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
@@ -122,6 +122,13 @@ namespace UnityEngine.InputSystem
                 ExecuteCommand(ref command);
             }
         }
+
+        public static InputControlLayout CreateSensorLayout(string name)
+        {
+            var layout = CreateDefaultLayout<Sensor>(name);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
     }
 
     /// <summary>
@@ -190,6 +197,12 @@ namespace UnityEngine.InputSystem
             acceleration = GetChildControl<Vector3Control>("acceleration");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Accelerometer, AccelerometerState>(name, AccelerometerState.kFormat);
+            return layout;
+        }
     }
 
     /// <summary>
@@ -230,6 +243,12 @@ namespace UnityEngine.InputSystem
         {
             angularVelocity = GetChildControl<Vector3Control>("angularVelocity");
             base.FinishSetup();
+        }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Gyroscope, GyroscopeState>(name, GyroscopeState.kFormat);
+            return layout;
         }
     }
 
@@ -272,6 +291,12 @@ namespace UnityEngine.InputSystem
             base.OnRemoved();
             if (current == this)
                 current = null;
+        }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<GravitySensor, GravityState>(name, GravityState.kFormat, "Gravity");
+            return layout;
         }
     }
 
@@ -316,6 +341,12 @@ namespace UnityEngine.InputSystem
             attitude = GetChildControl<QuaternionControl>("attitude");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<AttitudeSensor, AttitudeState>(name, AttitudeState.kFormat, "Attitude");
+            return layout;
+        }
     }
 
     /// <summary>
@@ -358,6 +389,13 @@ namespace UnityEngine.InputSystem
         {
             acceleration = GetChildControl<Vector3Control>("acceleration");
             base.FinishSetup();
+        }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<LinearAccelerationSensor, LinearAccelerationState>(name,
+                LinearAccelerationState.kFormat, "Linear Acceleration");
+            return layout;
         }
     }
 
@@ -405,6 +443,12 @@ namespace UnityEngine.InputSystem
             magneticField = GetChildControl<Vector3Control>("magneticField");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<MagneticFieldSensor>(name, "Magnetic Field");
+            return layout;
+        }
     }
 
     /// <summary>
@@ -447,6 +491,12 @@ namespace UnityEngine.InputSystem
             lightLevel = GetChildControl<AxisControl>("lightLevel");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<Accelerometer>(name, "Light");
+            return layout;
+        }
     }
 
     /// <summary>
@@ -488,6 +538,12 @@ namespace UnityEngine.InputSystem
         {
             atmosphericPressure = GetChildControl<AxisControl>("atmosphericPressure");
             base.FinishSetup();
+        }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<PressureSensor>(name, "Pressure");
+            return layout;
         }
     }
 
@@ -534,6 +590,12 @@ namespace UnityEngine.InputSystem
             distance = GetChildControl<AxisControl>("distance");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<ProximitySensor>(name, "Proximity");
+            return layout;
+        }
     }
 
     /// <summary>
@@ -576,6 +638,12 @@ namespace UnityEngine.InputSystem
             relativeHumidity = GetChildControl<AxisControl>("relativeHumidity");
             base.FinishSetup();
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<HumiditySensor>(name, "Humidity");
+            return layout;
+        }
     }
 
     /// <summary>
@@ -617,6 +685,12 @@ namespace UnityEngine.InputSystem
         {
             ambientTemperature = GetChildControl<AxisControl>("ambientTemperature");
             base.FinishSetup();
+        }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<AmbientTemperatureSensor>(name, "Ambient Temperature");
+            return layout;
         }
     }
 
@@ -662,6 +736,12 @@ namespace UnityEngine.InputSystem
         {
             stepCounter = GetChildControl<IntegerControl>("stepCounter");
             base.FinishSetup();
+        }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<StepCounter>(name, "Step Counter");
+            return layout;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -953,7 +953,7 @@ namespace UnityEngine.InputSystem
             return true;
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayoutFromStateType<Touchscreen, TouchscreenState>(name, TouchscreenState.Format);
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -953,6 +953,13 @@ namespace UnityEngine.InputSystem
             return true;
         }
 
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayoutFromStateType<Touchscreen, TouchscreenState>(name, TouchscreenState.Format);
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
+
         // We can only detect taps on touch *release*. At which point it acts like a button that triggers and releases
         // in one operation.
         private static void TriggerTap(TouchControl control, ref TouchState state, InputEventPtr eventPtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/TrackedDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/TrackedDevice.cs
@@ -36,7 +36,7 @@ namespace UnityEngine.InputSystem
             deviceRotation = GetChildControl<QuaternionControl>("deviceRotation");
         }
 
-        public static InputControlLayout CreateLayout(string name)
+        internal static InputControlLayout CreateLayout(string name)
         {
             var layout = CreateDefaultLayout<TrackedDevice>(name, "Tracked Device");
             layout.isGenericTypeOfDevice = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/TrackedDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/TrackedDevice.cs
@@ -35,5 +35,12 @@ namespace UnityEngine.InputSystem
             devicePosition = GetChildControl<Vector3Control>("devicePosition");
             deviceRotation = GetChildControl<QuaternionControl>("deviceRotation");
         }
+
+        public static InputControlLayout CreateLayout(string name)
+        {
+            var layout = CreateDefaultLayout<TrackedDevice>(name, "Tracked Device");
+            layout.isGenericTypeOfDevice = true;
+            return layout;
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
@@ -66,21 +66,21 @@ namespace UnityEngine.InputSystem.Editor
         {
             var types = new List<string>();
             var allLayouts = InputSystem.s_Manager.m_Layouts;
-            foreach (var layoutName in allLayouts.layoutTypes.Keys)
+            foreach (var layoutName in allLayouts.layoutConstructors.Keys)
             {
                 if (EditorInputControlLayoutCache.TryGetLayout(layoutName).hideInUI)
                     continue;
 
                 // If the action type is InputActionType.Value, skip button controls.
-                var type = allLayouts.layoutTypes[layoutName];
+                var type = allLayouts.layoutConstructors[layoutName];
                 if ((InputActionType)m_SelectedActionType == InputActionType.Value &&
-                    typeof(ButtonControl).IsAssignableFrom(type))
+                    typeof(ButtonControl).IsAssignableFrom(type.controlType))
                     continue;
 
                 ////TODO: skip aliases
 
-                if (typeof(InputControl).IsAssignableFrom(type) &&
-                    !typeof(InputDevice).IsAssignableFrom(type))
+                if (typeof(InputControl).IsAssignableFrom(type.controlType) &&
+                    !typeof(InputDevice).IsAssignableFrom(type.controlType))
                 {
                     types.Add(layoutName);
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -394,7 +394,7 @@ namespace UnityEngine.InputSystem
             var isReplacement = DoesLayoutExist(internedName);
 
             if (createLayoutFunc == null)
-                createLayoutFunc = n => InputControl.CreateDefaultLayout<TControl>(name);
+                createLayoutFunc = _ => InputControl.CreateDefaultLayout<TControl>(name);
 
             m_Layouts.layoutConstructors[internedName] =
                 new InputControlLayout.LayoutConstructor(typeof(TControl), createLayoutFunc);


### PR DESCRIPTION
### Description

Made some changes to enable control and device registrations be made using statically typed references to the control and state types. This should enable us in a later version to remove the Preserve attributes on all device types. Testing shows that all of the preserved types are adding about 60k to the size of a built IL2CPP player. So this PR doesn't do much to address that directly, but it does make control layout creation a little more efficient

### Changes made

Added a new method to InputManager to register controls that provide their own methods for creating InputControlLayouts. The method is called RegisterControlLayout<TControl>. The InputControlLayout creation method can be passed as a method group to be called later when a device is created. If no creation method is passed, a default one is inserted that creates a default InputControlLayout instance for the control being registered.

### Notes

* The new RegisterControlLayout<TControl> API is not exposed publicly yet intentionally while I wait and see if it was a good idea or not.
* Although this task was ostensibly about removing reflection use, the new API still uses reflection to build the list of child controls because testing this against the FromJson code path showed reflection to be about 4 times faster! The new path should use less memory though as it doesn't instantiate 'state' types to read the FourCC from them, and doesn't use Activator.CreateInstance anywhere. This seemed like the better route given the other two alternatives i.e. loading layouts from serialized json and loading from precompiled layouts. The former is much slower, and the latter adds thousands of lines of code to the code base.
* InputControlLayout constructor is now internal so controls and devices shipping with the framework can call it directly but this wouldn't be available for users.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
