### PR TITLE
Adding DualSense basic support

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -5283,4 +5283,108 @@ partial class CoreTests
         Assert.That(mouseDeltaAtKeyPressEvent, Is.EqualTo(new Vector2(5, 5)));
         Assert.That(mouseScrollAtKeyPressEvent, Is.EqualTo(new Vector2(5, 5)));
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct PreProcessorTestDeviceState : IInputStateTypeInfo
+    {
+        public static FourCC Format => new FourCC('P', 'P', 'T', 'D');
+        public FourCC format => Format;
+
+        [InputControl(layout = "Integer")] public int value1;
+        [InputControl(layout = "Integer")] public int value2;
+    }
+
+    [InputControlLayout(stateType = typeof(PreProcessorTestDeviceState))]
+    [Preserve]
+    public class PreProcessorTestDevice : InputDevice, IEventPreProcessor
+    {
+        public enum Behavior
+        {
+            PreserveEventsAsIs,
+            SkipEvents,
+            ConvertEventsInPlace,
+            ShrinkEventsInPlace,
+            GrowEventsInPlace
+        }
+
+        public Behavior behavior = Behavior.PreserveEventsAsIs;
+
+        public IntegerControl value1 { get; private set; }
+        public IntegerControl value2 { get; private set; }
+
+        protected override void FinishSetup()
+        {
+            value1 = GetChildControl<IntegerControl>("value1");
+            value2 = GetChildControl<IntegerControl>("value2");
+            base.FinishSetup();
+        }
+
+        unsafe bool IEventPreProcessor.PreProcessEvent(InputEventPtr currentEventPtr)
+        {
+            var inputEvent = (InputEvent*)currentEventPtr;
+            var stateEvent = StateEvent.FromUnchecked(inputEvent);
+            var size = stateEvent->stateSizeInBytes;
+            if (stateEvent->stateFormat != PreProcessorTestDeviceState.Format || size < sizeof(PreProcessorTestDeviceState))
+                return false;
+
+            var state = (PreProcessorTestDeviceState*)stateEvent->state;
+            switch (behavior)
+            {
+                case Behavior.SkipEvents:
+                    return false;
+                case Behavior.PreserveEventsAsIs:
+                    return true;
+                case Behavior.ConvertEventsInPlace:
+                    state->value1 = -state->value1;
+                    state->value2 = -state->value2;
+                    return true;
+                case Behavior.ShrinkEventsInPlace:
+                    state->value1 = -state->value1;
+                    state->value2 = int.MaxValue; // This change should not be visible in device state
+
+                    // This code shrinks down a state event in-place without changing a type signature,
+                    // it relies on a lose definition of state updating in InputManager.UpdateState where passing
+                    // a state event of size smaller than device state size will only update first N bytes,
+                    // in a way working similarly to delta state events with offset=0.
+                    //
+                    // In case if we move to strongly typed events this will not work and will need to be redesigned,
+                    // one option could be having two different FourCC state types and shrinking will convert to another type.
+                    inputEvent->sizeInBytes -= 4;
+                    return true;
+                case Behavior.GrowEventsInPlace:
+                    state->value1 = -state->value1;
+                    state->value2 = -state->value2;
+                    inputEvent->sizeInBytes += 4;
+                    return true;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+    };
+
+    [Test]
+    [Category("Devices")]
+    [TestCase(PreProcessorTestDevice.Behavior.PreserveEventsAsIs, 10, 20)]
+    [TestCase(PreProcessorTestDevice.Behavior.SkipEvents, 0, 0)]
+    [TestCase(PreProcessorTestDevice.Behavior.ConvertEventsInPlace, -10, -20)]
+    [TestCase(PreProcessorTestDevice.Behavior.ShrinkEventsInPlace, -10, 0)]
+    [TestCase(PreProcessorTestDevice.Behavior.GrowEventsInPlace, 0, 0, true)]
+    public void Devices_EventPreProcessor_Can(PreProcessorTestDevice.Behavior secondEventBehavior, int expectedValue1, int expectedValue2, bool expectAccessViolationException = false)
+    {
+        var device = InputSystem.AddDevice<PreProcessorTestDevice>();
+        device.behavior = secondEventBehavior;
+
+        InputSystem.QueueStateEvent(device, new PreProcessorTestDeviceState() {value1 = 10, value2 = 20});
+        if (!expectAccessViolationException)
+            InputSystem.Update();
+        else
+        {
+            LogAssert.Expect(LogType.Exception, "AccessViolationException: 'PreProcessorTestDevice:/PreProcessorTestDevice'.PreProcessEvent tries to grow an event from 32 bytes to 36 bytes, this will potentially corrupt events after the current event and/or cause out-of-bounds memory access.");
+            LogAssert.Expect(LogType.Error, "AccessViolationException during event processing of Dynamic update; resetting event buffer");
+            Assert.That(() => InputSystem.Update(), Throws.TypeOf<AccessViolationException>());
+        }
+
+        Assert.That(device.value1.ReadValue(), Is.EqualTo(expectedValue1));
+        Assert.That(device.value2.ReadValue(), Is.EqualTo(expectedValue2));
+    }
 }

--- a/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/DualShockISX.cs
+++ b/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/DualShockISX.cs
@@ -1,7 +1,9 @@
+using System;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.DualShock;
 
 public class DualShockISX : GamepadISX
 {
@@ -15,17 +17,17 @@ public class DualShockISX : GamepadISX
     void Start()
     {
         m_buttonAction = new InputAction(name: "DualShockButtonAction", InputActionType.PassThrough,
-            binding: "*DualShock*/<button>");
+            binding: "*Dual*/<button>");
         m_buttonAction.performed += callbackContext => OnControllerButtonPress(callbackContext.control as ButtonControl, isPS: true);
         m_buttonAction.Enable();
 
         m_dPadAction = new InputAction(name: "DualShockDpadAction", InputActionType.PassThrough,
-            binding: "*DualShock*/<dpad>");
+            binding: "*Dual*/<dpad>");
         m_dPadAction.performed += callbackContext => OnDpadPress(callbackContext.control as DpadControl);
         m_dPadAction.Enable();
 
         m_stickMoveAction = new InputAction(name: "DualShockStickMoveAction", InputActionType.PassThrough,
-            binding: "*DualShock*/<stick>");
+            binding: "*Dual*/<stick>");
         m_stickMoveAction.performed += callbackContext => StickMove(callbackContext.control as StickControl);
         m_stickMoveAction.Enable();
     }
@@ -52,5 +54,34 @@ public class DualShockISX : GamepadISX
             m_leftStickText.text = m_dualShock.leftStick.ReadValue().ToString("F2");
             m_rightStickText.text = m_dualShock.rightStick.ReadValue().ToString("F2");
         }
+    }
+
+    private void OnGUI()
+    {
+        if (!(Gamepad.current is DualShockGamepad))
+            return;
+        
+        var gamepad = Gamepad.current as DualShockGamepad;
+
+        if (GUILayout.Button("red"))
+            gamepad.SetLightBarColor(Color.red);
+        if (GUILayout.Button("green"))
+            gamepad.SetLightBarColor(Color.green);
+        if (GUILayout.Button("black"))
+            gamepad.SetLightBarColor(Color.black);
+        if (GUILayout.Button("1,1"))
+            gamepad.SetMotorSpeeds(1.0f, 1.0f);
+        if (GUILayout.Button("1,0"))
+            gamepad.SetMotorSpeeds(1.0f, 0.0f);
+        if (GUILayout.Button("0,1"))
+            gamepad.SetMotorSpeeds(0.0f, 1.0f);
+        if (GUILayout.Button("0.5,0.5"))
+            gamepad.SetMotorSpeeds(0.5f, 0.5f);
+        if (GUILayout.Button("0.5,0.0"))
+            gamepad.SetMotorSpeeds(0.5f, 0.0f);
+        if (GUILayout.Button("0.0,0.5"))
+            gamepad.SetMotorSpeeds(0.0f, 0.5f);
+        if (GUILayout.Button("0,0"))
+            gamepad.SetMotorSpeeds(0.0f, 0.0f);
     }
 }

--- a/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/DualShockISX.cs
+++ b/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/DualShockISX.cs
@@ -60,7 +60,7 @@ public class DualShockISX : GamepadISX
     {
         if (!(Gamepad.current is DualShockGamepad))
             return;
-        
+
         var gamepad = Gamepad.current as DualShockGamepad;
 
         if (GUILayout.Button("red"))

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,10 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
 - Any unhandled exception in `InputManager.OnUpdate` failing latter updates with `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?`. Instead the system will try to handle the exception and recover into a working state.
 
+### Added
+
+- Added support for PS5 DualSense controllers on Mac and Windows.
+
 ## [1.1.1] - 2021-09-03
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -114,10 +114,10 @@ PlayStation controllers are well supported on different Devices. The Input Syste
 * [`DualShock3GamepadHID`](../api/UnityEngine.InputSystem.DualShock.DualShock3GamepadHID.html): A DualShock 3 controller connected to a desktop computer using the HID interface. Currently only supported on macOS. Doesn't support [rumble](#rumble).
 
 * [`DualShock4GamepadHID`](../api/UnityEngine.InputSystem.DualShock.DualShock4GamepadHID.html): A DualShock 4 controller connected to a desktop computer using the HID interface. Supported on macOS, Windows, UWP, and Linux.
+*
+* [`DualSenseGamepadHID`](../api/UnityEngine.InputSystem.DualShock.DualSenseGamepadHID.html): A DualSense controller connected to a desktop computer using the HID interface. Supported on macOS, Windows.
 
 * [`DualShock4GampadiOS`](../api/UnityEngine.InputSystem.iOS.DualShock4GampadiOS.html): A DualShock 4 controller connected to an iOS Device via Bluetooth. Requires iOS 13 or higher.
-
-[`DualShock4GamepadHID`](../api/UnityEngine.InputSystem.DualShock.DualShock4GamepadHID.html) implements additional, DualShock-specific functionality on top the general support in the [`Gamepad`](../api/UnityEngine.InputSystem.Gamepad.html) class.
 
 * [`SetLightBarColor(Color)`](../api/UnityEngine.InputSystem.DualShock.DualShockGamepad.html#UnityEngine_InputSystem_DualShock_DualShockGamepad_SetLightBarColor_UnityEngine_Color_): Used to set the color of the light bar on the controller.
 

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -28,7 +28,7 @@ Support for the following Devices doesn't require specialized support of particu
 |------|-------|---|-----|---|-------|---|----|----|---|------|-----|
 |Xbox 360 (4)|Yes|Yes (3)|Yes|Yes|No|No|No|Yes|No|No|Sometimes (2)|
 |Xbox One|Yes (1)|Yes (3)|Yes (1)|Yes|Yes (1)|Yes (6)|Yes (6)|Yes|No|No|Sometimes (2)|
-|PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
+|PS3/PS4/PS5|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
 |Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
 |MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
 
@@ -37,7 +37,7 @@ Support for the following Devices doesn't require specialized support of particu
 >2. WebGL support varies between browsers, Devices, and operating systems.
 >3. XInput controllers on Mac currently require the installation of the [Xbox Controller Driver for macOS](https://github.com/360Controller/360Controller). This driver only supports only USB connections, and doesn't support wireless dongles. However, the latest generation of Xbox One controllers natively support Bluetooth, and are natively supported on Macs as HIDs without any additional drivers when connected via Bluetooth.
 >4. This includes any XInput-compatible Device.
->5. Unity doesn't support the gyro or accelerometer on PS4 controllers on platforms other than the PlayStation 4 console. Unity also doesn't support the DualShock 4 USB Wireless Adaptor.
+>5. Unity doesn't support motor rumble and lightbar color over Bluetooth. Unity doesn't support the gyro or accelerometer on PS4/PS5 controllers on platforms other than the PlayStation consoles. Unity also doesn't support the DualShock 4 USB Wireless Adaptor.
 >6. Unity supports Made for iOS (Mfi) certified controllers on iOS. Xbox One and PS4 controllers are only supported on iOS 13 or higher.
 >7. Consoles are supported using separate packages. You need to install these packages in your Project to enable console support.
 >8. Unity officially supports PS4 controllers only on [Android 10 or higher](https://playstation.com/en-us/support/hardware/ps4-pair-dualshock-4-wireless-with-sony-xperia-and-android).

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -28,8 +28,8 @@ Support for the following Devices doesn't require specialized support of particu
 |------|-------|---|-----|---|-------|---|----|----|---|------|-----|
 |Xbox 360 (4)|Yes|Yes (3)|Yes|Yes|No|No|No|Yes|No|No|Sometimes (2)|
 |Xbox One|Yes (1)|Yes (3)|Yes (1)|Yes|Yes (1)|Yes (6)|Yes (6)|Yes|No|No|Sometimes (2)|
-|PS3/PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
-|PS5|Yes(10)|Yes(10)|No(10)|Yes(10)|Yes(10)|No(10)|No(10)|No|Yes|No|Sometimes (2)|
+|PS3/PS4|Yes (5)|Yes (5)|No (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
+|PS5|Yes (10)|Yes (10)|No (10)|No (10)|Yes (10)|No (10)|No (10)|No|Yes|No|Sometimes (2)|
 |Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
 |MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
 

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -24,11 +24,12 @@ Support for the following Devices doesn't require specialized support of particu
 
 ## Gamepads
 
-|Device|Windows|Mac|Linux|UWP|Android|iOS(6)|tvOS(6)|Xbox(7)|PS4(7)|Switch(7)|WebGL|
+|Device|Windows|Mac|Linux|UWP|Android|iOS(6)|tvOS(6)|Xbox(7)|PS4/PS5(7)|Switch(7)|WebGL|
 |------|-------|---|-----|---|-------|---|----|----|---|------|-----|
 |Xbox 360 (4)|Yes|Yes (3)|Yes|Yes|No|No|No|Yes|No|No|Sometimes (2)|
 |Xbox One|Yes (1)|Yes (3)|Yes (1)|Yes|Yes (1)|Yes (6)|Yes (6)|Yes|No|No|Sometimes (2)|
-|PS3/PS4/PS5|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
+|PS3/PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
+|PS5|Yes(10)|Yes(10)|No(10)|Yes(10)|Yes(10)|No(10)|No(10)|No|Yes|No|Sometimes (2)|
 |Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
 |MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
 
@@ -42,6 +43,9 @@ Support for the following Devices doesn't require specialized support of particu
 >7. Consoles are supported using separate packages. You need to install these packages in your Project to enable console support.
 >8. Unity officially supports PS4 controllers only on [Android 10 or higher](https://playstation.com/en-us/support/hardware/ps4-pair-dualshock-4-wireless-with-sony-xperia-and-android).
 >9. Switch Joy-Cons are not currently supported on Windows and Mac. Also, Switch Pro controllers are supported only when connected via Bluetooth but not when connected via wired USB.
+>10. PS5 DualSense is supported on Windows and macOS via USB HID, though setting motor rumble and lightbar color when connected over Bluetooth is currently not supported.
+On Android it's expected to be working from Android 12.
+On iOS/tvOS it's currently recognized as a generic gamepad and most controls do work.
 
 ### WebGL
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs
@@ -1,17 +1,20 @@
-﻿using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.LowLevel;
 
 namespace UnityEngine.InputSystem
 {
     /// <summary>
     /// Gives an opportunity for device to modify event data in-place before it gets propagated to the rest of the system.
-    /// Beware that currently events can only shrink or stay the same size.
     /// </summary>
     /// <remarks>
     /// If device also implements <see cref="IEventMerger"/> it will run first, because we don't process events ahead-of-time.
     /// </remarks>
     internal interface IEventPreProcessor
     {
-        // return false to skip the event
+        /// <summary>
+        /// Preprocess the event. !!! Beware !!! currently events can only shrink or stay the same size.
+        /// </summary>
+        /// <param name="currentEventPtr">The event to preprocess.</param>
+        /// <returns>True if event should be processed further, false if event should be skipped and ignored.</returns>
         bool PreProcessEvent(InputEventPtr currentEventPtr);
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs
@@ -1,0 +1,17 @@
+﻿using UnityEngine.InputSystem.LowLevel;
+
+namespace UnityEngine.InputSystem
+{
+    /// <summary>
+    /// Gives an opportunity for device to modify event data in-place before it gets propagated to the rest of the system.
+    /// Beware that currently events can only shrink or stay the same size.
+    /// </summary>
+    /// <remarks>
+    /// If device also implements <see cref="IEventMerger"/> it will run first, because we don't process events ahead-of-time.
+    /// </remarks>
+    internal interface IEventPreProcessor
+    {
+        // return false to skip the event
+        bool PreProcessEvent(InputEventPtr currentEventPtr);
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0be28dce931f40f8a48953c52e03d5d7
+timeCreated: 1631188213

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -621,6 +621,7 @@ namespace UnityEngine.InputSystem
             HasControlsWithDefaultState = 1 << 2,
             HasDontResetControls = 1 << 10,
             HasEventMerger = 1 << 13,
+            HasEventPreProcessor = 1 << 14,
 
             Remote = 1 << 3, // It's a local mirror of a device from a remote player connection.
             Native = 1 << 4, // It's a device created from data surfaced by NativeInputRuntime.
@@ -788,6 +789,18 @@ namespace UnityEngine.InputSystem
                     m_DeviceFlags |= DeviceFlags.HasEventMerger;
                 else
                     m_DeviceFlags &= ~DeviceFlags.HasEventMerger;
+            }
+        }
+        
+        internal bool hasEventPreProcessor
+        {
+            get => (m_DeviceFlags & DeviceFlags.HasEventPreProcessor) == DeviceFlags.HasEventPreProcessor;
+            set
+            {
+                if (value)
+                    m_DeviceFlags |= DeviceFlags.HasEventPreProcessor;
+                else
+                    m_DeviceFlags &= ~DeviceFlags.HasEventPreProcessor;
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -791,7 +791,7 @@ namespace UnityEngine.InputSystem
                     m_DeviceFlags &= ~DeviceFlags.HasEventMerger;
             }
         }
-        
+
         internal bool hasEventPreProcessor
         {
             get => (m_DeviceFlags & DeviceFlags.HasEventPreProcessor) == DeviceFlags.HasEventPreProcessor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDeviceDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDeviceDebuggerWindow.cs
@@ -329,21 +329,23 @@ namespace UnityEngine.InputSystem.Editor
         private void UpdateDeviceFlags()
         {
             var flags = new List<string>();
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.Native) == InputDevice.DeviceFlags.Native)
+            if (m_Device.native)
                 flags.Add("Native");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.Remote) == InputDevice.DeviceFlags.Remote)
+            if (m_Device.remote)
                 flags.Add("Remote");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.UpdateBeforeRender) == InputDevice.DeviceFlags.UpdateBeforeRender)
+            if (m_Device.updateBeforeRender)
                 flags.Add("UpdateBeforeRender");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.HasStateCallbacks) == InputDevice.DeviceFlags.HasStateCallbacks)
+            if (m_Device.hasStateCallbacks)
                 flags.Add("HasStateCallbacks");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.HasEventMerger) == InputDevice.DeviceFlags.HasEventMerger)
+            if (m_Device.hasEventMerger)
                 flags.Add("HasEventMerger");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.DisabledInFrontend) == InputDevice.DeviceFlags.DisabledInFrontend)
+            if (m_Device.hasEventPreProcessor)
+                flags.Add("HasEventPreProcessor");
+            if (m_Device.disabledInFrontend)
                 flags.Add("DisabledInFrontend");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.DisabledInRuntime) == InputDevice.DeviceFlags.DisabledInRuntime)
+            if (m_Device.disabledInRuntime)
                 flags.Add("DisabledInRuntime");
-            if ((m_Device.m_DeviceFlags & InputDevice.DeviceFlags.DisabledWhileInBackground) == InputDevice.DeviceFlags.DisabledWhileInBackground)
+            if (m_Device.disabledWhileInBackground)
                 flags.Add("DisabledWhileInBackground");
             m_DeviceFlags = m_Device.m_DeviceFlags;
             m_DeviceFlagsString = string.Join(", ", flags.ToArray());

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3035,10 +3035,6 @@ namespace UnityEngine.InputSystem
                     var currentEventTimeInternal = currentEventReadPtr->internalTime;
                     var currentEventType = currentEventReadPtr->type;
 
-                    // Decide whether to skip the event.
-                    var skipEvent = false;
-                    var leaveInBuffer = false;
-
                     // In the editor, we discard all input events that occur in-between exiting edit mode and having
                     // entered play mode as otherwise we'll spill a bunch of UI events that have occurred while the
                     // UI was sort of neither in this mode nor in that mode. This would usually lead to the game receiving
@@ -3055,88 +3051,88 @@ namespace UnityEngine.InputSystem
                         (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
                          InputSystem.s_SystemObject.enterPlayModeTime == 0))
                     {
-                        skipEvent = true;
-                        leaveInBuffer = false;
+                        m_InputEventStream.Advance(false);
+                        continue;
                     }
-                    else
 #endif
+
                     // If we're timeslicing, check if the event time is within limits.
                     if (timesliceEvents && currentEventTimeInternal >= currentTime)
                     {
-                        skipEvent = true;
-                        leaveInBuffer = true;
+                        m_InputEventStream.Advance(true);
+                        continue;
                     }
-                    else
+
+                    // If we can't find the device, ignore the event.
+                    if (device == null)
+                        device = TryGetDeviceById(currentEventReadPtr->deviceId);
+                    if (device == null)
                     {
-                        // If we can't find the device, ignore the event.
-                        if (device == null)
-                            device = TryGetDeviceById(currentEventReadPtr->deviceId);
-                        if (device == null)
-                        {
 #if UNITY_EDITOR
-                            ////TODO: see if this is a device we haven't created and if so, just ignore
-                            m_Diagnostics?.OnCannotFindDeviceForEvent(new InputEventPtr(currentEventReadPtr));
+                        ////TODO: see if this is a device we haven't created and if so, just ignore
+                        m_Diagnostics?.OnCannotFindDeviceForEvent(new InputEventPtr(currentEventReadPtr));
 #endif
 
-                            skipEvent = true;
-                            leaveInBuffer = false;
-                        }
+                        m_InputEventStream.Advance(false);
+                        continue;
+                    }
 
-                        // In the editor, we may need to bump events from editor updates into player updates
-                        // and vice versa.
+                    // In the editor, we may need to bump events from editor updates into player updates
+                    // and vice versa.
 #if UNITY_EDITOR
-                        else if (isPlaying && !gameHasFocus)
+                    if (isPlaying && !gameHasFocus)
+                    {
+                        if (m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode
+                            .PointersAndKeyboardsRespectGameViewFocus &&
+                            m_Settings.backgroundBehavior !=
+                            InputSettings.BackgroundBehavior.ResetAndDisableAllDevices)
                         {
-                            if (m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode
-                                .PointersAndKeyboardsRespectGameViewFocus &&
-                                m_Settings.backgroundBehavior !=
-                                InputSettings.BackgroundBehavior.ResetAndDisableAllDevices)
+                            var isPointerOrKeyboard = device is Pointer || device is Keyboard;
+                            if (updateType != InputUpdateType.Editor)
                             {
-                                var isPointerOrKeyboard = device is Pointer || device is Keyboard;
-                                if (updateType != InputUpdateType.Editor)
+                                // Let everything but pointer and keyboard input through.
+                                // If the event is from a pointer or keyboard, leave it in the buffer so it can be dealt with
+                                // in a subsequent editor update. Otherwise, take it out.
+                                if (isPointerOrKeyboard)
                                 {
-                                    // Let everything but pointer and keyboard input through.
-                                    skipEvent = isPointerOrKeyboard;
-
-                                    // If the event is from a pointer or keyboard, leave it in the buffer so it can be dealt with
-                                    // in a subsequent editor update. Otherwise, take it out.
-                                    leaveInBuffer = isPointerOrKeyboard;
+                                    m_InputEventStream.Advance(true);
+                                    continue;
                                 }
-                                else
+                            }
+                            else
+                            {
+                                // Let only pointer and keyboard input through.
+                                if (!isPointerOrKeyboard)
                                 {
-                                    // Let only pointer and keyboard input through.
-                                    skipEvent = !isPointerOrKeyboard;
-                                    leaveInBuffer = skipEvent;
+                                    m_InputEventStream.Advance(true);
+                                    continue;
                                 }
                             }
                         }
-#endif
                     }
+                    #endif
 
                     // If device is disabled, we let the event through only in certain cases.
-                    if (!skipEvent && !device.enabled)
+                    // Removal and configuration change events should always be processed.
+                    if (!device.enabled &&
+                        currentEventType != DeviceRemoveEvent.Type &&
+                        currentEventType != DeviceConfigurationEvent.Type &&
+                        (device.m_DeviceFlags & (InputDevice.DeviceFlags.DisabledInRuntime |
+                                                 InputDevice.DeviceFlags.DisabledWhileInBackground)) != 0)
                     {
-                        // Removal and configuration change events should always be processed.
-                        if (currentEventType != DeviceRemoveEvent.Type &&
-                            currentEventType != DeviceConfigurationEvent.Type &&
-                            (device.m_DeviceFlags & (InputDevice.DeviceFlags.DisabledInRuntime |
-                                                     InputDevice.DeviceFlags.DisabledWhileInBackground)) != 0)
-                        {
 #if UNITY_EDITOR
-                            // If the device is disabled in the backend, getting events for them
-                            // is something that indicates a problem in the backend so diagnose.
-                            if ((device.m_DeviceFlags & InputDevice.DeviceFlags.DisabledInRuntime) != 0)
-                                m_Diagnostics?.OnEventForDisabledDevice(currentEventReadPtr, device);
+                        // If the device is disabled in the backend, getting events for them
+                        // is something that indicates a problem in the backend so diagnose.
+                        if ((device.m_DeviceFlags & InputDevice.DeviceFlags.DisabledInRuntime) != 0)
+                            m_Diagnostics?.OnEventForDisabledDevice(currentEventReadPtr, device);
 #endif
 
-                            skipEvent = true;
-                            leaveInBuffer = false;
-                        }
+                        m_InputEventStream.Advance(false);
+                        continue;
                     }
 
                     // Check if the device wants to merge successive events.
-                    if (!skipEvent && !settings.disableRedundantEventsMerging && device.hasEventMerger &&
-                        currentEventReadPtr != skipEventMergingFor)
+                    if (!settings.disableRedundantEventsMerging && device.hasEventMerger && currentEventReadPtr != skipEventMergingFor)
                     {
                         // NOTE: This relies on events in the buffer being consecutive for the same device. This is not
                         //       necessarily the case for events coming in from the background event queue where parallel
@@ -3149,7 +3145,7 @@ namespace UnityEngine.InputSystem
                             if (((IEventMerger)device).MergeForward(currentEventReadPtr, nextEvent))
                             {
                                 // Event was merged into next event, skipping.
-                                m_InputEventStream.Advance(leaveEventInBuffer: false);
+                                m_InputEventStream.Advance(false);
                                 continue;
                             }
 
@@ -3192,19 +3188,18 @@ namespace UnityEngine.InputSystem
                     }
 
                     // Give the device a chance to do something with data before we propagate it to event listeners.
-                    if (!skipEvent && device.hasEventPreProcessor)
-                        if (!((IEventPreProcessor)device).PreProcessEvent(currentEventReadPtr))
-                        {
-                            // Skip event if PreProcessEvent considers it to be irrelevant.
-                            skipEvent = true;
-                            leaveInBuffer = false;
-                        }
+                    if (device.hasEventPreProcessor && !((IEventPreProcessor)device).PreProcessEvent(currentEventReadPtr))
+                    {
+                        // Skip event if PreProcessEvent considers it to be irrelevant.
+                        m_InputEventStream.Advance(false);
+                        continue;
+                    }
 
                     // Give listeners a shot at the event.
                     // NOTE: We call listeners also for events where the device is disabled. This is crucial for code
                     //       such as TouchSimulation that disables the originating devices and then uses its events to
                     //       create simulated events from.
-                    if (!skipEvent && m_EventListeners.length > 0)
+                    if (m_EventListeners.length > 0)
                     {
                         DelegateHelpers.InvokeCallbacksSafe(ref m_EventListeners,
                             new InputEventPtr(currentEventReadPtr), device, "InputSystem.onEvent");
@@ -3212,15 +3207,9 @@ namespace UnityEngine.InputSystem
                         // If a listener marks the event as handled, we don't process it further.
                         if (currentEventReadPtr->handled)
                         {
-                            skipEvent = true;
-                            leaveInBuffer = false;
+                            m_InputEventStream.Advance(false);
+                            continue;
                         }
-                    }
-
-                    if (skipEvent)
-                    {
-                        m_InputEventStream.Advance(leaveEventInBuffer: leaveInBuffer);
-                        continue;
                     }
 
                     // Update metrics.
@@ -3361,7 +3350,7 @@ namespace UnityEngine.InputSystem
                             break;
                     }
 
-                    m_InputEventStream.Advance(leaveEventInBuffer: leaveInBuffer);
+                    m_InputEventStream.Advance(leaveEventInBuffer: false);
                 }
 
                 m_Metrics.totalEventProcessingTime +=

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1147,6 +1147,10 @@ namespace UnityEngine.InputSystem
             if (device is IEventMerger)
                 device.hasEventMerger = true;
 
+            // If the device has event preprocessor, make a note of it.
+            if (device is IEventPreProcessor)
+                device.hasEventPreProcessor = true;
+
             // If the device wants before-render updates, enable them if they
             // aren't already.
             if (device.updateBeforeRender)
@@ -3186,6 +3190,15 @@ namespace UnityEngine.InputSystem
                             skipEventMergingFor = nextEvent;
                         }
                     }
+
+                    // Give the device a chance to do something with data before we propagate it to event listeners.
+                    if (!skipEvent && device.hasEventPreProcessor)
+                        if (!((IEventPreProcessor)device).PreProcessEvent(currentEventReadPtr))
+                        {
+                            // Skip event if PreProcessEvent considers it to be irrelevant.
+                            skipEvent = true;
+                            leaveInBuffer = false;
+                        }
 
                     // Give listeners a shot at the event.
                     // NOTE: We call listeners also for events where the device is disabled. This is crucial for code

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3411,7 +3411,7 @@ namespace UnityEngine.InputSystem
             XInputSupport.Initialize();
             #endif
 
-            #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_PS4 || UNITY_WSA || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS
+            #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_PS4 || UNITY_PS5 || UNITY_WSA || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS
             DualShockSupport.Initialize();
             #endif
 
@@ -3434,7 +3434,6 @@ namespace UnityEngine.InputSystem
             #if UNITY_EDITOR || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA
             Switch.SwitchSupportHID.Initialize();
             #endif
-
 
             #if UNITY_XR_AVAILABLE && !UNITY_FORCE_INPUTSYSTEM_XR_OFF
             XR.XRSupport.Initialize();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
@@ -9,9 +9,9 @@ using UnityEngine.Scripting;
 namespace UnityEngine.InputSystem.DualShock
 {
     /// <summary>
-    /// A Sony DualShock controller.
+    /// A Sony DualShock/DualSense controller.
     /// </summary>
-    [InputControlLayout(displayName = "PS4 Controller")]
+    [InputControlLayout(displayName = "Playstation Controller")]
     [Preserve]
     public class DualShockGamepad : Gamepad, IDualShockHaptics
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
@@ -11,7 +11,7 @@ namespace UnityEngine.InputSystem.DualShock
     /// <summary>
     /// A Sony DualShock/DualSense controller.
     /// </summary>
-    [InputControlLayout(displayName = "Playstation Controller")]
+    [InputControlLayout(displayName = "PlayStation Controller")]
     [Preserve]
     public class DualShockGamepad : Gamepad, IDualShockHaptics
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -14,12 +14,12 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
 {
     // This is abstract input report, similar to what is on the wire, but not exactly matching state events.
     // See ConvertInputReport for the exact conversion.
-    [StructLayout(LayoutKind.Explicit, Size = 9 /* important, if you plan to increase this, think about how you gonna fit 10 byte state events because we can only shrink events in IEventPreProcessor */)] 
+    [StructLayout(LayoutKind.Explicit, Size = 9 /* important, if you plan to increase this, think about how you gonna fit 10 byte state events because we can only shrink events in IEventPreProcessor */)]
     public struct DualSenseHIDInputReport : IInputStateTypeInfo
     {
         public static FourCC Format = new FourCC('D', 'S', 'V', 'S'); // DualSense Virtual State
         public FourCC format => Format;
-        
+
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
         [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
         [InputControl(name = "leftStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
@@ -96,7 +96,7 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         [FieldOffset(0)] public InputDeviceCommand baseCommand;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public byte reportId;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public DualSenseHIDOutputReportPayload payload;
-        
+
         public static DualSenseHIDUSBOutputReport Create(DualSenseHIDOutputReportPayload payload)
         {
             return new DualSenseHIDUSBOutputReport
@@ -107,7 +107,7 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
             };
         }
     }
-    
+
     [StructLayout(LayoutKind.Explicit, Size = kSize)]
     internal struct DualSenseHIDBluetoothOutputReport : IInputDeviceCommandInfo
     {
@@ -122,7 +122,7 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 2)] public byte tag2;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 3)] public DualSenseHIDOutputReportPayload payload;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 74)] public uint crc32;
-        
+
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public unsafe fixed byte rawData[74];
 
         public static DualSenseHIDBluetoothOutputReport Create(DualSenseHIDOutputReportPayload payload, byte outputSequenceId)
@@ -343,7 +343,7 @@ namespace UnityEngine.InputSystem.DualShock
         // - Full Bluetooth report, first byte is 0x31, observed size 78
         // While USB and Bluetooth reports only differ in header,
         // Minimal report also differs in order of fields (buttons -> triggers vs triggers -> buttons).
-        
+
         public ButtonControl leftTriggerButton { get; protected set; }
         public ButtonControl rightTriggerButton { get; protected set; }
         public ButtonControl playStationButton { get; protected set; }
@@ -380,6 +380,7 @@ namespace UnityEngine.InputSystem.DualShock
 
             SetMotorSpeedsAndLightBarColor(m_LowFrequencyMotorSpeed, m_HighFrequenceyMotorSpeed, m_LightBarColor);
         }
+
         public override void ResumeHaptics()
         {
             if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue)
@@ -422,7 +423,7 @@ namespace UnityEngine.InputSystem.DualShock
             var lf = lowFrequency.HasValue ? lowFrequency.Value : 0;
             var hf = highFrequency.HasValue ? highFrequency.Value : 0;
             var c = color.HasValue ? color.Value : Color.black;
-            
+
             // DualSense differs a bit from DualShock 4 because all effects need to be set at a same time,
             // otherwise setting a color would disable motor rumble.
             var payload = new DualSenseHIDOutputReportPayload
@@ -446,31 +447,31 @@ namespace UnityEngine.InputSystem.DualShock
         private static unsafe bool MergeForward(DualSenseHIDUSBInputReport* currentState, DualSenseHIDUSBInputReport* nextState)
         {
             return currentState->buttons0 == nextState->buttons0 && currentState->buttons1 == nextState->buttons1 &&
-                   currentState->buttons2 == nextState->buttons2;
+                currentState->buttons2 == nextState->buttons2;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool MergeForward(DualSenseHIDBluetoothInputReport* currentState, DualSenseHIDBluetoothInputReport* nextState)
         {
             return currentState->buttons0 == nextState->buttons0 && currentState->buttons1 == nextState->buttons1 &&
-                   currentState->buttons2 == nextState->buttons2;
+                currentState->buttons2 == nextState->buttons2;
         }
-        
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool MergeForward(DualSenseHIDMinimalInputReport* currentState, DualSenseHIDMinimalInputReport* nextState)
         {
             return currentState->buttons0 == nextState->buttons0 && currentState->buttons1 == nextState->buttons1 &&
-                   currentState->buttons2 == nextState->buttons2;
+                currentState->buttons2 == nextState->buttons2;
         }
 
         unsafe bool IEventMerger.MergeForward(InputEventPtr currentEventPtr, InputEventPtr nextEventPtr)
         {
             if (currentEventPtr.type != StateEvent.Type || nextEventPtr.type != StateEvent.Type)
                 return false;
-        
+
             var currentEvent = StateEvent.FromUnchecked(currentEventPtr);
             var nextEvent = StateEvent.FromUnchecked(nextEventPtr);
-        
+
             if (currentEvent->stateFormat != DualSenseHIDGenericInputReport.Format || nextEvent->stateFormat != DualSenseHIDGenericInputReport.Format)
                 return false;
 
@@ -507,7 +508,7 @@ namespace UnityEngine.InputSystem.DualShock
             else
                 return false;
         }
-        
+
         unsafe bool IEventPreProcessor.PreProcessEvent(InputEventPtr eventPtr)
         {
             if (eventPtr.type != StateEvent.Type)
@@ -567,7 +568,7 @@ namespace UnityEngine.InputSystem.DualShock
             [FieldOffset(8)] public byte buttons0;
             [FieldOffset(9)] public byte buttons1;
             [FieldOffset(10)] public byte buttons2;
-            
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public DualSenseHIDInputReport ToHIDInputReport()
             {
@@ -581,11 +582,11 @@ namespace UnityEngine.InputSystem.DualShock
                     rightTrigger = rightTrigger,
                     buttons0 = buttons0,
                     buttons1 = buttons1,
-                    buttons2 = (byte)(buttons2 & 0x07) 
+                    buttons2 = (byte)(buttons2 & 0x07)
                 };
             }
         }
-        
+
         [StructLayout(LayoutKind.Explicit)]
         internal struct DualSenseHIDBluetoothInputReport
         {
@@ -599,7 +600,7 @@ namespace UnityEngine.InputSystem.DualShock
             [FieldOffset(9)] public byte buttons0;
             [FieldOffset(10)] public byte buttons1;
             [FieldOffset(11)] public byte buttons2;
-            
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public DualSenseHIDInputReport ToHIDInputReport()
             {
@@ -645,7 +646,7 @@ namespace UnityEngine.InputSystem.DualShock
                     rightTrigger = rightTrigger,
                     buttons0 = buttons0,
                     buttons1 = buttons1,
-                    buttons2 = (byte)(buttons2 & 0x03) // higher bits seem to contain random data, and mic button is not supported 
+                    buttons2 = (byte)(buttons2 & 0x03) // higher bits seem to contain random data, and mic button is not supported
                 };
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -12,10 +12,12 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.DualShock.LowLevel
 {
-    // This is abstract input report, similar to what is on the wire, but not exactly matching state events.
-    // See ConvertInputReport for the exact conversion.
-    [StructLayout(LayoutKind.Explicit, Size = 9 /* important, if you plan to increase this, think about how you gonna fit 10 byte state events because we can only shrink events in IEventPreProcessor */)]
-    public struct DualSenseHIDInputReport : IInputStateTypeInfo
+    /// <summary>
+    /// This is abstract input report for PS5 DualSense controller, similar to what is on the wire, but not exactly binary matching any state events.
+    /// See ConvertInputReport for the exact conversion.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 9 /* !!! Beware !!! If you plan to increase this, think about how you gonna fit 10 byte state events because we can only shrink events in IEventPreProcessor */)]
+    internal struct DualSenseHIDInputReport : IInputStateTypeInfo
     {
         public static FourCC Format = new FourCC('D', 'S', 'V', 'S'); // DualSense Virtual State
         public FourCC format => Format;
@@ -333,6 +335,9 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
 
 namespace UnityEngine.InputSystem.DualShock
 {
+    /// <summary>
+    /// PS5 DualSense controller that is interfaced to a HID backend.
+    /// </summary>
     [InputControlLayout(stateType = typeof(DualSenseHIDInputReport), displayName = "DualSense HID")]
     [Scripting.Preserve]
     public class DualSenseGamepadHID : DualShockGamepad, IEventMerger, IEventPreProcessor

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR || UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN || UNITY_WSA || PACKAGE_DOCS_GENERATION
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Layouts;
@@ -11,6 +12,135 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.DualShock.LowLevel
 {
+    // This is abstract input report, similar to what is on the wire, but not exactly matching state events.
+    // See ConvertInputReport for the exact conversion.
+    [StructLayout(LayoutKind.Explicit, Size = 9 /* important, if you plan to increase this, think about how you gonna fit 10 byte state events because we can only shrink events in IEventPreProcessor */)] 
+    public struct DualSenseHIDInputReport : IInputStateTypeInfo
+    {
+        public static FourCC Format = new FourCC('D', 'S', 'V', 'S'); // DualSense Virtual State
+        public FourCC format => Format;
+        
+        [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
+        [InputControl(name = "leftStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
+        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
+        [InputControl(name = "leftStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
+        [FieldOffset(0)] public byte leftStickX;
+        [FieldOffset(1)] public byte leftStickY;
+
+        [InputControl(name = "rightStick", layout = "Stick", format = "VC2B")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
+        [InputControl(name = "rightStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
+        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
+        [InputControl(name = "rightStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
+        [FieldOffset(2)] public byte rightStickX;
+        [FieldOffset(3)] public byte rightStickY;
+
+        [InputControl(name = "leftTrigger", format = "BYTE")]
+        [FieldOffset(4)] public byte leftTrigger;
+
+        [InputControl(name = "rightTrigger", format = "BYTE")]
+        [FieldOffset(5)] public byte rightTrigger;
+
+        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4, defaultState = 8)]
+        [InputControl(name = "dpad/up", format = "BIT", layout = "DiscreteButton", parameters = "minValue=7,maxValue=1,nullValue=8,wrapAtValue=7", bit = 0, sizeInBits = 4)]
+        [InputControl(name = "dpad/right", format = "BIT", layout = "DiscreteButton", parameters = "minValue=1,maxValue=3", bit = 0, sizeInBits = 4)]
+        [InputControl(name = "dpad/down", format = "BIT", layout = "DiscreteButton", parameters = "minValue=3,maxValue=5", bit = 0, sizeInBits = 4)]
+        [InputControl(name = "dpad/left", format = "BIT", layout = "DiscreteButton", parameters = "minValue=5, maxValue=7", bit = 0, sizeInBits = 4)]
+        [InputControl(name = "buttonWest", displayName = "Square", bit = 4)]
+        [InputControl(name = "buttonSouth", displayName = "Cross", bit = 5)]
+        [InputControl(name = "buttonEast", displayName = "Circle", bit = 6)]
+        [InputControl(name = "buttonNorth", displayName = "Triangle", bit = 7)]
+        [FieldOffset(6)] public byte buttons0;
+
+        [InputControl(name = "leftShoulder", bit = 0)]
+        [InputControl(name = "rightShoulder", bit = 1)]
+        [InputControl(name = "leftTriggerButton", layout = "Button", bit = 2)]
+        [InputControl(name = "rightTriggerButton", layout = "Button", bit = 3)]
+        [InputControl(name = "select", displayName = "Share", bit = 4)]
+        [InputControl(name = "start", displayName = "Options", bit = 5)]
+        [InputControl(name = "leftStickPress", bit = 6)]
+        [InputControl(name = "rightStickPress", bit = 7)]
+        [FieldOffset(7)] public byte buttons1;
+
+        [InputControl(name = "systemButton", layout = "Button", displayName = "System", bit = 0)]
+        [InputControl(name = "touchpadButton", layout = "Button", displayName = "Touchpad Press", bit = 1)]
+        [InputControl(name = "micButton", layout = "Button", displayName = "Mic Mute", bit = 2)]
+        [FieldOffset(8)] public byte buttons2;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 47)]
+    internal struct DualSenseHIDOutputReportPayload
+    {
+        [FieldOffset(0)] public byte enableFlags1;
+        [FieldOffset(1)] public byte enableFlags2;
+        [FieldOffset(2)] public byte highFrequencyMotorSpeed;
+        [FieldOffset(3)] public byte lowFrequencyMotorSpeed;
+        [FieldOffset(44)] public byte redColor;
+        [FieldOffset(45)] public byte greenColor;
+        [FieldOffset(46)] public byte blueColor;
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = kSize)]
+    internal struct DualSenseHIDUSBOutputReport : IInputDeviceCommandInfo
+    {
+        public static FourCC Type => new FourCC('H', 'I', 'D', 'O');
+        public FourCC typeStatic => Type;
+
+        internal const int kSize = InputDeviceCommand.BaseCommandSize + 48;
+
+        [FieldOffset(0)] public InputDeviceCommand baseCommand;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public byte reportId;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public DualSenseHIDOutputReportPayload payload;
+        
+        public static DualSenseHIDUSBOutputReport Create(DualSenseHIDOutputReportPayload payload)
+        {
+            return new DualSenseHIDUSBOutputReport
+            {
+                baseCommand = new InputDeviceCommand(Type, kSize),
+                reportId = 2,
+                payload = payload
+            };
+        }
+    }
+    
+    [StructLayout(LayoutKind.Explicit, Size = kSize)]
+    internal struct DualSenseHIDBluetoothOutputReport : IInputDeviceCommandInfo
+    {
+        public static FourCC Type => new FourCC('H', 'I', 'D', 'O');
+        public FourCC typeStatic => Type;
+
+        internal const int kSize = InputDeviceCommand.BaseCommandSize + 78;
+
+        [FieldOffset(0)] public InputDeviceCommand baseCommand;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public byte reportId;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public byte tag1;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 2)] public byte tag2;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 3)] public DualSenseHIDOutputReportPayload payload;
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 74)] public uint crc32;
+        
+        [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public unsafe fixed byte rawData[74];
+
+        public static DualSenseHIDBluetoothOutputReport Create(DualSenseHIDOutputReportPayload payload, byte outputSequenceId)
+        {
+            var report = new DualSenseHIDBluetoothOutputReport
+            {
+                baseCommand = new InputDeviceCommand(Type, kSize),
+                reportId = 0x31,
+                tag1 = (byte)((outputSequenceId & 0xf) << 4),
+                tag2 = 0x10,
+                payload = payload
+            };
+
+            ////FIXME: Calculate crc32 correctly
+            return report;
+        }
+    }
+
     /// <summary>
     /// Structure of HID input reports for PS4 DualShock 4 controllers.
     /// </summary>
@@ -203,6 +333,324 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
 
 namespace UnityEngine.InputSystem.DualShock
 {
+    [InputControlLayout(stateType = typeof(DualSenseHIDInputReport), displayName = "DualSense HID")]
+    [Scripting.Preserve]
+    public class DualSenseGamepadHID : DualShockGamepad, IEventMerger, IEventPreProcessor
+    {
+        // Gamepad might send 3 types of input reports:
+        // - Minimal report, first byte is 0x01, observed size is 78, also can be 10
+        // - Full USB report, first byte is 0x01, observed size is 64
+        // - Full Bluetooth report, first byte is 0x31, observed size 78
+        // While USB and Bluetooth reports only differ in header,
+        // Minimal report also differs in order of fields (buttons -> triggers vs triggers -> buttons).
+        
+        public ButtonControl leftTriggerButton { get; protected set; }
+        public ButtonControl rightTriggerButton { get; protected set; }
+        public ButtonControl playStationButton { get; protected set; }
+
+        private float? m_LowFrequencyMotorSpeed;
+        private float? m_HighFrequenceyMotorSpeed;
+        private Color? m_LightBarColor;
+        private byte outputSequenceId;
+
+        protected override void FinishSetup()
+        {
+            leftTriggerButton = GetChildControl<ButtonControl>("leftTriggerButton");
+            rightTriggerButton = GetChildControl<ButtonControl>("rightTriggerButton");
+            playStationButton = GetChildControl<ButtonControl>("systemButton");
+
+            base.FinishSetup();
+        }
+
+        public override void PauseHaptics()
+        {
+            if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue)
+                return;
+
+            SetMotorSpeedsAndLightBarColor(0.0f, 0.0f, m_LightBarColor);
+        }
+
+        public override void ResetHaptics()
+        {
+            if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue)
+                return;
+
+            m_HighFrequenceyMotorSpeed = null;
+            m_LowFrequencyMotorSpeed = null;
+
+            SetMotorSpeedsAndLightBarColor(m_LowFrequencyMotorSpeed, m_HighFrequenceyMotorSpeed, m_LightBarColor);
+        }
+        public override void ResumeHaptics()
+        {
+            if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue)
+                return;
+            SetMotorSpeedsAndLightBarColor(m_LowFrequencyMotorSpeed, m_HighFrequenceyMotorSpeed, m_LightBarColor);
+        }
+
+        public override void SetLightBarColor(Color color)
+        {
+            m_LightBarColor = color;
+            SetMotorSpeedsAndLightBarColor(m_LowFrequencyMotorSpeed, m_HighFrequenceyMotorSpeed, m_LightBarColor);
+        }
+
+        public override void SetMotorSpeeds(float lowFrequency, float highFrequency)
+        {
+            m_LowFrequencyMotorSpeed = lowFrequency;
+            m_HighFrequenceyMotorSpeed = highFrequency;
+            SetMotorSpeedsAndLightBarColor(m_LowFrequencyMotorSpeed, m_HighFrequenceyMotorSpeed, m_LightBarColor);
+        }
+
+        /// <summary>
+        /// Set motor speeds of both motors and the light bar color simultaneously.
+        /// </summary>
+        /// <param name="lowFrequency"><see cref="Haptics.IDualMotorRumble.SetMotorSpeeds"/></param>
+        /// <param name="highFrequency"><see cref="Haptics.IDualMotorRumble.SetMotorSpeeds"/></param>
+        /// <param name="color"><see cref="IDualShockHaptics.SetLightBarColor"/></param>
+        /// <returns>True if the command succeeded. Will return false if another command is currently being processed.</returns>
+        /// <remarks>
+        /// Use this method to set both the motor speeds and the light bar color in the same call. This method exists
+        /// because it is currently not possible to process an input/output control (IOCTL) command while another one
+        /// is in flight. For example, calling <see cref="SetMotorSpeeds"/> immediately after calling
+        /// <see cref="SetLightBarColor"/> might result in only the light bar color changing. The <see cref="SetMotorSpeeds"/>
+        /// call could fail. It is however possible to combine multiple IOCTL instructions into a single command, which
+        /// is what this method does.
+        ///
+        /// See <see cref="Haptics.IDualMotorRumble.SetMotorSpeeds"/> and <see cref="IDualShockHaptics.SetLightBarColor"/>
+        /// for the respective documentation regarding setting rumble and light bar color.</remarks>
+        public bool SetMotorSpeedsAndLightBarColor(float? lowFrequency, float? highFrequency, Color? color)
+        {
+            var lf = lowFrequency.HasValue ? lowFrequency.Value : 0;
+            var hf = highFrequency.HasValue ? highFrequency.Value : 0;
+            var c = color.HasValue ? color.Value : Color.black;
+            
+            // DualSense differs a bit from DualShock 4 because all effects need to be set at a same time,
+            // otherwise setting a color would disable motor rumble.
+            var payload = new DualSenseHIDOutputReportPayload
+            {
+                enableFlags1 = 0x1 | 0x2,
+                enableFlags2 = 0x4,
+                lowFrequencyMotorSpeed = (byte)NumberHelpers.NormalizedFloatToUInt(lf, byte.MinValue, byte.MinValue),
+                highFrequencyMotorSpeed = (byte)NumberHelpers.NormalizedFloatToUInt(hf, byte.MinValue, byte.MaxValue),
+                redColor = (byte)NumberHelpers.NormalizedFloatToUInt(c.r, byte.MinValue, byte.MaxValue),
+                greenColor = (byte)NumberHelpers.NormalizedFloatToUInt(c.g, byte.MinValue, byte.MaxValue),
+                blueColor = (byte)NumberHelpers.NormalizedFloatToUInt(c.b, byte.MinValue, byte.MaxValue)
+            };
+
+            ////FIXME: Bluetooth reports are not working
+            //var command = DualSenseHIDBluetoothOutputReport.Create(payload, ++outputSequenceId);
+            var command = DualSenseHIDUSBOutputReport.Create(payload);
+            return ExecuteCommand(ref command) >= 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool MergeForward(DualSenseHIDUSBInputReport* currentState, DualSenseHIDUSBInputReport* nextState)
+        {
+            return currentState->buttons0 == nextState->buttons0 && currentState->buttons1 == nextState->buttons1 &&
+                   currentState->buttons2 == nextState->buttons2;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool MergeForward(DualSenseHIDBluetoothInputReport* currentState, DualSenseHIDBluetoothInputReport* nextState)
+        {
+            return currentState->buttons0 == nextState->buttons0 && currentState->buttons1 == nextState->buttons1 &&
+                   currentState->buttons2 == nextState->buttons2;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe bool MergeForward(DualSenseHIDMinimalInputReport* currentState, DualSenseHIDMinimalInputReport* nextState)
+        {
+            return currentState->buttons0 == nextState->buttons0 && currentState->buttons1 == nextState->buttons1 &&
+                   currentState->buttons2 == nextState->buttons2;
+        }
+
+        unsafe bool IEventMerger.MergeForward(InputEventPtr currentEventPtr, InputEventPtr nextEventPtr)
+        {
+            if (currentEventPtr.type != StateEvent.Type || nextEventPtr.type != StateEvent.Type)
+                return false;
+        
+            var currentEvent = StateEvent.FromUnchecked(currentEventPtr);
+            var nextEvent = StateEvent.FromUnchecked(nextEventPtr);
+        
+            if (currentEvent->stateFormat != DualSenseHIDGenericInputReport.Format || nextEvent->stateFormat != DualSenseHIDGenericInputReport.Format)
+                return false;
+
+            if (currentEvent->stateSizeInBytes != nextEvent->stateSizeInBytes)
+                return false;
+
+            var currentGenericReport = (DualSenseHIDGenericInputReport*)currentEvent->state;
+            var nextGenericReport = (DualSenseHIDGenericInputReport*)nextEvent->state;
+
+            if (currentGenericReport->reportId != nextGenericReport->reportId)
+                return false;
+
+            if (currentGenericReport->reportId == 0x01)
+            {
+                if (currentEvent->stateSizeInBytes == 10 || currentEvent->stateSizeInBytes == 78)
+                {
+                    var currentState = (DualSenseHIDMinimalInputReport*)currentEvent->state;
+                    var nextState = (DualSenseHIDMinimalInputReport*)nextEvent->state;
+                    return MergeForward(currentState, nextState);
+                }
+                else
+                {
+                    var currentState = (DualSenseHIDUSBInputReport*)currentEvent->state;
+                    var nextState = (DualSenseHIDUSBInputReport*)nextEvent->state;
+                    return MergeForward(currentState, nextState);
+                }
+            }
+            else if (currentGenericReport->reportId == 0x31)
+            {
+                var currentState = (DualSenseHIDBluetoothInputReport*)currentEvent->state;
+                var nextState = (DualSenseHIDBluetoothInputReport*)nextEvent->state;
+                return MergeForward(currentState, nextState);
+            }
+            else
+                return false;
+        }
+        
+        unsafe bool IEventPreProcessor.PreProcessEvent(InputEventPtr eventPtr)
+        {
+            if (eventPtr.type != StateEvent.Type)
+                return eventPtr.type != DeltaStateEvent.Type; // only skip delta state events
+
+            var stateEvent = StateEvent.FromUnchecked(eventPtr);
+            var size = stateEvent->stateSizeInBytes;
+            if (stateEvent->stateFormat != DualSenseHIDGenericInputReport.Format || size < sizeof(DualSenseHIDInputReport))
+                return false; // skip unrecognized state events otherwise they will corrupt control states
+
+            var genericReport = (DualSenseHIDGenericInputReport*)stateEvent->state;
+            if (genericReport->reportId == 0x01)
+            {
+                if (stateEvent->stateSizeInBytes == 10 || stateEvent->stateSizeInBytes == 78)
+                {
+                    // minimal report
+                    var data = ((DualSenseHIDMinimalInputReport*)stateEvent->state)->ToHIDInputReport();
+                    *((DualSenseHIDInputReport*)stateEvent->state) = data;
+                }
+                else
+                {
+                    var data = ((DualSenseHIDUSBInputReport*)stateEvent->state)->ToHIDInputReport();
+                    *((DualSenseHIDInputReport*)stateEvent->state) = data;
+                }
+                stateEvent->stateFormat = DualSenseHIDInputReport.Format;
+                return true;
+            }
+            else if (genericReport->reportId == 0x31)
+            {
+                var data = ((DualSenseHIDBluetoothInputReport*)stateEvent->state)->ToHIDInputReport();
+                *((DualSenseHIDInputReport*)stateEvent->state) = data;
+                stateEvent->stateFormat = DualSenseHIDInputReport.Format;
+                return true;
+            }
+            else
+                return false; // skip unrecognized reportId
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct DualSenseHIDGenericInputReport
+        {
+            public static FourCC Format => new FourCC('H', 'I', 'D');
+
+            [FieldOffset(0)] public byte reportId;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct DualSenseHIDUSBInputReport
+        {
+            [FieldOffset(0)] public byte reportId;
+            [FieldOffset(1)] public byte leftStickX;
+            [FieldOffset(2)] public byte leftStickY;
+            [FieldOffset(3)] public byte rightStickX;
+            [FieldOffset(4)] public byte rightStickY;
+            [FieldOffset(5)] public byte leftTrigger;
+            [FieldOffset(6)] public byte rightTrigger;
+            [FieldOffset(8)] public byte buttons0;
+            [FieldOffset(9)] public byte buttons1;
+            [FieldOffset(10)] public byte buttons2;
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public DualSenseHIDInputReport ToHIDInputReport()
+            {
+                return new DualSenseHIDInputReport
+                {
+                    leftStickX = leftStickX,
+                    leftStickY = leftStickY,
+                    rightStickX = rightStickX,
+                    rightStickY = rightStickY,
+                    leftTrigger = leftTrigger,
+                    rightTrigger = rightTrigger,
+                    buttons0 = buttons0,
+                    buttons1 = buttons1,
+                    buttons2 = (byte)(buttons2 & 0x07) 
+                };
+            }
+        }
+        
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct DualSenseHIDBluetoothInputReport
+        {
+            [FieldOffset(0)] public byte reportId;
+            [FieldOffset(2)] public byte leftStickX;
+            [FieldOffset(3)] public byte leftStickY;
+            [FieldOffset(4)] public byte rightStickX;
+            [FieldOffset(5)] public byte rightStickY;
+            [FieldOffset(6)] public byte leftTrigger;
+            [FieldOffset(7)] public byte rightTrigger;
+            [FieldOffset(9)] public byte buttons0;
+            [FieldOffset(10)] public byte buttons1;
+            [FieldOffset(11)] public byte buttons2;
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public DualSenseHIDInputReport ToHIDInputReport()
+            {
+                return new DualSenseHIDInputReport
+                {
+                    leftStickX = leftStickX,
+                    leftStickY = leftStickY,
+                    rightStickX = rightStickX,
+                    rightStickY = rightStickY,
+                    leftTrigger = leftTrigger,
+                    rightTrigger = rightTrigger,
+                    buttons0 = buttons0,
+                    buttons1 = buttons1,
+                    buttons2 = (byte)(buttons2 & 0x07)
+                };
+            }
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct DualSenseHIDMinimalInputReport
+        {
+            [FieldOffset(0)] public byte reportId;
+            [FieldOffset(1)] public byte leftStickX;
+            [FieldOffset(2)] public byte leftStickY;
+            [FieldOffset(3)] public byte rightStickX;
+            [FieldOffset(4)] public byte rightStickY;
+            [FieldOffset(5)] public byte buttons0;
+            [FieldOffset(6)] public byte buttons1;
+            [FieldOffset(7)] public byte buttons2;
+            [FieldOffset(8)] public byte leftTrigger;
+            [FieldOffset(9)] public byte rightTrigger;
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public DualSenseHIDInputReport ToHIDInputReport()
+            {
+                return new DualSenseHIDInputReport
+                {
+                    leftStickX = leftStickX,
+                    leftStickY = leftStickY,
+                    rightStickX = rightStickX,
+                    rightStickY = rightStickY,
+                    leftTrigger = leftTrigger,
+                    rightTrigger = rightTrigger,
+                    buttons0 = buttons0,
+                    buttons1 = buttons1,
+                    buttons2 = (byte)(buttons2 & 0x03) // higher bits seem to contain random data, and mic button is not supported 
+                };
+            }
+        }
+    }
+
     /// <summary>
     /// PS4 DualShock controller that is interfaced to a HID backend.
     /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -27,6 +27,11 @@ namespace UnityEngine.InputSystem.DualShock
             //       not return anything from IOHIDDevice_GetProduct() and IOHIDevice_GetManufacturer()
             //       even though it will report the expected results when plugged in via USB.
             #if UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_WSA || UNITY_EDITOR
+            InputSystem.RegisterLayout<DualSenseGamepadHID>(
+                matches: new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x54C) // Sony Entertainment.
+                    .WithCapability("productId", 0xCE6));
             InputSystem.RegisterLayout<DualShock4GamepadHID>(
                 matches: new InputDeviceMatcher()
                     .WithInterface("HID")

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
@@ -28,7 +28,7 @@ namespace UnityEngine.InputSystem.DualShock
         {
             var builder = this.Setup(37, 11, 8)
                 .WithName("DualShock4GamepadHID")
-                .WithDisplayName("PS4 Controller")
+                .WithDisplayName("PlayStation Controller")
                 .WithChildren(0, 19)
                 .WithLayout(new InternedString("DualShock4GamepadHID"))
                 .WithStateBlock(new InputStateBlock { format = new FourCC(1212761120), sizeInBits = 80 });


### PR DESCRIPTION
### Description

Adding basic DualSense support.
Tested:
- All buttons work on PC/macOS over USB/Bluetooth (note, mic button doesn't work over bluetooth unless switched into full mode)
- Motor rumble/lightbar works on PC/macOS over USB. Bluetooth support not implemented (and apparently was not implemented for DualShock 4)
- More testing pending.

### Changes made

Had to add `IEventPreProcessor` to hijack and change events in-place before they reach `onEvent` callback, this is because the device can report at least 3 different report types which are not binary compatible with each other, and it can switch between them in runtime. The only architectural dead-end here is that we can only shrink events in-place. So when it will be time to add accelerometer/gyro support this will bite us.
