### PR TITLE
Adding events merging to reduce amount of redundant events (attempt number 3)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4212,4 +4212,167 @@ partial class CoreTests
         InputSystem.RemoveDevice(pointer);
         Assert.That(Pointer.current, Is.EqualTo(mouse));
     }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_EventMerging_CanMergeMouseMoveEvents()
+    {
+        var moveAction = new InputAction("Move", binding: "<Mouse>/position");
+        int performedCount = 0;
+        Vector2 mousePosition = Vector2.zero;
+        moveAction.performed += ctx =>
+        {
+            performedCount++;
+            mousePosition = ctx.ReadValue<Vector2>();
+        };
+        moveAction.Enable();
+
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(1.0f, 2.0f),
+                delta = new Vector2(1.0f, 1.0f),
+            }, time: 1);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(2.0f, 3.0f),
+                delta = new Vector2(1.0f, 1.0f),
+            }, time: 2);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(3.0f, 4.0f),
+                delta = new Vector2(1.0f, 1.0f),
+            }, time: 3);
+
+        InputSystem.Update();
+
+        Assert.That(performedCount, Is.EqualTo(1));
+        Assert.That(mousePosition, Is.EqualTo(new Vector2(3, 4)));
+        Assert.That(Mouse.current.delta.ReadValue(), Is.EqualTo(new Vector2(3, 3)));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_EventMerging_OnlyConsecutiveMoveEventsAreMerged()
+    {
+        var moveAction = new InputAction("Move", binding: "<Mouse>/position");
+        var clickAction = new InputAction("Click", binding: "<Mouse>/leftButton");
+        var keyPressAction = new InputAction("KeyPress", binding: "<Keyboard>/space");
+
+        var movePerformedCount = 0;
+        var clickPerformedCount = 0;
+        var keyPressPerformedCount = 0;
+
+        var mousePositionAtClickEvent = Vector2.zero;
+        var mouseDeltaAtClickEvent = Vector2.zero;
+        var mouseScrollAtClickEvent = Vector2.zero;
+        
+        var mousePositionAtKeyPressEvent = Vector2.zero;
+        var mouseDeltaAtKeyPressEvent = Vector2.zero;
+        var mouseScrollAtKeyPressEvent = Vector2.zero;
+        
+        moveAction.performed += ctx =>
+        {
+            movePerformedCount++;
+        };
+        clickAction.performed += ctx =>
+        {
+            clickPerformedCount++;
+            mousePositionAtClickEvent = Mouse.current.position.ReadValue();
+            mouseDeltaAtClickEvent = Mouse.current.delta.ReadValue();
+            mouseScrollAtClickEvent = Mouse.current.scroll.ReadValue();
+        };
+        keyPressAction.performed += ctx =>
+        {
+            keyPressPerformedCount++;
+            mousePositionAtKeyPressEvent = Mouse.current.position.ReadValue();
+            mouseDeltaAtKeyPressEvent = Mouse.current.delta.ReadValue();
+            mouseScrollAtKeyPressEvent = Mouse.current.scroll.ReadValue();
+        };
+        
+        moveAction.Enable();
+        clickAction.Enable();
+        keyPressAction.Enable();
+
+        var mouse = InputSystem.AddDevice<Mouse>();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(1.0f, 2.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one
+            }, time: 1);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(2.0f, 3.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one
+            }, time: 2);
+
+        // inject a click event.
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(3.0f, 4.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one
+            }.WithButton(MouseButton.Left), time: 3);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(4.0f, 5.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one,
+            }, time: 4);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(5.0f, 6.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one,
+            }, time: 5);
+        
+        // inject a keyboard press event
+        InputSystem.QueueStateEvent(keyboard,
+            new KeyboardState(Key.Space), time: 6);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(6.0f, 7.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one,
+            }, time: 7);
+        InputSystem.QueueStateEvent(mouse,
+            new MouseState
+            {
+                position = new Vector2(7.0f, 8.0f),
+                delta = Vector2.one,
+                scroll = Vector2.one,
+            }, time: 8);
+
+        InputSystem.Update();
+
+        Assert.That(movePerformedCount, Is.EqualTo(4));
+        Assert.That(clickPerformedCount, Is.EqualTo(1));
+        Assert.That(keyPressPerformedCount, Is.EqualTo(1));
+
+        Assert.That(Mouse.current.position.ReadValue(), Is.EqualTo(new Vector2(7, 8)));
+        Assert.That(Mouse.current.delta.ReadValue(), Is.EqualTo(new Vector2(7, 7)));
+        Assert.That(Mouse.current.scroll.ReadValue(), Is.EqualTo(new Vector2(7, 7)));
+
+        Assert.That(mousePositionAtClickEvent, Is.EqualTo(new Vector2(3, 4)));
+        Assert.That(mouseDeltaAtClickEvent, Is.EqualTo(new Vector2(3, 3)));
+        Assert.That(mouseScrollAtClickEvent, Is.EqualTo(new Vector2(3, 3)));
+
+        Assert.That(mousePositionAtKeyPressEvent, Is.EqualTo(new Vector2(5, 6)));
+        Assert.That(mouseDeltaAtKeyPressEvent, Is.EqualTo(new Vector2(5, 5)));
+        Assert.That(mouseScrollAtKeyPressEvent, Is.EqualTo(new Vector2(5, 5)));
+    }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4270,11 +4270,11 @@ partial class CoreTests
         var mousePositionAtClickEvent = Vector2.zero;
         var mouseDeltaAtClickEvent = Vector2.zero;
         var mouseScrollAtClickEvent = Vector2.zero;
-        
+
         var mousePositionAtKeyPressEvent = Vector2.zero;
         var mouseDeltaAtKeyPressEvent = Vector2.zero;
         var mouseScrollAtKeyPressEvent = Vector2.zero;
-        
+
         moveAction.performed += ctx =>
         {
             movePerformedCount++;
@@ -4293,7 +4293,7 @@ partial class CoreTests
             mouseDeltaAtKeyPressEvent = Mouse.current.delta.ReadValue();
             mouseScrollAtKeyPressEvent = Mouse.current.scroll.ReadValue();
         };
-        
+
         moveAction.Enable();
         clickAction.Enable();
         keyPressAction.Enable();
@@ -4338,7 +4338,7 @@ partial class CoreTests
                 delta = Vector2.one,
                 scroll = Vector2.one,
             }, time: 5);
-        
+
         // inject a keyboard press event
         InputSystem.QueueStateEvent(keyboard,
             new KeyboardState(Key.Space), time: 6);

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -2085,8 +2085,12 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
-    public void Events_CanQueueEventsFromWithinEventProcessing()
+    [TestCase(false)]
+    [TestCase(true)]
+    public void Events_CanQueueEventsFromWithinEventProcessing_WithEventMergingSetTo(bool mergeRedundantEvents)
     {
+        InputSystem.settings.disableRedundantEventsMerging = !mergeRedundantEvents;
+
         var mouse = InputSystem.AddDevice<Mouse>();
         var keyboard = InputSystem.AddDevice<Keyboard>();
 
@@ -2111,15 +2115,18 @@ partial class CoreTests
             // This way we not only test whether the events make it into the queue at all but
             // also that they still make it if we have to re-allocate the buffer.
             for (var i = 0; i < numMouseEventsQueued; ++i)
-                InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2(123, 234) }.WithButton(MouseButton.Left));
+                InputSystem.QueueStateEvent(mouse, new MouseState { position = new Vector2((i + 1), (i + 1) * 2), delta = Vector2.one}.WithButton(MouseButton.Left));
         };
         action.Enable();
 
         Press(keyboard.spaceKey);
 
         Assert.That(mouse.leftButton.isPressed, Is.True);
-        Assert.That(mouse.position.ReadValue(), Is.EqualTo(new Vector2(123, 234)));
-        Assert.That(numMouseEventsReceived, Is.EqualTo(numMouseEventsQueued));
+        Assert.That(mouse.position.ReadValue(), Is.EqualTo(new Vector2(numMouseEventsQueued, numMouseEventsQueued * 2)));
+        Assert.That(mouse.delta.ReadValue(), Is.EqualTo(new Vector2(numMouseEventsQueued, numMouseEventsQueued)));
+        Assert.That(numMouseEventsReceived, Is.EqualTo(mergeRedundantEvents ? 1 : numMouseEventsQueued));
+
+        InputSystem.settings.disableRedundantEventsMerging = false;
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -36,6 +36,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed UI issue where pressing the wrong button was possible while quickly moving through a UI because the submit action fired on action press instead of action release ([1333563](https://issuetracker.unity3d.com/issues/input-submit-action-is-called-on-release-rather-than-on-press-when-using-enter-key)).
 - Fixed InvalidOperationException when opening a preset created from a .inputactions asset ([case 1199544](https://issuetracker.unity3d.com/issues/input-system-properties-are-not-visible-and-invalidoperationexception-is-thrown-on-selecting-inputactionimporter-preset-asset)).
 - Fixed inconsistent usage of `ENABLE_PROFILER` define together with `Profiler.BeginSample`/`Profiler.EndSample` by removing `ENABLE_PROFILER` macro check because `BeginSample`/`EndSample` are already conditional with `[Conditional("ENABLE_PROFILER")]` ([case 1350139](https://issuetracker.unity3d.com/issues/inconsistent-enable-profiler-scripting-defines-in-inputmanager-dot-cs-when-using-profiler-dot-beginssample-and-profiler-dot-endsample)).
+- Remediated majority of performance issues with high frequency mice (>=1kHz poll rates) in release mode by merging consecutive mouse move events together ([case 1281266](https://issuetracker.unity3d.com/issues/many-input-events-when-using-1000hz-mouse)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventMerger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventMerger.cs
@@ -1,0 +1,9 @@
+using UnityEngine.InputSystem.LowLevel;
+
+namespace UnityEngine.InputSystem
+{
+    internal interface IEventMerger
+    {
+        bool MergeForward(InputEventPtr currentEvent, InputEventPtr nextEvent);
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventMerger.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventMerger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7522ce067dfd4acf8e9e136fc7a0ab64
+timeCreated: 1628242797

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
@@ -2,11 +2,6 @@ using UnityEngine.InputSystem.LowLevel;
 
 namespace UnityEngine.InputSystem
 {
-    internal interface IEventMerger
-    {
-        public bool MergeForward(InputEventPtr currentEvent, InputEventPtr nextEvent);
-    }
-    
     internal partial class FastMouse : IInputStateCallbackReceiver, IEventMerger
     {
         protected new void OnNextUpdate()
@@ -64,7 +59,7 @@ namespace UnityEngine.InputSystem
 
             if (currentEvent->stateFormat != MouseState.Format || nextEvent->stateFormat != MouseState.Format)
                 return false;
-            
+
             var currentState = (MouseState*)currentEvent->state;
             var nextState = (MouseState*)nextEvent->state;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
@@ -2,7 +2,12 @@ using UnityEngine.InputSystem.LowLevel;
 
 namespace UnityEngine.InputSystem
 {
-    internal partial class FastMouse : IInputStateCallbackReceiver
+    internal interface IEventMerger
+    {
+        public bool MergeForward(InputEventPtr currentEvent, InputEventPtr nextEvent);
+    }
+    
+    internal partial class FastMouse : IInputStateCallbackReceiver, IEventMerger
     {
         protected new void OnNextUpdate()
         {
@@ -47,6 +52,29 @@ namespace UnityEngine.InputSystem
         void IInputStateCallbackReceiver.OnStateEvent(InputEventPtr eventPtr)
         {
             OnStateEvent(eventPtr);
+        }
+
+        public unsafe bool MergeForward(InputEventPtr currentEventPtr, InputEventPtr nextEventPtr)
+        {
+            if (currentEventPtr.type != StateEvent.Type || nextEventPtr.type != StateEvent.Type)
+                return false;
+
+            var currentEvent = StateEvent.FromUnchecked(currentEventPtr);
+            var nextEvent = StateEvent.FromUnchecked(nextEventPtr);
+
+            if (currentEvent->stateFormat != MouseState.Format || nextEvent->stateFormat != MouseState.Format)
+                return false;
+            
+            var currentState = (MouseState*)currentEvent->state;
+            var nextState = (MouseState*)nextEvent->state;
+
+            // if buttons or clickCount changed we need to process it, so don't merge events together
+            if (currentState->buttons != nextState->buttons || currentState->clickCount != nextState->clickCount)
+                return false;
+
+            nextState->delta += currentState->delta;
+            nextState->scroll += currentState->scroll;
+            return true;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventStream.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventStream.cs
@@ -23,7 +23,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public InputEvent* currentEventPtr => m_RemainingNativeEventCount > 0
         ? m_CurrentNativeEventReadPtr
-        : m_CurrentAppendEventReadPtr;
+        : (m_RemainingAppendEventCount > 0 ? m_CurrentAppendEventReadPtr : null);
 
         public uint numBytesRetainedInBuffer =>
             (uint)((byte*)m_CurrentNativeEventWritePtr -
@@ -113,13 +113,37 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 m_NativeBuffer.AdvanceToNextEvent(ref m_CurrentNativeEventReadPtr, ref m_CurrentNativeEventWritePtr,
                     ref m_NumEventsRetainedInBuffer, ref m_RemainingNativeEventCount, leaveEventInBuffer);
-                return m_CurrentNativeEventReadPtr;
+            }
+            else if (m_RemainingAppendEventCount > 0)
+            {
+                var numEventRetained = 0;
+                m_AppendBuffer.AdvanceToNextEvent(ref m_CurrentAppendEventReadPtr, ref m_CurrentAppendEventWritePtr,
+                    ref numEventRetained, ref m_RemainingAppendEventCount, false);
             }
 
-            var numEventRetained = 0;
-            m_AppendBuffer.AdvanceToNextEvent(ref m_CurrentAppendEventReadPtr, ref m_CurrentAppendEventWritePtr,
-                ref numEventRetained, ref m_RemainingAppendEventCount, false);
-            return m_CurrentAppendEventReadPtr;
+            return currentEventPtr;
+        }
+
+        /// <summary>
+        /// Peeks next event in the stream
+        /// </summary>
+        public InputEvent* Peek()
+        {
+            // Advance will go to next event in m_NativeBuffer
+            if (m_RemainingNativeEventCount > 1)
+                return InputEvent.GetNextInMemory(m_CurrentNativeEventReadPtr);
+
+            // Advance will decrement m_RemainingNativeEventCount to 0
+            // and currentEventPtr will point to m_CurrentAppendEventReadPtr if any
+            if (m_RemainingNativeEventCount == 1)
+                return m_RemainingAppendEventCount > 0 ? m_CurrentAppendEventReadPtr : null;
+
+            // Advance will go to next event in m_AppendBuffer
+            if (m_RemainingAppendEventCount > 1)
+                return InputEvent.GetNextInMemory(m_CurrentAppendEventReadPtr);
+
+            // No next event
+            return null;
         }
 
         private InputEventBuffer m_NativeBuffer;

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2689,6 +2689,17 @@ namespace UnityEngine.InputSystem
                     continue;
                 }
 
+                if (!settings.disableRedundantEventsMerging && device is IEventMerger merger)
+                {
+                    var nextEvent = m_InputEventStream.Peek();
+                    if (nextEvent != null && merger.MergeForward(currentEventReadPtr, nextEvent))
+                    {
+                        // Event was merged into next event, skipping.
+                        m_InputEventStream.Advance(leaveEventInBuffer: false);
+                        continue;
+                    }
+                }
+
                 // Give listeners a shot at the event.
                 if (m_EventListeners.length > 0)
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -518,6 +518,33 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        /// <summary>
+        /// Disables redundant events merging. Disable it if you want to get all events.
+        /// </summary>
+        /// <remarks>
+        /// When using a high frequency mouse, the number of mouse move events in each frame can be
+        /// very large, which can have a negative effect on performance. To help with this,
+        /// merging events can be used which coalesces consecutive mouse move events into a single
+        /// input action update.
+        ///
+        /// For example, if there are one hundred mouse events, but they are all position updates
+        /// with no clicks, and there is an input action callback handler for the mouse position, that
+        /// callback handler will only be called one time in the current frame. Delta and scroll
+        /// values for the mouse will still be accumulated across all mouse events.
+        /// </remarks>
+        public bool disableRedundantEventsMerging
+        {
+            get => m_DisableRedundantEventsMerging;
+            set
+            {
+                if (m_DisableRedundantEventsMerging == value)
+                    return;
+
+                m_DisableRedundantEventsMerging = value;
+                OnChange();
+            }
+        }
+
         [Tooltip("Determine which type of devices are used by the application. By default, this is empty meaning that all devices recognized "
             + "by Unity will be used. Restricting the set of supported devices will make only those devices appear in the input system.")]
         [SerializeField] private string[] m_SupportedDevices;
@@ -541,6 +568,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_DefaultHoldTime = 0.4f;
         [SerializeField] private float m_TapRadius = 5;
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
+        [SerializeField] private bool m_DisableRedundantEventsMerging = false;
 
         internal void OnChange()
         {


### PR DESCRIPTION
### Description

Third attempt on slightly different flavor of merging events together. Is a compromise between https://github.com/Unity-Technologies/InputSystem/pull/1371 and https://github.com/Unity-Technologies/InputSystem/pull/1380 . Achieves functionality of first one with simplicity of second one.

### Changes made

Also fixed `Advance` in `InputEventStream` to correctly go over the border between two buffers.

### Notes

Performance in editor with 8khz mouse and script debugging enabled is still not acceptable (~0.7ms / frame), but with script debugging disabled it falls into reasonable category <0.1ms.

### Checklist

Before review:

- [x] Changelog entry added.
- [X] Tests added/changed, if applicable.
- [X] Docs for new/changed API's.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
