### PR TITLE
FIX: Case 1308637. fix's Android gamepad's right stick control description by correcting the size

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
@@ -652,5 +652,112 @@ internal class AndroidTests : CoreTestsFixture
 
         Assert.That(InputSystem.devices[0].layout, Is.EqualTo("CustomDevice"));
     }
+
+    // https://fogbugz.unity3d.com/f/cases/1308637/
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanReactToGamePadAxisChanges()
+    {
+        var device = InputSystem.AddDevice(new InputDeviceDescription
+        {
+            interfaceName = "Android",
+            deviceClass = "AndroidGameController",
+            capabilities = new AndroidDeviceCapabilities
+            {
+                inputSources = AndroidInputSource.Gamepad | AndroidInputSource.Joystick,
+            }.ToJson()
+        });
+
+        var controller = (AndroidGamepad)device;
+
+        var leftStick = new Vector2(0.3f, 0.3f);
+        var rightStick = new Vector2(0.35f, 0.35f);
+
+        var updateSticks = new Action(() =>
+        {
+            InputSystem.QueueStateEvent(controller,
+                new AndroidGameControllerState()
+                    .WithAxis(AndroidAxis.X, leftStick.x)
+                    .WithAxis(AndroidAxis.Y, leftStick.y)
+                    .WithAxis(AndroidAxis.Z, rightStick.x)
+                    .WithAxis(AndroidAxis.Rz, rightStick.y));
+        });
+
+        var processStickValue = new Func<Vector2, Vector2>(v =>
+        {
+            v.y = -v.y;
+            return new StickDeadzoneProcessor().Process(v);
+        });
+
+
+        updateSticks();
+        InputSystem.Update();
+        InputSystem.Update();
+
+        var leftStickAction = new InputAction(binding: "/<Gamepad>/leftStick");
+        var rightStickAction = new InputAction(binding: "/<Gamepad>/rightStick");
+
+        var leftStickActionPerformed = 0;
+        var rightStickActionPerformed = 0;
+        var receivedLeftStick = Vector2.zero;
+        var receivedRightStick = Vector2.zero;
+
+        leftStickAction.performed += ctx =>
+        {
+            receivedLeftStick = ctx.ReadValue<Vector2>();
+            ++leftStickActionPerformed;
+        };
+
+        rightStickAction.performed += ctx =>
+        {
+            receivedRightStick = ctx.ReadValue<Vector2>();
+            ++rightStickActionPerformed;
+        };
+
+        leftStickAction.Enable();
+        rightStickAction.Enable();
+
+        // Actions are called the first time they're enabled?
+        InputSystem.Update();
+        Assert.That(leftStickActionPerformed, Is.EqualTo(1));
+        Assert.That(rightStickActionPerformed, Is.EqualTo(1));
+
+        // Update only left stick's X value
+        leftStick.x += 0.1f;
+        updateSticks();
+        InputSystem.Update();
+        Assert.That(leftStickActionPerformed, Is.EqualTo(2));
+        Assert.That(rightStickActionPerformed, Is.EqualTo(1));
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(processStickValue(leftStick)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(processStickValue(rightStick)).Using(Vector2EqualityComparer.Instance));
+
+        // Update only left stick's Y value
+        leftStick.y += 0.1f;
+        updateSticks();
+        InputSystem.Update();
+        Assert.That(leftStickActionPerformed, Is.EqualTo(3));
+        Assert.That(rightStickActionPerformed, Is.EqualTo(1));
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(processStickValue(leftStick)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(processStickValue(rightStick)).Using(Vector2EqualityComparer.Instance));
+
+        // Update only right stick's X value
+        rightStick.x += 0.1f;
+        updateSticks();
+        InputSystem.Update();
+        Assert.That(leftStickActionPerformed, Is.EqualTo(3));
+        Assert.That(rightStickActionPerformed, Is.EqualTo(2));
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(processStickValue(leftStick)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(processStickValue(rightStick)).Using(Vector2EqualityComparer.Instance));
+
+        // Update only right stick's Y value
+        rightStick.y += 0.1f;
+        updateSticks();
+        InputSystem.Update();
+        Assert.That(leftStickActionPerformed, Is.EqualTo(3));
+        Assert.That(rightStickActionPerformed, Is.EqualTo(3));
+        Assert.That(controller.leftStick.ReadValue(), Is.EqualTo(processStickValue(leftStick)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(controller.rightStick.ReadValue(), Is.EqualTo(processStickValue(rightStick)).Using(Vector2EqualityComparer.Instance));
+    }
 }
+
 #endif // UNITY_EDITOR || UNITY_ANDROID

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a performance issue on entering/exiting playmode where HID device capabilities JSON could be parsed multiple times for a single device([case 1362733](https://issuetracker.unity3d.com/issues/input-package-deserializing-json-multiple-times-when-entering-slash-exiting-playmode)).
 - Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
 - Any unhandled exception in `InputManager.OnUpdate` failing latter updates with `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?`. Instead the system will try to handle the exception and recover into a working state.
+- Fixed case 1308637, input action for Android gamepad's right stick will be correctly invoked when only y axis is changing.
 
 ## [1.1.1] - 2021-09-03
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -54,7 +54,7 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         [InputControl(name = "leftStick/up", variants = kVariantGamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]
         [InputControl(name = "leftStick/down", variants = kVariantGamepad, parameters = "invert=false,clamp=1,clampMin=0,clampMax=1.0")]
         ////FIXME: state for this control is not contiguous
-        [InputControl(name = "rightStick", offset = (uint)AndroidAxis.Z * sizeof(float) + kAxisOffset, sizeInBits = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float) * 8, variants = kVariantGamepad)]
+        [InputControl(name = "rightStick", offset = (uint)AndroidAxis.Z * sizeof(float) + kAxisOffset, sizeInBits = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z + 1) * sizeof(float) * 8, variants = kVariantGamepad)]
         [InputControl(name = "rightStick/x", variants = kVariantGamepad)]
         [InputControl(name = "rightStick/y", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert")]
         [InputControl(name = "rightStick/up", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]


### PR DESCRIPTION
### Description

Input action for Android gamepad's right stick was not being invoked when only y axis was changing, this was because I didn't specify the correct size for the 'rightStick' control, so the input system was checking less memory for state changes than it should have.

### Changes made

Fixed Android's gamepad 'rightStick' control description, by correcting the size

### Notes

I think there should be some higher level test here, 
```
     [InputControl(name = "rightStick", offset = (uint)AndroidAxis.Z * sizeof(float) + kAxisOffset, sizeInBits = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z + 1) * sizeof(float) * 8, variants = kVariantGamepad)]
        [InputControl(name = "rightStick/x", variants = kVariantGamepad)]
        [InputControl(name = "rightStick/y", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert")]
        [InputControl(name = "rightStick/up", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]
        [InputControl(name = "rightStick/down", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert=false,clamp=1,clampMin=0,clampMax=1.0")]
```

For ex., if control has children (rightStick versus rightStick/x, rightStick/y), check that children don't go out of bounds of the parent, this would have helped to spot this earlier


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [-] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
