### PR TITLE
CHANGE: Improve performance when using high frequency mice

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4212,4 +4212,206 @@ partial class CoreTests
         InputSystem.RemoveDevice(pointer);
         Assert.That(Pointer.current, Is.EqualTo(mouse));
     }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_MouseMoveCompression_CanCompressMouseMoveEvents()
+    {
+        var moveAction = new InputAction("Move", binding: "<Mouse>/position");
+        int performedCount = 0;
+        Vector2 mousePosition = Vector2.zero;
+        moveAction.performed += ctx =>
+        {
+            performedCount++;
+            mousePosition = ctx.ReadValue<Vector2>();
+        };
+        moveAction.Enable();
+
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(1.0f, 2.0f),
+                delta = new Vector2(1.0f, 1.0f),
+            }, time: 1);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(2.0f, 3.0f),
+                delta = new Vector2(1.0f, 1.0f),
+            }, time: 2);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(3.0f, 4.0f),
+                delta = new Vector2(1.0f, 1.0f),
+            }, time: 3);
+
+        InputSystem.Update();
+
+        Assert.That(performedCount, Is.EqualTo(1));
+        Assert.That(mousePosition, Is.EqualTo(new Vector2(3, 4)));
+        Assert.That(Mouse.current.delta.ReadValue(), Is.EqualTo(new Vector2(3, 3)));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_MouseMoveCompression_OnlyConsecutiveMoveEventsAreCompressed()
+    {
+        var moveAction = new InputAction("Move", binding: "<Mouse>/position");
+        var clickAction = new InputAction("Click", binding: "<Mouse>/leftButton");
+        var movePerformedCount = 0;
+        var clickPerformedCount = 0;
+        Vector2 mousePositionAtClickEvent = Vector2.zero;
+        moveAction.performed += ctx =>
+        {
+            movePerformedCount++;
+        };
+        clickAction.performed += ctx =>
+        {
+            clickPerformedCount++;
+            mousePositionAtClickEvent = Mouse.current.position.ReadValue();
+        };
+        moveAction.Enable();
+        clickAction.Enable();
+
+        var mouse = InputSystem.AddDevice<Mouse>();
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(1.0f, 2.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one
+            }, time: 1);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(2.0f, 3.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one
+            }, time: 2);
+
+        // inject a click event.
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(3.0f, 4.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one
+            }.WithButton(MouseButton.Left), time: 3);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(4.0f, 5.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one,
+            }, time: 4);
+
+        InputSystem.Update();
+
+        Assert.That(movePerformedCount, Is.EqualTo(2));
+        Assert.That(clickPerformedCount, Is.EqualTo(1));
+        Assert.That(Mouse.current.position.ReadValue(), Is.EqualTo(new Vector2(4, 5)));
+        Assert.That(mousePositionAtClickEvent, Is.EqualTo(new Vector2(3, 4)));
+
+        // delta and scroll should accumulate across an entire frame. Compression shouldn't change that
+        Assert.That(Mouse.current.delta.ReadValue(), Is.EqualTo(new Vector2(4, 4)));
+        Assert.That(Mouse.current.scroll.ReadValue(), Is.EqualTo(new Vector2(4, 4)));
+    }
+
+    // Multi-device composite bindings of mouse position and any other control from another device are disabled
+    // because we can't detect the other devices control state from within FastMouse and so compression would
+    // result in inputs being missed in those cases.
+    [Test]
+    [Category("Devices")]
+    [TestCase("<Keyboard>/Ctrl", true)]
+    [TestCase("<Mouse>/Left", false)]
+    public void Devices_MouseMoveCompression_IsDisabledForMultiDeviceCompositeBindings(string modifier, bool compressionIsDisabled)
+    {
+        InputSystem.settings.disableMouseMoveCompression = false;
+
+        var moveAction = new InputAction();
+        moveAction.AddCompositeBinding("OneModifier")
+            .With("Modifier", modifier)
+            .With("Binding", "<Mouse>/position");
+
+        moveAction.performed += ctx => {};
+        moveAction.Enable();
+        InputSystem.AddDevice<Mouse>();
+
+        Assert.That(InputSystem.settings.disableMouseMoveCompression, Is.EqualTo(compressionIsDisabled));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_MouseMoveCompression_IsDisabledForMultiDeviceCompositeBindings_WithMultipleBindings()
+    {
+        InputSystem.settings.disableMouseMoveCompression = false;
+
+        var moveAction = new InputAction();
+        moveAction.AddBinding("<Mouse>/Left");
+        moveAction.AddCompositeBinding("OneModifier")
+            .With("Modifier", "<Mouse>/Left")
+            .With("Binding", "<Mouse>/position");
+        moveAction.AddCompositeBinding("OneModifier")
+            .With("Modifier", "<Keyboard>/Ctrl")
+            .With("Binding", "<Mouse>/position");
+
+        moveAction.performed += ctx => {};
+        moveAction.Enable();
+        InputSystem.AddDevice<Mouse>();
+
+        Assert.That(InputSystem.settings.disableMouseMoveCompression, Is.EqualTo(true));
+    }
+
+    [Test]
+    [Category("Devices")]
+    [TestCase("<Keyboard>/Ctrl", true)]
+    [TestCase("<Mouse>/Left", false)]
+    public void Devices_MouseMoveCompression_IsDisabledForMultiDeviceCompositeBindingsMap(string modifier, bool compressionIsDisabled)
+    {
+        InputSystem.settings.disableMouseMoveCompression = false;
+
+        var actionMap = new InputActionMap("ActionMap");
+
+        var moveAction = actionMap.AddAction("Move");
+        moveAction.AddCompositeBinding("OneModifier")
+            .With("Modifier", modifier)
+            .With("Binding", "<Mouse>/position");
+
+        moveAction.performed += ctx => {};
+        actionMap.Enable();
+
+        InputSystem.AddDevice<Mouse>();
+
+        Assert.That(InputSystem.settings.disableMouseMoveCompression, Is.EqualTo(compressionIsDisabled));
+    }
+
+    [Test]
+    [Category("Devices")]
+    [TestCase("<Keyboard>/Ctrl", true)]
+    [TestCase("<Mouse>/Left", false)]
+    public void Devices_MouseMoveCompression_IsDisabledForMultiDeviceCompositeBindingsAsset(string modifier, bool compressionIsDisabled)
+    {
+        InputSystem.settings.disableMouseMoveCompression = false;
+
+        var actionMap = new InputActionMap("ActionMap");
+
+        var moveAction = actionMap.AddAction("Move");
+        moveAction.AddCompositeBinding("OneModifier")
+            .With("Modifier", modifier)
+            .With("Binding", "<Mouse>/position");
+
+        moveAction.performed += ctx => {};
+
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        asset.AddActionMap(actionMap);
+
+        asset.Enable();
+
+        InputSystem.AddDevice<Mouse>();
+
+        Assert.That(InputSystem.settings.disableMouseMoveCompression, Is.EqualTo(compressionIsDisabled));
+    }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -57,6 +57,7 @@ however, it has to be formatted properly to pass verification tests.
 - `InputSystemUIInputModule` now defers removing pointers for touches by one frame.
   * This is to ensure that `IsPointerOverGameObject` can meaningfully be queried for touches that have happened within the frame &ndash; even if by the time the method is called, a touch has technically already ended ([case 1347048](https://issuetracker.unity3d.com/issues/input-system-ispointerovergameobject-returns-false-when-used-with-a-tap-interaction)).
   * More precisely, this means that whereas before a `PointerExit` and `PointerUp` was received in the same frame, a touch will now see a `PointerUp` in the frame of release but only see a `PointerExit` in the subsequent frame.
+- Changed FastMouse to support coalescing of consecutive mouse move events to alleviate some of the performance issues when using high frequency mice. ([case 1281266](https://issuetracker.unity3d.com/issues/many-input-events-when-using-1000hz-mouse)).
 
 ## [1.1.0-pre.5] - 2021-05-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -510,13 +510,16 @@ namespace UnityEngine.InputSystem
             // anyone queries it.
             map.ClearPerActionCachedBindingData();
 
-            // Make sure bindings get re-resolved.
-            map.LazyResolveBindings();
-
             // If we're looking at a singleton action, make sure m_Bindings is up to date just
-            // in case the action gets serialized.
+            // in case the action gets serialized. Note that it is important that this happens
+            // *before* the resolve bindings call below because that code can trigger other
+            // code to access the singleton action, and that shouldn't happen before it's
+            // bindings have been assigned.
             if (map.m_SingletonAction != null)
                 map.m_SingletonAction.m_SingletonActionBindings = map.m_Bindings;
+
+            // Make sure bindings get re-resolved.
+            map.LazyResolveBindings();
 
             return bindingIndex;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IFlushable.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IFlushable.cs
@@ -1,0 +1,7 @@
+namespace UnityEngine.InputSystem.LowLevel
+{
+    internal interface IFlushable
+    {
+        void Flush();
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IFlushable.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IFlushable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7da7247c4ba04906affefe1ad0468dc7
+timeCreated: 1626856235

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
@@ -2,7 +2,7 @@ using UnityEngine.InputSystem.LowLevel;
 
 namespace UnityEngine.InputSystem
 {
-    internal partial class FastMouse : IInputStateCallbackReceiver
+    internal partial class FastMouse : IInputStateCallbackReceiver, IFlushable
     {
         protected new void OnNextUpdate()
         {
@@ -10,6 +10,10 @@ namespace UnityEngine.InputSystem
             // compared to just doing an InputState.Change with a complete MouseState.
             InputState.Change(delta, Vector2.zero, InputState.currentUpdateType);
             InputState.Change(scroll, Vector2.zero, InputState.currentUpdateType);
+
+            m_AccumulatedDelta = Vector2.zero;
+            m_AccumulatedScroll = Vector2.zero;
+            m_DisableMouseMoveCompression = InputSystem.settings.disableMouseMoveCompression;
         }
 
         // For FastMouse, we know that our layout is MouseState so we can just go directly
@@ -31,12 +35,58 @@ namespace UnityEngine.InputSystem
             }
 
             var newState = *(MouseState*)stateEvent->state;
-            var stateFromDevice = (MouseState*)((byte*)currentStatePtr + m_StateBlock.byteOffset);
 
-            newState.delta += stateFromDevice->delta;
-            newState.scroll += stateFromDevice->scroll;
+            if (m_DisableMouseMoveCompression)
+            {
+                var stateFromDevice = (MouseState*)((byte*)currentStatePtr + m_StateBlock.byteOffset);
+                newState.delta += stateFromDevice->delta;
+                newState.scroll += stateFromDevice->scroll;
+                InputState.Change(this, ref newState, InputState.currentUpdateType, eventPtr: eventPtr);
+                return;
+            }
 
-            InputState.Change(this, ref newState, InputState.currentUpdateType, eventPtr: eventPtr);
+            m_AccumulatedDelta += newState.delta;
+            m_AccumulatedScroll += newState.scroll;
+
+            if (newState.buttons == m_PreviousEventState.buttons &&
+                newState.clickCount == m_PreviousEventState.clickCount)
+            {
+                m_LastEventPtr = eventPtr;
+            }
+            else
+            {
+                var state = new MouseState
+                {
+                    position = newState.position,
+                    delta = m_AccumulatedDelta,
+                    scroll = m_AccumulatedScroll,
+                    buttons = newState.buttons,
+                    clickCount = newState.clickCount
+                };
+                InputState.Change(this, ref state, InputState.currentUpdateType, eventPtr);
+
+                // this state has been handled now, so set m_LastEventPtr to null because there's nothing to flush later
+                m_LastEventPtr = null;
+            }
+
+            m_PreviousEventState = newState;
+        }
+
+        public void Flush()
+        {
+            if (m_LastEventPtr == null)
+                return;
+
+            var state = new MouseState
+            {
+                position = m_PreviousEventState.position,
+                delta = m_AccumulatedDelta,
+                scroll = m_AccumulatedScroll,
+                buttons = m_PreviousEventState.buttons,
+                clickCount = m_PreviousEventState.clickCount
+            };
+            InputState.Change(this, ref state, InputState.currentUpdateType, m_LastEventPtr);
+            m_LastEventPtr = null;
         }
 
         void IInputStateCallbackReceiver.OnNextUpdate()
@@ -48,5 +98,30 @@ namespace UnityEngine.InputSystem
         {
             OnStateEvent(eventPtr);
         }
+
+        /// <summary>
+        /// When mouse move compression is turned on, these variables are used to store accumulated
+        /// delta and scroll values during the frame. Without compression, the device state is
+        /// updated for every event, and so the accumulated values are simply store in there.
+        /// </summary>
+        private Vector2 m_AccumulatedDelta;
+        private Vector2 m_AccumulatedScroll;
+
+        /// <summary>
+        /// Stores the previous mouse event state so it can be applied in the Flush method, and also
+        /// so button and click count states can be tracked across frames.
+        /// </summary>
+        private MouseState m_PreviousEventState;
+
+        /// <summary>
+        /// When mouse move compression is turned on, it is necessary to store the last event
+        /// received in case the last events in the frame are all mouse moves. This is because
+        /// the OnStateEvent method has no idea if it is processing the last event of the frame
+        /// or not, and so can't know to update the device state. Instead, the Flush method
+        /// will be called when all events have been processed, and the device state will be
+        /// updated from this event.
+        /// </summary>
+        private InputEventPtr m_LastEventPtr;
+        private bool m_DisableMouseMoveCompression;
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2854,6 +2854,12 @@ namespace UnityEngine.InputSystem
                 m_InputEventStream.Advance(leaveEventInBuffer: leaveInBuffer);
             }
 
+            foreach (var device in devices)
+            {
+                if (device is IFlushable flushable)
+                    flushable.Flush();
+            }
+
             m_Metrics.totalEventProcessingTime += ((double)(Stopwatch.GetTimestamp() - processingStartTime)) / Stopwatch.Frequency;
             m_Metrics.totalEventLagTime += totalEventLag;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
@@ -40,6 +42,16 @@ namespace UnityEngine.InputSystem
     /// <seealso cref="InputSystem.onSettingsChange"/>
     public partial class InputSettings : ScriptableObject
     {
+        public void Awake()
+        {
+            HookDisableMouseCompressionListener();
+        }
+
+        public void OnDisable()
+        {
+            UnhookDisableMouseCompressionListener();
+        }
+
         /// <summary>
         /// Determine how the input system updates, i.e. processes pending input events.
         /// </summary>
@@ -518,6 +530,119 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        /// <summary>
+        /// Disables mouse move compression. Disable it if you want to get all mouse move events.
+        /// </summary>
+        /// <remarks>
+        /// When using a high frequency mouse, the number of mouse move events in each frame can be
+        /// very large, which can have a negative effect on performance. To help with this, mouse
+        /// move compression can be used which coalesces consecutive mouse move events into a single
+        /// input action update.
+        ///
+        /// For example, if there are one hundred mouse events, but they are all position updates
+        /// with no clicks, and there is an input action callback handler for the mouse position, that
+        /// callback handler will only be called one time in the current frame. Delta and scroll
+        /// values for the mouse will still be accumulated across all mouse events.
+        ///
+        /// Note that mouse move event compression cannot be used if any input actions use the mouse
+        /// position in a composite control. The input system will detect this and automatically
+        /// disable compression.
+        /// </remarks>
+        public bool disableMouseMoveCompression
+        {
+            get => m_DisableMouseMoveCompression;
+            set
+            {
+                if (m_DisableMouseMoveCompression == value)
+                    return;
+
+                m_DisableMouseMoveCompression = value;
+                OnChange();
+            }
+        }
+
+        private void HookDisableMouseCompressionListener()
+        {
+            InputSystem.onActionChange += DisableMouseCompressionListener;
+        }
+
+        private void UnhookDisableMouseCompressionListener()
+        {
+            InputSystem.onActionChange -= DisableMouseCompressionListener;
+        }
+
+        private void DisableMouseCompressionListener(object o, InputActionChange change)
+        {
+            if (disableMouseMoveCompression)
+                return;
+
+            if (change != InputActionChange.BoundControlsChanged)
+                return;
+
+            switch (o)
+            {
+                case InputAction action:
+                    DetectMultiDeviceMouseMoveCompositeBinding(action);
+                    break;
+
+                case InputActionMap actionMap:
+                    foreach (var action in actionMap.actions)
+                    {
+                        DetectMultiDeviceMouseMoveCompositeBinding(action);
+                    }
+                    break;
+
+                case InputActionAsset asset:
+                    foreach (var action in asset.actionMaps.SelectMany(map => map.actions))
+                    {
+                        DetectMultiDeviceMouseMoveCompositeBinding(action);
+                    }
+                    break;
+            }
+        }
+
+        private void DetectMultiDeviceMouseMoveCompositeBinding(InputAction action)
+        {
+            if (!action.controls.Any(c => c.device is FastMouse))
+                return;
+
+            for (var i = 0; i < action.bindings.Count;)
+            {
+                var binding = action.bindings[i];
+                if (!binding.isComposite)
+                {
+                    ++i;
+                    continue;
+                }
+
+                var mousePositionBindingFound = false;
+                var otherDeviceBindingFound = false;
+                while (++i < action.bindings.Count)
+                {
+                    binding = action.bindings[i];
+
+                    if (binding.isPartOfComposite == false)
+                        break;
+
+                    var bindingPath = binding.path;
+                    if (string.Equals(bindingPath, "<mouse>/position", StringComparison.OrdinalIgnoreCase))
+                        mousePositionBindingFound = true;
+                    else if (!bindingPath.StartsWith("<mouse>", StringComparison.OrdinalIgnoreCase))
+                        otherDeviceBindingFound = true;
+                }
+
+                if (mousePositionBindingFound && otherDeviceBindingFound)
+                {
+                    Debug.LogWarning($"Mouse move event compression will be disabled because the mouse position control " +
+                        $"is used in composite binding '{binding.name}'. Compression is not supported " +
+                        "when the mouse position control is used in a composite binding with any control from " +
+                        "another device.");
+                    disableMouseMoveCompression = true;
+                    return;
+                }
+            }
+        }
+
         [Tooltip("Determine which type of devices are used by the application. By default, this is empty meaning that all devices recognized "
             + "by Unity will be used. Restricting the set of supported devices will make only those devices appear in the input system.")]
         [SerializeField] private string[] m_SupportedDevices;
@@ -541,6 +666,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_DefaultHoldTime = 0.4f;
         [SerializeField] private float m_TapRadius = 5;
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
+        [SerializeField] private bool m_DisableMouseMoveCompression = false;
 
         internal void OnChange()
         {


### PR DESCRIPTION
Alleviates the issues from [case 1281266](https://fogbugz.unity3d.com/f/cases/1281266/)
The original PR for this idea is [here](https://github.com/Unity-Technologies/InputSystem/pull/1371). The approach here is slower but simpler and more self contained in FastMouse.

### Description

When using high frequency mouse too many move events are generated for us to handle, so processing time explodes to 1-2+ms (100+ms in worst cases).

### Changes made

Modified FastMouse so that consecutive mouse move events are coalesced into a single device state update.  This way if you have 100 mouse move events only last one will be raised for the rest of the code to process (move/scroll delta's are accumulated).

### Notes

- Compression of mouse move events is disabled automatically when a composite binding of mouse position and any control from any other device is detected. This is because mouse compression happens inside FastMouse which only ever sees mouse events, so it can't detect multi-device data dependencies. 
- The user can turn compression back on manually after it has been disabled and that could result in missed callbacks.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
