### PR TITLE
re-adds ENABLE_VR to specific XR C# files.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,10 +17,10 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed a performance issue on entering/exiting playmode where HID device capabilities JSON could be parsed multiple times for a single device([case 1362733](https://issuetracker.unity3d.com/issues/input-package-deserializing-json-multiple-times-when-entering-slash-exiting-playmode)).
-- Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
+- Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. (case 1342297)
 - Any unhandled exception in `InputManager.OnUpdate` failing latter updates with `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?`. Instead the system will try to handle the exception and recover into a working state.
 - Fixed an issue that broke the VirtualMouseInput component in the editor ([case 1367553](https://fogbugz.unity3d.com/f/cases/1367553/)).
-- Fixed a problem where only using runtimes that are not XR supported causes a compile error.This fix adds back in ENABLE_VR checks to prevent this case ([case 1368300](https://fogbugz.unity3d.com/f/cases/1368300))
+- Fixed a problem where only using runtimes that are not XR supported causes a compile error.This fix adds back in ENABLE_VR checks to prevent this case (case 1368300)
 
 ### Added
 
@@ -28,7 +28,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 
-- Improved the user experience when creating single vs multi-touch touchscreen bindings in the Input Action Asset editor by making both options visible in the input action dropdown menu. Now it's not neccessary to be aware of the touch*/press path binding syntax ([case 1357664](https://issuetracker.unity3d.com/issues/inputsystem-touchscreens-multi-touch-doesnt-work-when-using-a-custom-inputactionasset)).
+- Improved the user experience when creating single vs multi-touch touchscreen bindings in the Input Action Asset editor by making both options visible in the input action dropdown menu. Now it's not neccessary to be aware of the touch\*/press path binding syntax ([case 1357664](https://issuetracker.unity3d.com/issues/inputsystem-touchscreens-multi-touch-doesnt-work-when-using-a-custom-inputactionasset)).
 
 ## [1.1.1] - 2021-09-03
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
 - Any unhandled exception in `InputManager.OnUpdate` failing latter updates with `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?`. Instead the system will try to handle the exception and recover into a working state.
 - Fixed an issue that broke the VirtualMouseInput component in the editor ([case 1367553](https://fogbugz.unity3d.com/f/cases/1367553/)).
+- Fixed a problem where only using runtimes that are not XR supported causes a compile error.This fix adds back in ENABLE_VR checks to prevent this case ([case 1368300](https://fogbugz.unity3d.com/f/cases/1368300))
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3435,7 +3435,7 @@ namespace UnityEngine.InputSystem
             Switch.SwitchSupportHID.Initialize();
             #endif
 
-            #if UNITY_XR_AVAILABLE && !UNITY_FORCE_INPUTSYSTEM_XR_OFF
+            #if (UNITY_XR_AVAILABLE && !UNITY_FORCE_INPUTSYSTEM_XR_OFF) && ENABLE_VR
             XR.XRSupport.Initialize();
             #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
@@ -1,4 +1,4 @@
-#if (UNITY_XR_AVAILABLE && !UNITY_FORCE_INPUTSYSTEM_XR_OFF) || PACKAGE_DOCS_GENERATION
+#if (UNITY_XR_AVAILABLE && !UNITY_FORCE_INPUTSYSTEM_XR_OFF) && ENABLE_VR || PACKAGE_DOCS_GENERATION
 using System.Runtime.InteropServices;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.XR.Haptics;
 using UnityEngine.InputSystem.Layouts;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/BufferedRumble.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/BufferedRumble.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION
 namespace UnityEngine.InputSystem.XR.Haptics
 {
     public struct BufferedRumble

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetCurrentHapticStateCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetCurrentHapticStateCommand.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetHapticCapabilitiesCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/GetHapticCapabilitiesCommand.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendBufferedHapticsCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendBufferedHapticsCommand.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendHapticImpulseCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Haptics/SendHapticImpulseCommand.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION && !UNITY_FORCE_INPUTSYSTEM_XR_OFF
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION && !UNITY_FORCE_INPUTSYSTEM_XR_OFF
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE && !UNITY_FORCE_INPUTSYSTEM_XR_OFF
+#if UNITY_XR_AVAILABLE && ENABLE_VR && !UNITY_FORCE_INPUTSYSTEM_XR_OFF
 using System;
 using System.Collections.Generic;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
@@ -1,4 +1,4 @@
-#if UNITY_XR_AVAILABLE || PACKAGE_DOCS_GENERATION
+#if UNITY_XR_AVAILABLE && ENABLE_VR || PACKAGE_DOCS_GENERATION
 using System;
 using System.Collections.Generic;
 using UnityEngine.XR;


### PR DESCRIPTION
### Description

Fix for compile error when _only_ installing players that do not define ENABLE_VR.

### Changes made

This puts ENABLE_VR back into 
InputSystem.cs
PoseControl.cs
GenericXRDevices.cs
XRLayoutBuilder.cs
XRSupport.cs

### Notes

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [N/A] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [N/A] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
