### PR TITLE
FIX: InputControlPathDrawer duplicated instances in lists

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputControlPathDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputControlPathDrawer.cs
@@ -22,31 +22,25 @@ namespace UnityEngine.InputSystem.Editor
     /// </example>
     /// </remarks>
     [CustomPropertyDrawer(typeof(InputControlAttribute))]
-    internal sealed class InputControlPathDrawer : PropertyDrawer, IDisposable
+    internal sealed class InputControlPathDrawer : PropertyDrawer
     {
-        private InputControlPathEditor m_Editor;
         private InputControlPickerState m_PickerState;
-
-        public void Dispose()
-        {
-            m_Editor?.Dispose();
-        }
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             if (m_PickerState == null)
                 m_PickerState = new InputControlPickerState();
-            if (m_Editor == null)
-            {
-                m_Editor = new InputControlPathEditor(property, m_PickerState,
+                
+            var editor = new InputControlPathEditor(property, m_PickerState,
                     () => property.serializedObject.ApplyModifiedProperties(),
                     label: label);
-                m_Editor.SetExpectedControlLayoutFromAttribute();
-            }
+            editor.SetExpectedControlLayoutFromAttribute();
 
             EditorGUI.BeginProperty(position, label, property);
-            m_Editor.OnGUI(position);
+            editor.OnGUI(position);
             EditorGUI.EndProperty();
+            
+            editor.Dispose();
         }
     }
 }


### PR DESCRIPTION
### Description
Using [InputControl] for string members (as control path) of classes that are in a list resulted in all entries having (seemingly) the same value in the Inspector.
This was caused due to a cache in the InputControlPathDrawer. It didn't account for reusing the property drawer instance in lists.

Repro steps:
1. Add this to any MonoBehaviour / ScriptableObject
`[InputControl]
public string[] BindingPath;`
2. Display the object in the Inspector. Add 3-4 entries.
3. Change the first entry
Result: all the other entries will display the same value.
Expected: Only first entry should be changed.

### Changes made
Removed the editor cache in the InputControlPathDrawer. I believe it won't have big performance hit.

### Notes
Haven't really tested other non-string usages of [InputControl]

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
