### PR TITLE
Clarify timeline reset to 0 when entering play mode hence prior timestamps might appear negative

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -326,6 +326,8 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// Events other than <see cref="LowLevel.StateEvent"/> and <see cref="LowLevel.DeltaStateEvent"/> will
         /// not cause lastUpdateTime to be changed.
+        /// The "timeline" is reset to 0 when entering play mode. If there are any events incoming or device
+        /// updates which occur prior to entering play mode, these will appear negative.
         /// </remarks>
         public double lastUpdateTime => m_LastUpdateTimeInternal - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
 


### PR DESCRIPTION
### Changes made

Clarifying docs

