### PR TITLE
Added ClearPartBindings to BindingSyntax

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -1423,6 +1423,40 @@ namespace UnityEngine.InputSystem
                 return default;
             }
 
+            /// <summary>
+            /// Remove part bindings from a composite binding.
+            /// </summary>
+            /// <remarks>
+            /// If the binding is not a composite (see <see cref="InputBinding.isComposite"/>), nothing
+            /// will be removed, and an invalid BindingSyntax is returned.
+            /// </remarks>
+            /// <exception cref="InvalidOperationException">The instance is not <see cref="valid"/>.</exception>
+            public BindingSyntax ClearPartBindings () {
+                if (!valid)
+                    throw new InvalidOperationException("Instance not valid");
+
+                ref var bindings = ref m_ActionMap.m_Bindings;
+                var index = m_BindingIndexInMap;
+
+                if (!bindings[index].isComposite)
+                    return default;
+
+                index++; // Skip to first part binding
+
+                while (index < bindings.Length && bindings[index].isPartOfComposite)
+                    ArrayHelpers.EraseAt(ref bindings, index);
+
+                m_ActionMap.ClearPerActionCachedBindingData();
+                m_ActionMap.LazyResolveBindings();
+
+                // We have switched to a different binding array. For singleton actions, we need to
+                // sync up the reference that the action itself has.
+                if (m_ActionMap.m_SingletonAction != null)
+                    m_ActionMap.m_SingletonAction.m_SingletonActionBindings = bindings;
+
+                return this;
+            }
+
             ////TODO: allow setting overrides through this accessor
 
             /// <summary>


### PR DESCRIPTION
### Description

This adds a method to BindingSyntax that removes/clears all the part bindings of a composite binding.

### Changes made

The added method (ClearBindingParts) replaces code similar to this:

```
        void ClearBindingParts (BindingSyntax b) {
            if (b.valid)
                b = b.NextBinding();
            while (b.valid && b.binding.isPartOfComposite)
                b.Erase();
        }
```

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
