### PR TITLE
FIX: Incorrect array indexing in InputUser.

### DIFF
--- a/Assets/Tests/InputSystem/Utilities/ArrayHelperTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ArrayHelperTests.cs
@@ -99,4 +99,22 @@ internal class ArrayHelperTests
             array3.Dispose();
         }
     }
+
+    [Test]
+    [Category("Utilities")]
+    public void Utilities_IndexOfReference__IsUsingReferenceEqualsAndConstrainedByStartIndexAndCount()
+    {
+        var arr = new object[] { new object(), new object(), new object(), new object(), new object() };
+
+        Assert.AreEqual(-1, arr.IndexOfReference(new object(), 0, arr.Length));
+        Assert.AreEqual(-1, arr.IndexOfReference(arr[4], 4, 0));
+
+        Assert.AreEqual(0, arr.IndexOfReference(arr[0], 0, arr.Length));
+        Assert.AreEqual(4, arr.IndexOfReference(arr[4], 0, arr.Length));
+
+        Assert.AreEqual(-1, arr.IndexOfReference(arr[0], 1, 3));
+        Assert.AreEqual(-1, arr.IndexOfReference(arr[4], 1, 3));
+        Assert.AreEqual(1, arr.IndexOfReference(arr[1], 1, 3));
+        Assert.AreEqual(2, arr.IndexOfReference(arr[2], 1, 3));
+    }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `PointerInput` composite in `TouchSamples` project being registered only after scenes already loaded ([case 1215048](https://issuetracker.unity3d.com/issues/mobile-input-system-custom-binding-broken-slash-not-registered-when-using-runtimeinitializeonloadmethod-and-loading-scene-directly)).
 - Fixed `InputControlExtensions.EnumerateChangedControls` skipping over `left`, `right`, and `down` controls on PS4 controller's dpad ([case 1315107](https://issuetracker.unity3d.com/issues/input-system-left-right-and-down-directional-pad-buttons-do-not-switch-controls-over-to-controller)).
 - Fixed undo not working in `Input System Package` project settings pane ([case 1291709](https://issuetracker.unity3d.com/issues/inputsystem-exception-thrown-continuously-when-undo-operation-is-performed-with-supported-devices-list-in-the-project-settings)).
+- Fixed incorrect indexing in `InputUser.OnDeviceChanged` that could result in incorrect pairing of devices or `IndexOutOfRangeException` being thrown when removing, adding or reconfiguring a device. Fix contribution by [Mikael Klages](https://github.com/ITR13) in [#1359](https://github.com/Unity-Technologies/InputSystem/pull/1359).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1703,8 +1703,7 @@ namespace UnityEngine.InputSystem.Users
                             // Note that action is tied to user and hence we can skip to end of slice associated
                             // with the current user or at least one element forward.
                             var offsetNextSlice = deviceIndex + Math.Max(1, s_AllUserData[userIndex].deviceCount);
-                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, offsetNextSlice, 
-                                s_AllPairedDeviceCount - offsetNextSlice);
+                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, offsetNextSlice, s_AllPairedDeviceCount - offsetNextSlice);
                         }
                     }
                     break;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1641,8 +1641,10 @@ namespace UnityEngine.InputSystem.Users
                         AddDeviceToUser(userIndex, device);
 
                         // Search for another user who had lost the same device.
-                        deviceIndex =
-                            s_AllLostDevices.IndexOfReference(device, deviceIndex + 1, s_AllLostDeviceCount);
+                        // Note: s_AllLostDevices is modified (element erased) from within RemoveDeviceFromUser,
+                        //       hence, deviceIndex is not advanced and s_AllLostDeviceCount is one less than
+                        //       previous linear search iteration.
+                        deviceIndex = s_AllLostDevices.IndexOfReference(device, deviceIndex, s_AllLostDeviceCount);
                     }
                     break;
                 }
@@ -1698,7 +1700,11 @@ namespace UnityEngine.InputSystem.Users
                             UpdatePlatformUserAccount(userIndex, device);
 
                             // Search for another user paired to the same device.
-                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, deviceIndex + 1, s_AllPairedDeviceCount);
+                            // Note that action is tied to user and hence we can skip to end of slice associated
+                            // with the current user or at least one element forward.
+                            var offsetNextSlice = deviceIndex + Math.Max(1, s_AllUserData[userIndex].deviceCount);
+                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, offsetNextSlice, 
+                                s_AllPairedDeviceCount - offsetNextSlice);
                         }
                     }
                     break;
@@ -1859,8 +1865,15 @@ namespace UnityEngine.InputSystem.Users
 
             public InputControlScheme.MatchResult controlSchemeMatch;
 
+            /// <summary>
+            /// Number of devices in <see cref="InputUser.s_AllLostDevices"/> assigned to the user.
+            /// </summary>
             public int lostDeviceCount;
 
+            /// <summary>
+            /// Index in <see cref="InputUser.s_AllLostDevices"/> where the lost devices for this user start. Only valid
+            /// if <see cref="lostDeviceCount"/> is greater than zero.
+            /// </summary>
             public int lostDeviceStartIndex;
 
             ////TODO
@@ -1916,7 +1929,7 @@ namespace UnityEngine.InputSystem.Users
         private static InputUser[] s_AllUsers;
         private static UserData[] s_AllUserData;
         private static InputDevice[] s_AllPairedDevices; // We keep a single array that we slice out to each user.
-        private static InputDevice[] s_AllLostDevices;
+        private static InputDevice[] s_AllLostDevices;   // We keep a single array that we slice out to each user.
         private static InlinedArray<OngoingAccountSelection> s_OngoingAccountSelections;
         private static InlinedArray<Action<InputUser, InputUserChange, InputDevice>> s_OnChange;
         private static InlinedArray<Action<InputControl, InputEventPtr>> s_OnUnpairedDeviceUsed;


### PR DESCRIPTION
### Description

As highlighted in contribution by [Mikael Klages](https://github.com/Unity-Technologies/InputSystem/pull/1359) the array indexing in [InputUser.OnDeviceChange] is incorrect which is a valid statement. However in the proposed changes in contribution [1359](https://github.com/Unity-Technologies/InputSystem/pull/1359) it is suggested that remove functionality offset into the array, but this would better be avoided since the arrays iterated on are modified/shrinked as part of the loop. 

### Changes made

- As highlighted in original contribution [1359](https://github.com/Unity-Technologies/InputSystem/pull/1359) the code in handling of `InputDeviceChange.ConfigurationChanged` uses an incorrect range in the linear search. It has been modified to use a valid count and also to offset directly into the next user slice of devices since the action associated with this event is per user and should be executed twice for the same user (would only result in overhead).
- Added a clarification into handling of `InputDeviceChange.Added` event that no index offset is used since the array of devices iterated upon is lost devices which is modified inside the loop as part of `RemoveDeviceFromUser`. This is to avoid further confusion around indexing in this part of the code.

### Notes

- Extended test coverage of related ArrayHelpers.cs in ArrayHelpersTest.cs.
- Test case added to UserTests.cs: `Users_CanReacquireDevicesIfSingleDeviceIsPairedWithMultipleUsers()` which basically verifies that devices can be required but has been designed to trigger a scenario where incorrect offsets in ``InputDeviceChange.Added` or ``InputDeviceChange.Removed` would result in incorrect offsets.
- It was attempted during development of this PR to also provide test coverage of `InputDeviceChange.ConfigurationChanged` handler code but unfortunately source code seem to be non-testable in its current form since underlying triggers may not be mocked.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `UserTests.cs#Users_CanReacquireDevicesIfSingleDeviceIsPairedWithMultipleUsers`, `ArrayHelpersTest.cs#Utilities_IndexOfReference__IsUsingReferenceEqualsAndConstrainedByStartIndexAndCount`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
