### PR TITLE
FIX: HID device capabilities JSON being parsed more than once for same device

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 
+- Fixed a performance issue on entering/exiting playmode where HID device capabilities JSON could be parsed multiple times for a single device([case 1362733](https://issuetracker.unity3d.com/issues/input-package-deserializing-json-multiple-times-when-entering-slash-exiting-playmode)).
 - Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
 
 ## [1.1.1] - 2021-09-03

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1210,11 +1210,18 @@ namespace UnityEngine.InputSystem
         public InputDevice AddDevice(InputDeviceDescription description, InternedString layout, string deviceName = null,
             int deviceId = InputDevice.InvalidDeviceId, InputDevice.DeviceFlags deviceFlags = 0)
         {
-            Profiler.BeginSample("InputSystem.AddDevice");
-            var device = AddDevice(layout, deviceId, deviceName, description, deviceFlags);
-            device.m_Description = description;
-            Profiler.EndSample();
-            return device;
+            try
+            {
+                Profiler.BeginSample("InputSystem.AddDevice");
+
+                var device = AddDevice(layout, deviceId, deviceName, description, deviceFlags);
+                device.m_Description = description;
+                return device;
+            }
+            finally
+            {
+                Profiler.EndSample();
+            }
         }
 
         public void RemoveDevice(InputDevice device, bool keepOnListOfAvailableDevices = false)
@@ -2679,6 +2686,9 @@ namespace UnityEngine.InputSystem
                 }
                 catch (Exception)
                 {
+                    // the user might have changed the layout of one device, but others in the system might still have
+                    // layouts we can't make sense of. Just quietly swallow exceptions from those so as not to spam
+                    // the user with information about devices unrelated to what was actually changed.
                 }
             }
         }


### PR DESCRIPTION
[1362733](https://fogbugz.unity3d.com/f/cases/1362733/)

### Description

On the AddAvailableDevicesThatAreNowRecognized path, TryFindMatchingControlLayout was called twice, which for HID devices, results in the device capabilities JSON being parsed both times.

### Changes made

Removed a redundant call to TryFindMatchingControlLayout when adding devices.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
