### PR TITLE
CHANGE: Added isEnabledByDefault constructor option to generated action sets.

### DIFF
--- a/Assets/Samples/InGameHints/InGameHintsActions.cs
+++ b/Assets/Samples/InGameHints/InGameHintsActions.cs
@@ -17,10 +17,10 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Samples.InGameHints
 {
-    public partial class @InGameHintsActions: IInputActionCollection2, IDisposable
+    public partial class @InGameHintsActions : IInputActionCollection2, IDisposable
     {
         public InputActionAsset asset { get; }
-        public @InGameHintsActions()
+        public @InGameHintsActions(bool isEnabledByDefault = false)
         {
             asset = InputActionAsset.FromJson(@"{
     ""name"": ""InGameHintsActions"",
@@ -265,6 +265,7 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
             m_Gameplay_PickUp = m_Gameplay.FindAction("PickUp", throwIfNotFound: true);
             m_Gameplay_Drop = m_Gameplay.FindAction("Drop", throwIfNotFound: true);
             m_Gameplay_Throw = m_Gameplay.FindAction("Throw", throwIfNotFound: true);
+            if(isEnabledByDefault) Enable();
         }
 
         public void Dispose()
@@ -310,14 +311,12 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
         {
             asset.Disable();
         }
-
         public IEnumerable<InputBinding> bindings => asset.bindings;
 
         public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
         {
             return asset.FindAction(actionNameOrId, throwIfNotFound);
         }
-
         public int FindBinding(InputBinding bindingMask, out InputAction action)
         {
             return asset.FindBinding(bindingMask, out action);

--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -15,10 +15,10 @@ using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 
-public partial class @SimpleControls: IInputActionCollection2, IDisposable
+public partial class @SimpleControls : IInputActionCollection2, IDisposable
 {
     public InputActionAsset asset { get; }
-    public @SimpleControls()
+    public @SimpleControls(bool isEnabledByDefault = false)
     {
         asset = InputActionAsset.FromJson(@"{
     ""name"": ""SimpleControls"",
@@ -162,6 +162,7 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
         m_gameplay_fire = m_gameplay.FindAction("fire", throwIfNotFound: true);
         m_gameplay_move = m_gameplay.FindAction("move", throwIfNotFound: true);
         m_gameplay_look = m_gameplay.FindAction("look", throwIfNotFound: true);
+        if(isEnabledByDefault) Enable();
     }
 
     public void Dispose()
@@ -207,14 +208,12 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
     {
         asset.Disable();
     }
-
     public IEnumerable<InputBinding> bindings => asset.bindings;
 
     public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
     {
         return asset.FindAction(actionNameOrId, throwIfNotFound);
     }
-
     public int FindBinding(InputBinding bindingMask, out InputAction action)
     {
         return asset.FindBinding(bindingMask, out action);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,21 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 
 - Added `InputSystem.runUpdatesInEditMode` to enable processing of non-editor updates without entering playmode (only available for XR).
+- Added `isEnabledByDefault` check to generated action sets, this way you don't need to do `IInputActionCollection.Enable()` explicitly if you don't need to. 
+ ```CSharp
+public sealed class InputsTest : MonoBehaviour
+{
+    //private and only exists in this scope, so why bother with .Enable() and .Disable()?
+    private SimpleControls controls;
+
+    private void Awake() => controls = new Inputs(isEnabledByDefault: true);
+
+    private void OnEnable()
+    {
+        controls.gameplay.fire.performed += _ => Debug.Log(message: "Badabing Badaboom");
+    }
+}
+ ```
 
 ## [1.1.0-pre.4] - 2021-05-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -100,7 +100,7 @@ namespace UnityEngine.InputSystem.Editor
             writer.WriteLine($"public InputActionAsset asset {{ get; }}");
 
             // Default constructor.
-            writer.WriteLine($"public @{options.className}()");
+            writer.WriteLine($"public @{options.className}(bool isEnabledByDefault = false)");
             writer.BeginBlock();
             writer.WriteLine($"asset = InputActionAsset.FromJson(@\"{asset.ToJson().Replace("\"", "\"\"")}\");");
 
@@ -118,6 +118,9 @@ namespace UnityEngine.InputSystem.Editor
                     writer.WriteLine($"m_{mapName}_{actionName} = m_{mapName}.FindAction(\"{action.name}\", throwIfNotFound: true);");
                 }
             }
+            
+            writer.WriteLine(text: "if(isEnabledByDefault) Enable();");
+            
             writer.EndBlock();
             writer.WriteLine();
 


### PR DESCRIPTION
### Description

Changed code generation of actions sets so they now have an optional `isEnabledByDefault` parameter and check in it's constructor.
It will then automatically call `.Enable()` at the end of the constructor if set to true.

It's handy to have to ability to enable and disable all InputActionMaps.
But there should be an option to have it enabled by default - for when you don't need the control and want to minimize code bloat.

### Changes made

_Please write down a short description of what changes were made._
- Added optional `isEnabledByDefault` parameter to generated action set's C# class.
- Added call to `.Enable()` at end of generated constructor when isEnabledByDefault is **true**.
- Re-generated existing actions sets to implement the new functionality.

### Notes

- This requires no change to existing API apart from re-generating existing action sets.
The constructor is functionally the same and sending the parameter is purely optional and defaults to false.

- When using `(isEnabledByDefault: true)` it means you're restricted to  _where/when_ you're creating the action set; for instance you can't create it in `Reset()` anymore because it'll call .Enable() at a time it can't/shouldn't.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
