### PR TITLE
Compressing mouse move events (partially fixing 1281266)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4212,7 +4212,7 @@ partial class CoreTests
         InputSystem.RemoveDevice(pointer);
         Assert.That(Pointer.current, Is.EqualTo(mouse));
     }
-    
+
     [Test]
     [Category("Devices")]
     [TestCase(false)]
@@ -4221,12 +4221,12 @@ partial class CoreTests
     {
         InputSystem.settings.disableMouseMoveCompression = disableMouseMoveCompression;
         var mouse = InputSystem.AddDevice<Mouse>();
-        
+
         using (var trace = new InputEventTrace(mouse))
         {
             trace.Enable();
             Assert.That(trace.enabled, Is.True);
-            
+
             InputSystem.QueueStateEvent(mouse,
                 new MouseState
                 {
@@ -4257,8 +4257,8 @@ partial class CoreTests
             // first event is always preserved as-is
             {
                 var index = 0;
-                
-                Assert.That(events[index].type, Is.EqualTo((FourCC) StateEvent.Type));
+
+                Assert.That(events[index].type, Is.EqualTo((FourCC)StateEvent.Type));
                 Assert.That(events[index].deviceId, Is.EqualTo(mouse.deviceId));
                 Assert.That(events[index].time, Is.EqualTo(1).Within(0.000001));
                 Assert.That(events[index].sizeInBytes, Is.EqualTo(StateEvent.GetEventSizeWithPayload<MouseState>()));
@@ -4272,8 +4272,8 @@ partial class CoreTests
             if (disableMouseMoveCompression)
             {
                 var index = 1;
-                
-                Assert.That(events[index].type, Is.EqualTo((FourCC) StateEvent.Type));
+
+                Assert.That(events[index].type, Is.EqualTo((FourCC)StateEvent.Type));
                 Assert.That(events[index].deviceId, Is.EqualTo(mouse.deviceId));
                 Assert.That(events[index].time, Is.EqualTo(2).Within(0.000001));
                 Assert.That(events[index].sizeInBytes, Is.EqualTo(StateEvent.GetEventSizeWithPayload<MouseState>()));
@@ -4287,7 +4287,7 @@ partial class CoreTests
             {
                 var index = disableMouseMoveCompression ? 2 : 1;
 
-                Assert.That(events[index].type, Is.EqualTo((FourCC) StateEvent.Type));
+                Assert.That(events[index].type, Is.EqualTo((FourCC)StateEvent.Type));
                 Assert.That(events[index].deviceId, Is.EqualTo(mouse.deviceId));
                 Assert.That(events[index].time, Is.EqualTo(3).Within(0.000001));
                 Assert.That(events[index].sizeInBytes, Is.EqualTo(StateEvent.GetEventSizeWithPayload<MouseState>()));

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -31,6 +31,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed inconsistent behavior of WebGL gamepad left/right stick. Up/Down controls were reverse of X/Y controls. ([case 1348959](https://fogbugz.unity3d.com/f/cases/1348959))
 - Fixed `PlayerInputManager`s join action not triggering when using a referenced `InputAction` ([case 1260625](https://issuetracker.unity3d.com/issues/input-system-player-input-managers-join-action-is-not-triggered-when-using-a-referenced-input-action)).
 - Fixed UI issue where pressing the wrong button was possible while quickly moving through a UI because the submit action fired on action press instead of action release ([1333563](https://issuetracker.unity3d.com/issues/input-submit-action-is-called-on-release-rather-than-on-press-when-using-enter-key)).
+- Partially fixed performance issues with high frequency mice by compressing consecutive mouse move events together. Set `InputSystem.settings.disableMouseMoveCompression` to `true` if you want to keep receiving all mouse events ([case 1281266](https://issuetracker.unity3d.com/issues/many-input-events-when-using-1000hz-mouse)).
+
 
 #### Actions
 
@@ -50,6 +52,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 
 - Added `InputSystem.runUpdatesInEditMode` to enable processing of non-editor updates without entering playmode (only available for XR).
+- Added bursted job to compress compressing consecutive mouse move events together. If you observe any issues with burst, please set `UNITY_INPUT_SYSTEM_DO_NOT_USE_BURST` define to disable all burst usage.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -33,7 +33,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed UI issue where pressing the wrong button was possible while quickly moving through a UI because the submit action fired on action press instead of action release ([1333563](https://issuetracker.unity3d.com/issues/input-submit-action-is-called-on-release-rather-than-on-press-when-using-enter-key)).
 - Partially fixed performance issues with high frequency mice by compressing consecutive mouse move events together. Set `InputSystem.settings.disableMouseMoveCompression` to `true` if you want to keep receiving all mouse events ([case 1281266](https://issuetracker.unity3d.com/issues/many-input-events-when-using-1000hz-mouse)).
 
-
 #### Actions
 
 - Fixed right-clicking in empty action map or action list not popping up context menu ([case 1336426](https://issuetracker.unity3d.com/issues/cant-open-drop-down-menu-when-hovering-over-free-space-in-input-action)).
@@ -52,7 +51,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 
 - Added `InputSystem.runUpdatesInEditMode` to enable processing of non-editor updates without entering playmode (only available for XR).
-- Added bursted job to compress compressing consecutive mouse move events together. If you observe any issues with burst, please set `UNITY_INPUT_SYSTEM_DO_NOT_USE_BURST` define to disable all burst usage.
+- Added bursted job to compress consecutive mouse move events together. If you observe any issues with burst, please set `UNITY_INPUT_SYSTEM_DO_NOT_USE_BURST` define to disable all burst usage.
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/CompressMouseMoveEvents.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/CompressMouseMoveEvents.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
+using Unity.Jobs;
+using Unity.Profiling;
+using UnityEngine.InputSystem.LowLevel;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+#if !UNITY_INPUT_SYSTEM_DO_NOT_USE_BURST
+using Unity.Burst;
+#endif
+
+namespace UnityEngine.InputSystem
+{
+    // Utility to merges consecutive mouse move events into one.
+    // It operates directly on event buffer and does all modification in-place. It can only shrink event buffer.
+    // Use this define to completely disable any burst stuff, might be helpful if there are any issues with it.
+#if !UNITY_INPUT_SYSTEM_DO_NOT_USE_BURST
+    [BurstCompile(CompileSynchronously = true)]
+#endif
+    internal unsafe struct CompressMouseMoveEvents : IJob
+    {
+        private static ProfilerMarker s_ProfilerMarker = new ProfilerMarker("CompressMouseMoveEvents");
+
+        public static void ProcessEvents(InputUpdateType updateType, double processUntilTimestamp,
+            ref InputEventBuffer events)
+        {
+            using (s_ProfilerMarker.Auto())
+            {
+#if UNITY_EDITOR
+                // There are currently a few problems with our native callback from editor update loop:
+                // - Burst compilation is not very happy, it fails to reliably replace managed job with bursted job.
+                // - Temp allocator guard scope is missing in native, so it might leak, this also could be potentially true if we run a job on main thread.
+                if (!EditorApplication.isPlaying || updateType == InputUpdateType.Editor)
+                    return;
+#endif
+
+                if (events.sizeInBytes == 0 || events.sizeInBytes == InputEventBuffer.BufferSizeUnknown)
+                    return;
+
+                var resultEventCount = 0;
+                var resultEventSizeInBytes = 0L;
+
+                new CompressMouseMoveEvents
+                {
+                    updateType = updateType,
+                    processUntilTimestamp = processUntilTimestamp,
+                    eventPtr = events.bufferPtr.ToPointer(),
+                    eventCount = events.eventCount,
+                    eventSizeInBytes = events.sizeInBytes,
+                    resultEventCount = &resultEventCount,
+                    resultEventSizeInBytes = &resultEventSizeInBytes
+                }.Run();
+
+                events.Shrink(resultEventCount, resultEventSizeInBytes);
+            }
+        }
+
+        public InputUpdateType updateType;
+        public double processUntilTimestamp;
+
+        [NativeDisableUnsafePtrRestriction] public InputEvent* eventPtr;
+
+        public int eventCount;
+        public long eventSizeInBytes;
+
+        // Job fields are copied, so to read results back from a job we need to write to a pointer.
+        [NativeDisableUnsafePtrRestriction] public int* resultEventCount;
+        [NativeDisableUnsafePtrRestriction] public long* resultEventSizeInBytes;
+
+        public void Execute()
+        {
+            // Write down no-op results now.
+            *resultEventCount = eventCount;
+            *resultEventSizeInBytes = eventSizeInBytes;
+
+            // Step 1: early out if any mouse event is propagated via delta state event.
+            // It's a bit involved to support compression of delta state events,
+            // and given that no backend sends mouse delta events today it's probably safe to early out.
+            // Also calculate correct event count for fixed update.
+            var currentEvent = eventPtr;
+            var eventPtrs = new NativeArray<IntPtr>(eventCount + 1, Allocator.Temp);
+            var eventToProcessCount = eventCount;
+            for (var i = 0; i < eventCount; ++i)
+            {
+                eventPtrs[i] = (IntPtr) currentEvent;
+
+                if (currentEvent->type == DeltaStateEvent.Type)
+                {
+                    var stateEvent = DeltaStateEvent.FromUnchecked(currentEvent);
+                    if (stateEvent->stateFormat == MouseState.Format)
+                        return;
+                }
+
+                currentEvent = InputEvent.GetNextInMemory(currentEvent);
+
+                if (updateType == InputUpdateType.Fixed && currentEvent->internalTime >= processUntilTimestamp)
+                {
+                    eventToProcessCount = i;
+                    break;
+                }
+            }
+            eventPtrs[eventToProcessCount] = (IntPtr) currentEvent; // Remember the end pointer, will make life easier later.
+
+            // Step 2: compress move events in-place, mark redundant events for skipping 
+            NativeMouseStateBurstFriendly* previousState = null;
+            var previousStateIndex = 0;
+            var skipEvent = new NativeArray<bool>(eventToProcessCount, Allocator.Temp);
+            currentEvent = eventPtr;
+            var skipFirstOne = true;
+            for (var i = 0; i < eventToProcessCount; ++i)
+            {
+                NativeMouseStateBurstFriendly* currentState = null;
+
+                // Find if current event is mouse state event.
+                if (currentEvent->type == StateEvent.Type)
+                {
+                    var stateEvent = StateEvent.FromUnchecked(currentEvent);
+                    if (stateEvent->stateFormat == MouseState.Format)
+                    {
+                        currentState = (NativeMouseStateBurstFriendly*) stateEvent->state;
+                    }
+                }
+
+                if (currentState != null)
+                {
+                    // If buttons and other states stay the same,
+                    // modify current event in-place and mark previous one for skipping.
+                    if (previousState != null &&
+                        currentState->buttons == previousState->buttons &&
+                        currentState->displayIndex == previousState->displayIndex &&
+                        currentState->clickCount == previousState->clickCount)
+                    {
+                        currentState->delta += previousState->delta;
+                        currentState->scroll += previousState->scroll;
+                        skipEvent[previousStateIndex] = true;
+                    }
+
+                    if (skipFirstOne)
+                    {
+                        // Skip first one so we don't need to track device state.
+                        // For example imagine we have two frames:
+                        // - First frame, one event, button not pressed, delta x is 5
+                        //   t=1,left_btn=0,dx=5
+                        // - Second frame, three events, in first one button gets pressed, second and third are just move events.
+                        //   t=2,left_btn=1,dx=10   t=3,left_btn=1,dx=20   t=4,left_btn=1,dx=30
+                        // If we would not skip first event in second frame it would get merged with second and third events to make:
+                        //                                                 t=4,left_btn=1,dx=60
+                        // So now if we have a button action on left button it would trigger on timestamp=4 instead of timestamp=2.
+                        // Which is suboptimal because we pretend like mouse press was happening much later in time.
+                        // A more robust way would be to read device state and compare to that, but that's involves too much poking and device tracking.
+                        // A compromise is to always preserve first event and base from it, so we will end up with: 
+                        //   t=2,left_btn=1,dx=10                          t=4,left_btn=1,dx=50
+                        // This way any potential mouse press/release/etc will be correctly reported, and the rest of events compressed.
+                        // Paying price of one event for this simplicity is a reasonable tradeoff at this point.
+                        skipFirstOne = false;
+                    }
+                    else
+                    {
+                        // Remember current mouse state event
+                        previousState = currentState;
+                        previousStateIndex = i;
+                    }
+                }
+                else
+                {
+                    // Stop compression if we have anything else. This is important to catch hidden data dependencies.
+                    // For example let's say we have one button composite of mouse position and ctrl key:
+                    // t=1,dx=10 t=2,ctrl=1 t=3,dx=20 t=4,ctrl=0 t=5,dx=30
+                    // If we would compress all mouse move events together we will get:
+                    //           t=2,ctrl=1           t=4,ctrl=0 t=5,dx=60
+                    // And look there are no movement of mouse during ctrl being pressed.
+                    // To fix this we stop compression if any other event is present in the buffer, and we will get:
+                    // t=1,dx=10 t=2,ctrl=1 t=3,dx=20 t=4,ctrl=0 t=5,dx=30
+                    // E.g. no compression will take place here.
+                    // This is over conservative because we're lacking data to understand if events have dependency or not.
+                    previousState = null;
+                    previousStateIndex = 0;
+                }
+
+                currentEvent = InputEvent.GetNextInMemory(currentEvent);
+            }
+
+            // Step 3: move data around, think about it as RLE encoding of sorts.
+            for (var i = 0; i < eventToProcessCount;)
+            {
+                if (!skipEvent[i])
+                {
+                    i++;
+                    continue;
+                }
+
+                // Let's say we have event buffer of 11 events, where p is for preserve, s is for skip:
+                //   0123456789a
+                //   pppssssppps
+                // We end up in this line with i = 3.
+                // Then toSkip will be 4 and toMove = 3.
+                // So we gonna have dst, src and next as following:
+                //   0123456789a
+                //   pppssssppps
+                //   ---^---^--^
+                // Then we jump and i becomes 10. 
+
+                // find how many events to skip first
+                var toSkip = 1;
+                for (var j = i + 1; j < eventToProcessCount; ++j)
+                {
+                    if (!skipEvent[j])
+                        break;
+                    toSkip++;
+                }
+
+                // find how much data we need to move
+                var toMove = 0;
+                for (var j = i + toSkip; j < eventToProcessCount; ++j)
+                {
+                    if (skipEvent[j])
+                        break;
+                    toMove++;
+                }
+
+                // do the actual moving
+                var dst = (byte*) eventPtrs[i];
+                var src = (byte*) eventPtrs[i + toSkip];
+                var next = (byte*) eventPtrs[i + toSkip + toMove];
+                var skipLength = src - dst;
+                var moveLength = next - src;
+                if (moveLength > 0)
+                    UnsafeUtility.MemMove(dst, src, moveLength);
+
+                // decrease amount of events and bytes
+                *resultEventCount -= toSkip;
+                *resultEventSizeInBytes -= skipLength;
+
+                // skip ahead of two sections
+                i += toSkip + toMove;
+            }
+
+            skipEvent.Dispose();
+            eventPtrs.Dispose();
+        }
+
+        // should be 30
+        [StructLayout(LayoutKind.Explicit, Size = 32)]
+        private struct NativeMouseStateBurstFriendly
+        {
+            [FieldOffset(0)] public Vector2 position;
+            [FieldOffset(8)] public Vector2 delta;
+            [FieldOffset(16)] public Vector2 scroll;
+            [FieldOffset(24)] public ushort buttons;
+            [FieldOffset(26)] public ushort displayIndex; // unused
+            [FieldOffset(28)] public ushort clickCount; // unused
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Events/CompressMouseMoveEvents.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/CompressMouseMoveEvents.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
@@ -85,7 +85,7 @@ namespace UnityEngine.InputSystem
             var eventToProcessCount = eventCount;
             for (var i = 0; i < eventCount; ++i)
             {
-                eventPtrs[i] = (IntPtr) currentEvent;
+                eventPtrs[i] = (IntPtr)currentEvent;
 
                 if (currentEvent->type == DeltaStateEvent.Type)
                 {
@@ -102,9 +102,9 @@ namespace UnityEngine.InputSystem
                     break;
                 }
             }
-            eventPtrs[eventToProcessCount] = (IntPtr) currentEvent; // Remember the end pointer, will make life easier later.
+            eventPtrs[eventToProcessCount] = (IntPtr)currentEvent;  // Remember the end pointer, will make life easier later.
 
-            // Step 2: compress move events in-place, mark redundant events for skipping 
+            // Step 2: compress move events in-place, mark redundant events for skipping
             NativeMouseStateBurstFriendly* previousState = null;
             var previousStateIndex = 0;
             var skipEvent = new NativeArray<bool>(eventToProcessCount, Allocator.Temp);
@@ -120,7 +120,7 @@ namespace UnityEngine.InputSystem
                     var stateEvent = StateEvent.FromUnchecked(currentEvent);
                     if (stateEvent->stateFormat == MouseState.Format)
                     {
-                        currentState = (NativeMouseStateBurstFriendly*) stateEvent->state;
+                        currentState = (NativeMouseStateBurstFriendly*)stateEvent->state;
                     }
                 }
 
@@ -151,7 +151,7 @@ namespace UnityEngine.InputSystem
                         // So now if we have a button action on left button it would trigger on timestamp=4 instead of timestamp=2.
                         // Which is suboptimal because we pretend like mouse press was happening much later in time.
                         // A more robust way would be to read device state and compare to that, but that's involves too much poking and device tracking.
-                        // A compromise is to always preserve first event and base from it, so we will end up with: 
+                        // A compromise is to always preserve first event and base from it, so we will end up with:
                         //   t=2,left_btn=1,dx=10                          t=4,left_btn=1,dx=50
                         // This way any potential mouse press/release/etc will be correctly reported, and the rest of events compressed.
                         // Paying price of one event for this simplicity is a reasonable tradeoff at this point.
@@ -201,7 +201,7 @@ namespace UnityEngine.InputSystem
                 //   0123456789a
                 //   pppssssppps
                 //   ---^---^--^
-                // Then we jump and i becomes 10. 
+                // Then we jump and i becomes 10.
 
                 // find how many events to skip first
                 var toSkip = 1;
@@ -222,9 +222,9 @@ namespace UnityEngine.InputSystem
                 }
 
                 // do the actual moving
-                var dst = (byte*) eventPtrs[i];
-                var src = (byte*) eventPtrs[i + toSkip];
-                var next = (byte*) eventPtrs[i + toSkip + toMove];
+                var dst = (byte*)eventPtrs[i];
+                var src = (byte*)eventPtrs[i + toSkip];
+                var next = (byte*)eventPtrs[i + toSkip + toMove];
                 var skipLength = src - dst;
                 var moveLength = next - src;
                 if (moveLength > 0)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/CompressMouseMoveEvents.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/CompressMouseMoveEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dc1c1b599a3616a48b976eeb2f7caf98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
@@ -13,10 +13,12 @@ namespace UnityEngine.InputSystem.LowLevel
     /// Avoids having to send a full state memory snapshot when only a small
     /// part of the state has changed.
     /// </remarks>
-    [StructLayout(LayoutKind.Explicit, Pack = 1, Size = InputEvent.kBaseEventSize + 9)]
+    [StructLayout(LayoutKind.Explicit, Size = 32 /* make burst happy InputEvent.kBaseEventSize + 9 */)]
     public unsafe struct DeltaStateEvent : IInputEventTypeInfo
     {
         public const int Type = 0x444C5441; // 'DLTA'
+        
+        internal const int kDeltaStateEventSize = InputEvent.kBaseEventSize + sizeof(int) + sizeof(uint);
 
         [FieldOffset(0)]
         public InputEvent baseEvent;
@@ -30,7 +32,7 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(InputEvent.kBaseEventSize + 8)]
         internal fixed byte stateData[1]; // Variable-sized.
 
-        public uint deltaStateSizeInBytes => baseEvent.sizeInBytes - (InputEvent.kBaseEventSize + 8);
+        public uint deltaStateSizeInBytes => baseEvent.sizeInBytes - kDeltaStateEventSize;
 
         public void* deltaState
         {
@@ -86,7 +88,7 @@ namespace UnityEngine.InputSystem.LowLevel
             stateSize += controlStateBlock.bitOffset / 8;
             var stateOffset = controlStateBlock.byteOffset;
             var statePtr = (byte*)control.currentStatePtr + (int)stateOffset;
-            var eventSize = InputEvent.kBaseEventSize + sizeof(int) * 2 + stateSize;
+            var eventSize = kDeltaStateEventSize + stateSize;
 
             var buffer = new NativeArray<byte>((int)eventSize, allocator);
             var stateEventPtr = (DeltaStateEvent*)buffer.GetUnsafePtr();

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeltaStateEvent.cs
@@ -17,7 +17,7 @@ namespace UnityEngine.InputSystem.LowLevel
     public unsafe struct DeltaStateEvent : IInputEventTypeInfo
     {
         public const int Type = 0x444C5441; // 'DLTA'
-        
+
         internal const int kDeltaStateEventSize = InputEvent.kBaseEventSize + sizeof(int) + sizeof(uint);
 
         [FieldOffset(0)]

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -53,13 +53,13 @@ namespace UnityEngine.InputSystem.LowLevel
     /// </remarks>
     /// <seealso cref="InputEventPtr"/>
     // NOTE: This has to be layout compatible with native events.
-    [StructLayout(LayoutKind.Explicit, Size = kBaseEventSize, Pack = 1)]
+    [StructLayout(LayoutKind.Explicit, Size = kBaseEventSize)]
     public struct InputEvent
     {
         private const uint kHandledMask = 0x80000000;
         private const uint kIdMask = 0x7FFFFFFF;
 
-        internal const int kBaseEventSize = NativeInputEvent.structSize;
+        internal const int kBaseEventSize = NativeInputEventBurstFriendly.structSize;
 
         /// <summary>
         /// Default, invalid value for <see cref="eventId"/>. Upon being queued with
@@ -70,7 +70,23 @@ namespace UnityEngine.InputSystem.LowLevel
         internal const int kAlignment = 4;
 
         [FieldOffset(0)]
-        private NativeInputEvent m_Event;
+        private NativeInputEventBurstFriendly m_Event;
+        
+        [StructLayout(LayoutKind.Explicit, Size = 24 /* make burst happy */ )]
+        internal struct NativeInputEventBurstFriendly
+        {
+            public const int structSize = 20;
+            [FieldOffset(0)]
+            public NativeInputEventType type;
+            [FieldOffset(4)]
+            public ushort sizeInBytes;
+            [FieldOffset(6)]
+            public ushort deviceId;
+            [FieldOffset(8)]
+            public double time;
+            [FieldOffset(16)]
+            public int eventId;
+        }
 
         /// <summary>
         /// Type code for the event.

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -71,8 +71,8 @@ namespace UnityEngine.InputSystem.LowLevel
 
         [FieldOffset(0)]
         private NativeInputEventBurstFriendly m_Event;
-        
-        [StructLayout(LayoutKind.Explicit, Size = 24 /* make burst happy */ )]
+
+        [StructLayout(LayoutKind.Explicit, Size = 24 /* make burst happy */)]
         internal struct NativeInputEventBurstFriendly
         {
             public const int structSize = 20;

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventBuffer.cs
@@ -322,6 +322,12 @@ namespace UnityEngine.InputSystem.LowLevel
             --numRemainingEvents;
         }
 
+        internal void Shrink(int newEventsCount, long newSizeInBytes)
+        {
+            m_EventCount = newEventsCount;
+            m_SizeInBytes = newSizeInBytes;
+        }
+
         public IEnumerator<InputEventPtr> GetEnumerator()
         {
             return new Enumerator(this);

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -779,7 +779,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 {
                     type = FrameMarkerEvent,
                     internalTime = InputRuntime.s_Instance.currentTime,
-                    sizeInBytes = (uint)UnsafeUtility.SizeOf<InputEvent>()
+                    sizeInBytes = InputEvent.kBaseEventSize
                 };
 
                 OnInputEvent(new InputEventPtr((InputEvent*)UnsafeUtility.AddressOf(ref frameMarkerEvent)), null);

--- a/Packages/com.unity.inputsystem/InputSystem/Events/StateEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/StateEvent.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.LowLevel
     public unsafe struct StateEvent : IInputEventTypeInfo
     {
         public const int Type = 0x53544154; // 'STAT'
-        
+
         internal const int kStateEventSize = InputEvent.kBaseEventSize + sizeof(int);
 
         [FieldOffset(0)]

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2556,6 +2556,20 @@ namespace UnityEngine.InputSystem
                 m_HaveSentStartupAnalytics = true;
             }
             #endif
+            
+            // See if we're supposed to only take events up to a certain time.
+            // NOTE: We do not require the events in the queue to be sorted. Instead, we will walk over
+            //       all events in the buffer each time. Note that if there are multiple events for the same
+            //       device, it depends on the producer of these events to queue them in correct order.
+            //       Otherwise, once an event with a newer timestamp has been processed, events coming later
+            //       in the buffer and having older timestamps will get rejected.
+
+            var currentTime = updateType == InputUpdateType.Fixed ? m_Runtime.currentTimeForFixedUpdate : m_Runtime.currentTime;
+            var timesliceEvents = shouldProcessInputEvents && InputSystem.settings.updateMode == InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
+            
+            // mouse move compression will modify event buffer in-place
+            if (!settings.disableMouseMoveCompression)
+                CompressMouseMoveEvents.ProcessEvents(updateType, timesliceEvents ? currentTime : -1.0f, ref eventBuffer);
 
             ////TODO: manual mode must be treated like lockInputToGameView in editor
 
@@ -2573,16 +2587,6 @@ namespace UnityEngine.InputSystem
             InputStateBuffers.SwitchTo(m_StateBuffers, updateType);
 
             InputUpdate.OnUpdate(updateType);
-
-            // See if we're supposed to only take events up to a certain time.
-            // NOTE: We do not require the events in the queue to be sorted. Instead, we will walk over
-            //       all events in the buffer each time. Note that if there are multiple events for the same
-            //       device, it depends on the producer of these events to queue them in correct order.
-            //       Otherwise, once an event with a newer timestamp has been processed, events coming later
-            //       in the buffer and having older timestamps will get rejected.
-
-            var currentTime = updateType == InputUpdateType.Fixed ? m_Runtime.currentTimeForFixedUpdate : m_Runtime.currentTime;
-            var timesliceEvents = shouldProcessInputEvents && InputSystem.settings.updateMode == InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
 
             // Early out if there's no events to process.
             if (eventBuffer.eventCount <= 0)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2556,7 +2556,7 @@ namespace UnityEngine.InputSystem
                 m_HaveSentStartupAnalytics = true;
             }
             #endif
-            
+
             // See if we're supposed to only take events up to a certain time.
             // NOTE: We do not require the events in the queue to be sorted. Instead, we will walk over
             //       all events in the buffer each time. Note that if there are multiple events for the same
@@ -2566,7 +2566,7 @@ namespace UnityEngine.InputSystem
 
             var currentTime = updateType == InputUpdateType.Fixed ? m_Runtime.currentTimeForFixedUpdate : m_Runtime.currentTime;
             var timesliceEvents = shouldProcessInputEvents && InputSystem.settings.updateMode == InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
-            
+
             // mouse move compression will modify event buffer in-place
             if (!settings.disableMouseMoveCompression)
                 CompressMouseMoveEvents.ProcessEvents(updateType, timesliceEvents ? currentTime : -1.0f, ref eventBuffer);

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -470,6 +470,22 @@ namespace UnityEngine.InputSystem
                 OnChange();
             }
         }
+        
+        /// <summary>
+        /// Disables mouse move compression. Disable it if you want to get all mouse move events.
+        /// </summary>
+        public bool disableMouseMoveCompression
+        {
+            get => m_DisableMouseMoveCompression;
+            set
+            {
+                if (m_DisableMouseMoveCompression == value)
+                    return;
+
+                m_DisableMouseMoveCompression = value;
+                OnChange();
+            }
+        }
 
         /// <summary>
         /// List of device layouts used by the project.
@@ -541,6 +557,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_DefaultHoldTime = 0.4f;
         [SerializeField] private float m_TapRadius = 5;
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
+        [SerializeField] private bool m_DisableMouseMoveCompression = false;
 
         internal void OnChange()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -470,7 +470,7 @@ namespace UnityEngine.InputSystem
                 OnChange();
             }
         }
-        
+
         /// <summary>
         /// Disables mouse move compression. Disable it if you want to get all mouse move events.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2404,7 +2404,7 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentException(
                     $"Size of '{typeof(TState).Name}' exceeds maximum supported state size of {StateEventBuffer.kMaxSize}",
                     nameof(state));
-            var eventSize = UnsafeUtility.SizeOf<StateEvent>() + stateSize - StateEvent.kStateDataSizeToSubtract;
+            var eventSize = StateEvent.kStateEventSize + stateSize;
 
             if (time < 0)
                 time = InputRuntime.s_Instance.currentTime;
@@ -2475,7 +2475,7 @@ namespace UnityEngine.InputSystem
                     $"Size {deltaSize} of delta state of type {typeof(TDelta).Name} provided for control '{control}' does not match size {control.stateBlock.alignedSizeInBytes} of control",
                     nameof(delta));
 
-            var eventSize = UnsafeUtility.SizeOf<DeltaStateEvent>() + deltaSize - 1;
+            var eventSize = DeltaStateEvent.kDeltaStateEventSize + deltaSize;
 
             DeltaStateEventBuffer eventBuffer;
             eventBuffer.stateEvent =

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -1,7 +1,8 @@
 {
     "name": "Unity.InputSystem",
     "references": [
-        "Unity.ugui"
+        "Unity.ugui",
+        "Unity.Burst"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -15,6 +15,7 @@
 		"xr"
 	],
 	"dependencies" : {
+		"com.unity.burst": "1.5.4",
 		"com.unity.modules.uielements": "1.0.0"
 	}
 }


### PR DESCRIPTION
### Description

When using high frequency mouse too many move events are generated for us to handle, so processing time explodes to 1-2+ms (100+ms in worst cases).

### Changes made

This change _partially_ fixes the problem by combining all consecutive mouse move state events into the last one of them. This way if you have 100 mouse move events only last one will be present for rest of the code to process (move/scroll delta's are accumulated).

It accomplishes them by running event buffer through a utility bursted job that modifies states in place. Code comments hopefully contain enough information about specifics of the algorithm.

Due to us using burst for the first time I made escape hatches to completely bypass this change from user side just in case.

### Notes

- This change achieves approx 20x speedup, but cost of running a job is non zero, so speedup might be negligible or absent in some cases.

- If any mouse delta state events are present I currently disable the compression because it's tricky to support them when we modify data in-place (we can only shrink the buffer, never grow). None of real backends are using mouse delta state events, but our test fixture uses them quite a bit.
