### PR TITLE
FIX: Incorrect usage of IndexOfReference

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1642,7 +1642,7 @@ namespace UnityEngine.InputSystem.Users
 
                         // Search for another user who had lost the same device.
                         deviceIndex =
-                            s_AllLostDevices.IndexOfReference(device, deviceIndex + 1, s_AllLostDeviceCount);
+                            s_AllLostDevices.IndexOfReference(device, deviceIndex + 1, s_AllLostDeviceCount - deviceIndex - 1);
                     }
                     break;
                 }
@@ -1698,7 +1698,7 @@ namespace UnityEngine.InputSystem.Users
                             UpdatePlatformUserAccount(userIndex, device);
 
                             // Search for another user paired to the same device.
-                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, deviceIndex + 1, s_AllPairedDeviceCount);
+                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, deviceIndex + 1, s_AllPairedDeviceCount - deviceIndex - 1);
                         }
                     }
                     break;


### PR DESCRIPTION

### Description

In InputUser.OnDeviceChange IndexOfReference is used to search through s_AllLostDevices and s_AllPairedDevices, if any device is found it will search again from the found index.
The fourth argument of IndexOfReference should be the remaining amount of indices to look through, but in this method the total count was passed. Since the array starts at 0 it is safe to just subtract the starting index from the total count.

### Changes made

Subtracted new starting index from total count. 

### Notes

I have also checked through all other uses of this method in the project, and could not find any other incorrect usages.
When a device is removed it currently loops through the entire list again whenever it finds a device, this could potentially be shortened by passing in `deviceIndex` (without +1 since it's removed) and `s_AllPairedDeviceCount - deviceIndex`.

