### PR TITLE
CHANGE: Clamp defaultButtonPressPoint to 0.0001 (case 1349002).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1004,6 +1004,48 @@ partial class CoreTests
 
     [Test]
     [Category("Controls")]
+    public void Controls_CanCustomizeDefaultButtonPressPoint()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        InputSystem.settings.defaultButtonPressPoint = 0.4f;
+
+        Set(gamepad.leftTrigger, 0.39f);
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.False);
+
+        Set(gamepad.leftTrigger, 0.4f);
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.True);
+
+        InputSystem.settings.defaultButtonPressPoint = 0.5f;
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.False);
+
+        InputSystem.settings.defaultButtonPressPoint = 0;
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.True);
+
+        // Setting the trigger to 0 requires the system to be "smart" enough to
+        // figure out that 0 as a default button press point doesn't make sense
+        // and that instead the press point should clamp off at some low, non-zero value.
+        // https://fogbugz.unity3d.com/f/cases/1349002/
+        Set(gamepad.leftTrigger, 0f);
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.False);
+
+        Set(gamepad.leftTrigger, 0.001f);
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.True);
+
+        InputSystem.settings.defaultButtonPressPoint = -1;
+        Set(gamepad.leftTrigger, 0f);
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.False);
+    }
+
+    [Test]
+    [Category("Controls")]
     public void Controls_CanCustomizePressPointOfGamepadTriggers()
     {
         var json = @"

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,14 +10,6 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
-### Changed
-
-- Changed `TrackedPoseDriver` to use properties of type `InputActionProperty` rather than `InputAction` to allow more flexibility.
-- XRLayoutBuilder now supports `_` in sanitized names.
-- Added method `SetMotorSpeedsAndLightBarColor` as a workaround for setting both the light bar and motor speeds simultaneously on a DualShock 4 controller ([case 1271119](https://issuetracker.unity3d.com/issues/dualshock4-setlightbarcolor-and-setmotorspeeds-cannot-be-called-on-the-same-frame-using-input-system)).
-- Updated documentation for sensor WebGL support in 2021.2.
-- Added value clamping to 'up' and 'down' synthetic controls on `WebGLGamepad` left and right sticks.
-
 ### Fixed
 
 - Fixed pairing devices to existing `InputUser`s potentially corrupting list of paired devices from other `InputUser`s ([case 1327628](https://issuetracker.unity3d.com/issues/input-system-devices-are-reassigned-to-the-wrong-users-after-adding-a-new-device)).
@@ -59,13 +51,16 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 
 - Added `InputSystem.runUpdatesInEditMode` to enable processing of non-editor updates without entering playmode (only available for XR).
+- Added method `SetMotorSpeedsAndLightBarColor` as a workaround for setting both the light bar and motor speeds simultaneously on a DualShock 4 controller ([case 1271119](https://issuetracker.unity3d.com/issues/dualshock4-setlightbarcolor-and-setmotorspeeds-cannot-be-called-on-the-same-frame-using-input-system)).
 
 ### Changed
 
+- `InputSystem.defaultButtonPressPoint` is now clamped to a minimum value of `0.0001` ([case 1349002](https://issuetracker.unity3d.com/issues/onclick-not-working-when-in-player)).
 - `InputDevice.OnConfigurationChanged` can now be overridden in derived classes.
 - `InputSystemUIInputModule` now defers removing pointers for touches by one frame.
   * This is to ensure that `IsPointerOverGameObject` can meaningfully be queried for touches that have happened within the frame &ndash; even if by the time the method is called, a touch has technically already ended ([case 1347048](https://issuetracker.unity3d.com/issues/input-system-ispointerovergameobject-returns-false-when-used-with-a-tap-interaction)).
   * More precisely, this means that whereas before a `PointerExit` and `PointerUp` was received in the same frame, a touch will now see a `PointerUp` in the frame of release but only see a `PointerExit` in the subsequent frame.
+- Changed `TrackedPoseDriver` to use properties of type `InputActionProperty` rather than `InputAction` to allow more flexibility.
 
 ## [1.1.0-pre.5] - 2021-05-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.InputSystem.Controls
         /// </summary>
         /// <value>Effective value to use for press point thresholds.</value>
         /// <seealso cref="InputSettings.defaultButtonPressPoint"/>
-        public float pressPointOrDefault => pressPoint >= 0 ? pressPoint : s_GlobalDefaultButtonPressPoint;
+        public float pressPointOrDefault => pressPoint > 0 ? pressPoint : s_GlobalDefaultButtonPressPoint;
 
         /// <summary>
         /// Default-initialize the control.
@@ -101,5 +101,9 @@ namespace UnityEngine.InputSystem.Controls
         // constantly make the hop from InputSystem.settings -> InputManager.m_Settings -> defaultButtonPressPoint.
         internal static float s_GlobalDefaultButtonPressPoint;
         internal static float s_GlobalDefaultButtonReleaseThreshold;
+
+        // We clamp button press points to this value as allowing 0 as the press point causes all buttons
+        // to implicitly be pressed all the time. Not useful.
+        internal const float kMinButtonPressPoint = 0.0001f;
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2353,7 +2353,8 @@ namespace UnityEngine.InputSystem
             Touchscreen.s_TapTime = settings.defaultTapTime;
             Touchscreen.s_TapDelayTime = settings.multiTapDelayTime;
             Touchscreen.s_TapRadiusSquared = settings.tapRadius * settings.tapRadius;
-            ButtonControl.s_GlobalDefaultButtonPressPoint = settings.defaultButtonPressPoint;
+            // Extra clamp here as we can't tell what we're getting from serialized data.
+            ButtonControl.s_GlobalDefaultButtonPressPoint = Mathf.Clamp(settings.defaultButtonPressPoint, ButtonControl.kMinButtonPressPoint, float.MaxValue);
             ButtonControl.s_GlobalDefaultButtonReleaseThreshold = settings.buttonReleaseThreshold;
 
             // Let listeners know.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -1,7 +1,9 @@
+using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.UI;
 
 ////TODO: make sure that alterations made to InputSystem.settings in play mode do not leak out into edit mode or the asset
 
@@ -259,6 +261,9 @@ namespace UnityEngine.InputSystem
         ///
         /// The default value is 0.5.
         ///
+        /// Any value will implicitly be clamped to <c>0.0001f</c> as allowing a value of 0 would
+        /// cause all buttons in their default state to already be pressed.
+        ///
         /// Lowering the button press point will make triggers feel more like hair-triggers (akin
         /// to using the hair-trigger feature on Xbox Elite controllers). However, it may make using
         /// the directional buttons (i.e. <see cref="Controls.StickControl.up"/> etc) be fickle as
@@ -297,7 +302,7 @@ namespace UnityEngine.InputSystem
                 // ReSharper disable once CompareOfFloatsByEqualityOperator
                 if (m_DefaultButtonPressPoint == value)
                     return;
-                m_DefaultButtonPressPoint = value;
+                m_DefaultButtonPressPoint = Mathf.Clamp(value, ButtonControl.kMinButtonPressPoint, float.MaxValue);
                 OnChange();
             }
         }
@@ -561,6 +566,7 @@ namespace UnityEngine.InputSystem
         // A setting of 0.5 seems to roughly be what games generally use on the gamepad triggers.
         // Having a higher value here also obsoletes the need for custom press points on stick buttons
         // (the up/down/left/right ones).
+        [Min(ButtonControl.kMinButtonPressPoint)]
         [SerializeField] private float m_DefaultButtonPressPoint = 0.5f;
         [SerializeField] private float m_ButtonReleaseThreshold = 0.75f;
         [SerializeField] private float m_DefaultTapTime = 0.2f;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -3,7 +3,6 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine.UI;
 
 ////TODO: make sure that alterations made to InputSystem.settings in play mode do not leak out into edit mode or the asset
 


### PR DESCRIPTION
Addresses [1349002](https://issuetracker.unity3d.com/issues/onclick-not-working-when-in-player) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1349002/)).

### Description

Setting `InputSystem.settings.defaultButtonPressPoint` to 0 was an easy mistake to make and caused all button press functionality to be rendered fubar.

### Changes made

Clamp to a min of 0.0001 so that we don't consider buttons in their default state pressed.

### Notes

Some misc cleanup in CHANGELOG.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
