### PR TITLE
Fixed BindingSyntax.InsertPartBinding not assigning action

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -1471,8 +1471,9 @@ namespace UnityEngine.InputSystem
                 if (!binding.isPartOfComposite && !binding.isComposite)
                     throw new InvalidOperationException("Binding accessor must point to composite or part binding");
 
+                var bindingAction = m_ActionMap.m_Bindings[m_BindingIndexInMap].action;
                 AddBindingInternal(m_ActionMap,
-                    new InputBinding { path = path, isPartOfComposite = true, name = partName },
+                    new InputBinding { path = path, isPartOfComposite = true, name = partName, action = bindingAction },
                     m_BindingIndexInMap + 1);
 
                 return new BindingSyntax(m_ActionMap, m_BindingIndexInMap + 1, m_Action);


### PR DESCRIPTION
### Description

_BindingSyntax.InsertPartBinding_ was not assigning the _action_ field on the inserted binding.
_action_ on part bindings are required by _InputActionMap.SetUpPerActionCachedBindingData()_

### Changes made

**InputActionSetupExtensions.InsertPartBinding** now passes on the action to the created part binding.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
