### PR TITLE
WebGL gamepad up/down controls were not being inverted

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed incorrect indexing in `InputUser.OnDeviceChanged` that could result in incorrect pairing of devices or `IndexOutOfRangeException` being thrown when removing, adding or reconfiguring a device. Fix contribution by [Mikael Klages](https://github.com/ITR13) in [#1359](https://github.com/Unity-Technologies/InputSystem/pull/1359).
 - Fixed incorrect indexing when sorting magnitude based on score in `InputActionRebindingExtensions.RebindingOperation` which could result in incorrect magnitudes for candidates. Contribution by [Fredrik Ludvigsen](https://github.com/steinbitglis) in [#1348](https://github.com/Unity-Technologies/InputSystem/pull/1348).
 - Fixed inconsistent ordering and execution when adding to or removing from the various callbacks in the API (such as `InputSystem.onDeviceChange` but also `InputAction.started` etc.) during the execution of a callback ([case 1322530](https://issuetracker.unity3d.com/issues/inputsystems-events-are-not-called-the-order-they-were-added-when-they-are-modified-in-the-middle-of-the-call-by-other-listener).
+- Fixed inconsistent behavior of WebGL gamepad left/right stick. Up/Down controls were reverse of X/Y controls. ([case 1348959](https://fogbugz.unity3d.com/f/cases/1348959))
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLGamepad.cs
@@ -19,7 +19,11 @@ namespace UnityEngine.InputSystem.WebGL.LowLevel
         [InputControl(name = "leftStick", offset = 0)]
         [InputControl(name = "rightStick", offset = 8)]
         [InputControl(name = "leftStick/y", parameters = "invert")]
+        [InputControl(name = "leftStick/up", parameters = "invert")]
+        [InputControl(name = "leftStick/down", parameters = "invert=false")]
         [InputControl(name = "rightStick/y", parameters = "invert")]
+        [InputControl(name = "rightStick/up", parameters = "invert")]
+        [InputControl(name = "rightStick/down", parameters = "invert=false")]
         // All the buttons we need to bump from single bits to full floats and reset bit offsets.
         [InputControl(name = "buttonSouth", offset = ButtonOffset + 0 * 4, bit = 0, format = "FLT")]
         [InputControl(name = "buttonEast", offset = ButtonOffset + 1 * 4, bit = 0, format = "FLT")]


### PR DESCRIPTION


### Description

Because the up/down controls were not being inverted for WebGL, a composite up/down/left/right binding of the gamepad leftStick had reverse behavior as a direct x/y binding of the leftStick. Adding the invert property to the WebGL gamepad sticks ensures they have consistent behavior.

### Changes made

Added the invert property to the leftStick/up, leftStick/down, rightStick/up, and rightStick/down, using the DualShockGamepadHID as an example.

### Notes

This change will need to be backported to the other supported versions of the package.

