### PR TITLE
CHANGE: UI module now defaults to having DefaultInputActions (case 1359306).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -109,6 +109,7 @@ internal class UITests : CoreTestsFixture
         var systemObject = new GameObject(namePrefix + "System");
         objects.eventSystem = systemObject.AddComponent<TestEventSystem>();
         var uiModule = systemObject.AddComponent<InputSystemUIInputModule>();
+        uiModule.UnassignActions();
         objects.uiModule = uiModule;
         objects.eventSystem.UpdateModules();
 
@@ -180,6 +181,40 @@ internal class UITests : CoreTestsFixture
         objects.eventSystem.InvokeUpdate(); // Initial update only sets current module.
 
         return objects;
+    }
+
+    [Test]
+    [Category("UI")]
+    public void UI_InputModuleHasDefaultActions()
+    {
+        var go = new GameObject();
+        var uiModule = go.AddComponent<InputSystemUIInputModule>();
+
+        Assert.That(uiModule.actionsAsset, Is.Not.Null);
+        Assert.That(uiModule.point?.action, Is.SameAs(uiModule.actionsAsset["UI/Point"]));
+        Assert.That(uiModule.leftClick?.action, Is.SameAs(uiModule.actionsAsset["UI/Click"]));
+        Assert.That(uiModule.rightClick?.action, Is.SameAs(uiModule.actionsAsset["UI/RightClick"]));
+        Assert.That(uiModule.middleClick?.action, Is.SameAs(uiModule.actionsAsset["UI/MiddleClick"]));
+        Assert.That(uiModule.scrollWheel?.action, Is.SameAs(uiModule.actionsAsset["UI/ScrollWheel"]));
+        Assert.That(uiModule.submit?.action, Is.SameAs(uiModule.actionsAsset["UI/Submit"]));
+        Assert.That(uiModule.cancel?.action, Is.SameAs(uiModule.actionsAsset["UI/Cancel"]));
+        Assert.That(uiModule.move?.action, Is.SameAs(uiModule.actionsAsset["UI/Navigate"]));
+        Assert.That(uiModule.trackedDeviceOrientation?.action, Is.SameAs(uiModule.actionsAsset["UI/TrackedDeviceOrientation"]));
+        Assert.That(uiModule.trackedDevicePosition?.action, Is.SameAs(uiModule.actionsAsset["UI/TrackedDevicePosition"]));
+
+        uiModule.UnassignActions();
+
+        Assert.That(uiModule.actionsAsset, Is.Null);
+        Assert.That(uiModule.point, Is.Null);
+        Assert.That(uiModule.leftClick, Is.Null);
+        Assert.That(uiModule.rightClick, Is.Null);
+        Assert.That(uiModule.middleClick, Is.Null);
+        Assert.That(uiModule.scrollWheel, Is.Null);
+        Assert.That(uiModule.submit, Is.Null);
+        Assert.That(uiModule.cancel, Is.Null);
+        Assert.That(uiModule.move, Is.Null);
+        Assert.That(uiModule.trackedDeviceOrientation, Is.Null);
+        Assert.That(uiModule.trackedDevicePosition, Is.Null);
     }
 
     // Comprehensive test for general pointer input behaviors.
@@ -3371,8 +3406,8 @@ internal class UITests : CoreTestsFixture
 
         Assert.That(scene.actions.UI.Click.phase.IsInProgress(), Is.True);
 
-        var clickWasCanceled = false;
-        scene.actions.UI.Click.canceled += _ => clickWasCanceled = true;
+        var clickCanceled = 0;
+        scene.actions.UI.Click.canceled += _ => ++ clickCanceled;
 
         yield return null;
 
@@ -3391,7 +3426,7 @@ internal class UITests : CoreTestsFixture
         scene.leftChildReceiver.events.Clear();
 
         runtime.PlayerFocusLost();
-        Assert.That(clickWasCanceled, Is.True);
+        Assert.That(clickCanceled, Is.EqualTo(1));
         scene.eventSystem.SendMessage("OnApplicationFocus", false);
 
         Assert.That(scene.leftChildReceiver.events, Is.Empty);
@@ -3412,7 +3447,7 @@ internal class UITests : CoreTestsFixture
         Assert.That(clicked, Is.False);
     }
 
-    public class MyButton : UnityEngine.UI.Button
+    public class MyButton : Button
     {
         public bool receivedPointerDown;
         public bool receivedPointerUp;

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3447,7 +3447,7 @@ internal class UITests : CoreTestsFixture
         Assert.That(clicked, Is.False);
     }
 
-    public class MyButton : Button
+    public class MyButton : UnityEngine.UI.Button
     {
         public bool receivedPointerDown;
         public bool receivedPointerUp;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,10 +16,26 @@ however, it has to be formatted properly to pass verification tests.
   * This caused a regression with some setups that, for example, bound the same control multiple times in a composite using processors to alter the value of the control.
   * Internally, a control is now again allowed to feed into the same action through more than one binding.
   * However, externally the control will be mentioned on the action's `InputAction.controls` list only once.
+- Adding `InputSystemUIInputModule` from code now installs `DefaultInputActions`. This is equivalent to the default setup when adding the component in the editor ([case 1259306](https://issuetracker.unity3d.com/issues/input-system-ugui-button-does-not-react-when-clicked)).
+  ```CSharp
+  var go = new GameObject();
+  go.AddComponent<EventSystem>();
+  var uiModule = go.AddComponent<InputSystemUIInputModule>();
+  // uiModule.actionsAsset now has a DefaultInputActions() asset assigned to it and the various
+  // action references point to its actions.
+  ```
+  * `InputSystemUIInputModule.UnassignActions` has been added to remove all actions from the module en bloc.
+  ```CSharp
+  uiModule.UnassignActions();
+  ```
 
 ### Fixed
 
 - Fixed an issue where mixing test cases based on `InputTestFixture` (using mocked `InputSystem`) and regular test cases (using real `InputSystem`) would lead to static state leaking between test cases causing random failures and unexpected/undefined behavior ([case 1329015](https://issuetracker.unity3d.com/product/unity/issues/guid/1329015)).
+- Fixed `InputSystemUIInputModule.AssignDefaultActions` not assigning `trackedDeviceOrientation` and `trackedDevicePosition`.
+- Fixed regression introduced by [previous change](#ui_multiple_scenes_fix) where `InputSystemUIInputModule` would not disable actions correctly.
+- Fixed `InputAction.canceled` not getting triggered reliably for `InputActionType.PassThrough` actions when `InputSystem.ResetDevice` was called.
+- Fixed device resets (e.g. happening as part of focus changes) leading to only some actions bound to these devices getting cancelled instead of all of them.
 
 ## [1.1.0-pre.6] - 2021-08-23
 
@@ -185,7 +201,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `AxisDeadzoneProcessor` min/max values not being settable to 0 in editor UI ([case 1293744](https://issuetracker.unity3d.com/issues/input-system-input-system-axis-deadzone-minimum-value-fallsback-to-default-value-if-its-set-to-0)).
 - Fixed blurry icons in input debugger, asset editor, input settings ([case 1299595](https://issuetracker.unity3d.com/issues/inputsystem-supported-device-list-dropdown-icons-present-under-project-settings-are-not-user-friendly)).
 - Fixed `clickCount` not being incremented correctly by `InputSystemUIInputModule` for successive mouse clicks ([case 1317239](https://issuetracker.unity3d.com/issues/eventdata-dot-clickcount-doesnt-increase-when-clicking-repeatedly-in-the-new-input-system)).
-- Fixed UI not working after additively loading scenes with additional InputSystemUIInputModule modules ([case 1251720](https://issuetracker.unity3d.com/issues/input-system-buttons-cannot-be-pressed-after-additively-loading-scenes-with-additional-event-systems)).
+- <a name="ui_multiple_scenes_fix"></a>Fixed UI not working after additively loading scenes with additional InputSystemUIInputModule modules ([case 1251720](https://issuetracker.unity3d.com/issues/input-system-buttons-cannot-be-pressed-after-additively-loading-scenes-with-additional-event-systems)).
 - Fixed no `OnPointerExit` received when changing UI state without moving pointer ([case 1232705](https://issuetracker.unity3d.com/issues/input-system-onpointerexit-is-not-triggered-when-a-ui-element-interrupts-a-mouse-hover)).
 - Fixed reference to `.inputactions` of `Player Prefab` referenced by `PlayerInputManager` being destroyed on going into play mode, if the player prefab was a nested prefab ([case 1319756](https://issuetracker.unity3d.com/issues/playerinput-component-loses-its-reference-to-an-inputactionasset)).
 - Fixed "Scheme Name" label clipped in "Add Control Schema" popup window ([case 1199560]https://issuetracker.unity3d.com/issues/themes-input-system-scheme-name-is-clipped-in-add-control-schema-window-with-inter-default-font)).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionPhase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionPhase.cs
@@ -7,7 +7,7 @@ using UnityEngine.InputSystem.Interactions;
 namespace UnityEngine.InputSystem
 {
     /// <summary>
-    /// Trigger phase of an <see cref="InputAction">action</see>.
+    /// Trigger phase of an <see cref="InputAction"/>.
     /// </summary>
     /// <remarks>
     /// Actions can be triggered in steps. For example, a <see cref="SlowTapInteraction">
@@ -17,6 +17,11 @@ namespace UnityEngine.InputSystem
     /// the button is release before the timer expires, the action will be <see cref="Canceled"/>
     /// whereas if the button is held long enough, the action will be <see cref="Performed"/>.
     /// </remarks>
+    /// <seealso cref="InputAction.phase"/>
+    /// <seealso cref="InputAction.CallbackContext.phase"/>
+    /// <seealso cref="InputAction.started"/>
+    /// <seealso cref="InputAction.performed"/>
+    /// <seealso cref="InputAction.canceled"/>
     public enum InputActionPhase
     {
         /// <summary>
@@ -26,18 +31,16 @@ namespace UnityEngine.InputSystem
 
         /// <summary>
         /// The action is enabled and waiting for input on its associated controls.
-        /// </summary>
-        /// <remarks>
+        ///
         /// This is the phase that an action goes back to once it has been <see cref="Performed"/>
         /// or <see cref="Canceled"/>.
-        /// </remarks>
+        /// </summary>
         Waiting,
 
         /// <summary>
         /// An associated control has been actuated such that it may lead to the action
-        /// being triggered.
-        /// </summary>
-        /// <remarks>
+        /// being triggered. Will lead to <see cref="InputAction.started"/> getting called.
+        ///
         /// This phase will only be invoked if there are interactions on the respective control
         /// binding. Without any interactions, an action will go straight from <see cref="Waiting"/>
         /// into <see cref="Performed"/> and back into <see cref="Waiting"/> whenever an associated
@@ -53,7 +56,7 @@ namespace UnityEngine.InputSystem
         ///
         /// <see cref="Started"/> can be useful for UI feedback. For example, in a game where the weapon can be charged,
         /// UI feedback can be initiated when the action is <see cref="Started"/>.
-        /// </remarks>
+        ///
         /// <example>
         /// <code>
         /// fireAction.started +=
@@ -78,18 +81,55 @@ namespace UnityEngine.InputSystem
         ///     }
         /// </code>
         /// </example>
+        ///
+        /// By default, an action is started as soon as a control moves away from its default value. This is
+        /// the case for both <see cref="InputActionType.Button"/> actions (which, however, does not yet have to mean
+        /// that the button press threshold has been reached; see <see cref="InputSettings.defaultButtonPressPoint"/>)
+        /// and <see cref="InputActionType.Value"/> actions. <see cref="InputActionType.PassThrough"/> does not use
+        /// the <c>Started</c> phase and instead goes straight to <see cref="Performed"/>.
+        ///
+        /// For <see cref="InputActionType.Value"/> actions, <c>Started</c> will immediately be followed by <see cref="Performed"/>.
+        ///
+        /// Note that interactions (see <see cref="IInputInteraction"/>) can alter how an action does or does not progress through
+        /// the phases.
+        /// </summary>
         Started,
 
         /// <summary>
+        /// The action has been performed. Leads to <see cref="InputAction.performed"/> getting called.
         ///
+        /// By default, a <see cref="InputActionType.Button"/> action performs when a control crosses the button
+        /// press threshold (see <see cref="InputSettings.defaultButtonPressPoint"/>), a <see cref="InputActionType.Value"/>
+        /// action performs on any value change that isn't the default value, and a <see cref="InputActionType.PassThrough"/>
+        /// action performs on any value change including going back to the default value.
+        ///
+        /// Note that interactions (see <see cref="IInputInteraction"/>) can alter how an action does or does not progress through
+        /// the phases.
+        ///
+        /// For a given action, finding out whether it was performed in the current frame can be done with <see cref="InputAction.WasPerformedThisFrame"/>.
+        ///
+        /// <example>
+        /// <code>
+        /// action.WasPerformedThisFrame();
+        /// </code>
+        /// </example>
         /// </summary>
-        /// <seealso cref="InputAction.performed"/>
         Performed,
 
         /// <summary>
+        /// The action has stopped. Leads to <see cref="InputAction.canceled"/> getting called.
         ///
+        /// By default, a <see cref="InputActionType.Button"/> action cancels when a control falls back below the button
+        /// press threshold (see <see cref="InputSettings.defaultButtonPressPoint"/>) and a <see cref="InputActionType.Value"/>
+        /// action cancels when a control moves back to its default value. A <see cref="InputActionType.PassThrough"/> action
+        /// does not generally cancel based on input on its controls.
+        ///
+        /// An action will also get canceled when it is disabled while in progress (see <see cref="InputAction.Disable"/>).
+        /// Also, when an <see cref="InputDevice"/> that is
+        ///
+        /// Note that interactions (see <see cref="IInputInteraction"/>) can alter how an action does or does not progress through
+        /// the phases.
         /// </summary>
-        /// <seealso cref="InputAction.canceled"/>
         Canceled
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionType.cs
@@ -156,12 +156,25 @@ namespace UnityEngine.InputSystem
         /// trigger immediately on input. For example, if <see cref="Interactions.HoldInteraction"/> is used, the
         /// action will start as soon as a bound button crosses its press threshold but will not trigger until the
         /// button is held for the set hold duration (<see cref="Interactions.HoldInteraction.duration"/>).
+        ///
+        /// Irrespective of which type an action is set to, it is possible to find out whether it was or is considered
+        /// pressed and/or released using <see cref="InputAction.IsPressed"/>, <see cref="InputAction.WasPressedThisFrame"/>,
+        /// and <see cref="InputAction.WasReleasedThisFrame"/>.
+        ///
+        /// <example>
+        /// <code>
+        /// action.IsPressed();
+        /// action.WasPressedThisFrame();
+        /// action.WasReleasedThisFrame();
+        /// </code>
+        /// </example>
         /// </summary>
         Button,
 
         /// <summary>
         /// An action that has no specific type of behavior and instead acts as a simple pass-through for
-        /// any value change on any bound control.
+        /// any value change on any bound control. In effect, this turns an action from a single value producer into a mere
+        /// input "sink".
         ///
         /// This is in some ways similar to <see cref="Value"/>. However, there are two key differences.
         ///
@@ -176,6 +189,17 @@ namespace UnityEngine.InputSystem
         /// on every value change regardless of what the value is. This is different from <see cref="Value"/> where the
         /// action will trigger <see cref="InputActionPhase.Started"/> when moving away from its default value and will
         /// trigger <see cref="InputActionPhase.Canceled"/> when going back to the default value.
+        ///
+        /// Note that a pass-through action my still get cancelled and thus see <see cref="InputAction.canceled"/> getting called.
+        /// This happens when a factor other than input on a device causes an action in progress to be cancelled. An example
+        /// of this is when an action is disabled (see <see cref="InputAction.Disable"/>) or when focus is lost (see <see cref="InputSettings.backgroundBehavior"/>)
+        /// and a device connection to an action is reset (see <see cref="InputSystem.ResetDevice"/>).
+        ///
+        /// Also note that for a pass-through action, calling <see cref="InputAction.ReadValue{TValue}"/> is often not
+        /// very useful as it will only return the value of the very last control that fed into the action. For pass-through
+        /// actions, it is usually best to listen to <see cref="InputAction.performed"/> in order to be notified about every
+        /// single value change. Where this is not necessary, it is generally better to employ a <see cref="Value"/> action
+        /// instead.
         /// </summary>
         PassThrough,
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -41,6 +41,10 @@ namespace UnityEngine.InputSystem.UI
     /// This UI input module has the advantage over other such modules that it doesn't have to know
     /// what devices and types of devices input is coming from. Instead, the actions hide the actual
     /// sources of input from the module.
+    ///
+    /// When adding this component from code (such as through <c>GameObject.AddComponent</c>), the
+    /// resulting module will automatically have a set of default input actions assigned to it
+    /// (see <see cref="AssignDefaultActions"/>).
     /// </remarks>
     [HelpURL(InputSystem.kDocUrl + "/manual/UISupport.html#setting-up-ui-input")]
     public class InputSystemUIInputModule : BaseInputModule
@@ -1261,6 +1265,10 @@ namespace UnityEngine.InputSystem.UI
         /// Assigns default input actions asset and input actions, similar to how defaults are assigned when creating UI module in editor.
         /// Useful for creating <see cref="InputSystemUIInputModule"/> at runtime.
         /// </summary>
+        /// <remarks>
+        /// This instantiates <see cref="DefaultInputActions"/> and assigns it to <see cref="actionsAsset"/>. It also
+        /// assigns all the various individual actions such as <see cref="point"/> and <see cref="leftClick"/>.
+        /// </remarks>
         public void AssignDefaultActions()
         {
             var defaultActions = new DefaultInputActions();
@@ -1273,8 +1281,29 @@ namespace UnityEngine.InputSystem.UI
             middleClick = InputActionReference.Create(defaultActions.UI.MiddleClick);
             point = InputActionReference.Create(defaultActions.UI.Point);
             scrollWheel = InputActionReference.Create(defaultActions.UI.ScrollWheel);
+            trackedDeviceOrientation = InputActionReference.Create(defaultActions.UI.TrackedDeviceOrientation);
+            trackedDevicePosition = InputActionReference.Create(defaultActions.UI.TrackedDevicePosition);
+        }
 
-            defaultActions.Enable();
+        /// <summary>
+        /// Remove all action assignment
+        /// </summary>
+        /// <remarks>
+        /// This clears <see cref="actionsAsset"/> and the various individual action references such as <see cref="point"/> and <see cref="leftClick"/>.
+        /// </remarks>
+        public void UnassignActions()
+        {
+            actionsAsset = default;
+            cancel = default;
+            submit = default;
+            move = default;
+            leftClick = default;
+            rightClick = default;
+            middleClick = default;
+            point = default;
+            scrollWheel = default;
+            trackedDeviceOrientation = default;
+            trackedDevicePosition = default;
         }
 
         [Obsolete("'trackedDeviceSelect' has been obsoleted; use 'leftClick' instead.", true)]
@@ -1320,6 +1349,9 @@ namespace UnityEngine.InputSystem.UI
                 m_OnControlsChangedDelegate = OnControlsChanged;
             InputActionState.s_GlobalState.onActionControlsChanged.AddCallback(m_OnControlsChangedDelegate);
 
+            if (HasNoActions())
+                AssignDefaultActions();
+
             HookActions();
             EnableAllActions();
         }
@@ -1332,6 +1364,22 @@ namespace UnityEngine.InputSystem.UI
 
             DisableAllActions();
             UnhookActions();
+        }
+
+        private bool HasNoActions()
+        {
+            if (m_ActionsAsset != null)
+                return false;
+
+            return m_PointAction?.action == null
+                && m_LeftClickAction?.action == null
+                && m_RightClickAction?.action == null
+                && m_MiddleClickAction?.action == null
+                && m_SubmitAction?.action == null
+                && m_CancelAction?.action == null
+                && m_ScrollWheelAction?.action == null
+                && m_TrackedDeviceOrientationAction?.action == null
+                && m_TrackedDevicePositionAction?.action == null;
         }
 
         private bool IsAnyActionEnabled()
@@ -1378,38 +1426,45 @@ namespace UnityEngine.InputSystem.UI
 
         private void EnableInputAction(InputActionReference inputActionReference)
         {
-            if (inputActionReference == null ||
-                inputActionReference.m_ActionId == null ||
-                inputActionReference.action == null)
+            var action = inputActionReference?.action;
+            if (action == null)
                 return;
 
-            if (s_InputActionReferenceCounts.TryGetValue(inputActionReference.m_ActionId, out var referenceState))
+            if (s_InputActionReferenceCounts.TryGetValue(action, out var referenceState))
             {
                 referenceState.refCount++;
-                s_InputActionReferenceCounts[inputActionReference.m_ActionId] = referenceState;
+                s_InputActionReferenceCounts[action] = referenceState;
             }
             else
             {
                 // if the action is already enabled but its reference count is zero then it was enabled by
                 // something outside the input module and the input module should never disable it.
-                referenceState = new InputActionReferenceState {refCount = 1, enabledByInputModule = !inputActionReference.action.enabled};
-                s_InputActionReferenceCounts.Add(inputActionReference.m_ActionId, referenceState);
+                referenceState = new InputActionReferenceState {refCount = 1, enabledByInputModule = !action.enabled};
+                s_InputActionReferenceCounts.Add(action, referenceState);
             }
 
-            inputActionReference.action.Enable();
+            action.Enable();
         }
 
         private static void DisableInputAction(InputActionReference inputActionReference)
         {
-            if (!s_InputActionReferenceCounts.TryGetValue(inputActionReference?.m_ActionId ?? string.Empty,
+            var action = inputActionReference?.action;
+            if (action == null)
+                return;
+
+            if (!s_InputActionReferenceCounts.TryGetValue(action,
                 out var referenceState))
                 return;
 
             if (referenceState.refCount - 1 == 0 && referenceState.enabledByInputModule)
-                inputActionReference?.action?.Disable();
+            {
+                action.Disable();
+                s_InputActionReferenceCounts.Remove(action);
+                return;
+            }
 
             referenceState.refCount--;
-            s_InputActionReferenceCounts[inputActionReference.m_ActionId] = referenceState;
+            s_InputActionReferenceCounts[action] = referenceState;
         }
 
         private int GetPointerStateIndexFor(int pointerOrTouchId)
@@ -2030,7 +2085,7 @@ namespace UnityEngine.InputSystem.UI
             var oldActionMap = oldAction.actionMap;
             Debug.Assert(oldActionMap != null, "Not expected to end up with a singleton action here");
 
-            var newActionMap = m_ActionsAsset.FindActionMap(oldActionMap.name);
+            var newActionMap = m_ActionsAsset?.FindActionMap(oldActionMap.name);
             if (newActionMap == null)
                 return null;
 
@@ -2049,7 +2104,10 @@ namespace UnityEngine.InputSystem.UI
                 if (value != m_ActionsAsset)
                 {
                     var wasEnabled = IsAnyActionEnabled();
+
                     DisableAllActions();
+                    UnhookActions();
+
                     m_ActionsAsset = value;
 
                     point = UpdateReferenceForNewAsset(point);
@@ -2060,8 +2118,12 @@ namespace UnityEngine.InputSystem.UI
                     scrollWheel = UpdateReferenceForNewAsset(scrollWheel);
                     submit = UpdateReferenceForNewAsset(submit);
                     cancel = UpdateReferenceForNewAsset(cancel);
+
                     if (wasEnabled)
+                    {
+                        HookActions();
                         EnableAllActions();
+                    }
                 }
             }
         }
@@ -2081,7 +2143,7 @@ namespace UnityEngine.InputSystem.UI
         [SerializeField] private bool m_DeselectOnBackgroundClick = true;
         [SerializeField] private UIPointerBehavior m_PointerBehavior = UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack;
 
-        private static Dictionary<string, InputActionReferenceState> s_InputActionReferenceCounts = new Dictionary<string, InputActionReferenceState>();
+        private static Dictionary<InputAction, InputActionReferenceState> s_InputActionReferenceCounts = new Dictionary<InputAction, InputActionReferenceState>();
 
         private struct InputActionReferenceState
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/PointerModel.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/PointerModel.cs
@@ -219,6 +219,11 @@ namespace UnityEngine.InputSystem.UI
                 }
             }
 
+            /// <summary>
+            /// When we "release" a button other than through user interaction (e.g. through focus switching),
+            /// we don't want this to count as an actual release that ends up clicking. This flag will cause
+            /// generated events to have <c>eligibleForClick</c> to be false.
+            /// </summary>
             public bool ignoreNextClick
             {
                 get => m_IgnoreNextClick;


### PR DESCRIPTION
Fixes [1359306](https://issuetracker.unity3d.com/issues/input-system-ugui-button-does-not-react-when-clicked) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1359306/)).

### Description

We landed a change previously (#1317) where behavior in the editor was no consistent with the player in that `InputSystemUIInputModule` would have no actions assigned to it by default. We previously added an `AssignDefaultActions` method that needs to be manually called to put the default actions in place.

This PR simply calls that method implicitly if the UI module has no input actions assigned to it.

### Changes made

As part of putting the change in place, I discovered several other issues. See CHANGELOG.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
