### PR TITLE
Fix in InputActionSetupExtensions.ChangeBinding

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1193,6 +1193,18 @@ namespace UnityEngine.InputSystem
         /// <inheritdoc/>
         public int FindBinding(InputBinding mask, out InputAction action)
         {
+            var n = FindBindingRelativeToMap(mask);
+            if (n == -1) {
+                action = null;
+                return -1;
+            }
+
+            action = m_SingletonAction ?? FindAction(bindings[n].action);
+            return action.BindingIndexOnMapToBindingIndexOnAction(n);
+        }
+
+        public int FindBindingRelativeToMap(InputBinding mask)
+        {
             var bindings = m_Bindings;
             var bindingsCount = bindings.LengthSafe();
 
@@ -1200,13 +1212,9 @@ namespace UnityEngine.InputSystem
             {
                 ref var binding = ref bindings[n];
                 if (mask.Matches(ref binding))
-                {
-                    action = m_SingletonAction ?? FindAction(binding.action);
-                    return action.BindingIndexOnMapToBindingIndexOnAction(n);
-                }
+                    return n;
             }
 
-            action = null;
             return -1;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -730,11 +730,11 @@ namespace UnityEngine.InputSystem
             match.action = action.name;
 
             var actionMap = action.GetOrCreateActionMap();
-            var bindingIndex = actionMap.FindBinding(match, out _);
-            if (bindingIndex == -1)
+            var bindingIndexInMap = actionMap.FindBindingRelativeToMap(match);
+            if (bindingIndexInMap == -1)
                 return default;
 
-            return new BindingSyntax(actionMap, bindingIndex);
+            return new BindingSyntax(actionMap, bindingIndexInMap);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed problem with assumption that indexes relative to actions and action maps are the same in `InputActionSetupExtensions.ChangeBinding( this InputAction, InputBinding )`

### Description

The following code wouldn't work correctly. The wrong binding would be returned.
A binding within an action is sought via guid. The action is not the first action within its action map.

>        var inputActionAsset = (InputActionAsset) UnityEditor.AssetDatabase.LoadMainAssetAtPath("Assets/Input/Teslagrad2Inputs.inputactions");
>        var inputAction   = inputActionAsset["33842c35-16f8-484b-adef-aeb21f23133e"];
>        var bindingSyntax = inputAction.ChangeBindingWithId("6651d749-db7a-43a2-9a0f-cbb42b1b687e");

It seems that the ChangeBinding extension method was fetching an index that was relative to
an action, and passing it on to `new BindingSyntax`, as if the index was relative to an `InputActionMap`.

### Notes

This bug could be other places as well. I have no idea.

### Changes made

InputActionMap was refactored so that an index relative to the map could be retrieved from a new method.
This method `FindBindingRelativeToMap` was used instead of `FindBinding`, when the index would be retrieved
to be passed on to `new BindingSyntax`.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
