### PR TITLE
FIX: Console errors for PlayerInput with empty action maps (case 131735).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed binding paths being misaligned in UI when switching to text mode editing ([case 1200107](https://issuetracker.unity3d.com/issues/input-system-path-input-field-text-is-clipping-under-binding-in-the-properties-section)).
+- Fixed `"Exception: Style.Draw may not be called with GUIContent that is null."` error from `PlayerInput` inspector when having an action map with no actions ([case 1317735](https://issuetracker.unity3d.com/issues/multiple-error-messages-are-thrown-when-trying-to-expand-the-event-list-of-an-input-actions-asset-that-has-an-empty-action-map)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -183,6 +183,10 @@ namespace UnityEngine.InputSystem.Editor
                             {
                                 for (var n = 0; n < m_NumActionMaps; ++n)
                                 {
+                                    // Skip action maps that have no names (case 1317735).
+                                    if (m_ActionMapNames[n] == null)
+                                        continue;
+
                                     m_ActionMapEventsUnfolded[n] = EditorGUILayout.Foldout(m_ActionMapEventsUnfolded[n],
                                         m_ActionMapNames[n], toggleOnLabelClick: true);
                                     using (new EditorGUI.IndentLevelScope())
@@ -428,9 +432,6 @@ namespace UnityEngine.InputSystem.Editor
                     ArrayHelpers.PutAtIfNotSet(ref m_ActionMapNames, actionMapIndex,
                         () => new GUIContent(action.actionMap.name));
                 }
-
-                ////REVIEW: this is destructive; we may be losing connections here that the user has set up
-                ////        if the action goes missing
 
                 // Bring over any action events that we already have and that are still in the asset.
                 var oldActionEvents = playerInput.m_ActionEvents;


### PR DESCRIPTION
Fixes [1317735](https://issuetracker.unity3d.com/issues/multiple-error-messages-are-thrown-when-trying-to-expand-the-event-list-of-an-input-actions-asset-that-has-an-empty-action-map) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1317735/)).

### Description

If you had an action map with no actions hooked up to a `PlayerInput` that was set to `Invoke UnityEvents`, you'd see errors in the console when the inspector was shown for the component.

### Changes made

Skip over empty entries in the action map name array. We do not need to care about maps without actions in that part of the code.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
