### PR TITLE
Fixed wrong DisplayStringFormat for TwoModifiersComposite

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/TwoModifiersComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/TwoModifiersComposite.cs
@@ -56,7 +56,7 @@ namespace UnityEngine.InputSystem.Composites
     /// </remarks>
     /// <seealso cref="OneModifierComposite"/>
     [Preserve]
-    [DisplayStringFormat("{modifier1}+{modifier2}+{button}")]
+    [DisplayStringFormat("{modifier1}+{modifier2}+{binding}")]
     [DisplayName("Binding With Two Modifiers")]
     public class TwoModifiersComposite : InputBindingComposite
     {


### PR DESCRIPTION
### Description
Calling `InputAction.GetBindingDisplayString(int)`  for composite binding of type `TwoModifiersComposite` returned a string without the binding key.

Repro:
1. Example setup:
![image](https://user-images.githubusercontent.com/2332996/126037651-d1d5d780-6f73-49b4-b31b-e28a1dc981ea.png)
2. Now call `action.GetBindingDisplayString(1)` 

Result: the returned string is "_Control+Alt+_" instead of "_Control+Alt+T_"

### Changes made
Updated the DisplayStringFormat attribute of the TwoModifiersComposite class with the correct template:
From: _"{modifier1}+{modifier2}+{button}"_
To: _"{modifier1}+{modifier2}+{binding}"_

### Notes
I assumed that the "{binding}" is the correct format as the `OneModifierComposite` format works fine. On the other hand `ButtonWithOneModifier` and `ButtonWithTwoModifier` use the "{button}" format.
Haven't checked the other attributes as I don't know how and where the part-bindings get their names from (probably generated in the .inputasset).

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
