### PR TITLE
Fix change binding indices

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -1347,13 +1347,13 @@ internal partial class CoreTests
     {
         var actionMap = new InputActionMap();
         var action = actionMap.AddAction("action1");
-        actionMap.AddBinding("/keyboard/a", action); // 0
-        actionMap.AddBinding("/keyboard/b", action); // 1
+        actionMap.AddBinding("<Keyboard>/a", action); // 0
+        actionMap.AddBinding("<Keyboard>/b", action); // 1
 
         Assert.AreEqual(0, actionMap.FindBinding(new InputBinding(), out _)); // match anything
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("/keyboard/a"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/b"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/b"), out _)); // not found
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("<Keyboard>/a"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _)); // not found
     }
 
     [Test]
@@ -1362,10 +1362,10 @@ internal partial class CoreTests
     {
         var actionMap = new InputActionMap();
         var action = actionMap.AddAction("action1");
-        actionMap.AddBinding("/keyboard/a", action); // 0
-        actionMap.AddBinding("/keyboard/b", action); // 1
+        actionMap.AddBinding("<Keyboard>/a", action); // 0
+        actionMap.AddBinding("<Keyboard>/b", action); // 1
 
-        Assert.AreEqual(-1, actionMap.FindBinding(new InputBinding("/keyboard/c"), out _)); // not found
+        Assert.AreEqual(-1, actionMap.FindBinding(new InputBinding("<Keyboard>/c"), out _)); // not found
     }
 
     [Test]
@@ -1376,17 +1376,17 @@ internal partial class CoreTests
         var firstActionInMap = actionMap.AddAction("action1");
         var secondActionInMap = actionMap.AddAction("action2");
 
-        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
-        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
-        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
-        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
-        actionMap.AddBinding("/keyboard/e", secondActionInMap); // second, 2
+        actionMap.AddBinding("<Keyboard>/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("<Keyboard>/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("<Keyboard>/e", secondActionInMap); // second, 2
 
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("/keyboard/a"), out _)); // exact match
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("/keyboard/b"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/c"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/d"), out _)); // exact match
-        Assert.AreEqual(2, actionMap.FindBinding(new InputBinding("/keyboard/e"), out _)); // exact match
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("<Keyboard>/a"), out _)); // exact match
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/c"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/d"), out _)); // exact match
+        Assert.AreEqual(2, actionMap.FindBinding(new InputBinding("<Keyboard>/e"), out _)); // exact match
     }
 
     [Test]
@@ -1397,12 +1397,12 @@ internal partial class CoreTests
         var firstActionInMap = actionMap.AddAction("action1");
         var secondActionInMap = actionMap.AddAction("action2");
 
-        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
-        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
-        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
-        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("<Keyboard>/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("<Keyboard>/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
 
-        Assert.AreEqual(-1, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/q"))); // exact match
+        Assert.AreEqual(-1, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/q"))); // exact match
     }
 
     [Test]
@@ -1413,10 +1413,10 @@ internal partial class CoreTests
         var firstActionInMap = actionMap.AddAction("action1");
         var secondActionInMap = actionMap.AddAction("action2");
 
-        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
-        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
-        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
-        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("<Keyboard>/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("<Keyboard>/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
 
         Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding())); // unconditional
     }
@@ -1429,16 +1429,36 @@ internal partial class CoreTests
         var firstActionInMap = actionMap.AddAction("action1");
         var secondActionInMap = actionMap.AddAction("action2");
 
-        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
-        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
-        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
-        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
-        actionMap.AddBinding("/keyboard/e", secondActionInMap); // second, 2
+        actionMap.AddBinding("<Keyboard>/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("<Keyboard>/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("<Keyboard>/e", secondActionInMap); // second, 2
 
-        Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/a"))); // exact match
-        Assert.AreEqual(1, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/b"))); // exact match
-        Assert.AreEqual(2, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/c"))); // exact match
-        Assert.AreEqual(3, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/d"))); // exact match
-        Assert.AreEqual(4, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/e"))); // exact match
+        Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/a"))); // exact match
+        Assert.AreEqual(1, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/b"))); // exact match
+        Assert.AreEqual(2, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/c"))); // exact match
+        Assert.AreEqual(3, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/d"))); // exact match
+        Assert.AreEqual(4, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/e"))); // exact match
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_InputActionSetupExtensionsChange_ShouldChangeBindingIfFound()
+    {
+        var actionMap = new InputActionMap();
+        var firstActionInMap = actionMap.AddAction("action1");
+        var secondActionInMap = actionMap.AddAction("action2");
+
+        var binding1 = actionMap.AddBinding("<Keyboard>/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("<Keyboard>/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("<Keyboard>/e", secondActionInMap); // second, 2
+
+        var accessor = secondActionInMap.ChangeBinding(binding1.binding.name);
+        Assert.IsTrue(accessor.valid);
+        secondActionInMap.ChangeBinding(new InputBinding("<Keyboard>/e")).WithPath("<Keyboard>/f");
+        Assert.AreEqual(2, actionMap.FindBinding(new InputBinding("<Keyboard>/f"), out _)); // exact match
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -1350,10 +1350,10 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/a", action); // 0
         actionMap.AddBinding("<Keyboard>/b", action); // 1
 
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding(), out _)); // match anything
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("<Keyboard>/a"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _)); // not found
+        Assert.That(actionMap.FindBinding(new InputBinding(), out _), Is.EqualTo(0)); // match anything
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/a"), out _), Is.EqualTo(0)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _), Is.EqualTo(1)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _), Is.EqualTo(1)); // not found
     }
 
     [Test]
@@ -1365,7 +1365,7 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/a", action); // 0
         actionMap.AddBinding("<Keyboard>/b", action); // 1
 
-        Assert.AreEqual(-1, actionMap.FindBinding(new InputBinding("<Keyboard>/c"), out _)); // not found
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/c"), out _), Is.EqualTo(-1)); // not found
     }
 
     [Test]
@@ -1382,11 +1382,11 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
         actionMap.AddBinding("<Keyboard>/e", secondActionInMap); // second, 2
 
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("<Keyboard>/a"), out _)); // exact match
-        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/c"), out _)); // exact match
-        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("<Keyboard>/d"), out _)); // exact match
-        Assert.AreEqual(2, actionMap.FindBinding(new InputBinding("<Keyboard>/e"), out _)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/a"), out _), Is.EqualTo(0)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/b"), out _), Is.EqualTo(0)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/c"), out _), Is.EqualTo(1)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/d"), out _), Is.EqualTo(1)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/e"), out _), Is.EqualTo(2)); // exact match
     }
 
     [Test]
@@ -1402,7 +1402,7 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
         actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
 
-        Assert.AreEqual(-1, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/q"))); // exact match
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/q")), Is.EqualTo(-1)); // exact match
     }
 
     [Test]
@@ -1418,7 +1418,7 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
         actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
 
-        Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding())); // unconditional
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding()), Is.EqualTo(0)); // unconditional
     }
 
     [Test]
@@ -1435,11 +1435,11 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1
         actionMap.AddBinding("<Keyboard>/e", secondActionInMap); // second, 2
 
-        Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/a"))); // exact match
-        Assert.AreEqual(1, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/b"))); // exact match
-        Assert.AreEqual(2, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/c"))); // exact match
-        Assert.AreEqual(3, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/d"))); // exact match
-        Assert.AreEqual(4, actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/e"))); // exact match
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/a")), Is.EqualTo(0)); // exact match
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/b")), Is.EqualTo(1)); // exact match
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/c")), Is.EqualTo(2)); // exact match
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/d")), Is.EqualTo(3)); // exact match
+        Assert.That(actionMap.FindBindingRelativeToMap(new InputBinding("<Keyboard>/e")), Is.EqualTo(4)); // exact match
     }
 
     [Test]
@@ -1457,8 +1457,8 @@ internal partial class CoreTests
         actionMap.AddBinding("<Keyboard>/e", secondActionInMap); // second, 2
 
         var accessor = secondActionInMap.ChangeBinding(binding1.binding.name);
-        Assert.IsTrue(accessor.valid);
+        Assert.That(accessor.valid, Is.True);
         secondActionInMap.ChangeBinding(new InputBinding("<Keyboard>/e")).WithPath("<Keyboard>/f");
-        Assert.AreEqual(2, actionMap.FindBinding(new InputBinding("<Keyboard>/f"), out _)); // exact match
+        Assert.That(actionMap.FindBinding(new InputBinding("<Keyboard>/f"), out _), Is.EqualTo(2)); // exact match
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -46,7 +46,7 @@ internal partial class CoreTests
         var action = map.AddAction("action1", binding: "<Keyboard>/enter");
         map.Enable();
 
-        Assert.That(action.controls, Is.EquivalentTo(new[] { keyboard.enterKey }));
+        Assert.That(action.controls, Is.EquivalentTo(new[] {keyboard.enterKey}));
 
         map.ApplyBindingOverrides(new List<InputBinding>
         {
@@ -54,7 +54,7 @@ internal partial class CoreTests
         });
 
         Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/leftTrigger"));
-        Assert.That(action.controls, Is.EquivalentTo(new[] { gamepad.leftTrigger }));
+        Assert.That(action.controls, Is.EquivalentTo(new[] {gamepad.leftTrigger}));
     }
 
     [Test]
@@ -98,12 +98,12 @@ internal partial class CoreTests
 
         map.Enable();
 
-        Assert.That(action.controls, Is.EquivalentTo(new[] { gamepad.leftTrigger }));
+        Assert.That(action.controls, Is.EquivalentTo(new[] {gamepad.leftTrigger}));
 
         map.RemoveBindingOverrides(overrides);
 
         Assert.That(action.bindings[0].overridePath, Is.Null);
-        Assert.That(action.controls, Is.EquivalentTo(new[] { keyboard.enterKey }));
+        Assert.That(action.controls, Is.EquivalentTo(new[] {keyboard.enterKey}));
     }
 
     [Test]
@@ -491,7 +491,7 @@ internal partial class CoreTests
             Set(gamepad.leftStick, Vector2.right);
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.candidates, Is.EquivalentTo(new[] { gamepad.leftStick.x, gamepad.leftStick.right }));
+            Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick.x, gamepad.leftStick.right}));
             Assert.That(rebind.scores, Has.Count.EqualTo(2));
             Assert.That(rebind.scores[0], Is.GreaterThan(rebind.scores[1]));
 
@@ -541,7 +541,7 @@ internal partial class CoreTests
             Assert.That(rebind.completed, Is.False);
             Assert.That(rebind.candidates, Is.Empty);
 
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { rightTrigger = 0.5f });
+            InputSystem.QueueStateEvent(gamepad, new GamepadState {rightTrigger = 0.5f});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -590,7 +590,7 @@ internal partial class CoreTests
                    .Start())
         {
             // Gamepad leftStick should get ignored.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = Vector2.one });
+            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = Vector2.one});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
@@ -599,7 +599,7 @@ internal partial class CoreTests
             Assert.That(action.bindings[0].overridePath, Is.Null);
 
             // Gamepad leftTrigger should bind.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0.5f });
+            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.5f});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -803,7 +803,7 @@ internal partial class CoreTests
                        .WithBindingGroup("Gamepad")
                        .Start())
         {
-            Assert.That(rebind.bindingMask, Is.EqualTo(new InputBinding { groups = "Gamepad" }));
+            Assert.That(rebind.bindingMask, Is.EqualTo(new InputBinding { groups = "Gamepad"}));
 
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.North));
             InputSystem.Update();
@@ -859,21 +859,21 @@ internal partial class CoreTests
                        .Start())
         {
             // Actuate leftStick above deadzone.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = new Vector2(0.3f, 0.3f) });
+            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = new Vector2(0.3f, 0.3f)});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.candidates, Is.EquivalentTo(new[] { gamepad.leftStick }));
+            Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick}));
 
             // Advance time by half a second.
             runtime.currentTime += 0.5f;
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.candidates, Is.EquivalentTo(new[] { gamepad.leftStick }));
+            Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick}));
 
             // Actuate rightStick even further than leftStick.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { rightStick = new Vector2(0.7f, 0.7f) });
+            InputSystem.QueueStateEvent(gamepad, new GamepadState {rightStick = new Vector2(0.7f, 0.7f)});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
@@ -933,7 +933,7 @@ internal partial class CoreTests
                        .WithAction(action)
                        .WithControlsHavingToMatchPath("<Keyboard>")
                        .WithControlsHavingToMatchPath("<Mouse>")
-                       .OnPotentialMatch(operation => { })  // Don't complete. Just keep going.
+                       .OnPotentialMatch(operation => {})  // Don't complete. Just keep going.
                        .Start())
         {
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South));
@@ -969,13 +969,13 @@ internal partial class CoreTests
                        .WithControlsExcluding("<Mouse>/position")
                        .Start())
         {
-            InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(123, 345) });
+            InputSystem.QueueStateEvent(mouse, new MouseState {position = new Vector2(123, 345)});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
             Assert.That(rebind.candidates, Is.Empty);
 
-            InputSystem.QueueStateEvent(mouse, new MouseState { delta = new Vector2(123, 345) });
+            InputSystem.QueueStateEvent(mouse, new MouseState {delta = new Vector2(123, 345)});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -1075,7 +1075,7 @@ internal partial class CoreTests
                 })
                 .Start();
 
-            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = new Vector2(1, 0) });
+            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = new Vector2(1, 0)});
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -1095,7 +1095,7 @@ internal partial class CoreTests
             rebind
                 .WithExpectedControlType("Button")
                 .OnPotentialMatch(ctx => candidates = ctx.candidates.ToArray())
-                .OnApplyBinding((operation, s) => { });
+                .OnApplyBinding((operation, s) => {});
 
             rebind.Start();
             PressAndRelease(gamepad.buttonSouth);
@@ -1450,7 +1450,7 @@ internal partial class CoreTests
         var firstActionInMap = actionMap.AddAction("action1");
         var secondActionInMap = actionMap.AddAction("action2");
 
-        var binding1 = actionMap.AddBinding("<Keyboard>/a", firstActionInMap);  // first, 0
+        var binding1 = actionMap.AddBinding("<Keyboard>/a", firstActionInMap); // first, 0
         actionMap.AddBinding("<Keyboard>/b", secondActionInMap); // second, 0
         actionMap.AddBinding("<Keyboard>/c", firstActionInMap);  // first, 1
         actionMap.AddBinding("<Keyboard>/d", secondActionInMap); // second, 1

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -46,7 +46,7 @@ internal partial class CoreTests
         var action = map.AddAction("action1", binding: "<Keyboard>/enter");
         map.Enable();
 
-        Assert.That(action.controls, Is.EquivalentTo(new[] {keyboard.enterKey}));
+        Assert.That(action.controls, Is.EquivalentTo(new[] { keyboard.enterKey }));
 
         map.ApplyBindingOverrides(new List<InputBinding>
         {
@@ -54,7 +54,7 @@ internal partial class CoreTests
         });
 
         Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/leftTrigger"));
-        Assert.That(action.controls, Is.EquivalentTo(new[] {gamepad.leftTrigger}));
+        Assert.That(action.controls, Is.EquivalentTo(new[] { gamepad.leftTrigger }));
     }
 
     [Test]
@@ -98,12 +98,12 @@ internal partial class CoreTests
 
         map.Enable();
 
-        Assert.That(action.controls, Is.EquivalentTo(new[] {gamepad.leftTrigger}));
+        Assert.That(action.controls, Is.EquivalentTo(new[] { gamepad.leftTrigger }));
 
         map.RemoveBindingOverrides(overrides);
 
         Assert.That(action.bindings[0].overridePath, Is.Null);
-        Assert.That(action.controls, Is.EquivalentTo(new[] {keyboard.enterKey}));
+        Assert.That(action.controls, Is.EquivalentTo(new[] { keyboard.enterKey }));
     }
 
     [Test]
@@ -491,7 +491,7 @@ internal partial class CoreTests
             Set(gamepad.leftStick, Vector2.right);
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick.x, gamepad.leftStick.right}));
+            Assert.That(rebind.candidates, Is.EquivalentTo(new[] { gamepad.leftStick.x, gamepad.leftStick.right }));
             Assert.That(rebind.scores, Has.Count.EqualTo(2));
             Assert.That(rebind.scores[0], Is.GreaterThan(rebind.scores[1]));
 
@@ -541,7 +541,7 @@ internal partial class CoreTests
             Assert.That(rebind.completed, Is.False);
             Assert.That(rebind.candidates, Is.Empty);
 
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {rightTrigger = 0.5f});
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { rightTrigger = 0.5f });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -590,7 +590,7 @@ internal partial class CoreTests
                    .Start())
         {
             // Gamepad leftStick should get ignored.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = Vector2.one});
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = Vector2.one });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
@@ -599,7 +599,7 @@ internal partial class CoreTests
             Assert.That(action.bindings[0].overridePath, Is.Null);
 
             // Gamepad leftTrigger should bind.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.5f});
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftTrigger = 0.5f });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -803,7 +803,7 @@ internal partial class CoreTests
                        .WithBindingGroup("Gamepad")
                        .Start())
         {
-            Assert.That(rebind.bindingMask, Is.EqualTo(new InputBinding { groups = "Gamepad"}));
+            Assert.That(rebind.bindingMask, Is.EqualTo(new InputBinding { groups = "Gamepad" }));
 
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.North));
             InputSystem.Update();
@@ -859,21 +859,21 @@ internal partial class CoreTests
                        .Start())
         {
             // Actuate leftStick above deadzone.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = new Vector2(0.3f, 0.3f)});
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = new Vector2(0.3f, 0.3f) });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick}));
+            Assert.That(rebind.candidates, Is.EquivalentTo(new[] { gamepad.leftStick }));
 
             // Advance time by half a second.
             runtime.currentTime += 0.5f;
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
-            Assert.That(rebind.candidates, Is.EquivalentTo(new[] {gamepad.leftStick}));
+            Assert.That(rebind.candidates, Is.EquivalentTo(new[] { gamepad.leftStick }));
 
             // Actuate rightStick even further than leftStick.
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {rightStick = new Vector2(0.7f, 0.7f)});
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { rightStick = new Vector2(0.7f, 0.7f) });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
@@ -933,7 +933,7 @@ internal partial class CoreTests
                        .WithAction(action)
                        .WithControlsHavingToMatchPath("<Keyboard>")
                        .WithControlsHavingToMatchPath("<Mouse>")
-                       .OnPotentialMatch(operation => {})  // Don't complete. Just keep going.
+                       .OnPotentialMatch(operation => { })  // Don't complete. Just keep going.
                        .Start())
         {
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South));
@@ -969,13 +969,13 @@ internal partial class CoreTests
                        .WithControlsExcluding("<Mouse>/position")
                        .Start())
         {
-            InputSystem.QueueStateEvent(mouse, new MouseState {position = new Vector2(123, 345)});
+            InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(123, 345) });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.False);
             Assert.That(rebind.candidates, Is.Empty);
 
-            InputSystem.QueueStateEvent(mouse, new MouseState {delta = new Vector2(123, 345)});
+            InputSystem.QueueStateEvent(mouse, new MouseState { delta = new Vector2(123, 345) });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -1075,7 +1075,7 @@ internal partial class CoreTests
                 })
                 .Start();
 
-            InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = new Vector2(1, 0)});
+            InputSystem.QueueStateEvent(gamepad, new GamepadState { leftStick = new Vector2(1, 0) });
             InputSystem.Update();
 
             Assert.That(rebind.completed, Is.True);
@@ -1095,7 +1095,7 @@ internal partial class CoreTests
             rebind
                 .WithExpectedControlType("Button")
                 .OnPotentialMatch(ctx => candidates = ctx.candidates.ToArray())
-                .OnApplyBinding((operation, s) => {});
+                .OnApplyBinding((operation, s) => { });
 
             rebind.Start();
             PressAndRelease(gamepad.buttonSouth);
@@ -1331,5 +1331,114 @@ internal partial class CoreTests
         Assert.That(secondActionInAsset.controls, Has.Exactly(1).SameAs(joystick.trigger));
         Assert.That(secondActionInAsset.bindings[0].overrideInteractions, Is.EqualTo("tap"));
         Assert.That(secondActionInAsset.bindings[0].overrideProcessors, Is.EqualTo("invert"));
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBinding_ShouldReturnNegativeOne_IfEmpty()
+    {
+        var actionMap = new InputActionMap();
+        Assert.AreEqual(-1, actionMap.FindBinding(new InputBinding(), out _)); // match anything
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBinding_ShouldReturnZero_IfUnconditionalMatchAndNotEmpty()
+    {
+        var actionMap = new InputActionMap();
+        var action = actionMap.AddAction("action1");
+        actionMap.AddBinding("/keyboard/a", action); // 0
+        actionMap.AddBinding("/keyboard/b", action); // 1
+
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding(), out _)); // match anything
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("/keyboard/a"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/b"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/b"), out _)); // not found
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBinding_ShouldReturnNegativeOne_IfConditionalAnotNotFound()
+    {
+        var actionMap = new InputActionMap();
+        var action = actionMap.AddAction("action1");
+        actionMap.AddBinding("/keyboard/a", action); // 0
+        actionMap.AddBinding("/keyboard/b", action); // 1
+
+        Assert.AreEqual(-1, actionMap.FindBinding(new InputBinding("/keyboard/c"), out _)); // not found
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBinding_ShouldReturnIndexOnAction_IfMatched()
+    {
+        var actionMap = new InputActionMap();
+        var firstActionInMap = actionMap.AddAction("action1");
+        var secondActionInMap = actionMap.AddAction("action2");
+
+        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("/keyboard/e", secondActionInMap); // second, 2
+
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("/keyboard/a"), out _)); // exact match
+        Assert.AreEqual(0, actionMap.FindBinding(new InputBinding("/keyboard/b"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/c"), out _)); // exact match
+        Assert.AreEqual(1, actionMap.FindBinding(new InputBinding("/keyboard/d"), out _)); // exact match
+        Assert.AreEqual(2, actionMap.FindBinding(new InputBinding("/keyboard/e"), out _)); // exact match
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBindingRelativeToMap_ShouldReturnNegativeOne_IfNotFound()
+    {
+        var actionMap = new InputActionMap();
+        var firstActionInMap = actionMap.AddAction("action1");
+        var secondActionInMap = actionMap.AddAction("action2");
+
+        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
+
+        Assert.AreEqual(-1, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/q"))); // exact match
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBindingRelativeToMap_ShouldReturnZero_IfUnconditional()
+    {
+        var actionMap = new InputActionMap();
+        var firstActionInMap = actionMap.AddAction("action1");
+        var secondActionInMap = actionMap.AddAction("action2");
+
+        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
+
+        Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding())); // unconditional
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_ActionMapFindBindingRelativeToMap_ShouldReturnIndexOfBinding_IfMatches()
+    {
+        var actionMap = new InputActionMap();
+        var firstActionInMap = actionMap.AddAction("action1");
+        var secondActionInMap = actionMap.AddAction("action2");
+
+        actionMap.AddBinding("/keyboard/a", firstActionInMap);  // first, 0
+        actionMap.AddBinding("/keyboard/b", secondActionInMap); // second, 0
+        actionMap.AddBinding("/keyboard/c", firstActionInMap);  // first, 1
+        actionMap.AddBinding("/keyboard/d", secondActionInMap); // second, 1
+        actionMap.AddBinding("/keyboard/e", secondActionInMap); // second, 2
+
+        Assert.AreEqual(0, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/a"))); // exact match
+        Assert.AreEqual(1, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/b"))); // exact match
+        Assert.AreEqual(2, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/c"))); // exact match
+        Assert.AreEqual(3, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/d"))); // exact match
+        Assert.AreEqual(4, actionMap.FindBindingRelativeToMap(new InputBinding("/keyboard/e"))); // exact match
     }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -46,6 +46,7 @@ however, it has to be formatted properly to pass verification tests.
 - `PlayerInput` no longer logs an error message when it is set to `Invoke UnityEvents` and can't find  an action in the given `.inputactions` asset ([case 1259577](https://issuetracker.unity3d.com/issues/an-error-is-thrown-when-deleting-an-input-action-and-entering-play-mode)).
 - Fixed `HoldInteraction` getting stuck when hold and release happens in same event ([case 1346786](https://issuetracker.unity3d.com/issues/input-system-the-canceled-event-is-not-fired-when-clicking-a-button-for-a-precise-amount-of-time)).
 - Fixed adding an action in the `.inputactions` editor automatically duplicating interactions and processors from the first action in the map.
+- Fixed incorrect indexing in `InputActionsSetupExtensions.ChangeBinding`. Contribution by [Fredrik Ludvigsen](https://github.com/steinbitglis) in [#1348](https://github.com/Unity-Technologies/InputSystem/pull/1352).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -46,7 +46,7 @@ however, it has to be formatted properly to pass verification tests.
 - `PlayerInput` no longer logs an error message when it is set to `Invoke UnityEvents` and can't find  an action in the given `.inputactions` asset ([case 1259577](https://issuetracker.unity3d.com/issues/an-error-is-thrown-when-deleting-an-input-action-and-entering-play-mode)).
 - Fixed `HoldInteraction` getting stuck when hold and release happens in same event ([case 1346786](https://issuetracker.unity3d.com/issues/input-system-the-canceled-event-is-not-fired-when-clicking-a-button-for-a-precise-amount-of-time)).
 - Fixed adding an action in the `.inputactions` editor automatically duplicating interactions and processors from the first action in the map.
-- Fixed incorrect indexing in `InputActionsSetupExtensions.ChangeBinding`. Contribution by [Fredrik Ludvigsen](https://github.com/steinbitglis) in [#1348](https://github.com/Unity-Technologies/InputSystem/pull/1352).
+- Fixed `InputActionSetupExtensions.ChangeBinding` when modifying binding from a different action than specified. Contribution by [Fredrik Ludvigsen](https://github.com/steinbitglis) in [#1348](https://github.com/Unity-Technologies/InputSystem/pull/1352).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1230,7 +1230,7 @@ namespace UnityEngine.InputSystem
             var bindings = m_Bindings;
             var bindingsCount = bindings.LengthSafe();
 
-            for (var i=0; i < bindingsCount; ++i)
+            for (var i = 0; i < bindingsCount; ++i)
             {
                 ref var binding = ref bindings[i];
                 if (mask.Matches(ref binding))

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1774,7 +1774,7 @@ namespace UnityEngine.InputSystem
             }
 
             // Make sure we don't retain any cached per-action data when using serialization
-            // to doctor around in action map configurations in the editor. 
+            // to doctor around in action map configurations in the editor.
             ClearPerActionCachedBindingData();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1202,23 +1202,6 @@ namespace UnityEngine.InputSystem
 
             action = m_SingletonAction ?? FindAction(bindings[index].action);
             return action.BindingIndexOnMapToBindingIndexOnAction(index);
-
-            // OLD CODE:
-            //var bindings = m_Bindings;
-            //var bindingsCount = bindings.LengthSafe();
-
-            //for (var n = 0; n < bindingsCount; ++n)
-            //{
-            //    ref var binding = ref bindings[n];
-            //    if (mask.Matches(ref binding))
-            //    {
-            //        action = m_SingletonAction ?? FindAction(binding.action);
-            //        return action.BindingIndexOnMapToBindingIndexOnAction(n);
-            //    }
-            //}
-
-            //action = null;
-            //return -1;
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1193,20 +1193,67 @@ namespace UnityEngine.InputSystem
         /// <inheritdoc/>
         public int FindBinding(InputBinding mask, out InputAction action)
         {
+            var index = FindBindingRelativeToMap(mask);
+            if (index == -1)
+            {
+                action = null;
+                return -1;
+            }
+
+            action = m_SingletonAction ?? FindAction(bindings[index].action);
+            return action.BindingIndexOnMapToBindingIndexOnAction(index);
+
+            // OLD CODE:
+            //var bindings = m_Bindings;
+            //var bindingsCount = bindings.LengthSafe();
+
+            //for (var n = 0; n < bindingsCount; ++n)
+            //{
+            //    ref var binding = ref bindings[n];
+            //    if (mask.Matches(ref binding))
+            //    {
+            //        action = m_SingletonAction ?? FindAction(binding.action);
+            //        return action.BindingIndexOnMapToBindingIndexOnAction(n);
+            //    }
+            //}
+
+            //action = null;
+            //return -1;
+        }
+
+        /// <summary>
+        /// Find the index of the first binding that matches the given mask.
+        /// </summary>
+        /// <param name="mask">A binding. See <see cref="InputBinding.Matches"/> for details.</param>
+        /// <returns>Index into <see cref="InputAction.bindings"/> of <paramref name="action"/> of the binding
+        /// that matches <paramref name="mask"/>. If no binding matches, will return -1.</returns>
+        /// <remarks>
+        /// For details about matching bindings by a mask, see <see cref="InputBinding.Matches"/>.
+        ///
+        /// <example>
+        /// <code>
+        /// var index = playerInput.actions.FindBindingRelativeToMap(
+        ///     new InputBinding { path = "&lt;Gamepad&gt;/buttonSouth" });
+        ///
+        /// if (index != -1)
+        ///     Debug.Log($"Found binding with index {index}");
+        /// </code>
+        /// </example>
+        /// </remarks>
+        /// <seealso cref="InputBinding.Matches"/>
+        /// <seealso cref="bindings"/>
+        internal int FindBindingRelativeToMap(InputBinding mask)
+        {
             var bindings = m_Bindings;
             var bindingsCount = bindings.LengthSafe();
 
-            for (var n = 0; n < bindingsCount; ++n)
+            for (var i=0; i < bindingsCount; ++i)
             {
-                ref var binding = ref bindings[n];
+                ref var binding = ref bindings[i];
                 if (mask.Matches(ref binding))
-                {
-                    action = m_SingletonAction ?? FindAction(binding.action);
-                    return action.BindingIndexOnMapToBindingIndexOnAction(n);
-                }
+                    return i;
             }
 
-            action = null;
             return -1;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1774,7 +1774,7 @@ namespace UnityEngine.InputSystem
             }
 
             // Make sure we don't retain any cached per-action data when using serialization
-            // to doctor around in action map configurations in the editor.
+            // to doctor around in action map configurations in the editor. 
             ClearPerActionCachedBindingData();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -727,10 +727,22 @@ namespace UnityEngine.InputSystem
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
 
-            match.action = action.name;
-
             var actionMap = action.GetOrCreateActionMap();
-            var bindingIndexInMap = actionMap.FindBindingRelativeToMap(match);
+
+            int bindingIndexInMap = -1;
+            var id = action.idDontGenerate;
+            if (id != null)
+            {
+                // Prio1: Attempt to match action id (stronger)
+                match.action = action.id.ToString();
+                bindingIndexInMap = actionMap.FindBindingRelativeToMap(match);
+            }
+            if (bindingIndexInMap == -1)
+            {
+                // Prio2: Attempt to match action name (weaker)
+                match.action = action.name;
+                bindingIndexInMap = actionMap.FindBindingRelativeToMap(match);
+            }
             if (bindingIndexInMap == -1)
                 return default;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -730,11 +730,11 @@ namespace UnityEngine.InputSystem
             match.action = action.name;
 
             var actionMap = action.GetOrCreateActionMap();
-            var bindingIndex = actionMap.FindBinding(match, out _);
-            if (bindingIndex == -1)
+            var bindingIndexInMap = actionMap.FindBindingRelativeToMap(match);
+            if (bindingIndexInMap == -1)
                 return default;
 
-            return new BindingSyntax(actionMap, bindingIndex);
+            return new BindingSyntax(actionMap, bindingIndexInMap);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

Extension of fix submitted by @steinbitglis in https://github.com/Unity-Technologies/InputSystem/pull/1352.

### Changes made

Fixed incorrect indexing when searching for bindings when changing existing bindings and added missing unit tests.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
