### PR TITLE
Fix input test fixture state

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2618,7 +2618,7 @@ partial class CoreTests
         var action = new InputAction(binding: "<Gamepad>/buttonSouth");
         action.Enable();
 
-        Assert.That(InputActionState.s_GlobalList.length, Is.EqualTo(1));
+        Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(1));
         Assert.That(InputSystem.s_Manager.m_StateChangeMonitors.Length, Is.GreaterThan(0));
         Assert.That(InputSystem.s_Manager.m_StateChangeMonitors[0].count, Is.EqualTo(1));
 
@@ -2626,7 +2626,7 @@ partial class CoreTests
         InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingPlayMode);
         InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredEditMode);
 
-        Assert.That(InputActionState.s_GlobalList.length, Is.Zero);
+        Assert.That(InputActionState.s_GlobalState.globalList.length, Is.Zero);
         Assert.That(InputSystem.s_Manager.m_StateChangeMonitors[0].listeners[0].control, Is.Null); // Won't get removed, just cleared.
     }
 

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -26,7 +26,7 @@ internal class EnhancedTouchTests : CoreTestsFixture
         base.Setup();
 
         // Disable() will not reset this so default initialize it here.
-        Touch.s_HistoryLengthPerFinger = 64;
+        Touch.s_GlobalState.historyLengthPerFinger = 64;
 
         if (!TestContext.CurrentContext.Test.Properties.ContainsKey("EnhancedTouchDisabled"))
         {
@@ -45,16 +45,16 @@ internal class EnhancedTouchTests : CoreTestsFixture
         EnhancedTouchSupport.Disable();
 
         // Make sure cleanup really did clean up.
-        Assert.That(Touch.s_Touchscreens.length, Is.EqualTo(0));
-        Assert.That(Touch.s_PlayerState, Is.EqualTo(default(Touch.FingerAndTouchState)));
+        Assert.That(Touch.s_GlobalState.touchscreens.length, Is.EqualTo(0));
+        Assert.That(Touch.s_GlobalState.playerState, Is.EqualTo(default(Touch.FingerAndTouchState)));
         #if UNITY_EDITOR
-        Assert.That(Touch.s_EditorState, Is.EqualTo(default(Touch.FingerAndTouchState)));
+        Assert.That(Touch.s_GlobalState.editorState, Is.EqualTo(default(Touch.FingerAndTouchState)));
         #endif
 
         // Some state is kept alive in-between Disable/Enable. Manually clean it out.
-        Touch.s_OnFingerDown = default;
-        Touch.s_OnFingerUp = default;
-        Touch.s_OnFingerMove = default;
+        Touch.s_GlobalState.onFingerDown = default;
+        Touch.s_GlobalState.onFingerUp = default;
+        Touch.s_GlobalState.onFingerMove = default;
 
         TouchSimulation.Destroy();
         TouchSimulation.s_Instance = m_OldTouchSimulationInstance;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [1.1.0-verified]
+
+### Fixed
+
+- Fixed an issue where mixing test cases based on `InputTestFixture` (using mocked `InputSystem`) and regular test cases (using real `InputSystem`) would lead to static state leaking between test cases causing random failures and unexpected/undefined behavior.
+
 ## [1.1.0-pre.6] - 2021-08-23
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
-## [1.1.0-verified]
+## [Unreleased]
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,7 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 
-- Fixed an issue where mixing test cases based on `InputTestFixture` (using mocked `InputSystem`) and regular test cases (using real `InputSystem`) would lead to static state leaking between test cases causing random failures and unexpected/undefined behavior.
+- Fixed an issue where mixing test cases based on `InputTestFixture` (using mocked `InputSystem`) and regular test cases (using real `InputSystem`) would lead to static state leaking between test cases causing random failures and unexpected/undefined behavior ([case 1329015](https://issuetracker.unity3d.com/product/unity/issues/guid/1329015)).
 
 ## [1.1.0-pre.6] - 2021-08-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -127,7 +127,7 @@ namespace UnityEngine.InputSystem
         public void Initialize(InputBindingResolver resolver)
         {
             ClaimDataFrom(resolver);
-            AddToGlobaList();
+            AddToGlobalList();
         }
 
         internal void ClaimDataFrom(InputBindingResolver resolver)
@@ -390,7 +390,7 @@ namespace UnityEngine.InputSystem
             HookOnBeforeUpdate();
 
             // Fire notifications.
-            if (s_OnActionChange.length > 0)
+            if (s_GlobalState.onActionChange.length > 0)
             {
                 for (var i = 0; i < totalMapCount; ++i)
                 {
@@ -1949,7 +1949,7 @@ namespace UnityEngine.InputSystem
         {
             // If there's no listeners, don't bother with anything else.
             var callbacksOnMap = actionMap.m_ActionCallbacks;
-            if (listeners.length == 0 && callbacksOnMap.length == 0 && s_OnActionChange.length == 0)
+            if (listeners.length == 0 && callbacksOnMap.length == 0 && s_GlobalState.onActionChange.length == 0)
                 return;
 
             var context = new InputAction.CallbackContext
@@ -1962,7 +1962,7 @@ namespace UnityEngine.InputSystem
 
             // Global callback goes first.
             var action = context.action;
-            if (s_OnActionChange.length > 0)
+            if (s_GlobalState.onActionChange.length > 0)
             {
                 InputActionChange change;
                 switch (phase)
@@ -1981,7 +1981,7 @@ namespace UnityEngine.InputSystem
                         return;
                 }
 
-                DelegateHelpers.InvokeCallbacksSafe(ref s_OnActionChange, action, change, "InputSystem.onActionChange");
+                DelegateHelpers.InvokeCallbacksSafe(ref s_GlobalState.onActionChange, action, change, "InputSystem.onActionChange");
             }
 
             // Run callbacks (if any) directly on action.
@@ -3610,25 +3610,30 @@ namespace UnityEngine.InputSystem
         ///
         /// Both of these needs are served by this global list.
         /// </remarks>
-        internal static InlinedArray<GCHandle> s_GlobalList;
-        internal static CallbackArray<Action<object, InputActionChange>> s_OnActionChange;
-        internal static CallbackArray<Action<object>> s_OnActionControlsChanged;
+        internal struct GlobalState
+        {
+            internal InlinedArray<GCHandle> globalList;
+            internal CallbackArray<Action<object, InputActionChange>> onActionChange;
+            internal CallbackArray<Action<object>> onActionControlsChanged;
+        }
 
-        private void AddToGlobaList()
+        internal static GlobalState s_GlobalState;
+
+        private void AddToGlobalList()
         {
             CompactGlobalList();
             var handle = GCHandle.Alloc(this, GCHandleType.Weak);
-            s_GlobalList.AppendWithCapacity(handle);
+            s_GlobalState.globalList.AppendWithCapacity(handle);
         }
 
         private void RemoveMapFromGlobalList()
         {
-            var count = s_GlobalList.length;
+            var count = s_GlobalState.globalList.length;
             for (var i = 0; i < count; ++i)
-                if (s_GlobalList[i].Target == this)
+                if (s_GlobalState.globalList[i].Target == this)
                 {
-                    s_GlobalList[i].Free();
-                    s_GlobalList.RemoveAtByMovingTailWithCapacity(i);
+                    s_GlobalState.globalList[i].Free();
+                    s_GlobalState.globalList.RemoveAtByMovingTailWithCapacity(i);
                     break;
                 }
         }
@@ -3638,25 +3643,25 @@ namespace UnityEngine.InputSystem
         /// </summary>
         private static void CompactGlobalList()
         {
-            var length = s_GlobalList.length;
+            var length = s_GlobalState.globalList.length;
             var head = 0;
             for (var i = 0; i < length; ++i)
             {
-                var handle = s_GlobalList[i];
+                var handle = s_GlobalState.globalList[i];
                 if (handle.IsAllocated && handle.Target != null)
                 {
                     if (head != i)
-                        s_GlobalList[head] = handle;
+                        s_GlobalState.globalList[head] = handle;
                     ++head;
                 }
                 else
                 {
                     if (handle.IsAllocated)
-                        s_GlobalList[i].Free();
-                    s_GlobalList[i] = default;
+                        s_GlobalState.globalList[i].Free();
+                    s_GlobalState.globalList[i] = default;
                 }
             }
-            s_GlobalList.length = head;
+            s_GlobalState.globalList.length = head;
         }
 
         internal static void NotifyListenersOfActionChange(InputActionChange change, object actionOrMapOrAsset)
@@ -3665,9 +3670,9 @@ namespace UnityEngine.InputSystem
             Debug.Assert(actionOrMapOrAsset is InputAction || (actionOrMapOrAsset as InputActionMap)?.m_SingletonAction == null,
                 "Must not send notifications for changes made to hidden action maps of singleton actions");
 
-            DelegateHelpers.InvokeCallbacksSafe(ref s_OnActionChange, actionOrMapOrAsset, change, "onActionChange");
+            DelegateHelpers.InvokeCallbacksSafe(ref s_GlobalState.onActionChange, actionOrMapOrAsset, change, "onActionChange");
             if (change == InputActionChange.BoundControlsChanged)
-                DelegateHelpers.InvokeCallbacksSafe(ref s_OnActionControlsChanged, actionOrMapOrAsset, "onActionControlsChange");
+                DelegateHelpers.InvokeCallbacksSafe(ref s_GlobalState.onActionControlsChanged, actionOrMapOrAsset, "onActionControlsChange");
         }
 
         /// <summary>
@@ -3676,22 +3681,22 @@ namespace UnityEngine.InputSystem
         internal static void ResetGlobals()
         {
             DestroyAllActionMapStates();
-            for (var i = 0; i < s_GlobalList.length; ++i)
-                if (s_GlobalList[i].IsAllocated)
-                    s_GlobalList[i].Free();
-            s_GlobalList.length = 0;
-            s_OnActionChange.Clear();
-            s_OnActionControlsChanged.Clear();
+            for (var i = 0; i < s_GlobalState.globalList.length; ++i)
+                if (s_GlobalState.globalList[i].IsAllocated)
+                    s_GlobalState.globalList[i].Free();
+            s_GlobalState.globalList.length = 0;
+            s_GlobalState.onActionChange.Clear();
+            s_GlobalState.onActionControlsChanged.Clear();
         }
 
         // Walk all maps with enabled actions and add all enabled actions to the given list.
         internal static int FindAllEnabledActions(List<InputAction> result)
         {
             var numFound = 0;
-            var stateCount = s_GlobalList.length;
+            var stateCount = s_GlobalState.globalList.length;
             for (var i = 0; i < stateCount; ++i)
             {
-                var handle = s_GlobalList[i];
+                var handle = s_GlobalState.globalList[i];
                 if (!handle.IsAllocated)
                     continue;
                 var state = (InputActionState)handle.Target;
@@ -3755,15 +3760,15 @@ namespace UnityEngine.InputSystem
                 change == InputDeviceChange.SoftReset || change == InputDeviceChange.HardReset,
                 "Should only be called for relevant changes");
 
-            for (var i = 0; i < s_GlobalList.length; ++i)
+            for (var i = 0; i < s_GlobalState.globalList.length; ++i)
             {
-                var handle = s_GlobalList[i];
+                var handle = s_GlobalState.globalList[i];
                 if (!handle.IsAllocated || handle.Target == null)
                 {
                     // Stale entry in the list. State has already been reclaimed by GC. Remove it.
                     if (handle.IsAllocated)
-                        s_GlobalList[i].Free();
-                    s_GlobalList.RemoveAtWithCapacity(i);
+                        s_GlobalState.globalList[i].Free();
+                    s_GlobalState.globalList.RemoveAtWithCapacity(i);
                     --i;
                     continue;
                 }
@@ -3827,15 +3832,15 @@ namespace UnityEngine.InputSystem
             ++InputActionMap.s_DeferBindingResolution;
             try
             {
-                for (var i = 0; i < s_GlobalList.length; ++i)
+                for (var i = 0; i < s_GlobalState.globalList.length; ++i)
                 {
-                    var handle = s_GlobalList[i];
+                    var handle = s_GlobalState.globalList[i];
                     if (!handle.IsAllocated || handle.Target == null)
                     {
                         // Stale entry in the list. State has already been reclaimed by GC. Remove it.
                         if (handle.IsAllocated)
-                            s_GlobalList[i].Free();
-                        s_GlobalList.RemoveAtWithCapacity(i);
+                            s_GlobalState.globalList[i].Free();
+                        s_GlobalState.globalList.RemoveAtWithCapacity(i);
                         --i;
                         continue;
                     }
@@ -3853,9 +3858,9 @@ namespace UnityEngine.InputSystem
 
         internal static void DisableAllActions()
         {
-            for (var i = 0; i < s_GlobalList.length; ++i)
+            for (var i = 0; i < s_GlobalState.globalList.length; ++i)
             {
-                var handle = s_GlobalList[i];
+                var handle = s_GlobalState.globalList[i];
                 if (!handle.IsAllocated || handle.Target == null)
                     continue;
                 var state = (InputActionState)handle.Target;
@@ -3879,16 +3884,16 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         internal static void DestroyAllActionMapStates()
         {
-            while (s_GlobalList.length > 0)
+            while (s_GlobalState.globalList.length > 0)
             {
-                var index = s_GlobalList.length - 1;
-                var handle = s_GlobalList[index];
+                var index = s_GlobalState.globalList.length - 1;
+                var handle = s_GlobalState.globalList[index];
                 if (!handle.IsAllocated || handle.Target == null)
                 {
                     // Already destroyed.
                     if (handle.IsAllocated)
-                        s_GlobalList[index].Free();
-                    s_GlobalList.RemoveAtWithCapacity(index);
+                        s_GlobalState.globalList[index].Free();
+                    s_GlobalState.globalList.RemoveAtWithCapacity(index);
                     continue;
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -3623,14 +3623,9 @@ namespace UnityEngine.InputSystem
         {
             // Save current state
             var savedState = new SavedStructState<GlobalState>(
-                ref s_GlobalState, (ref GlobalState state) =>
-                {
-                    // Free/dispose any resources allocated for the current state
-                    ResetGlobals();
-
-                    // Restore stored state
-                    s_GlobalState = state;
-                });
+                ref s_GlobalState,
+                (ref GlobalState state) => s_GlobalState = state, // restore
+                () => ResetGlobals()); // static dispose
 
             // Reset global state
             s_GlobalState = default;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -3617,6 +3617,7 @@ namespace UnityEngine.InputSystem
             internal CallbackArray<Action<object>> onActionControlsChanged;
         }
 
+        internal static GlobalState CreateGlobalState() => default;
         internal static GlobalState s_GlobalState;
 
         private void AddToGlobalList()

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -3619,7 +3619,7 @@ namespace UnityEngine.InputSystem
 
         internal static GlobalState s_GlobalState;
 
-        internal static SavedStructState<GlobalState> SaveAndResetState()
+        internal static ISavedState SaveAndResetState()
         {
             // Save current state
             var savedState = new SavedStructState<GlobalState>(

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -3601,7 +3601,7 @@ namespace UnityEngine.InputSystem
         #region Global State
 
         /// <summary>
-        /// List of weak references to all action map states currently in the system.
+        /// Global state containing a list of weak references to all action map states currently in the system.
         /// </summary>
         /// <remarks>
         /// When the control setup in the system changes, we need a way for control resolution that

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -3617,8 +3617,26 @@ namespace UnityEngine.InputSystem
             internal CallbackArray<Action<object>> onActionControlsChanged;
         }
 
-        internal static GlobalState CreateGlobalState() => default;
         internal static GlobalState s_GlobalState;
+
+        internal static SavedStructState<GlobalState> SaveAndResetState()
+        {
+            // Save current state
+            var savedState = new SavedStructState<GlobalState>(
+                ref s_GlobalState, (ref GlobalState state) =>
+                {
+                    // Free/dispose any resources allocated for the current state
+                    ResetGlobals();
+
+                    // Restore stored state
+                    s_GlobalState = state;
+                });
+
+            // Reset global state
+            s_GlobalState = default;
+
+            return savedState;
+        }
 
         private void AddToGlobalList()
         {
@@ -3679,7 +3697,7 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Nuke global state we have to keep track of action map states.
         /// </summary>
-        internal static void ResetGlobals()
+        private static void ResetGlobals()
         {
             DestroyAllActionMapStates();
             for (var i = 0; i < s_GlobalState.globalList.length; ++i)

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3609,18 +3609,23 @@ namespace UnityEngine.InputSystem
         {
             Debug.Assert(s_SavedStateStack != null && s_SavedStateStack.Count > 0);
 
+            // Load back previous state.
+            var state = s_SavedStateStack.Pop();
+
+            state.inputUserState.StaticDisposeCurrentState();
+            state.touchState.StaticDisposeCurrentState();
+            state.inputActionState.StaticDisposeCurrentState();
+
             // Nuke what we have.
             Destroy();
 
-            // Load back previous state.
-            var state = s_SavedStateStack.Pop();
+            state.inputUserState.RestoreSavedState();
+            state.touchState.RestoreSavedState();
+            state.inputActionState.RestoreSavedState();
+
             s_Manager = state.manager;
             s_Remote = state.remote;
             s_RemoteConnection = state.remoteConnection;
-
-            state.inputActionState.Restore();
-            state.touchState.Restore();
-            state.inputUserState.Restore();
 
             InputUpdate.Restore(state.managerState.updateState);
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3592,10 +3592,10 @@ namespace UnityEngine.InputSystem
                 #if UNITY_EDITOR
                 userSettings = InputEditorUserSettings.s_Settings,
                 systemObject = JsonUtility.ToJson(s_SystemObject),
+                #endif
                 inputActionState = InputActionState.SaveAndResetState(),
                 touchState = EnhancedTouch.Touch.SaveAndResetState(),
                 inputUserState = InputUser.SaveAndResetState()
-                #endif
             });
 
             Reset(enableRemoting, runtime ?? InputRuntime.s_Instance); // Keep current runtime.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2917,13 +2917,13 @@ namespace UnityEngine.InputSystem
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                InputActionState.s_OnActionChange.AddCallback(value);
+                InputActionState.s_GlobalState.onActionChange.AddCallback(value);
             }
             remove
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                InputActionState.s_OnActionChange.RemoveCallback(value);
+                InputActionState.s_GlobalState.onActionChange.RemoveCallback(value);
             }
         }
 
@@ -3553,6 +3553,8 @@ namespace UnityEngine.InputSystem
             [SerializeField] public string systemObject;
             #endif
             ////REVIEW: preserve InputUser state? (if even possible)
+            ///
+            [NonSerialized] public InputActionState.GlobalState inputActionState;
         }
 
         private static Stack<State> s_SavedStateStack;
@@ -3589,8 +3591,12 @@ namespace UnityEngine.InputSystem
                 #if UNITY_EDITOR
                 userSettings = InputEditorUserSettings.s_Settings,
                 systemObject = JsonUtility.ToJson(s_SystemObject),
+                inputActionState = InputActionState.s_GlobalState
                 #endif
             });
+
+            // Replace global state with new state
+            InputActionState.s_GlobalState = new InputActionState.GlobalState();
 
             Reset(enableRemoting, runtime ?? InputRuntime.s_Instance); // Keep current runtime.
         }
@@ -3611,6 +3617,8 @@ namespace UnityEngine.InputSystem
             s_Manager = state.manager;
             s_Remote = state.remote;
             s_RemoteConnection = state.remoteConnection;
+
+            InputActionState.s_GlobalState = state.inputActionState;
 
             InputUpdate.Restore(state.managerState.updateState);
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3552,8 +3552,7 @@ namespace UnityEngine.InputSystem
             [SerializeField] public InputEditorUserSettings.SerializedState userSettings;
             [SerializeField] public string systemObject;
             #endif
-            ////REVIEW: preserve InputUser state? (if even possible)
-            ///
+            ////TODO: make these saved states capable of surviving domain reloads
             [NonSerialized] public ISavedState inputActionState;
             [NonSerialized] public ISavedState touchState;
             [NonSerialized] public ISavedState inputUserState;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3555,6 +3555,7 @@ namespace UnityEngine.InputSystem
             ////REVIEW: preserve InputUser state? (if even possible)
             ///
             [NonSerialized] public InputActionState.GlobalState inputActionState;
+            [NonSerialized] public EnhancedTouch.Touch.GlobalState touchState;
         }
 
         private static Stack<State> s_SavedStateStack;
@@ -3591,7 +3592,8 @@ namespace UnityEngine.InputSystem
                 #if UNITY_EDITOR
                 userSettings = InputEditorUserSettings.s_Settings,
                 systemObject = JsonUtility.ToJson(s_SystemObject),
-                inputActionState = InputActionState.s_GlobalState
+                inputActionState = InputActionState.s_GlobalState,
+                touchState = EnhancedTouch.Touch.s_GlobalState
                 #endif
             });
 
@@ -3619,6 +3621,7 @@ namespace UnityEngine.InputSystem
             s_RemoteConnection = state.remoteConnection;
 
             InputActionState.s_GlobalState = state.inputActionState;
+            EnhancedTouch.Touch.s_GlobalState = state.touchState;
 
             InputUpdate.Restore(state.managerState.updateState);
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3556,6 +3556,7 @@ namespace UnityEngine.InputSystem
             ///
             [NonSerialized] public InputActionState.GlobalState inputActionState;
             [NonSerialized] public EnhancedTouch.Touch.GlobalState touchState;
+            [NonSerialized] public InputUser.GlobalState inputUserState;
         }
 
         private static Stack<State> s_SavedStateStack;
@@ -3598,7 +3599,9 @@ namespace UnityEngine.InputSystem
             });
 
             // Replace global state with new state
-            InputActionState.s_GlobalState = new InputActionState.GlobalState();
+            InputActionState.s_GlobalState = InputActionState.CreateGlobalState();
+            EnhancedTouch.Touch.s_GlobalState = EnhancedTouch.Touch.CreateGlobalState();
+            InputUser.s_GlobalState = InputUser.CreateGlobalState();
 
             Reset(enableRemoting, runtime ?? InputRuntime.s_Instance); // Keep current runtime.
         }
@@ -3622,6 +3625,7 @@ namespace UnityEngine.InputSystem
 
             InputActionState.s_GlobalState = state.inputActionState;
             EnhancedTouch.Touch.s_GlobalState = state.touchState;
+            InputUser.s_GlobalState = state.inputUserState;
 
             InputUpdate.Restore(state.managerState.updateState);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/EnhancedTouchSupport.cs
@@ -124,21 +124,21 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
         internal static void Reset()
         {
-            Touch.s_Touchscreens = default;
-            Touch.s_PlayerState.Destroy();
-            Touch.s_PlayerState = default;
+            Touch.s_GlobalState.touchscreens = default;
+            Touch.s_GlobalState.playerState.Destroy();
+            Touch.s_GlobalState.playerState = default;
             #if UNITY_EDITOR
-            Touch.s_EditorState.Destroy();
-            Touch.s_EditorState = default;
+            Touch.s_GlobalState.editorState.Destroy();
+            Touch.s_GlobalState.editorState = default;
             #endif
             s_Enabled = 0;
         }
 
         private static void SetUpState()
         {
-            Touch.s_PlayerState.updateMask = InputUpdateType.Dynamic | InputUpdateType.Manual;
+            Touch.s_GlobalState.playerState.updateMask = InputUpdateType.Dynamic | InputUpdateType.Manual;
             #if UNITY_EDITOR
-            Touch.s_EditorState.updateMask = InputUpdateType.Editor;
+            Touch.s_GlobalState.editorState.updateMask = InputUpdateType.Editor;
             #endif
 
             s_UpdateMode = InputSystem.settings.updateMode;
@@ -152,14 +152,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             foreach (var device in InputSystem.devices)
                 OnDeviceChange(device, InputDeviceChange.Removed);
 
-            Touch.s_PlayerState.Destroy();
+            Touch.s_GlobalState.playerState.Destroy();
             #if UNITY_EDITOR
-            Touch.s_EditorState.Destroy();
+            Touch.s_GlobalState.editorState.Destroy();
             #endif
 
-            Touch.s_PlayerState = default;
+            Touch.s_GlobalState.playerState = default;
             #if UNITY_EDITOR
-            Touch.s_EditorState = default;
+            Touch.s_GlobalState.editorState = default;
             #endif
         }
 
@@ -196,8 +196,8 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         private static void OnBeforeDomainReload()
         {
             // We need to release NativeArrays we're holding before losing track of them during domain reloads.
-            Touch.s_PlayerState.Destroy();
-            Touch.s_EditorState.Destroy();
+            Touch.s_GlobalState.playerState.Destroy();
+            Touch.s_GlobalState.editorState.Destroy();
         }
 
         #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -157,12 +157,12 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             touchState->updateStepCount = InputUpdate.s_UpdateStepCount;
 
             // Invalidate activeTouches.
-            Touch.s_PlayerState.haveBuiltActiveTouches = false;
+            Touch.s_GlobalState.playerState.haveBuiltActiveTouches = false;
 
             // Record the extra data we maintain for each touch.
             var extraData = (Touch.ExtraDataPerTouchState*)((byte*)touchHeader + m_StateHistory.bytesPerRecord -
                 UnsafeUtility.SizeOf<Touch.ExtraDataPerTouchState>());
-            extraData->uniqueId = ++Touch.s_PlayerState.lastId;
+            extraData->uniqueId = ++Touch.s_GlobalState.playerState.lastId;
 
             // We get accumulated deltas from Touchscreen. Store the accumulated
             // value and "unaccumulate" the value we store on delta.
@@ -190,14 +190,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             switch (touchState->phase)
             {
                 case TouchPhase.Began:
-                    DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_OnFingerDown, this, "Touch.onFingerDown");
+                    DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_GlobalState.onFingerDown, this, "Touch.onFingerDown");
                     break;
                 case TouchPhase.Moved:
-                    DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_OnFingerMove, this, "Touch.onFingerMove");
+                    DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_GlobalState.onFingerMove, this, "Touch.onFingerMove");
                     break;
                 case TouchPhase.Ended:
                 case TouchPhase.Canceled:
-                    DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_OnFingerUp, this, "Touch.onFingerUp");
+                    DelegateHelpers.InvokeCallbacksSafe(ref Touch.s_GlobalState.onFingerUp, this, "Touch.onFingerUp");
                     break;
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -585,12 +585,28 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 #endif
         }
 
-        internal static GlobalState CreateGlobalState()
-        {
+        private static GlobalState CreateGlobalState()
+        {   // Convenient method since parameterized construction is default
             return new GlobalState { historyLengthPerFinger = 64 };
         }
 
         internal static GlobalState s_GlobalState = CreateGlobalState();
+
+        internal static ISavedState SaveAndResetState()
+        {
+            // Save current state
+            var savedState = new SavedStructState<GlobalState>(
+                ref s_GlobalState, (ref GlobalState state) =>
+                {
+                    // Restore stored state
+                    s_GlobalState = state;
+                });
+
+            // Reset global state
+            s_GlobalState = CreateGlobalState();
+
+            return savedState;
+        }
 
         // In scenarios where we have to support multiple different types of input updates (e.g. in editor or in
         // player when both dynamic and fixed input updates are enabled), we need more than one copy of touch state.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -596,11 +596,9 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         {
             // Save current state
             var savedState = new SavedStructState<GlobalState>(
-                ref s_GlobalState, (ref GlobalState state) =>
-                {
-                    // Restore stored state
-                    s_GlobalState = state;
-                });
+                ref s_GlobalState,
+                (ref GlobalState state) => s_GlobalState = state,
+                () => { /* currently nothing to dispose */ });
 
             // Reset global state
             s_GlobalState = CreateGlobalState();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -332,8 +332,8 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             {
                 EnhancedTouchSupport.CheckEnabled();
                 // We lazily construct the array of active touches.
-                s_PlayerState.UpdateActiveTouches();
-                return new ReadOnlyArray<Touch>(s_PlayerState.activeTouches, 0, s_PlayerState.activeTouchCount);
+                s_GlobalState.playerState.UpdateActiveTouches();
+                return new ReadOnlyArray<Touch>(s_GlobalState.playerState.activeTouches, 0, s_GlobalState.playerState.activeTouchCount);
             }
         }
 
@@ -356,7 +356,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             get
             {
                 EnhancedTouchSupport.CheckEnabled();
-                return new ReadOnlyArray<Finger>(s_PlayerState.fingers, 0, s_PlayerState.totalFingerCount);
+                return new ReadOnlyArray<Finger>(s_GlobalState.playerState.fingers, 0, s_GlobalState.playerState.totalFingerCount);
             }
         }
 
@@ -372,8 +372,8 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             {
                 EnhancedTouchSupport.CheckEnabled();
                 // We lazily construct the array of active fingers.
-                s_PlayerState.UpdateActiveFingers();
-                return new ReadOnlyArray<Finger>(s_PlayerState.activeFingers, 0, s_PlayerState.activeFingerCount);
+                s_GlobalState.playerState.UpdateActiveFingers();
+                return new ReadOnlyArray<Finger>(s_GlobalState.playerState.activeFingers, 0, s_GlobalState.playerState.activeFingerCount);
             }
         }
 
@@ -386,7 +386,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             get
             {
                 EnhancedTouchSupport.CheckEnabled();
-                return s_Touchscreens;
+                return s_GlobalState.touchscreens;
             }
         }
 
@@ -403,14 +403,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnFingerDown.AddCallback(value);
+                s_GlobalState.onFingerDown.AddCallback(value);
             }
             remove
             {
                 EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnFingerDown.RemoveCallback(value);
+                s_GlobalState.onFingerDown.RemoveCallback(value);
             }
         }
 
@@ -427,14 +427,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnFingerUp.AddCallback(value);
+                s_GlobalState.onFingerUp.AddCallback(value);
             }
             remove
             {
                 EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnFingerUp.RemoveCallback(value);
+                s_GlobalState.onFingerUp.RemoveCallback(value);
             }
         }
 
@@ -452,14 +452,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnFingerMove.AddCallback(value);
+                s_GlobalState.onFingerMove.AddCallback(value);
             }
             remove
             {
                 EnhancedTouchSupport.CheckEnabled();
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnFingerMove.RemoveCallback(value);
+                s_GlobalState.onFingerMove.RemoveCallback(value);
             }
         }
 
@@ -481,7 +481,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         /// </remarks>
         public static int maxHistoryLengthPerFinger
         {
-            get => s_HistoryLengthPerFinger;
+            get => s_GlobalState.historyLengthPerFinger;
 
             ////TODO
             /*set { throw new NotImplementedException(); }*/
@@ -521,63 +521,76 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
         internal static void AddTouchscreen(Touchscreen screen)
         {
-            Debug.Assert(!s_Touchscreens.ContainsReference(screen), "Already added touchscreen");
-            s_Touchscreens.AppendWithCapacity(screen, capacityIncrement: 5);
+            Debug.Assert(!s_GlobalState.touchscreens.ContainsReference(screen), "Already added touchscreen");
+            s_GlobalState.touchscreens.AppendWithCapacity(screen, capacityIncrement: 5);
 
             // Add finger tracking to states.
-            s_PlayerState.AddFingers(screen);
-            #if UNITY_EDITOR
-            s_EditorState.AddFingers(screen);
-            #endif
+            s_GlobalState.playerState.AddFingers(screen);
+#if UNITY_EDITOR
+            s_GlobalState.editorState.AddFingers(screen);
+#endif
         }
 
         internal static void RemoveTouchscreen(Touchscreen screen)
         {
-            Debug.Assert(s_Touchscreens.ContainsReference(screen), "Did not add touchscreen");
+            Debug.Assert(s_GlobalState.touchscreens.ContainsReference(screen), "Did not add touchscreen");
 
             // Remove from list.
-            var index = s_Touchscreens.IndexOfReference(screen);
-            s_Touchscreens.RemoveAtWithCapacity(index);
+            var index = s_GlobalState.touchscreens.IndexOfReference(screen);
+            s_GlobalState.touchscreens.RemoveAtWithCapacity(index);
 
             // Remove fingers from states.
-            s_PlayerState.RemoveFingers(screen);
-            #if UNITY_EDITOR
-            s_EditorState.RemoveFingers(screen);
-            #endif
+            s_GlobalState.playerState.RemoveFingers(screen);
+#if UNITY_EDITOR
+            s_GlobalState.editorState.RemoveFingers(screen);
+#endif
         }
 
         ////TODO: only have this hooked when we actually need it
         internal static void BeginUpdate()
         {
-            #if UNITY_EDITOR
-            if ((InputState.currentUpdateType == InputUpdateType.Editor && s_PlayerState.updateMask != InputUpdateType.Editor) ||
-                (InputState.currentUpdateType != InputUpdateType.Editor && s_PlayerState.updateMask == InputUpdateType.Editor))
+#if UNITY_EDITOR
+            if ((InputState.currentUpdateType == InputUpdateType.Editor && s_GlobalState.playerState.updateMask != InputUpdateType.Editor) ||
+                (InputState.currentUpdateType != InputUpdateType.Editor && s_GlobalState.playerState.updateMask == InputUpdateType.Editor))
             {
                 // Either swap in editor state and retain currently active player state in s_EditorState
                 // or swap player state back in.
-                MemoryHelpers.Swap(ref s_PlayerState, ref s_EditorState);
+                MemoryHelpers.Swap(ref s_GlobalState.playerState, ref s_GlobalState.editorState);
             }
-            #endif
+#endif
 
             // If we have any touches in activeTouches that are ended or canceled,
             // we need to clear them in the next frame.
-            if (s_PlayerState.haveActiveTouchesNeedingRefreshNextUpdate)
-                s_PlayerState.haveBuiltActiveTouches = false;
+            if (s_GlobalState.playerState.haveActiveTouchesNeedingRefreshNextUpdate)
+                s_GlobalState.playerState.haveBuiltActiveTouches = false;
         }
 
         private readonly Finger m_Finger;
         internal InputStateHistory<TouchState>.Record m_TouchRecord;
 
-        internal static InlinedArray<Touchscreen> s_Touchscreens;
-        internal static int s_HistoryLengthPerFinger = 64;
-        internal static CallbackArray<Action<Finger>> s_OnFingerDown;
-        internal static CallbackArray<Action<Finger>> s_OnFingerMove;
-        internal static CallbackArray<Action<Finger>> s_OnFingerUp;
+        /// <summary>
+        /// Holds global (static) touch state.
+        /// </summary>
+        internal struct GlobalState
+        {
+            internal InlinedArray<Touchscreen> touchscreens;
+            internal int historyLengthPerFinger;
+            internal CallbackArray<Action<Finger>> onFingerDown;
+            internal CallbackArray<Action<Finger>> onFingerMove;
+            internal CallbackArray<Action<Finger>> onFingerUp;
 
-        internal static FingerAndTouchState s_PlayerState;
-        #if UNITY_EDITOR
-        internal static FingerAndTouchState s_EditorState;
-        #endif
+            internal FingerAndTouchState playerState;
+#if UNITY_EDITOR
+            internal FingerAndTouchState editorState;
+#endif
+        }
+
+        internal static GlobalState CreateGlobalState()
+        {
+            return new GlobalState { historyLengthPerFinger = 64 };
+        }
+
+        internal static GlobalState s_GlobalState = CreateGlobalState();
 
         // In scenarios where we have to support multiple different types of input updates (e.g. in editor or in
         // player when both dynamic and fixed input updates are enabled), we need more than one copy of touch state.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1318,7 +1318,7 @@ namespace UnityEngine.InputSystem.UI
 
             if (m_OnControlsChangedDelegate == null)
                 m_OnControlsChangedDelegate = OnControlsChanged;
-            InputActionState.s_OnActionControlsChanged.AddCallback(m_OnControlsChangedDelegate);
+            InputActionState.s_GlobalState.onActionControlsChanged.AddCallback(m_OnControlsChangedDelegate);
 
             HookActions();
             EnableAllActions();
@@ -1328,7 +1328,7 @@ namespace UnityEngine.InputSystem.UI
         {
             base.OnDisable();
 
-            InputActionState.s_OnActionControlsChanged.RemoveCallback(m_OnControlsChangedDelegate);
+            InputActionState.s_GlobalState.onActionControlsChanged.RemoveCallback(m_OnControlsChangedDelegate);
 
             DisableAllActions();
             UnhookActions();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -2025,6 +2025,33 @@ namespace UnityEngine.InputSystem.Users
             s_OnEventHooked = false;
         }
 
+        internal struct GlobalState
+        {
+            private int s_PairingStateVersion;
+            private uint s_LastUserId;
+            private int s_AllUserCount;
+            private int s_AllPairedDeviceCount;
+            private int s_AllLostDeviceCount;
+            private InputUser[] s_AllUsers;
+            private UserData[] s_AllUserData;
+            private InputDevice[] s_AllPairedDevices; // We keep a single array that we slice out to each user.
+            private InputDevice[] s_AllLostDevices;   // We keep a single array that we slice out to each user.
+            private InlinedArray<OngoingAccountSelection> s_OngoingAccountSelections;
+            private CallbackArray<Action<InputUser, InputUserChange, InputDevice>> s_OnChange;
+            private CallbackArray<Action<InputControl, InputEventPtr>> s_OnUnpairedDeviceUsed;
+            private CallbackArray<Func<InputDevice, InputEventPtr, bool>> s_OnPreFilterUnpairedDeviceUsed;
+            private Action<object, InputActionChange> s_ActionChangeDelegate;
+            private Action<InputDevice, InputDeviceChange> s_OnDeviceChangeDelegate;
+            private Action<InputEventPtr, InputDevice> s_OnEventDelegate;
+            private bool s_OnActionChangeHooked;
+            private bool s_OnDeviceChangeHooked;
+            private bool s_OnEventHooked;
+            private int s_ListenForUnpairedDeviceActivity;
+        }
+
+        internal static GlobalState CreateGlobalState() => default;
+        internal static GlobalState s_GlobalState;
+
         internal static void ResetGlobals()
         {
             UnhookFromActionChange();
@@ -2041,13 +2068,16 @@ namespace UnityEngine.InputSystem.Users
             s_PairingStateVersion = 0;
             s_AllUserCount = 0;
             s_AllPairedDeviceCount = 0;
+            s_AllLostDeviceCount = 0;
             s_AllUsers = null;
             s_AllUserData = null;
             s_AllPairedDevices = null;
+            s_AllLostDevices = null;
             s_OngoingAccountSelections = default;
             s_OnChange = default;
             s_OnUnpairedDeviceUsed = default;
             s_OnPreFilterUnpairedDeviceUsed = default;
+            s_ActionChangeDelegate = null;
             s_OnDeviceChangeDelegate = null;
             s_OnEventDelegate = null;
             s_OnDeviceChangeHooked = false;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1979,14 +1979,9 @@ namespace UnityEngine.InputSystem.Users
         {
             // Save current state and provide an opaque interface to restore it
             var savedState = new SavedStructState<GlobalState>(
-                ref s_GlobalState, (ref GlobalState state) =>
-                {
-                    // Free/dispose any resources allocated for the current state
-                    DisposeAndResetGlobalState();
-
-                    // Restore stored state
-                    s_GlobalState = state;
-                });
+                ref s_GlobalState,
+                (ref GlobalState state) => s_GlobalState = state, // restore
+                () => DisposeAndResetGlobalState()); // static dispose
 
             // Reset global state
             s_GlobalState = default;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Unity.Collections;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
@@ -67,8 +66,8 @@ namespace UnityEngine.InputSystem.Users
                     return false;
 
                 // See if there's a currently active user with the given ID.
-                for (var i = 0; i < s_AllUserCount; ++i)
-                    if (s_AllUsers[i].m_Id == m_Id)
+                for (var i = 0; i < s_GlobalState.allUserCount; ++i)
+                    if (s_GlobalState.allUsers[i].m_Id == m_Id)
                         return true;
 
                 return false;
@@ -134,7 +133,7 @@ namespace UnityEngine.InputSystem.Users
         /// <seealso cref="platformUserAccountName"/>
         /// <seealso cref="platformUserAccountId"/>
         /// <seealso cref="InputUserChange.AccountChanged"/>
-        public InputUserAccountHandle? platformUserAccountHandle => s_AllUserData[index].platformUserAccountHandle;
+        public InputUserAccountHandle? platformUserAccountHandle => s_GlobalState.allUserData[index].platformUserAccountHandle;
 
         /// <summary>
         /// Human-readable name assigned to the user account at the platform level.
@@ -149,7 +148,7 @@ namespace UnityEngine.InputSystem.Users
         /// <seealso cref="platformUserAccountId"/>
         /// <seealso cref="InputUserChange.AccountChanged"/>
         /// <seealso cref="InputUserChange.AccountNameChanged"/>
-        public string platformUserAccountName => s_AllUserData[index].platformUserAccountName;
+        public string platformUserAccountName => s_GlobalState.allUserData[index].platformUserAccountName;
 
         /// <summary>
         /// Platform-specific user ID that is valid across sessions even if the <see cref="platformUserAccountName"/> of
@@ -164,7 +163,7 @@ namespace UnityEngine.InputSystem.Users
         /// <seealso cref="platformUserAccountHandle"/>
         /// <seealso cref="platformUserAccountName"/>
         /// <seealso cref="InputUserChange.AccountChanged"/>
-        public string platformUserAccountId => s_AllUserData[index].platformUserAccountId;
+        public string platformUserAccountId => s_GlobalState.allUserData[index].platformUserAccountId;
 
         ////REVIEW: Does it make sense to track used devices separately from paired devices?
         /// <summary>
@@ -195,8 +194,8 @@ namespace UnityEngine.InputSystem.Users
             get
             {
                 var userIndex = index;
-                return new ReadOnlyArray<InputDevice>(s_AllPairedDevices, s_AllUserData[userIndex].deviceStartIndex,
-                    s_AllUserData[userIndex].deviceCount);
+                return new ReadOnlyArray<InputDevice>(s_GlobalState.allPairedDevices, s_GlobalState.allUserData[userIndex].deviceStartIndex,
+                    s_GlobalState.allUserData[userIndex].deviceCount);
             }
         }
 
@@ -215,8 +214,8 @@ namespace UnityEngine.InputSystem.Users
             get
             {
                 var userIndex = index;
-                return new ReadOnlyArray<InputDevice>(s_AllLostDevices, s_AllUserData[userIndex].lostDeviceStartIndex,
-                    s_AllUserData[userIndex].lostDeviceCount);
+                return new ReadOnlyArray<InputDevice>(s_GlobalState.allLostDevices, s_GlobalState.allUserData[userIndex].lostDeviceStartIndex,
+                    s_GlobalState.allUserData[userIndex].lostDeviceCount);
             }
         }
 
@@ -237,7 +236,7 @@ namespace UnityEngine.InputSystem.Users
         /// <seealso cref="InputActionMap"/>
         /// <seealso cref="InputActionAsset"/>
         /// <seealso cref="InputUserChange.ControlsChanged"/>
-        public IInputActionCollection actions => s_AllUserData[index].actions;
+        public IInputActionCollection actions => s_GlobalState.allUserData[index].actions;
 
         /// <summary>
         /// The control scheme currently employed by the user.
@@ -256,7 +255,7 @@ namespace UnityEngine.InputSystem.Users
         /// <seealso cref="ActivateControlScheme(string)"/>
         /// <seealso cref="ActivateControlScheme(InputControlScheme)"/>
         /// <seealso cref="InputUserChange.ControlSchemeChanged"/>
-        public InputControlScheme? controlScheme => s_AllUserData[index].controlScheme;
+        public InputControlScheme? controlScheme => s_GlobalState.allUserData[index].controlScheme;
 
         /// <summary>
         /// The result of matching the device requirements given by <see cref="controlScheme"/> against
@@ -268,7 +267,7 @@ namespace UnityEngine.InputSystem.Users
         /// </remarks>
         /// <seealso cref="InputControlScheme.deviceRequirements"/>
         /// <seealso cref="InputControlScheme.PickDevicesFrom{TDevices}"/>
-        public InputControlScheme.MatchResult controlSchemeMatch => s_AllUserData[index].controlSchemeMatch;
+        public InputControlScheme.MatchResult controlSchemeMatch => s_GlobalState.allUserData[index].controlSchemeMatch;
 
         /// <summary>
         /// Whether the user is missing devices required by the <see cref="controlScheme"/> activated
@@ -280,7 +279,7 @@ namespace UnityEngine.InputSystem.Users
         /// devices if they cannot be satisfied based on the devices paired to the user.
         /// </remarks>
         /// <seealso cref="InputControlScheme.deviceRequirements"/>
-        public bool hasMissingRequiredDevices => s_AllUserData[index].controlSchemeMatch.hasMissingRequiredDevices;
+        public bool hasMissingRequiredDevices => s_GlobalState.allUserData[index].controlSchemeMatch.hasMissingRequiredDevices;
 
         /// <summary>
         /// List of all current users.
@@ -297,7 +296,7 @@ namespace UnityEngine.InputSystem.Users
         /// </remarks>
         /// <seealso cref="PerformPairingWithDevice"/>
         /// <seealso cref="UnpairDevicesAndRemoveUser"/>
-        public static ReadOnlyArray<InputUser> all => new ReadOnlyArray<InputUser>(s_AllUsers, 0, s_AllUserCount);
+        public static ReadOnlyArray<InputUser> all => new ReadOnlyArray<InputUser>(s_GlobalState.allUsers, 0, s_GlobalState.allUserCount);
 
         /// <summary>
         /// Event that is triggered when the <see cref="InputUser">user</see> setup in the system
@@ -314,13 +313,13 @@ namespace UnityEngine.InputSystem.Users
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnChange.AddCallback(value);
+                s_GlobalState.onChange.AddCallback(value);
             }
             remove
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnChange.RemoveCallback(value);
+                s_GlobalState.onChange.RemoveCallback(value);
             }
         }
 
@@ -390,16 +389,16 @@ namespace UnityEngine.InputSystem.Users
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnUnpairedDeviceUsed.AddCallback(value);
-                if (s_ListenForUnpairedDeviceActivity > 0)
+                s_GlobalState.onUnpairedDeviceUsed.AddCallback(value);
+                if (s_GlobalState.listenForUnpairedDeviceActivity > 0)
                     HookIntoEvents();
             }
             remove
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnUnpairedDeviceUsed.RemoveCallback(value);
-                if (s_OnUnpairedDeviceUsed.length == 0)
+                s_GlobalState.onUnpairedDeviceUsed.RemoveCallback(value);
+                if (s_GlobalState.onUnpairedDeviceUsed.length == 0)
                     UnhookFromDeviceStateChange();
             }
         }
@@ -431,13 +430,13 @@ namespace UnityEngine.InputSystem.Users
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnPreFilterUnpairedDeviceUsed.AddCallback(value);
+                s_GlobalState.onPreFilterUnpairedDeviceUsed.AddCallback(value);
             }
             remove
             {
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
-                s_OnPreFilterUnpairedDeviceUsed.RemoveCallback(value);
+                s_GlobalState.onPreFilterUnpairedDeviceUsed.RemoveCallback(value);
             }
         }
 
@@ -462,16 +461,16 @@ namespace UnityEngine.InputSystem.Users
         /// <seealso cref="PerformPairingWithDevice"/>
         public static int listenForUnpairedDeviceActivity
         {
-            get => s_ListenForUnpairedDeviceActivity;
+            get => s_GlobalState.listenForUnpairedDeviceActivity;
             set
             {
                 if (value < 0)
                     throw new ArgumentOutOfRangeException(nameof(value), "Cannot be negative");
-                if (value > 0 && s_OnUnpairedDeviceUsed.length > 0)
+                if (value > 0 && s_GlobalState.onUnpairedDeviceUsed.length > 0)
                     HookIntoEvents();
                 else if (value == 0)
                     UnhookFromDeviceStateChange();
-                s_ListenForUnpairedDeviceActivity = value;
+                s_GlobalState.listenForUnpairedDeviceActivity = value;
             }
         }
 
@@ -519,18 +518,18 @@ namespace UnityEngine.InputSystem.Users
         public void AssociateActionsWithUser(IInputActionCollection actions)
         {
             var userIndex = index; // Throws if user is invalid.
-            if (s_AllUserData[userIndex].actions == actions)
+            if (s_GlobalState.allUserData[userIndex].actions == actions)
                 return;
 
             // If we already had actions associated, reset the binding mask and device list.
-            var oldActions = s_AllUserData[userIndex].actions;
+            var oldActions = s_GlobalState.allUserData[userIndex].actions;
             if (oldActions != null)
             {
                 oldActions.devices = null;
                 oldActions.bindingMask = null;
             }
 
-            s_AllUserData[userIndex].actions = actions;
+            s_GlobalState.allUserData[userIndex].actions = actions;
 
             // If we've switched to a different set of actions, synchronize our state.
             if (actions != null)
@@ -538,8 +537,8 @@ namespace UnityEngine.InputSystem.Users
                 HookIntoActionChange();
 
                 actions.devices = pairedDevices;
-                if (s_AllUserData[userIndex].controlScheme != null)
-                    ActivateControlSchemeInternal(userIndex, s_AllUserData[userIndex].controlScheme.Value);
+                if (s_GlobalState.allUserData[userIndex].controlScheme != null)
+                    ActivateControlSchemeInternal(userIndex, s_GlobalState.allUserData[userIndex].controlScheme.Value);
             }
         }
 
@@ -553,11 +552,11 @@ namespace UnityEngine.InputSystem.Users
 
                 // Need actions to be available to be able to activate control schemes
                 // by name only.
-                if (s_AllUserData[userIndex].actions == null)
+                if (s_GlobalState.allUserData[userIndex].actions == null)
                     throw new InvalidOperationException(
                         $"Cannot set control scheme '{schemeName}' by name on user #{userIndex} as not actions have been associated with the user yet (AssociateActionsWithUser)");
 
-                var controlSchemes = s_AllUserData[userIndex].actions.controlSchemes;
+                var controlSchemes = s_GlobalState.allUserData[userIndex].actions.controlSchemes;
                 for (var i = 0; i < controlSchemes.Count; ++i)
                     if (string.Compare(controlSchemes[i].name, schemeName,
                         StringComparison.InvariantCultureIgnoreCase) == 0)
@@ -569,7 +568,7 @@ namespace UnityEngine.InputSystem.Users
                 // Throw if we can't find it.
                 if (scheme == default)
                     throw new ArgumentException(
-                        $"Cannot find control scheme '{schemeName}' in actions '{s_AllUserData[userIndex].actions}'");
+                        $"Cannot find control scheme '{schemeName}' in actions '{s_GlobalState.allUserData[userIndex].actions}'");
             }
 
             return ActivateControlScheme(scheme);
@@ -579,14 +578,14 @@ namespace UnityEngine.InputSystem.Users
         {
             var userIndex = index; // Throws if user is invalid.
 
-            if (s_AllUserData[userIndex].controlScheme != scheme ||
-                (scheme == default && s_AllUserData[userIndex].controlScheme != null))
+            if (s_GlobalState.allUserData[userIndex].controlScheme != scheme ||
+                (scheme == default && s_GlobalState.allUserData[userIndex].controlScheme != null))
             {
                 ActivateControlSchemeInternal(userIndex, scheme);
                 Notify(userIndex, InputUserChange.ControlSchemeChanged, null);
             }
 
-            return new ControlSchemeChangeSyntax {m_UserIndex = userIndex};
+            return new ControlSchemeChangeSyntax { m_UserIndex = userIndex };
         }
 
         private void ActivateControlSchemeInternal(int userIndex, InputControlScheme scheme)
@@ -594,26 +593,26 @@ namespace UnityEngine.InputSystem.Users
             var isEmpty = scheme == default;
 
             if (isEmpty)
-                s_AllUserData[userIndex].controlScheme = null;
+                s_GlobalState.allUserData[userIndex].controlScheme = null;
             else
-                s_AllUserData[userIndex].controlScheme = scheme;
+                s_GlobalState.allUserData[userIndex].controlScheme = scheme;
 
-            if (s_AllUserData[userIndex].actions != null)
+            if (s_GlobalState.allUserData[userIndex].actions != null)
             {
                 if (isEmpty)
                 {
-                    s_AllUserData[userIndex].actions.bindingMask = null;
-                    s_AllUserData[userIndex].controlSchemeMatch.Dispose();
-                    s_AllUserData[userIndex].controlSchemeMatch = new InputControlScheme.MatchResult();
+                    s_GlobalState.allUserData[userIndex].actions.bindingMask = null;
+                    s_GlobalState.allUserData[userIndex].controlSchemeMatch.Dispose();
+                    s_GlobalState.allUserData[userIndex].controlSchemeMatch = new InputControlScheme.MatchResult();
                 }
                 else
                 {
-                    s_AllUserData[userIndex].actions.bindingMask = new InputBinding {groups = scheme.bindingGroup};
+                    s_GlobalState.allUserData[userIndex].actions.bindingMask = new InputBinding { groups = scheme.bindingGroup };
                     UpdateControlSchemeMatch(userIndex);
 
                     // If we had lost some devices, flush the list. We haven't regained the device
                     // but we're no longer missing devices to play.
-                    if (s_AllUserData[userIndex].controlSchemeMatch.isSuccessfulMatch)
+                    if (s_GlobalState.allUserData[userIndex].controlSchemeMatch.isSuccessfulMatch)
                         RemoveLostDevicesForUser(userIndex);
                 }
             }
@@ -682,32 +681,32 @@ namespace UnityEngine.InputSystem.Users
                 // We could remove the devices in bulk here but we still have to notify one
                 // by one which ends up being more complicated than just unpairing the devices
                 // individually here.
-                while (s_AllUserData[userIndex].deviceCount > 0)
-                    UnpairDevice(s_AllPairedDevices[s_AllUserData[userIndex].deviceStartIndex + s_AllUserData[userIndex].deviceCount - 1]);
+                while (s_GlobalState.allUserData[userIndex].deviceCount > 0)
+                    UnpairDevice(s_GlobalState.allPairedDevices[s_GlobalState.allUserData[userIndex].deviceStartIndex + s_GlobalState.allUserData[userIndex].deviceCount - 1]);
             }
 
             // Update control scheme, if necessary.
-            if (s_AllUserData[userIndex].controlScheme != null)
+            if (s_GlobalState.allUserData[userIndex].controlScheme != null)
                 UpdateControlSchemeMatch(userIndex);
         }
 
         private static void RemoveLostDevicesForUser(int userIndex)
         {
-            var lostDeviceCount = s_AllUserData[userIndex].lostDeviceCount;
+            var lostDeviceCount = s_GlobalState.allUserData[userIndex].lostDeviceCount;
             if (lostDeviceCount > 0)
             {
-                var lostDeviceStartIndex = s_AllUserData[userIndex].lostDeviceStartIndex;
-                ArrayHelpers.EraseSliceWithCapacity(ref s_AllLostDevices, ref s_AllLostDeviceCount,
+                var lostDeviceStartIndex = s_GlobalState.allUserData[userIndex].lostDeviceStartIndex;
+                ArrayHelpers.EraseSliceWithCapacity(ref s_GlobalState.allLostDevices, ref s_GlobalState.allLostDeviceCount,
                     lostDeviceStartIndex, lostDeviceCount);
 
-                s_AllUserData[userIndex].lostDeviceCount = 0;
-                s_AllUserData[userIndex].lostDeviceStartIndex = 0;
+                s_GlobalState.allUserData[userIndex].lostDeviceCount = 0;
+                s_GlobalState.allUserData[userIndex].lostDeviceStartIndex = 0;
 
                 // Adjust indices of other users.
-                for (var i = 0; i < s_AllUserCount; ++i)
+                for (var i = 0; i < s_GlobalState.allUserCount; ++i)
                 {
-                    if (s_AllUserData[i].lostDeviceStartIndex > lostDeviceStartIndex)
-                        s_AllUserData[i].lostDeviceStartIndex -= lostDeviceCount;
+                    if (s_GlobalState.allUserData[i].lostDeviceStartIndex > lostDeviceStartIndex)
+                        s_GlobalState.allUserData[i].lostDeviceStartIndex -= lostDeviceCount;
                 }
             }
         }
@@ -774,7 +773,7 @@ namespace UnityEngine.InputSystem.Users
             {
                 // If it's in s_AllPairedDevices, there is *some* user that is using the device.
                 // We don't care which one it is here.
-                if (ArrayHelpers.ContainsReference(s_AllPairedDevices, s_AllPairedDeviceCount, device))
+                if (ArrayHelpers.ContainsReference(s_GlobalState.allPairedDevices, s_GlobalState.allPairedDeviceCount, device))
                     continue;
 
                 list.Add(device);
@@ -808,7 +807,7 @@ namespace UnityEngine.InputSystem.Users
             if (userIndex == -1)
                 return null;
 
-            return s_AllUsers[userIndex];
+            return s_GlobalState.allUsers[userIndex];
         }
 
         public static InputUser? FindUserByAccount(InputUserAccountHandle platformUserAccountHandle)
@@ -820,13 +819,13 @@ namespace UnityEngine.InputSystem.Users
             if (userIndex == -1)
                 return null;
 
-            return s_AllUsers[userIndex];
+            return s_GlobalState.allUsers[userIndex];
         }
 
         public static InputUser CreateUserWithoutPairedDevices()
         {
             var userIndex = AddUser();
-            return s_AllUsers[userIndex];
+            return s_GlobalState.allUsers[userIndex];
         }
 
         ////REVIEW: allow re-adding a user through this method?
@@ -968,7 +967,7 @@ namespace UnityEngine.InputSystem.Users
             if (!accountSelectionInProgress)
                 AddDeviceToUser(userIndex, device);
 
-            return s_AllUsers[userIndex];
+            return s_GlobalState.allUsers[userIndex];
         }
 
         private static bool InitiateUserAccountSelection(int userIndex, InputDevice device,
@@ -991,12 +990,12 @@ namespace UnityEngine.InputSystem.Users
             {
                 if (InitiateUserAccountSelectionAtPlatformLevel(device))
                 {
-                    s_AllUserData[userIndex].flags |= UserFlags.UserAccountSelectionInProgress;
-                    s_OngoingAccountSelections.Append(
+                    s_GlobalState.allUserData[userIndex].flags |= UserFlags.UserAccountSelectionInProgress;
+                    s_GlobalState.ongoingAccountSelections.Append(
                         new OngoingAccountSelection
                         {
                             device = device,
-                            userId = s_AllUsers[userIndex].id,
+                            userId = s_GlobalState.allUsers[userIndex].id,
                         });
 
                     // Make sure we receive a notification for the configuration event.
@@ -1052,12 +1051,12 @@ namespace UnityEngine.InputSystem.Users
         /// </remarks>
         private static int AddUser()
         {
-            var id = ++s_LastUserId;
+            var id = ++s_GlobalState.lastUserId;
 
             // Add to list.
-            var userCount = s_AllUserCount;
-            ArrayHelpers.AppendWithCapacity(ref s_AllUsers, ref userCount, new InputUser {m_Id = id});
-            var userIndex = ArrayHelpers.AppendWithCapacity(ref s_AllUserData, ref s_AllUserCount, new UserData());
+            var userCount = s_GlobalState.allUserCount;
+            ArrayHelpers.AppendWithCapacity(ref s_GlobalState.allUsers, ref userCount, new InputUser { m_Id = id });
+            var userIndex = ArrayHelpers.AppendWithCapacity(ref s_GlobalState.allUserData, ref s_GlobalState.allUserCount, new UserData());
 
             // Send notification.
             Notify(userIndex, InputUserChange.Added, null);
@@ -1075,27 +1074,27 @@ namespace UnityEngine.InputSystem.Users
         /// </remarks>
         private static void RemoveUser(int userIndex)
         {
-            Debug.Assert(userIndex >= 0 && userIndex < s_AllUserCount, "User index is invalid");
-            Debug.Assert(s_AllUserData[userIndex].deviceCount == 0, "User must not have paired devices still");
+            Debug.Assert(userIndex >= 0 && userIndex < s_GlobalState.allUserCount, "User index is invalid");
+            Debug.Assert(s_GlobalState.allUserData[userIndex].deviceCount == 0, "User must not have paired devices still");
 
             // Reset data from control scheme.
-            if (s_AllUserData[userIndex].controlScheme != null)
+            if (s_GlobalState.allUserData[userIndex].controlScheme != null)
             {
-                if (s_AllUserData[userIndex].actions != null)
-                    s_AllUserData[userIndex].actions.bindingMask = null;
+                if (s_GlobalState.allUserData[userIndex].actions != null)
+                    s_GlobalState.allUserData[userIndex].actions.bindingMask = null;
             }
-            s_AllUserData[userIndex].controlSchemeMatch.Dispose();
+            s_GlobalState.allUserData[userIndex].controlSchemeMatch.Dispose();
 
             // Remove lost devices.
             RemoveLostDevicesForUser(userIndex);
 
             // Remove account selections that are in progress.
-            for (var i = 0; i < s_OngoingAccountSelections.length; ++i)
+            for (var i = 0; i < s_GlobalState.ongoingAccountSelections.length; ++i)
             {
-                if (s_OngoingAccountSelections[i].userId != s_AllUsers[userIndex].id)
+                if (s_GlobalState.ongoingAccountSelections[i].userId != s_GlobalState.allUsers[userIndex].id)
                     continue;
 
-                s_OngoingAccountSelections.RemoveAtByMovingTailWithCapacity(i);
+                s_GlobalState.ongoingAccountSelections.RemoveAtByMovingTailWithCapacity(i);
                 --i;
             }
 
@@ -1103,12 +1102,12 @@ namespace UnityEngine.InputSystem.Users
             Notify(userIndex, InputUserChange.Removed, null);
 
             // Remove.
-            var userCount = s_AllUserCount;
-            s_AllUsers.EraseAtWithCapacity(ref userCount, userIndex);
-            s_AllUserData.EraseAtWithCapacity(ref s_AllUserCount, userIndex);
+            var userCount = s_GlobalState.allUserCount;
+            s_GlobalState.allUsers.EraseAtWithCapacity(ref userCount, userIndex);
+            s_GlobalState.allUserData.EraseAtWithCapacity(ref s_GlobalState.allUserCount, userIndex);
 
             // Remove our hook if we no longer need it.
-            if (s_AllUserCount == 0)
+            if (s_GlobalState.allUserCount == 0)
             {
                 UnhookFromDeviceChange();
                 UnhookFromActionChange();
@@ -1117,17 +1116,17 @@ namespace UnityEngine.InputSystem.Users
 
         private static void Notify(int userIndex, InputUserChange change, InputDevice device)
         {
-            Debug.Assert(userIndex >= 0 && userIndex < s_AllUserCount, "User index is invalid");
+            Debug.Assert(userIndex >= 0 && userIndex < s_GlobalState.allUserCount, "User index is invalid");
 
-            if (s_OnChange.length == 0)
+            if (s_GlobalState.onChange.length == 0)
                 return;
             Profiler.BeginSample("InputUser.onChange");
-            s_OnChange.LockForChanges();
-            for (var i = 0; i < s_OnChange.length; ++i)
+            s_GlobalState.onChange.LockForChanges();
+            for (var i = 0; i < s_GlobalState.onChange.length; ++i)
             {
                 try
                 {
-                    s_OnChange[i](s_AllUsers[userIndex], change, device);
+                    s_GlobalState.onChange[i](s_GlobalState.allUsers[userIndex], change, device);
                 }
                 catch (Exception exception)
                 {
@@ -1135,7 +1134,7 @@ namespace UnityEngine.InputSystem.Users
                     Debug.LogException(exception);
                 }
             }
-            s_OnChange.UnlockForChanges();
+            s_GlobalState.onChange.UnlockForChanges();
             Profiler.EndSample();
         }
 
@@ -1143,9 +1142,9 @@ namespace UnityEngine.InputSystem.Users
         {
             Debug.Assert(userId != InvalidId, "User ID is invalid");
 
-            for (var i = 0; i < s_AllUserCount; ++i)
+            for (var i = 0; i < s_GlobalState.allUserCount; ++i)
             {
-                if (s_AllUsers[i].m_Id == userId)
+                if (s_GlobalState.allUsers[i].m_Id == userId)
                     return i;
             }
             return -1;
@@ -1155,9 +1154,9 @@ namespace UnityEngine.InputSystem.Users
         {
             Debug.Assert(platformHandle != default, "User platform handle is invalid");
 
-            for (var i = 0; i < s_AllUserCount; ++i)
+            for (var i = 0; i < s_GlobalState.allUserCount; ++i)
             {
-                if (s_AllUserData[i].platformUserAccountHandle == platformHandle)
+                if (s_GlobalState.allUserData[i].platformUserAccountHandle == platformHandle)
                     return i;
             }
             return -1;
@@ -1173,14 +1172,14 @@ namespace UnityEngine.InputSystem.Users
         {
             Debug.Assert(device != null, "Device cannot be null");
 
-            var indexOfDevice = s_AllPairedDevices.IndexOfReference(device, s_AllPairedDeviceCount);
+            var indexOfDevice = s_GlobalState.allPairedDevices.IndexOfReference(device, s_GlobalState.allPairedDeviceCount);
             if (indexOfDevice == -1)
                 return -1;
 
-            for (var i = 0; i < s_AllUserCount; ++i)
+            for (var i = 0; i < s_GlobalState.allUserCount; ++i)
             {
-                var startIndex = s_AllUserData[i].deviceStartIndex;
-                if (startIndex <= indexOfDevice && indexOfDevice < startIndex + s_AllUserData[i].deviceCount)
+                var startIndex = s_GlobalState.allUserData[i].deviceStartIndex;
+                if (startIndex <= indexOfDevice && indexOfDevice < startIndex + s_GlobalState.allUserData[i].deviceCount)
                     return i;
             }
 
@@ -1195,67 +1194,67 @@ namespace UnityEngine.InputSystem.Users
         /// <param name="asLostDevice"></param>
         private static void AddDeviceToUser(int userIndex, InputDevice device, bool asLostDevice = false, bool dontUpdateControlScheme = false)
         {
-            Debug.Assert(userIndex >= 0 && userIndex < s_AllUserCount, "User index is invalid");
+            Debug.Assert(userIndex >= 0 && userIndex < s_GlobalState.allUserCount, "User index is invalid");
             Debug.Assert(device != null, "Device cannot be null");
             if (asLostDevice)
-                Debug.Assert(!s_AllUsers[userIndex].lostDevices.ContainsReference(device), "Device already in set of lostDevices for user");
+                Debug.Assert(!s_GlobalState.allUsers[userIndex].lostDevices.ContainsReference(device), "Device already in set of lostDevices for user");
             else
-                Debug.Assert(!s_AllUsers[userIndex].pairedDevices.ContainsReference(device), "Device already in set of pairedDevices for user");
+                Debug.Assert(!s_GlobalState.allUsers[userIndex].pairedDevices.ContainsReference(device), "Device already in set of pairedDevices for user");
 
             var deviceCount = asLostDevice
-                ? s_AllUserData[userIndex].lostDeviceCount
-                : s_AllUserData[userIndex].deviceCount;
+                ? s_GlobalState.allUserData[userIndex].lostDeviceCount
+                : s_GlobalState.allUserData[userIndex].deviceCount;
             var deviceStartIndex = asLostDevice
-                ? s_AllUserData[userIndex].lostDeviceStartIndex
-                : s_AllUserData[userIndex].deviceStartIndex;
+                ? s_GlobalState.allUserData[userIndex].lostDeviceStartIndex
+                : s_GlobalState.allUserData[userIndex].deviceStartIndex;
 
-            ++s_PairingStateVersion;
+            ++s_GlobalState.pairingStateVersion;
 
             // Move our devices to end of array.
             if (deviceCount > 0)
             {
-                ArrayHelpers.MoveSlice(asLostDevice ? s_AllLostDevices : s_AllPairedDevices, deviceStartIndex,
-                    asLostDevice ? s_AllLostDeviceCount - deviceCount : s_AllPairedDeviceCount - deviceCount,
+                ArrayHelpers.MoveSlice(asLostDevice ? s_GlobalState.allLostDevices : s_GlobalState.allPairedDevices, deviceStartIndex,
+                    asLostDevice ? s_GlobalState.allLostDeviceCount - deviceCount : s_GlobalState.allPairedDeviceCount - deviceCount,
                     deviceCount);
 
                 // Adjust users that have been impacted by the change.
-                for (var i = 0; i < s_AllUserCount; ++i)
+                for (var i = 0; i < s_GlobalState.allUserCount; ++i)
                 {
                     if (i == userIndex)
                         continue;
 
-                    if ((asLostDevice ? s_AllUserData[i].lostDeviceStartIndex : s_AllUserData[i].deviceStartIndex) <= deviceStartIndex)
+                    if ((asLostDevice ? s_GlobalState.allUserData[i].lostDeviceStartIndex : s_GlobalState.allUserData[i].deviceStartIndex) <= deviceStartIndex)
                         continue;
 
                     if (asLostDevice)
-                        s_AllUserData[i].lostDeviceStartIndex -= deviceCount;
+                        s_GlobalState.allUserData[i].lostDeviceStartIndex -= deviceCount;
                     else
-                        s_AllUserData[i].deviceStartIndex -= deviceCount;
+                        s_GlobalState.allUserData[i].deviceStartIndex -= deviceCount;
                 }
             }
 
             // Append to array.
             if (asLostDevice)
             {
-                s_AllUserData[userIndex].lostDeviceStartIndex = s_AllLostDeviceCount - deviceCount;
-                ArrayHelpers.AppendWithCapacity(ref s_AllLostDevices, ref s_AllLostDeviceCount, device);
-                ++s_AllUserData[userIndex].lostDeviceCount;
+                s_GlobalState.allUserData[userIndex].lostDeviceStartIndex = s_GlobalState.allLostDeviceCount - deviceCount;
+                ArrayHelpers.AppendWithCapacity(ref s_GlobalState.allLostDevices, ref s_GlobalState.allLostDeviceCount, device);
+                ++s_GlobalState.allUserData[userIndex].lostDeviceCount;
             }
             else
             {
-                s_AllUserData[userIndex].deviceStartIndex = s_AllPairedDeviceCount - deviceCount;
-                ArrayHelpers.AppendWithCapacity(ref s_AllPairedDevices, ref s_AllPairedDeviceCount, device);
-                ++s_AllUserData[userIndex].deviceCount;
+                s_GlobalState.allUserData[userIndex].deviceStartIndex = s_GlobalState.allPairedDeviceCount - deviceCount;
+                ArrayHelpers.AppendWithCapacity(ref s_GlobalState.allPairedDevices, ref s_GlobalState.allPairedDeviceCount, device);
+                ++s_GlobalState.allUserData[userIndex].deviceCount;
 
                 // If the user has actions, sync the devices on them with what we have now.
-                var actions = s_AllUserData[userIndex].actions;
+                var actions = s_GlobalState.allUserData[userIndex].actions;
                 if (actions != null)
                 {
-                    actions.devices = s_AllUsers[userIndex].pairedDevices;
+                    actions.devices = s_GlobalState.allUsers[userIndex].pairedDevices;
 
                     // Also, if we have a control scheme, update the matching of device requirements
                     // against the device we now have.
-                    if (!dontUpdateControlScheme && s_AllUserData[userIndex].controlScheme != null)
+                    if (!dontUpdateControlScheme && s_GlobalState.allUserData[userIndex].controlScheme != null)
                         UpdateControlSchemeMatch(userIndex);
                 }
             }
@@ -1269,12 +1268,12 @@ namespace UnityEngine.InputSystem.Users
 
         private static void RemoveDeviceFromUser(int userIndex, InputDevice device, bool asLostDevice = false)
         {
-            Debug.Assert(userIndex >= 0 && userIndex < s_AllUserCount, "User index is invalid");
+            Debug.Assert(userIndex >= 0 && userIndex < s_GlobalState.allUserCount, "User index is invalid");
             Debug.Assert(device != null, "Device cannot be null");
 
             var deviceIndex = asLostDevice
-                ? s_AllLostDevices.IndexOfReference(device, s_AllLostDeviceCount)
-                : s_AllPairedDevices.IndexOfReference(device, s_AllPairedDeviceCount);
+                ? s_GlobalState.allLostDevices.IndexOfReference(device, s_GlobalState.allLostDeviceCount)
+                : s_GlobalState.allPairedDevices.IndexOfReference(device, s_GlobalState.allPairedDeviceCount);
             if (deviceIndex == -1)
             {
                 // Device not in list. Ignore.
@@ -1283,48 +1282,48 @@ namespace UnityEngine.InputSystem.Users
 
             if (asLostDevice)
             {
-                s_AllLostDevices.EraseAtWithCapacity(ref s_AllLostDeviceCount, deviceIndex);
-                --s_AllUserData[userIndex].lostDeviceCount;
+                s_GlobalState.allLostDevices.EraseAtWithCapacity(ref s_GlobalState.allLostDeviceCount, deviceIndex);
+                --s_GlobalState.allUserData[userIndex].lostDeviceCount;
             }
             else
             {
-                ++s_PairingStateVersion;
-                s_AllPairedDevices.EraseAtWithCapacity(ref s_AllPairedDeviceCount, deviceIndex);
-                --s_AllUserData[userIndex].deviceCount;
+                ++s_GlobalState.pairingStateVersion;
+                s_GlobalState.allPairedDevices.EraseAtWithCapacity(ref s_GlobalState.allPairedDeviceCount, deviceIndex);
+                --s_GlobalState.allUserData[userIndex].deviceCount;
             }
 
             // Adjust indices of other users.
-            for (var i = 0; i < s_AllUserCount; ++i)
+            for (var i = 0; i < s_GlobalState.allUserCount; ++i)
             {
-                if ((asLostDevice ? s_AllUserData[i].lostDeviceStartIndex : s_AllUserData[i].deviceStartIndex) <= deviceIndex)
+                if ((asLostDevice ? s_GlobalState.allUserData[i].lostDeviceStartIndex : s_GlobalState.allUserData[i].deviceStartIndex) <= deviceIndex)
                     continue;
 
                 if (asLostDevice)
-                    --s_AllUserData[i].lostDeviceStartIndex;
+                    --s_GlobalState.allUserData[i].lostDeviceStartIndex;
                 else
-                    --s_AllUserData[i].deviceStartIndex;
+                    --s_GlobalState.allUserData[i].deviceStartIndex;
             }
 
             if (!asLostDevice)
             {
                 // Remove any ongoing account selections for the user on the given device.
-                for (var i = 0; i < s_OngoingAccountSelections.length; ++i)
+                for (var i = 0; i < s_GlobalState.ongoingAccountSelections.length; ++i)
                 {
-                    if (s_OngoingAccountSelections[i].userId != s_AllUsers[userIndex].id ||
-                        s_OngoingAccountSelections[i].device != device)
+                    if (s_GlobalState.ongoingAccountSelections[i].userId != s_GlobalState.allUsers[userIndex].id ||
+                        s_GlobalState.ongoingAccountSelections[i].device != device)
                         continue;
 
-                    s_OngoingAccountSelections.RemoveAtByMovingTailWithCapacity(i);
+                    s_GlobalState.ongoingAccountSelections.RemoveAtByMovingTailWithCapacity(i);
                     --i;
                 }
 
                 // If the user has actions, sync the devices on them with what we have now.
-                var actions = s_AllUserData[userIndex].actions;
+                var actions = s_GlobalState.allUserData[userIndex].actions;
                 if (actions != null)
                 {
-                    actions.devices = s_AllUsers[userIndex].pairedDevices;
+                    actions.devices = s_GlobalState.allUsers[userIndex].pairedDevices;
 
-                    if (s_AllUsers[userIndex].controlScheme != null)
+                    if (s_GlobalState.allUsers[userIndex].controlScheme != null)
                         UpdateControlSchemeMatch(userIndex);
                 }
 
@@ -1335,26 +1334,26 @@ namespace UnityEngine.InputSystem.Users
 
         private static void UpdateControlSchemeMatch(int userIndex, bool autoPairMissing = false)
         {
-            Debug.Assert(userIndex >= 0 && userIndex < s_AllUserCount, "User index is invalid");
+            Debug.Assert(userIndex >= 0 && userIndex < s_GlobalState.allUserCount, "User index is invalid");
 
             // Nothing to do if we don't have a control scheme.
-            if (s_AllUserData[userIndex].controlScheme == null)
+            if (s_GlobalState.allUserData[userIndex].controlScheme == null)
                 return;
 
             // Get rid of last match result and start new match.
-            s_AllUserData[userIndex].controlSchemeMatch.Dispose();
+            s_GlobalState.allUserData[userIndex].controlSchemeMatch.Dispose();
             var matchResult = new InputControlScheme.MatchResult();
             try
             {
                 // Match the control scheme's requirements against the devices paired to the user.
-                var scheme = s_AllUserData[userIndex].controlScheme.Value;
+                var scheme = s_GlobalState.allUserData[userIndex].controlScheme.Value;
                 if (scheme.deviceRequirements.Count > 0)
                 {
                     var availableDevices = new InputControlList<InputDevice>(Allocator.Temp);
                     try
                     {
                         // Add devices already paired to user.
-                        availableDevices.AddSlice(s_AllUsers[userIndex].pairedDevices);
+                        availableDevices.AddSlice(s_GlobalState.allUsers[userIndex].pairedDevices);
 
                         // If we're supposed to grab whatever additional devices we need from what's
                         // available, add all unpaired devices to the list.
@@ -1368,11 +1367,11 @@ namespace UnityEngine.InputSystem.Users
                             // We want to favor devices that are already assigned to the same platform user account.
                             // Sort the unpaired devices we've added to the list such that the ones belonging to the
                             // same user account come first.
-                            if (s_AllUserData[userIndex].platformUserAccountHandle != null)
+                            if (s_GlobalState.allUserData[userIndex].platformUserAccountHandle != null)
                                 availableDevices.Sort(startIndex, count,
                                     new CompareDevicesByUserAccount
                                     {
-                                        platformUserAccountHandle = s_AllUserData[userIndex].platformUserAccountHandle.Value
+                                        platformUserAccountHandle = s_GlobalState.allUserData[userIndex].platformUserAccountHandle.Value
                                     });
                         }
 
@@ -1384,12 +1383,12 @@ namespace UnityEngine.InputSystem.Users
                             if (autoPairMissing)
                             {
                                 // Update match result on user before potentially invoking callbacks.
-                                s_AllUserData[userIndex].controlSchemeMatch = matchResult;
+                                s_GlobalState.allUserData[userIndex].controlSchemeMatch = matchResult;
 
                                 foreach (var device in matchResult.devices)
                                 {
                                     // Skip if already paired to user.
-                                    if (s_AllUsers[userIndex].pairedDevices.ContainsReference(device))
+                                    if (s_GlobalState.allUsers[userIndex].pairedDevices.ContainsReference(device))
                                         continue;
 
                                     AddDeviceToUser(userIndex, device, dontUpdateControlScheme: true);
@@ -1403,7 +1402,7 @@ namespace UnityEngine.InputSystem.Users
                     }
                 }
 
-                s_AllUserData[userIndex].controlSchemeMatch = matchResult;
+                s_GlobalState.allUserData[userIndex].controlSchemeMatch = matchResult;
             }
             catch (Exception)
             {
@@ -1416,7 +1415,7 @@ namespace UnityEngine.InputSystem.Users
 
         private static long UpdatePlatformUserAccount(int userIndex, InputDevice device)
         {
-            Debug.Assert(userIndex >= 0 && userIndex < s_AllUserCount, "User index is invalid");
+            Debug.Assert(userIndex >= 0 && userIndex < s_GlobalState.allUserCount, "User index is invalid");
 
             // Fetch account details from backend.
             var queryResult = QueryPairedPlatformUserAccount(device, out var platformUserAccountHandle,
@@ -1428,18 +1427,18 @@ namespace UnityEngine.InputSystem.Users
                 // Check if there's an account selection in progress. There shouldn't be as it's
                 // weird for the device to no signal it does not support querying user account, but
                 // just to be safe, we check.
-                if ((s_AllUserData[userIndex].flags & UserFlags.UserAccountSelectionInProgress) != 0)
+                if ((s_GlobalState.allUserData[userIndex].flags & UserFlags.UserAccountSelectionInProgress) != 0)
                     Notify(userIndex, InputUserChange.AccountSelectionCanceled, null);
 
-                s_AllUserData[userIndex].platformUserAccountHandle = null;
-                s_AllUserData[userIndex].platformUserAccountName = null;
-                s_AllUserData[userIndex].platformUserAccountId = null;
+                s_GlobalState.allUserData[userIndex].platformUserAccountHandle = null;
+                s_GlobalState.allUserData[userIndex].platformUserAccountName = null;
+                s_GlobalState.allUserData[userIndex].platformUserAccountId = null;
 
                 return queryResult;
             }
 
             // Check if there's an account selection that we have initiated.
-            if ((s_AllUserData[userIndex].flags & UserFlags.UserAccountSelectionInProgress) != 0)
+            if ((s_GlobalState.allUserData[userIndex].flags & UserFlags.UserAccountSelectionInProgress) != 0)
             {
                 // Yes, there is. See if it is complete.
 
@@ -1455,26 +1454,26 @@ namespace UnityEngine.InputSystem.Users
                 else
                 {
                     // Yes, it is complete.
-                    s_AllUserData[userIndex].flags &= ~UserFlags.UserAccountSelectionInProgress;
+                    s_GlobalState.allUserData[userIndex].flags &= ~UserFlags.UserAccountSelectionInProgress;
 
-                    s_AllUserData[userIndex].platformUserAccountHandle = platformUserAccountHandle;
-                    s_AllUserData[userIndex].platformUserAccountName = platformUserAccountName;
-                    s_AllUserData[userIndex].platformUserAccountId = platformUserAccountId;
+                    s_GlobalState.allUserData[userIndex].platformUserAccountHandle = platformUserAccountHandle;
+                    s_GlobalState.allUserData[userIndex].platformUserAccountName = platformUserAccountName;
+                    s_GlobalState.allUserData[userIndex].platformUserAccountId = platformUserAccountId;
 
                     Notify(userIndex, InputUserChange.AccountSelectionComplete, device);
                 }
             }
             // Check if user account details have changed.
-            else if (s_AllUserData[userIndex].platformUserAccountHandle != platformUserAccountHandle ||
-                     s_AllUserData[userIndex].platformUserAccountId != platformUserAccountId)
+            else if (s_GlobalState.allUserData[userIndex].platformUserAccountHandle != platformUserAccountHandle ||
+                     s_GlobalState.allUserData[userIndex].platformUserAccountId != platformUserAccountId)
             {
-                s_AllUserData[userIndex].platformUserAccountHandle = platformUserAccountHandle;
-                s_AllUserData[userIndex].platformUserAccountName = platformUserAccountName;
-                s_AllUserData[userIndex].platformUserAccountId = platformUserAccountId;
+                s_GlobalState.allUserData[userIndex].platformUserAccountHandle = platformUserAccountHandle;
+                s_GlobalState.allUserData[userIndex].platformUserAccountName = platformUserAccountName;
+                s_GlobalState.allUserData[userIndex].platformUserAccountId = platformUserAccountId;
 
                 Notify(userIndex, InputUserChange.AccountChanged, device);
             }
-            else if (s_AllUserData[userIndex].platformUserAccountName != platformUserAccountName)
+            else if (s_GlobalState.allUserData[userIndex].platformUserAccountName != platformUserAccountName)
             {
                 Notify(userIndex, InputUserChange.AccountNameChanged, device);
             }
@@ -1563,9 +1562,9 @@ namespace UnityEngine.InputSystem.Users
         {
             if (change == InputActionChange.BoundControlsChanged)
             {
-                for (var i = 0; i < s_AllUserCount; ++i)
+                for (var i = 0; i < s_GlobalState.allUserCount; ++i)
                 {
-                    ref var user = ref s_AllUsers[i];
+                    ref var user = ref s_GlobalState.allUsers[i];
                     if (ReferenceEquals(user.actions, obj))
                         Notify(i, InputUserChange.ControlsChanged, null);
                 }
@@ -1592,15 +1591,15 @@ namespace UnityEngine.InputSystem.Users
                 {
                     // Could have been removed from multiple users. Repeatedly search in s_AllPairedDevices
                     // until we can't find the device anymore.
-                    var deviceIndex = s_AllPairedDevices.IndexOfReference(device, s_AllPairedDeviceCount);
+                    var deviceIndex = s_GlobalState.allPairedDevices.IndexOfReference(device, s_GlobalState.allPairedDeviceCount);
                     while (deviceIndex != -1)
                     {
                         // Find user. Must be there as we found the device in s_AllPairedDevices.
                         var userIndex = -1;
-                        for (var i = 0; i < s_AllUserCount; ++i)
+                        for (var i = 0; i < s_GlobalState.allUserCount; ++i)
                         {
-                            var deviceStartIndex = s_AllUserData[i].deviceStartIndex;
-                            if (deviceStartIndex <= deviceIndex && deviceIndex < deviceStartIndex + s_AllUserData[i].deviceCount)
+                            var deviceStartIndex = s_GlobalState.allUserData[i].deviceStartIndex;
+                            if (deviceStartIndex <= deviceIndex && deviceIndex < deviceStartIndex + s_GlobalState.allUserData[i].deviceCount)
                             {
                                 userIndex = i;
                                 break;
@@ -1616,7 +1615,7 @@ namespace UnityEngine.InputSystem.Users
                         RemoveDeviceFromUser(userIndex, device);
 
                         // Search for another user paired to the same device.
-                        deviceIndex = s_AllPairedDevices.IndexOfReference(device, s_AllPairedDeviceCount);
+                        deviceIndex = s_GlobalState.allPairedDevices.IndexOfReference(device, s_GlobalState.allPairedDeviceCount);
                     }
                     break;
                 }
@@ -1626,15 +1625,15 @@ namespace UnityEngine.InputSystem.Users
                 {
                     // Could be a previously lost device. Could affect multiple users. Repeatedly search in
                     // s_AllLostDevices until we can't find the device anymore.
-                    var deviceIndex = s_AllLostDevices.IndexOfReference(device, s_AllLostDeviceCount);
+                    var deviceIndex = s_GlobalState.allLostDevices.IndexOfReference(device, s_GlobalState.allLostDeviceCount);
                     while (deviceIndex != -1)
                     {
                         // Find user. Must be there as we found the device in s_AllLostDevices.
                         var userIndex = -1;
-                        for (var i = 0; i < s_AllUserCount; ++i)
+                        for (var i = 0; i < s_GlobalState.allUserCount; ++i)
                         {
-                            var deviceStartIndex = s_AllUserData[i].lostDeviceStartIndex;
-                            if (deviceStartIndex <= deviceIndex && deviceIndex < deviceStartIndex + s_AllUserData[i].lostDeviceCount)
+                            var deviceStartIndex = s_GlobalState.allUserData[i].lostDeviceStartIndex;
+                            if (deviceStartIndex <= deviceIndex && deviceIndex < deviceStartIndex + s_GlobalState.allUserData[i].lostDeviceCount)
                             {
                                 userIndex = i;
                                 break;
@@ -1654,7 +1653,7 @@ namespace UnityEngine.InputSystem.Users
                         // Note: s_AllLostDevices is modified (element erased) from within RemoveDeviceFromUser,
                         //       hence, deviceIndex is not advanced and s_AllLostDeviceCount is one less than
                         //       previous linear search iteration.
-                        deviceIndex = s_AllLostDevices.IndexOfReference(device, deviceIndex, s_AllLostDeviceCount);
+                        deviceIndex = s_GlobalState.allLostDevices.IndexOfReference(device, deviceIndex, s_GlobalState.allLostDeviceCount);
                     }
                     break;
                 }
@@ -1666,21 +1665,21 @@ namespace UnityEngine.InputSystem.Users
                     // See if the this is a device that we were waiting for an account selection on. If so, pair
                     // it to the user that was waiting.
                     var wasOngoingAccountSelection = false;
-                    for (var i = 0; i < s_OngoingAccountSelections.length; ++i)
+                    for (var i = 0; i < s_GlobalState.ongoingAccountSelections.length; ++i)
                     {
-                        if (s_OngoingAccountSelections[i].device != device)
+                        if (s_GlobalState.ongoingAccountSelections[i].device != device)
                             continue;
 
-                        var userIndex = new InputUser { m_Id = s_OngoingAccountSelections[i].userId }.index;
+                        var userIndex = new InputUser { m_Id = s_GlobalState.ongoingAccountSelections[i].userId }.index;
                         var queryResult = UpdatePlatformUserAccount(userIndex, device);
                         if ((queryResult & (long)QueryPairedUserAccountCommand.Result.UserAccountSelectionInProgress) == 0)
                         {
                             wasOngoingAccountSelection = true;
-                            s_OngoingAccountSelections.RemoveAtByMovingTailWithCapacity(i);
+                            s_GlobalState.ongoingAccountSelections.RemoveAtByMovingTailWithCapacity(i);
                             --i;
 
                             // If the device wasn't paired to the user, pair it now.
-                            if (!s_AllUsers[userIndex].pairedDevices.ContainsReference(device))
+                            if (!s_GlobalState.allUsers[userIndex].pairedDevices.ContainsReference(device))
                                 AddDeviceToUser(userIndex, device);
                         }
                     }
@@ -1691,15 +1690,15 @@ namespace UnityEngine.InputSystem.Users
                     {
                         // Could be paired to multiple users. Repeatedly search in s_AllPairedDevices
                         // until we can't find the device anymore.
-                        var deviceIndex = s_AllPairedDevices.IndexOfReference(device, s_AllPairedDeviceCount);
+                        var deviceIndex = s_GlobalState.allPairedDevices.IndexOfReference(device, s_GlobalState.allPairedDeviceCount);
                         while (deviceIndex != -1)
                         {
                             // Find user. Must be there as we found the device in s_AllPairedDevices.
                             var userIndex = -1;
-                            for (var i = 0; i < s_AllUserCount; ++i)
+                            for (var i = 0; i < s_GlobalState.allUserCount; ++i)
                             {
-                                var deviceStartIndex = s_AllUserData[i].deviceStartIndex;
-                                if (deviceStartIndex <= deviceIndex && deviceIndex < deviceStartIndex + s_AllUserData[i].deviceCount)
+                                var deviceStartIndex = s_GlobalState.allUserData[i].deviceStartIndex;
+                                if (deviceStartIndex <= deviceIndex && deviceIndex < deviceStartIndex + s_GlobalState.allUserData[i].deviceCount)
                                 {
                                     userIndex = i;
                                     break;
@@ -1712,8 +1711,8 @@ namespace UnityEngine.InputSystem.Users
                             // Search for another user paired to the same device.
                             // Note that action is tied to user and hence we can skip to end of slice associated
                             // with the current user or at least one element forward.
-                            var offsetNextSlice = deviceIndex + Math.Max(1, s_AllUserData[userIndex].deviceCount);
-                            deviceIndex = s_AllPairedDevices.IndexOfReference(device, offsetNextSlice, s_AllPairedDeviceCount - offsetNextSlice);
+                            var offsetNextSlice = deviceIndex + Math.Max(1, s_GlobalState.allUserData[userIndex].deviceCount);
+                            deviceIndex = s_GlobalState.allPairedDevices.IndexOfReference(device, offsetNextSlice, s_GlobalState.allPairedDeviceCount - offsetNextSlice);
                         }
                     }
                     break;
@@ -1731,16 +1730,16 @@ namespace UnityEngine.InputSystem.Users
         //       NOT from state changes applied directly through InputState.Change.
         private static void OnEvent(InputEventPtr eventPtr, InputDevice device)
         {
-            Debug.Assert(s_ListenForUnpairedDeviceActivity != 0,
+            Debug.Assert(s_GlobalState.listenForUnpairedDeviceActivity != 0,
                 "This should only be called while listening for unpaired device activity");
-            if (s_ListenForUnpairedDeviceActivity == 0)
+            if (s_GlobalState.listenForUnpairedDeviceActivity == 0)
                 return;
 
             // Ignore input in editor.
-            #if UNITY_EDITOR
+#if UNITY_EDITOR
             if (InputState.currentUpdateType == InputUpdateType.Editor)
                 return;
-            #endif
+#endif
 
             // Ignore any state change not triggered from a state event.
             var eventType = eventPtr.type;
@@ -1752,7 +1751,7 @@ namespace UnityEngine.InputSystem.Users
                 return;
 
             // See if it's a device not belonging to any user.
-            if (ArrayHelpers.ContainsReference(s_AllPairedDevices, s_AllPairedDeviceCount, device))
+            if (ArrayHelpers.ContainsReference(s_GlobalState.allPairedDevices, s_GlobalState.allPairedDeviceCount, device))
             {
                 // No, it's a device already paired to a player so do nothing.
                 return;
@@ -1763,7 +1762,7 @@ namespace UnityEngine.InputSystem.Users
             // Apply the pre-filter. If there's callbacks and none of them return true,
             // we early out and ignore the event entirely.
             if (!DelegateHelpers.InvokeCallbacksSafe_AnyCallbackReturnsTrue(
-                ref s_OnPreFilterUnpairedDeviceUsed, device, eventPtr, "InputUser.onPreFilterUnpairedDeviceActivity"))
+                ref s_GlobalState.onPreFilterUnpairedDeviceUsed, device, eventPtr, "InputUser.onPreFilterUnpairedDeviceActivity"))
                 return;
 
             // Go through the changed controls in the event and look for ones actuated
@@ -1771,14 +1770,14 @@ namespace UnityEngine.InputSystem.Users
             foreach (var control in eventPtr.EnumerateChangedControls(device: device, magnitudeThreshold: 0.0001f))
             {
                 var deviceHasBeenPaired = false;
-                s_OnUnpairedDeviceUsed.LockForChanges();
-                for (var n = 0; n < s_OnUnpairedDeviceUsed.length; ++n)
+                s_GlobalState.onUnpairedDeviceUsed.LockForChanges();
+                for (var n = 0; n < s_GlobalState.onUnpairedDeviceUsed.length; ++n)
                 {
-                    var pairingStateVersionBefore = s_PairingStateVersion;
+                    var pairingStateVersionBefore = s_GlobalState.pairingStateVersion;
 
                     try
                     {
-                        s_OnUnpairedDeviceUsed[n](control, eventPtr);
+                        s_GlobalState.onUnpairedDeviceUsed[n](control, eventPtr);
                     }
                     catch (Exception exception)
                     {
@@ -1786,14 +1785,14 @@ namespace UnityEngine.InputSystem.Users
                         Debug.LogException(exception);
                     }
 
-                    if (pairingStateVersionBefore != s_PairingStateVersion
+                    if (pairingStateVersionBefore != s_GlobalState.pairingStateVersion
                         && FindUserPairedToDevice(device) != null)
                     {
                         deviceHasBeenPaired = true;
                         break;
                     }
                 }
-                s_OnUnpairedDeviceUsed.UnlockForChanges();
+                s_GlobalState.onUnpairedDeviceUsed.UnlockForChanges();
 
                 // If the device was paired in one of the callbacks, stop processing
                 // changes on it.
@@ -1950,107 +1949,118 @@ namespace UnityEngine.InputSystem.Users
             public uint userId;
         }
 
-        private static int s_PairingStateVersion;
-        private static uint s_LastUserId;
-        private static int s_AllUserCount;
-        private static int s_AllPairedDeviceCount;
-        private static int s_AllLostDeviceCount;
-        private static InputUser[] s_AllUsers;
-        private static UserData[] s_AllUserData;
-        private static InputDevice[] s_AllPairedDevices; // We keep a single array that we slice out to each user.
-        private static InputDevice[] s_AllLostDevices;   // We keep a single array that we slice out to each user.
-        private static InlinedArray<OngoingAccountSelection> s_OngoingAccountSelections;
-        private static CallbackArray<Action<InputUser, InputUserChange, InputDevice>> s_OnChange;
-        private static CallbackArray<Action<InputControl, InputEventPtr>> s_OnUnpairedDeviceUsed;
-        private static CallbackArray<Func<InputDevice, InputEventPtr, bool>> s_OnPreFilterUnpairedDeviceUsed;
-        private static Action<object, InputActionChange> s_ActionChangeDelegate;
-        private static Action<InputDevice, InputDeviceChange> s_OnDeviceChangeDelegate;
-        private static Action<InputEventPtr, InputDevice> s_OnEventDelegate;
-        private static bool s_OnActionChangeHooked;
-        private static bool s_OnDeviceChangeHooked;
-        private static bool s_OnEventHooked;
-        private static int s_ListenForUnpairedDeviceActivity;
+        private struct GlobalState
+        {
+            internal int pairingStateVersion;
+            internal uint lastUserId;
+            internal int allUserCount;
+            internal int allPairedDeviceCount;
+            internal int allLostDeviceCount;
+            internal InputUser[] allUsers;
+            internal UserData[] allUserData;
+            internal InputDevice[] allPairedDevices; // We keep a single array that we slice out to each user.
+            internal InputDevice[] allLostDevices;   // We keep a single array that we slice out to each user.
+            internal InlinedArray<OngoingAccountSelection> ongoingAccountSelections;
+            internal CallbackArray<Action<InputUser, InputUserChange, InputDevice>> onChange;
+            internal CallbackArray<Action<InputControl, InputEventPtr>> onUnpairedDeviceUsed;
+            internal CallbackArray<Func<InputDevice, InputEventPtr, bool>> onPreFilterUnpairedDeviceUsed;
+            internal Action<object, InputActionChange> actionChangeDelegate;
+            internal Action<InputDevice, InputDeviceChange> onDeviceChangeDelegate;
+            internal Action<InputEventPtr, InputDevice> onEventDelegate;
+            internal bool onActionChangeHooked;
+            internal bool onDeviceChangeHooked;
+            internal bool onEventHooked;
+            internal int listenForUnpairedDeviceActivity;
+        }
+
+        private static GlobalState s_GlobalState;
+
+        internal static ISavedState SaveAndResetState()
+        {
+            // Save current state and provide an opaque interface to restore it
+            var savedState = new SavedStructState<GlobalState>(
+                ref s_GlobalState, (ref GlobalState state) =>
+                {
+                    // Free/dispose any resources allocated for the current state
+                    DisposeAndResetGlobalState();
+
+                    // Restore stored state
+                    s_GlobalState = state;
+                });
+
+            // Reset global state
+            s_GlobalState = default;
+
+            return savedState;
+        }
 
         private static void HookIntoActionChange()
         {
-            if (s_OnActionChangeHooked)
+            if (s_GlobalState.onActionChangeHooked)
                 return;
-            if (s_ActionChangeDelegate == null)
-                s_ActionChangeDelegate = OnActionChange;
+            if (s_GlobalState.actionChangeDelegate == null)
+                s_GlobalState.actionChangeDelegate = OnActionChange;
             InputSystem.onActionChange += OnActionChange;
-            s_OnActionChangeHooked = true;
+            s_GlobalState.onActionChangeHooked = true;
         }
 
         private static void UnhookFromActionChange()
         {
-            if (!s_OnActionChangeHooked)
+            if (!s_GlobalState.onActionChangeHooked)
                 return;
             InputSystem.onActionChange -= OnActionChange;
-            s_OnActionChangeHooked = false;
+            s_GlobalState.onActionChangeHooked = false;
         }
 
         private static void HookIntoDeviceChange()
         {
-            if (s_OnDeviceChangeHooked)
+            if (s_GlobalState.onDeviceChangeHooked)
                 return;
-            if (s_OnDeviceChangeDelegate == null)
-                s_OnDeviceChangeDelegate = OnDeviceChange;
-            InputSystem.onDeviceChange += s_OnDeviceChangeDelegate;
-            s_OnDeviceChangeHooked = true;
+            if (s_GlobalState.onDeviceChangeDelegate == null)
+                s_GlobalState.onDeviceChangeDelegate = OnDeviceChange;
+            InputSystem.onDeviceChange += s_GlobalState.onDeviceChangeDelegate;
+            s_GlobalState.onDeviceChangeHooked = true;
         }
 
         private static void UnhookFromDeviceChange()
         {
-            if (!s_OnDeviceChangeHooked)
+            if (!s_GlobalState.onDeviceChangeHooked)
                 return;
-            InputSystem.onDeviceChange -= s_OnDeviceChangeDelegate;
-            s_OnDeviceChangeHooked = false;
+            InputSystem.onDeviceChange -= s_GlobalState.onDeviceChangeDelegate;
+            s_GlobalState.onDeviceChangeHooked = false;
         }
 
         private static void HookIntoEvents()
         {
-            if (s_OnEventHooked)
+            if (s_GlobalState.onEventHooked)
                 return;
-            if (s_OnEventDelegate == null)
-                s_OnEventDelegate = OnEvent;
-            InputSystem.onEvent += s_OnEventDelegate;
-            s_OnEventHooked = true;
+            if (s_GlobalState.onEventDelegate == null)
+                s_GlobalState.onEventDelegate = OnEvent;
+            InputSystem.onEvent += s_GlobalState.onEventDelegate;
+            s_GlobalState.onEventHooked = true;
         }
 
         private static void UnhookFromDeviceStateChange()
         {
-            if (!s_OnEventHooked)
+            if (!s_GlobalState.onEventHooked)
                 return;
-            InputSystem.onEvent -= s_OnEventDelegate;
-            s_OnEventHooked = false;
+            InputSystem.onEvent -= s_GlobalState.onEventDelegate;
+            s_GlobalState.onEventHooked = false;
         }
 
-        internal struct GlobalState
+        private static void DisposeAndResetGlobalState()
         {
-            private int s_PairingStateVersion;
-            private uint s_LastUserId;
-            private int s_AllUserCount;
-            private int s_AllPairedDeviceCount;
-            private int s_AllLostDeviceCount;
-            private InputUser[] s_AllUsers;
-            private UserData[] s_AllUserData;
-            private InputDevice[] s_AllPairedDevices; // We keep a single array that we slice out to each user.
-            private InputDevice[] s_AllLostDevices;   // We keep a single array that we slice out to each user.
-            private InlinedArray<OngoingAccountSelection> s_OngoingAccountSelections;
-            private CallbackArray<Action<InputUser, InputUserChange, InputDevice>> s_OnChange;
-            private CallbackArray<Action<InputControl, InputEventPtr>> s_OnUnpairedDeviceUsed;
-            private CallbackArray<Func<InputDevice, InputEventPtr, bool>> s_OnPreFilterUnpairedDeviceUsed;
-            private Action<object, InputActionChange> s_ActionChangeDelegate;
-            private Action<InputDevice, InputDeviceChange> s_OnDeviceChangeDelegate;
-            private Action<InputEventPtr, InputDevice> s_OnEventDelegate;
-            private bool s_OnActionChangeHooked;
-            private bool s_OnDeviceChangeHooked;
-            private bool s_OnEventHooked;
-            private int s_ListenForUnpairedDeviceActivity;
-        }
+            // Release native memory held by control scheme match results.
+            for (var i = 0; i < s_GlobalState.allUserCount; ++i)
+                s_GlobalState.allUserData[i].controlSchemeMatch.Dispose();
 
-        internal static GlobalState CreateGlobalState() => default;
-        internal static GlobalState s_GlobalState;
+            // Don't reset s_LastUserId and just let it increment instead so we never generate
+            // the same ID twice.
+
+            var storedLastUserId = s_GlobalState.lastUserId;
+            s_GlobalState = default;
+            s_GlobalState.lastUserId = storedLastUserId;
+        }
 
         internal static void ResetGlobals()
         {
@@ -2058,32 +2068,7 @@ namespace UnityEngine.InputSystem.Users
             UnhookFromDeviceChange();
             UnhookFromDeviceStateChange();
 
-            // Release native memory held by control scheme match results.
-            for (var i = 0; i < s_AllUserCount; ++i)
-                s_AllUserData[i].controlSchemeMatch.Dispose();
-
-            // Don't reset s_LastUserId and just let it increment instead so we never generate
-            // the same ID twice.
-
-            s_PairingStateVersion = 0;
-            s_AllUserCount = 0;
-            s_AllPairedDeviceCount = 0;
-            s_AllLostDeviceCount = 0;
-            s_AllUsers = null;
-            s_AllUserData = null;
-            s_AllPairedDevices = null;
-            s_AllLostDevices = null;
-            s_OngoingAccountSelections = default;
-            s_OnChange = default;
-            s_OnUnpairedDeviceUsed = default;
-            s_OnPreFilterUnpairedDeviceUsed = default;
-            s_ActionChangeDelegate = null;
-            s_OnDeviceChangeDelegate = null;
-            s_OnEventDelegate = null;
-            s_OnDeviceChangeHooked = false;
-            s_OnActionChangeHooked = false;
-            s_OnEventHooked = false;
-            s_ListenForUnpairedDeviceActivity = 0;
+            DisposeAndResetGlobalState();
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/SavedState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/SavedState.cs
@@ -8,8 +8,15 @@ namespace UnityEngine.InputSystem.Utilities
     /// </summary>
     internal interface ISavedState
     {
+        /// <summary>
+        /// Dispose current state, should be invoked before RestoreSavedState()
+        /// to dispose the current state before restoring a saved state.
+        /// </summary>
         void StaticDisposeCurrentState();
 
+        /// <summary>
+        /// Restore previous state, should be invoked after StaticDisposeCurrentState().
+        /// </summary>
         void RestoreSavedState();
     }
 
@@ -28,8 +35,8 @@ namespace UnityEngine.InputSystem.Utilities
         /// </summary>
         /// <param name="state">The value-type state to be saved.</param>
         /// <param name="restoreAction">The action to be carried out to restore state.</param>
-        /// <param name="staticDisposeCurrentState">The action to be carried out to dispose current state.</param>
-        internal SavedStructState(ref T state, TypedRestore restoreAction, Action staticDisposeCurrentState)
+        /// <param name="staticDisposeCurrentState">The action to be carried out to dispose current state. May be null.</param>
+        internal SavedStructState(ref T state, TypedRestore restoreAction, Action staticDisposeCurrentState = null)
         {
             Debug.Assert(restoreAction != null, "Restore action is required");
 
@@ -38,9 +45,6 @@ namespace UnityEngine.InputSystem.Utilities
             m_StaticDisposeCurrentState = staticDisposeCurrentState;
         }
 
-        /// <summary>
-        /// Dispose current state, should be invoked before RestoreSavedState().
-        /// </summary>
         public void StaticDisposeCurrentState()
         {
             if (m_StaticDisposeCurrentState != null)
@@ -50,13 +54,11 @@ namespace UnityEngine.InputSystem.Utilities
             }
         }
 
-        /// <summary>
-        /// Restore previous state, should be invoked after StaticDisposeCurrentState().
-        /// </summary>
         public void RestoreSavedState()
         {
-            Debug.Assert(m_StaticDisposeCurrentState == null, "Only restore once");
-            Debug.Assert(m_RestoreAction != null, "Only restore once");
+            Debug.Assert(m_StaticDisposeCurrentState == null,
+                $"Should have been disposed via {nameof(StaticDisposeCurrentState)} before invoking {nameof(RestoreSavedState)}");
+            Debug.Assert(m_RestoreAction != null, $"Only invoke {nameof(RestoreSavedState)} once ");
             m_RestoreAction(ref m_State);
             m_RestoreAction = null;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/SavedState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/SavedState.cs
@@ -1,0 +1,45 @@
+namespace UnityEngine.InputSystem.Utilities
+{
+    /// <summary>
+    /// Provides type erasure and an abstraction of a saved state that
+    /// will (must) be restored at a later point.
+    /// </summary>
+    internal interface ISavedState
+    {
+        void Restore();
+    }
+
+    /// <summary>
+    /// Provides functionality to store and support later restoration of a saved
+    /// state. The state is expected to be a value-type. If the state is not restored
+    /// it must be disposed to not leak resources.
+    /// </summary>
+    /// <typeparam name="T">The value-type representing the state to be stored.</typeparam>
+    internal sealed class SavedStructState<T> : ISavedState where T : struct
+    {
+        public delegate void TypedRestore(ref T state);
+
+        internal SavedStructState(ref T state, TypedRestore restoreAction)
+        {
+            Debug.Assert(restoreAction != null);
+
+            m_State = state; // copy
+            m_RestoreAction = restoreAction;
+        }
+
+        /// <summary>
+        /// Restore previous state
+        /// </summary>
+        public void Restore()
+        {
+            if (m_RestoreAction != null)
+            {
+                m_RestoreAction(ref m_State);
+                m_RestoreAction = null;
+            }
+        }
+
+        private T m_State;
+        private TypedRestore m_RestoreAction;
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/SavedState.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/SavedState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e988a22b82d97847b9e8e3cf14a1526
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

This PR addresses problems related to `InputTestFixture` and its `SetUp`() and `TearDown`() where mixing test cases based on `InputTestFixture` (using mocked InputSystem) and regular test cases (using real InputSystem) would lead to static state leaking between test cases causing random failures and unexpected/undefined behavior. 

### Changes made

Static state in `InputUser`, `InputActionState`, `Touch` have been adressed and a save/revert mechanism have been introduced via `ISavedState` providing an opaque interface to restore a previously saved non-serialized state without knowing internals of the class from which the state was saved. The motivation for this pattern was that initialization/reset require knowledge and is different between classes and that restore might or might not need additional "static dispose" code. Unfortunately, there is currently no consistent "static disposal pattern" implemented in the repository that I am aware of, so that could be a future extension to better encapsulate and handle static state.

### Notes

This relates to, and have been tested/verified against https://issuetracker.unity3d.com/product/unity/issues/guid/1329015 (https://fogbugz.unity3d.com/f/cases/1329015/).

No tests of test harness was added as part of this fix. Extra care should be taken in review to check the removed clean-up code in InputSystem#Destroy() since this seems to relate to test cases but should not be needed with this fix (!?)

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
