### PR TITLE
CHANGE: Touch OnPointerExit now deferred one frame (case 1347048).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -866,14 +866,14 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.clickTime, Is.EqualTo(clickTime));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.clickCount, Is.EqualTo(clickCount));
-        Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(isTouch ? null : scene.rightGameObject)); // Pointer-exit comes before pointer-up.
+        Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(scene.rightGameObject)); // Pointer-exit comes before pointer-up.
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerPress, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.lastPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[0].pointerData.dragging, Is.True);
         Assert.That(scene.leftChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
-        Assert.That(scene.leftChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(isTouch ? Enumerable.Empty<GameObject>() : new[] { scene.rightGameObject, scene.parentGameObject }));
+        Assert.That(scene.leftChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
             Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
@@ -889,14 +889,14 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.clickTime, Is.EqualTo(clickTime));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.clickCount, Is.EqualTo(clickCount));
-        Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerEnter, Is.SameAs(isTouch ? null : scene.rightGameObject));
+        Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerEnter, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.rawPointerPress, Is.Null);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.lastPress, Is.SameAs(scene.leftGameObject)); // Remembers last pointerPress.
         Assert.That(scene.leftChildReceiver.events[1].pointerData.dragging, Is.True);
         Assert.That(scene.leftChildReceiver.events[1].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
-        Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(isTouch ? Enumerable.Empty<GameObject>() : new[] { scene.rightGameObject, scene.parentGameObject }));
+        Assert.That(scene.leftChildReceiver.events[1].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerCurrentRaycast.screenPosition,
             Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
@@ -904,107 +904,33 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.leftChildReceiver.events[1].pointerData.pointerPressRaycast.screenPosition,
             Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
 
-        // For touch, the pointer ceases to exist so we get exit events.
-        if (isTouch)
-        {
-            Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.False);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.True);
+        Assert.That(scene.parentReceiver.events, Is.Empty);
 
-            // Right child should have seen exit and drop.
-            Assert.That(scene.rightChildReceiver.events,
-                EventSequence(
-                    AllEvents("pointerId", pointerId),
-                    AllEvents("position", thirdScreenPosition),
-                    AllEvents("delta", Vector2.zero),
-                    AllEvents("pressPosition", firstScreenPosition),
-                    AllEvents("clickTime", clickTime),
-                    AllEvents("clickCount", clickCount),
-                    AllEvents("pointerDrag", scene.leftGameObject), // Drop not yet processed.
-                    AllEvents("pointerPress", scene.leftGameObject),
-                    AllEvents("rawPointerPress", scene.leftGameObject),
-                    AllEvents("lastPress", null), // See PointerModel.ButtonState.CopyPressStateTo.
-                    AllEvents("dragging", true),
-                    AllEvents("useDragThreshold", false),
-                    AllEvents("pointerCurrentRaycast.gameObject", scene.rightGameObject),
-                    AllEvents("pointerCurrentRaycast.screenPosition", thirdScreenPosition),
-                    AllEvents("pointerPressRaycast.gameObject", scene.leftGameObject),
-                    AllEvents("pointerPressRaycast.screenPosition", firstScreenPosition),
-
-                    // PointerExit.
-                    OneEvent("type", EventType.PointerExit),
-                    OneEvent("button", PointerEventData.InputButton.Left), // PointerExit always coming from left buffer.
-                    OneEvent("pointerEnter", scene.rightGameObject), // Reset after event.
-                    OneEvent("hovered", new[] { scene.rightGameObject, scene.parentGameObject }),
-
-                    // Drop.
-                    OneEvent("type", EventType.Drop),
-                    OneEvent("button", clickButton),
-                    OneEvent("pointerEnter", null),
-                    OneEvent("hovered", new GameObject[0])
-                )
-            );
-
-            // Parent should have seen an exit, too. However, no PointerMove as we
-            // released the touch in a position we had already moved to.
-            Assert.That(scene.parentReceiver.events,
-                EventSequence(
-                    AllEvents("button", PointerEventData.InputButton.Left),
-                    AllEvents("pointerId", pointerId),
-                    AllEvents("position", thirdScreenPosition),
-                    AllEvents("delta", Vector2.zero),
-                    AllEvents("pressPosition", firstScreenPosition),
-                    AllEvents("clickTime", clickTime),
-                    AllEvents("clickCount", clickCount),
-                    AllEvents("pointerEnter", scene.rightGameObject), // Reset after event.
-                    AllEvents("pointerDrag", scene.leftGameObject), // Drop not yet processed.
-                    AllEvents("pointerPress", scene.leftGameObject),
-                    AllEvents("rawPointerPress", scene.leftGameObject),
-                    AllEvents("lastPress", null),
-                    AllEvents("dragging", true),
-                    AllEvents("useDragThreshold", false), // We set it in OnInitializePotentialDrag.
-                    ////REVIEW: This behavior is inconsistent between "normal" pointer-enter/exit sequences but is consistent with what StandaloneInputModule does.
-                    ////        However, it seems wrong that on one path, GOs are removed one-by-one from `hovered` as the callbacks step through the hierarchy, whereas
-                    ////        on the other path, the list stays unmodified until the end and is then cleared en-bloc.
-                    AllEvents("hovered", new[] { scene.rightGameObject, scene.parentGameObject }),
-                    AllEvents("pointerCurrentRaycast.gameObject", scene.rightGameObject),
-                    AllEvents("pointerCurrentRaycast.screenPosition", thirdScreenPosition),
-                    AllEvents("pointerPressRaycast.gameObject", scene.leftGameObject),
-                    AllEvents("pointerPressRaycast.screenPosition", firstScreenPosition),
-
-                    OneEvent("type", EventType.PointerExit)
-                )
-            );
-        }
-        else
-        {
-            // For mouse and pen, pointer stays put.
-            Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.True);
-            Assert.That(scene.parentReceiver.events, Is.Empty);
-
-            // Right child should have seen drop.
-            Assert.That(scene.rightChildReceiver.events, Has.Count.EqualTo(1));
-            Assert.That(scene.rightChildReceiver.events[0].type, Is.EqualTo(EventType.Drop));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.button, Is.EqualTo(clickButton));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerId, Is.EqualTo(pointerId));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.position, Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.delta, Is.EqualTo(Vector2.zero));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.clickTime, Is.EqualTo(clickTime));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.clickCount, Is.EqualTo(clickCount));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(scene.rightGameObject));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPress, Is.SameAs(scene.leftGameObject)); // For the drop, this is still set.
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.lastPress, Is.Null); // See PointerModel.ButtonState.CopyPressStateTo.
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.dragging, Is.True);
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
-                Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPressRaycast.gameObject, Is.SameAs(scene.leftGameObject));
-            Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPressRaycast.screenPosition,
-                Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
-        }
+        // Right child should have seen drop.
+        Assert.That(scene.rightChildReceiver.events, Has.Count.EqualTo(1));
+        Assert.That(scene.rightChildReceiver.events[0].type, Is.EqualTo(EventType.Drop));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.button, Is.EqualTo(clickButton));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerId, Is.EqualTo(pointerId));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.position, Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.delta, Is.EqualTo(Vector2.zero));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pressPosition, Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.clickTime, Is.EqualTo(clickTime));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.clickCount, Is.EqualTo(clickCount));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerEnter, Is.SameAs(scene.rightGameObject));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerDrag, Is.SameAs(scene.leftGameObject));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPress, Is.SameAs(scene.leftGameObject)); // For the drop, this is still set.
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.rawPointerPress, Is.SameAs(scene.leftGameObject));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.lastPress, Is.Null); // See PointerModel.ButtonState.CopyPressStateTo.
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.dragging, Is.True);
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.useDragThreshold, Is.False); // We set it in OnInitializePotentialDrag.
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.hovered, Is.EquivalentTo(new[] { scene.rightGameObject, scene.parentGameObject }));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.gameObject, Is.SameAs(scene.rightGameObject));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerCurrentRaycast.screenPosition,
+            Is.EqualTo(thirdScreenPosition).Using(Vector2EqualityComparer.Instance));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPressRaycast.gameObject, Is.SameAs(scene.leftGameObject));
+        Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPressRaycast.screenPosition,
+            Is.EqualTo(firstScreenPosition).Using(Vector2EqualityComparer.Instance));
 
         scene.leftChildReceiver.events.Clear();
         scene.rightChildReceiver.events.Clear();
@@ -1053,6 +979,77 @@ internal class UITests : CoreTestsFixture
                 Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPressRaycast.gameObject, Is.Null);
                 Assert.That(scene.rightChildReceiver.events[0].pointerData.pointerPressRaycast.screenPosition, Is.EqualTo(default(Vector2)));
             }
+        }
+
+        // For touch, the pointer should cease to exist one frame after and we should get exit events.
+        if (isTouch)
+        {
+            scene.leftChildReceiver.events.Clear();
+            scene.rightChildReceiver.events.Clear();
+            scene.parentReceiver.events.Clear();
+
+            yield return null;
+
+            Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.False);
+
+            // Right child should have seen exit.
+            Assert.That(scene.rightChildReceiver.events,
+                EventSequence(
+                    AllEvents("pointerId", pointerId),
+                    AllEvents("position", thirdScreenPosition),
+                    AllEvents("delta", Vector2.zero),
+                    AllEvents("pressPosition", firstScreenPosition),
+                    AllEvents("clickTime", clickTime),
+                    AllEvents("clickCount", clickCount),
+                    AllEvents("pointerDrag", null),
+                    AllEvents("pointerPress", null),
+                    AllEvents("rawPointerPress", null),
+                    AllEvents("lastPress", scene.leftGameObject),
+                    AllEvents("dragging", false),
+                    AllEvents("useDragThreshold", false),
+                    AllEvents("pointerCurrentRaycast.gameObject", scene.rightGameObject),
+                    AllEvents("pointerCurrentRaycast.screenPosition", thirdScreenPosition),
+                    AllEvents("pointerPressRaycast.gameObject", scene.leftGameObject),
+                    AllEvents("pointerPressRaycast.screenPosition", firstScreenPosition),
+
+                    // PointerExit.
+                    OneEvent("type", EventType.PointerExit),
+                    OneEvent("button", PointerEventData.InputButton.Left), // PointerExit always coming from left buffer.
+                    OneEvent("pointerEnter", scene.rightGameObject), // Reset after event.
+                    OneEvent("hovered", new[] { scene.rightGameObject, scene.parentGameObject })
+                )
+            );
+
+            // Parent should have seen an exit, too. However, no PointerMove as we
+            // released the touch in a position we had already moved to.
+            Assert.That(scene.parentReceiver.events,
+                EventSequence(
+                    AllEvents("button", PointerEventData.InputButton.Left),
+                    AllEvents("pointerId", pointerId),
+                    AllEvents("position", thirdScreenPosition),
+                    AllEvents("delta", Vector2.zero),
+                    AllEvents("pressPosition", firstScreenPosition),
+                    AllEvents("clickTime", clickTime),
+                    AllEvents("clickCount", clickCount),
+                    AllEvents("pointerEnter", scene.rightGameObject),
+                    AllEvents("pointerDrag", null),
+                    AllEvents("pointerPress", null),
+                    AllEvents("rawPointerPress", null),
+                    AllEvents("lastPress", scene.leftGameObject),
+                    AllEvents("dragging", false),
+                    AllEvents("useDragThreshold", false), // We set it in OnInitializePotentialDrag.
+                    ////REVIEW: This behavior is inconsistent between "normal" pointer-enter/exit sequences but is consistent with what StandaloneInputModule does.
+                    ////        However, it seems wrong that on one path, GOs are removed one-by-one from `hovered` as the callbacks step through the hierarchy, whereas
+                    ////        on the other path, the list stays unmodified until the end and is then cleared en-bloc.
+                    AllEvents("hovered", new[] { scene.rightGameObject, scene.parentGameObject }),
+                    AllEvents("pointerCurrentRaycast.gameObject", scene.rightGameObject),
+                    AllEvents("pointerCurrentRaycast.screenPosition", thirdScreenPosition),
+                    AllEvents("pointerPressRaycast.gameObject", scene.leftGameObject),
+                    AllEvents("pointerPressRaycast.screenPosition", firstScreenPosition),
+
+                    OneEvent("type", EventType.PointerExit)
+                )
+            );
         }
     }
 
@@ -1456,6 +1453,22 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.True);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(3), Is.True);
+
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerUp).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == fifthPosition));
+        Assert.That(scene.leftChildReceiver.events, Is.Empty);
+
+        scene.eventSystem.InvokeUpdate();
+
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.True);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(3), Is.True);
 
@@ -1465,13 +1478,6 @@ internal class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == fifthPosition));
-        Assert.That(scene.rightChildReceiver.events,
-            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerUp).And
-                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
-                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
-                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
-                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == fifthPosition));
-        Assert.That(scene.leftChildReceiver.events, Is.Empty);
 
         scene.leftChildReceiver.events.Clear();
         scene.rightChildReceiver.events.Clear();
@@ -1950,6 +1956,47 @@ internal class UITests : CoreTestsFixture
                 AllEvents("clickTime", 0f)
             )
         );
+    }
+
+    // The UI input module needs to return true from IsPointerOverGameObject() for touches
+    // that have ended in the current frame. I.e. even though the touch is already concluded
+    // at the InputDevice level, the UI module needs to maintain state for one more frame.
+    //
+    // https://fogbugz.unity3d.com/f/cases/1347048/
+    [UnityTest]
+    [Category("UI")]
+    public IEnumerator UI_TouchPointersAreKeptForOneFrameAfterRelease()
+    {
+        InputSystem.AddDevice<Touchscreen>();
+
+        var scene = CreateTestUI();
+
+        var actions = ScriptableObject.CreateInstance<InputActionAsset>();
+        var uiActions = actions.AddActionMap("UI");
+        var pointAction = uiActions.AddAction("point", type: InputActionType.PassThrough, binding: "<Touchscreen>/position");
+        var clickAction = uiActions.AddAction("press", type: InputActionType.PassThrough, binding: "<Touchscreen>/press");
+
+        pointAction.Enable();
+        clickAction.Enable();
+
+        scene.uiModule.point = InputActionReference.Create(pointAction);
+        scene.uiModule.leftClick = InputActionReference.Create(clickAction);
+
+        yield return null;
+
+        BeginTouch(1, new Vector2(100, 100), queueEventOnly: true);
+        yield return null;
+
+        Assert.That(EventSystem.current.IsPointerOverGameObject(), Is.True);
+
+        EndTouch(1, new Vector2(100, 100), queueEventOnly: true);
+        yield return null;
+
+        Assert.That(EventSystem.current.IsPointerOverGameObject(), Is.True);
+
+        yield return null;
+
+        Assert.That(EventSystem.current.IsPointerOverGameObject(), Is.False);
     }
 
 #if UNITY_IOS || UNITY_TVOS

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -43,6 +43,9 @@ however, it has to be formatted properly to pass verification tests.
 ### Changed
 
 - `InputDevice.OnConfigurationChanged` can now be overridden in derived classes.
+- `InputSystemUIInputModule` now defers removing pointers for touches by one frame.
+  * This is to ensure that `IsPointerOverGameObject` can meaningfully be queried for touches that have happened within the frame &ndash; even if by the time the method is called, a touch has technically already ended ([case 1347048](https://issuetracker.unity3d.com/issues/input-system-ispointerovergameobject-returns-false-when-used-with-a-tap-interaction)).
+  * More precisely, this means that whereas before a `PointerExit` and `PointerUp` was received in the same frame, a touch will now see a `PointerUp` in the frame of release but only see a `PointerExit` in the subsequent frame.
 
 ## [1.1.0-pre.5] - 2021-05-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
@@ -86,6 +86,7 @@ namespace UnityEngine.InputSystem.UI
             stringBuilder.AppendLine("device: " + device);
             stringBuilder.AppendLine("pointerType: " + pointerType);
             stringBuilder.AppendLine("touchId: " + touchId);
+            stringBuilder.AppendLine("pressPosition: " + pressPosition);
             stringBuilder.AppendLine("trackedDevicePosition: " + trackedDevicePosition);
             stringBuilder.AppendLine("trackedDeviceOrientation: " + trackedDeviceOrientation);
             return stringBuilder.ToString();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1885,6 +1885,9 @@ namespace UnityEngine.InputSystem.UI
                     ProcessPointer(ref state);
 
                     // If it's a touch and the touch has ended, release the pointer state.
+                    // NOTE: We defer this by one frame such that OnPointerUp happens in the frame of release
+                    //       and OnPointerExit happens one frame later. This is so that IsPointerOverGameObject()
+                    //       stays true for the touch in the frame of release (see UI_TouchPointersAreKeptForOneFrameAfterRelease).
                     if (state.pointerType == UIPointerType.Touch && !state.leftButton.isPressed && !state.leftButton.wasReleasedThisFrame)
                     {
                         RemovePointerAtIndex(i);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -98,6 +98,11 @@ namespace UnityEngine.InputSystem.UI
         /// to this are touches as a <see cref="Touchscreen"/> may have multiple pointers (one for each active
         /// finger). For touch, you can use the <see cref="TouchControl.touchId"/> of the touch.
         ///
+        /// Note that for touch, a pointer will stay valid for one frame before being removed. In other words,
+        /// when <see cref="TouchPhase.Ended"/> or <see cref="TouchPhase.Canceled"/> is received for a touch
+        /// and the touch was over a <c>GameObject</c>, the associated pointer is still considered over that
+        /// object for the frame in which the touch ended.
+        ///
         /// To check whether any pointer is over a <c>GameObject</c>, simply pass a negative value such as -1.</param>
         /// <returns>True if the given pointer is currently hovering over a <c>GameObject</c>.</returns>
         /// <remarks>
@@ -298,8 +303,6 @@ namespace UnityEngine.InputSystem.UI
 
             ProcessPointerButton(ref state.middleButton, eventData);
             ProcessPointerButtonDrag(ref state.middleButton, eventData);
-
-            state.OnFrameFinished();
         }
 
         // if we are using a MultiplayerEventSystem, ignore any transforms
@@ -317,9 +320,9 @@ namespace UnityEngine.InputSystem.UI
         private void ProcessPointerMovement(ref PointerModel pointer, ExtendedPointerEventData eventData)
         {
             var currentPointerTarget =
-                // If the pointer is a touch that was released this frame, we generate pointer-exit events
+                // If the pointer is a touch that was released the *previous* frame, we generate pointer-exit events
                 // and then later remove the pointer.
-                (eventData.pointerType == UIPointerType.Touch && pointer.leftButton.wasReleasedThisFrame) ||
+                (eventData.pointerType == UIPointerType.Touch && !pointer.leftButton.isPressed && !pointer.leftButton.wasReleasedThisFrame) ||
                 (eventData.pointerType == UIPointerType.MouseOrPen && Cursor.lockState == CursorLockMode.Locked)
                 ? null
                 : eventData.pointerCurrentRaycast.gameObject;
@@ -1868,7 +1871,10 @@ namespace UnityEngine.InputSystem.UI
             }
             else
             {
+                // Navigation input.
                 ProcessNavigation(ref m_NavigationState);
+
+                // Pointer input.
                 for (var i = 0; i < m_PointerStates.length; i++)
                 {
                     ref var state = ref GetPointerStateForIndex(i);
@@ -1879,13 +1885,14 @@ namespace UnityEngine.InputSystem.UI
                     ProcessPointer(ref state);
 
                     // If it's a touch and the touch has ended, release the pointer state.
-                    // NOTE: We have no guarantee that the system reuses touch IDs so the touch ID we used
-                    //       as a pointer ID may be a one-off thing.
-                    if (state.pointerType == UIPointerType.Touch && !state.leftButton.isPressed)
+                    if (state.pointerType == UIPointerType.Touch && !state.leftButton.isPressed && !state.leftButton.wasReleasedThisFrame)
                     {
                         RemovePointerAtIndex(i);
                         --i;
+                        continue;
                     }
+
+                    state.OnFrameFinished();
                 }
             }
         }


### PR DESCRIPTION
Fixes [1347048](https://issuetracker.unity3d.com/issues/input-system-ispointerovergameobject-returns-false-when-used-with-a-tap-interaction) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1347048/)).

### Description

`InputSystemUIInputModule` creates and removes pointers for touch input on the fly. So, finger goes down, pointer is created; finger moves around, pointer is updated; finger is lifted, pointer is removed. This is different from mouse and pen input where a pointer is created for the whole device and just sticks around.

This creates a problem with `IsPointerOverGameObject()` that relies on a) a pointer being there in the first place and b) it having a state of "over GameObject".

### Changes made

Pointer removal is now simply deferred one frame. So, the `OnPointerUp` event does happen in the same frame as before but the `OnPointerExit` now happens one frame later.

### Notes

#### Potential for Regression

We now have pointer states that may "leak" into the next frame. If a platform reuses touch IDs, we may end up picking up a pointer record that before did not exist.

I believe this is not an issue. Even if a pointer record gets reused this way, the event sequence that we surface from the record should be unaffected.

#### Old Input System

I have not verified how this behaves in the old input system. I believe that in most but not all situations it would work as `StandaloneInputModule` uses `UnityEngine.Input.touches` which implicitly delays some touch endings by one frame. IIRC this only happens, however, if there's also a `Moved` in the same frame. In practice, that is likely to almost always be the case but in practice, it seems the same problem may occur with the old input system depending on frame vs input timing.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
