### PR TITLE
FIX: Inspectors no longer displaying property names (case 1340394).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,8 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed binding paths being misaligned in UI when switching to text mode editing ([case 1200107](https://issuetracker.unity3d.com/issues/input-system-path-input-field-text-is-clipping-under-binding-in-the-properties-section)).
+- Fixed inspector for `InputAction` and `InputActionMap` properties (such as in `MonoBehaviour`s) no longer displaying name of property but rather just "Input Action" or "Input Action Map" ([case 1340394](https://issuetracker.unity3d.com/product/unity/issues/guid/1340394/)).
+  * Regression introduced in 1.1-pre.5.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -102,14 +102,15 @@ namespace UnityEngine.InputSystem.Editor
 
         private static string GetPropertyTitle(SerializedProperty property)
         {
-            var propertyTitleNumeral = string.Empty;
-
             if (property.GetParentProperty() != null && property.GetParentProperty().isArray)
-                propertyTitleNumeral = $" {property.GetIndexOfArrayElement()}";
+            {
+                var propertyTitleNumeral = $" {property.GetIndexOfArrayElement()}";
+                return property.type == nameof(InputActionMap) ?
+                    $"Action Map {propertyTitleNumeral}" :
+                    $"Action {propertyTitleNumeral}";
+            }
 
-            return property.type == nameof(InputActionMap) ?
-                $"{property.displayName}{propertyTitleNumeral}" :
-                $"{property.displayName}{propertyTitleNumeral}";
+            return property.displayName;
         }
 
         private void OnItemDoubleClicked(ActionTreeItemBase item, SerializedProperty property)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -108,8 +108,8 @@ namespace UnityEngine.InputSystem.Editor
                 propertyTitleNumeral = $" {property.GetIndexOfArrayElement()}";
 
             return property.type == nameof(InputActionMap) ?
-                $"Input Action Map{propertyTitleNumeral}" :
-                $"Input Action{propertyTitleNumeral}";
+                $"{property.displayName}{propertyTitleNumeral}" :
+                $"{property.displayName}{propertyTitleNumeral}";
         }
 
         private void OnItemDoubleClicked(ActionTreeItemBase item, SerializedProperty property)


### PR DESCRIPTION
Fixes [1340394](https://issuetracker.unity3d.com/product/unity/issues/guid/1340394/) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1340394/)).

### Description

Minor regression introduced in 1.1-pre.5. Inspectors for embedded `InputAction` and `InputActionMap` properties no longer used the name of the property for display.

### Changes made

Made the code grab `property.displayName` again.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
