### PR TITLE
FIX: broken alignment of InputActionRebindingExtensions.RebindingOper…

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -2103,7 +2103,7 @@ namespace UnityEngine.InputSystem
                     {
                         m_Scores.SwapElements(j, j - 1);
                         m_Candidates.SwapElements(j, j - 1);
-                        m_Magnitudes.SwapElements(i, j - 1);
+                        m_Magnitudes.SwapElements(j, j - 1);
                     }
                 }
             }


### PR DESCRIPTION
…ation.magnitudes

According to the documentation of 'magnitudes'

> This array mirrors <see cref="candidates"/>, i.e. each entry corresponds to the entry in <see cref="candidates"/> at the same index.

But some other index had been used during 'SortCandidatesByScore'.

### Description

This pull request addresses an error in `SortCandidatesByScore`  (in `InputActionRebindingExtensions.RebindingOperation`)

### Changes made

An index in the insertion sort algorithm was changed from `i` to `j`

### Notes

I leave it to the **Unity developers** to check for correctness, create tests and all those things.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
