### PR TITLE
Fixing upgrade issues

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,9 +10,10 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
 - Fixed `InvalidCastException: Specified cast is not valid.` and `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?` when upgrading from 1.1.0-pre.5 or earlier. If you experience this issue you can also restart the editor to resolve it.
+- Fixed `InputDeviceChange.Destroyed` not being available, now it's correctly marked as obsolete instead.
 
 ## [1.1.0] - 2021-08-27
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Changed
+
+- Fixed `InvalidCastException: Specified cast is not valid.` and `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?` when upgrading from 1.1.0-pre.5 or earlier. If you experience this issue you can also restart the editor to resolve it.
+
 ## [1.1.0] - 2021-08-27
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -619,16 +619,16 @@ namespace UnityEngine.InputSystem
 
             HasStateCallbacks = 1 << 1,
             HasControlsWithDefaultState = 1 << 2,
-            HasDontResetControls = 1 << 3,
-            HasEventMerger = 1 << 4,
+            HasDontResetControls = 1 << 10,
+            HasEventMerger = 1 << 13,
 
-            Remote = 1 << 5, // It's a local mirror of a device from a remote player connection.
-            Native = 1 << 6, // It's a device created from data surfaced by NativeInputRuntime.
+            Remote = 1 << 3, // It's a local mirror of a device from a remote player connection.
+            Native = 1 << 4, // It's a device created from data surfaced by NativeInputRuntime.
 
-            DisabledInFrontend = 1 << 7, // Explicitly disabled on the managed side.
-            DisabledInRuntime = 1 << 8, // Disabled in the native runtime.
-            DisabledWhileInBackground = 1 << 9, // Disabled while the player is running in the background.
-            DisabledStateHasBeenQueriedFromRuntime = 1 << 10, // Whether we have fetched the current enable/disable state from the runtime.
+            DisabledInFrontend = 1 << 5, // Explicitly disabled on the managed side.
+            DisabledInRuntime = 1 << 7, // Disabled in the native runtime.
+            DisabledWhileInBackground = 1 << 8, // Disabled while the player is running in the background.
+            DisabledStateHasBeenQueriedFromRuntime = 1 << 6, // Whether we have fetched the current enable/disable state from the runtime.
 
             CanRunInBackground = 1 << 11,
             CanRunInBackgroundHasBeenQueried = 1 << 12,

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceChange.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceChange.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 
@@ -119,5 +120,8 @@ namespace UnityEngine.InputSystem
         /// This notification is sent before the actual reset happens.
         /// </summary>
         HardReset,
+
+        [Obsolete("Destroyed enum has been deprecated.")]
+        Destroyed,
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3114,7 +3114,7 @@ namespace UnityEngine.InputSystem
                         // carries crucial entropy (button changed state, phase changed, counter changed, etc).
                         // Hence semantic meaning for current event is "can't merge current with next because next is different".
                         // But semantic meaning for next event is "next event carries important information and should be preserved",
-                        // from that point of few next event should not be merged with current nor with _next after next_ event.
+                        // from that point of view next event should not be merged with current nor with _next after next_ event.
                         //
                         // For example, given such stream of events:
                         // Mouse       Mouse       Mouse       Mouse       Mouse       Mouse       Mouse
@@ -3724,6 +3724,11 @@ namespace UnityEngine.InputSystem
         /// Most of the state we re-recreate in-between reloads and do not store
         /// in this structure. In particular, we do not preserve anything from
         /// the various RegisterXXX().
+        ///
+        /// WARNING
+        ///
+        /// Making changes to serialized data format will likely to break upgrading projects from older versions.
+        /// That is until you restart the editor, then we recreate everything from clean state.
         /// </remarks>
         [Serializable]
         internal struct SerializedState


### PR DESCRIPTION
### Description

- When upgrading from <=1.1.0-pre.5 to >=1.1.0-pre.6 we experience broken serialized data during domain reload because we change enum values for `DeviceFlags`.
- Also when upgrading to >=1.1.0-pre.6 `InputDeviceChange.Destroyed` was missing.

### Changes made

- Restored original `DeviceFlags` values from <=1.1.0-preview.3, incorporated new values so they map more cleanly.
- Restored `InputDeviceChange.Destroyed`
