### PR TITLE
NEW: Show single and multi-touch press controls in input action dropdown

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2958,6 +2958,38 @@ partial class CoreTests
         EditorHelpers.RestartEditorAndRecompileScripts(dryRun: true);
     }
 
+    [Test]
+    [Category("Editor")]
+    public void Editor_InputControlPicker_TouchscreenPickerContainsSingleAndMultiTouchControls()
+    {
+        var dropdown = new StubInputControlPickerDropdown(new InputControlPickerState(), _ => {});
+        var root = dropdown.BuildRoot();
+
+        Assert.That(() =>
+        {
+            var touchscreen = root.children.FirstOrDefault(c => c.name == "Touchscreen");
+            if (touchscreen == null)
+                return false;
+
+            return touchscreen.children.Any(c => c.name == "Press (Single touch)") &&
+            touchscreen.children.Any(c => c.name == "Press (Multi-touch)");
+        });
+    }
+
+    internal class StubInputControlPickerDropdown : InputControlPickerDropdown
+    {
+        public StubInputControlPickerDropdown(InputControlPickerState state, Action<string> onPickCallback,
+                                              InputControlPicker.Mode mode = InputControlPicker.Mode.PickControl)
+            : base(state, onPickCallback, mode)
+        {
+        }
+
+        public UnityEngine.InputSystem.Editor.AdvancedDropdownItem BuildRoot()
+        {
+            return base.BuildRoot();
+        }
+    }
+
     ////TODO: tests for InputAssetImporter; for this we need C# mocks to be able to cut us off from the actual asset DB
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,10 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
 - Any unhandled exception in `InputManager.OnUpdate` failing latter updates with `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?`. Instead the system will try to handle the exception and recover into a working state.
 
+### Added
+
+- Improved the user experience when creating single vs multi-touch touchscreen bindings in the Input Action Asset editor by making both options visible in the input action dropdown menu. Now it's not neccessary to be aware of the touch*/press path binding syntax ([case 1357664](https://issuetracker.unity3d.com/issues/inputsystem-touchscreens-multi-touch-doesnt-work-when-using-a-custom-inputactionasset)).
+
 ## [1.1.1] - 2021-09-03
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/IInputControlPickerLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/IInputControlPickerLayout.cs
@@ -1,0 +1,11 @@
+using UnityEngine.InputSystem.Layouts;
+
+namespace UnityEngine.InputSystem.Editor
+{
+    internal interface IInputControlPickerLayout
+    {
+        void AddControlItem(InputControlPickerDropdown dropdown, DeviceDropdownItem parent,
+            ControlDropdownItem parentControl,
+            InputControlLayout.ControlItem control, string device, string usage, bool searchable);
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/IInputControlPickerLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/IInputControlPickerLayout.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine.InputSystem.Layouts;
 
 namespace UnityEngine.InputSystem.Editor
@@ -9,3 +10,4 @@ namespace UnityEngine.InputSystem.Editor
             InputControlLayout.ControlItem control, string device, string usage, bool searchable);
     }
 }
+#endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/IInputControlPickerLayout.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/IInputControlPickerLayout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f4390a0cc25d424d9adc1d6d6699a1f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -143,17 +143,23 @@ namespace UnityEngine.InputSystem.Editor
             // Add devices that are marked as generic types of devices directly to the parent.
             // E.g. adds "Gamepad" and then underneath all the more specific types of gamepads.
             foreach (var deviceLayout in EditorInputControlLayoutCache.allLayouts
-                     .Where(x => x.isDeviceLayout && !x.isOverride && x.isGenericTypeOfDevice && !x.hideInUI).OrderBy(a => a.displayName))
+                     .Where(x => x.isDeviceLayout && !x.isOverride && x.isGenericTypeOfDevice && !x.hideInUI)
+                     .OrderBy(a => a.displayName))
+            {
                 AddDeviceTreeItemRecursive(deviceLayout, parent);
+            }
 
             // We have devices that are based directly on InputDevice but are not marked as generic types
             // of devices (e.g. Vive Lighthouses). We do not want them to clutter the list at the root so we
-            // all of them in a group called "Other" at the end of the list.
+            // put all of them in a group called "Other" at the end of the list.
             var otherGroup = new AdvancedDropdownItem("Other");
             foreach (var deviceLayout in EditorInputControlLayoutCache.allLayouts
-                     .Where(x => x.isDeviceLayout && !x.isOverride && !x.isGenericTypeOfDevice && x.type.BaseType == typeof(InputDevice) &&
+                     .Where(x => x.isDeviceLayout && !x.isOverride && !x.isGenericTypeOfDevice &&
+                         x.type.BaseType == typeof(InputDevice) &&
                          !x.hideInUI && !x.baseLayouts.Any()).OrderBy(a => a.displayName))
+            {
                 AddDeviceTreeItemRecursive(deviceLayout, otherGroup);
+            }
 
             if (otherGroup.children.Any())
                 parent.AddChild(otherGroup);
@@ -176,6 +182,8 @@ namespace UnityEngine.InputSystem.Editor
             var deviceItem = new DeviceDropdownItem(layout, searchable: searchable);
             parent.AddChild(deviceItem);
 
+            var defaultControlPickerLayout = new DefaultInputControlPickerLayout();
+
             // Add common usage variants.
             if (layout.commonUsages.Count > 0)
             {
@@ -183,7 +191,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     var usageItem = new DeviceDropdownItem(layout, usage);
                     if (m_Mode == InputControlPicker.Mode.PickControl)
-                        AddControlTreeItemsRecursive(layout, usageItem, layout.name, usage, searchable);
+                        AddControlTreeItemsRecursive(defaultControlPickerLayout, layout, usageItem, layout.name, usage, searchable);
                     deviceItem.AddChild(usageItem);
                 }
                 deviceItem.AddSeparator();
@@ -213,12 +221,16 @@ namespace UnityEngine.InputSystem.Editor
                     AddPhysicalKeyBindingsTo(byLocationGroup, keyboard, searchable);
 
                     // AnyKey won't appear in either group. Add it explicitly.
-                    AddControlItem(deviceItem, null,
+                    AddControlItem(defaultControlPickerLayout, deviceItem, null,
                         layout.FindControl(new InternedString("anyKey")).Value, layout.name, null, searchable);
+                }
+                else if (layout.type == typeof(Touchscreen))
+                {
+                    AddControlTreeItemsRecursive(new TouchscreenControlPickerLayout(), layout, deviceItem, layout.name, null, searchable);
                 }
                 else
                 {
-                    AddControlTreeItemsRecursive(layout, deviceItem, layout.name, null, searchable);
+                    AddControlTreeItemsRecursive(defaultControlPickerLayout, layout, deviceItem, layout.name, null, searchable);
                 }
             }
 
@@ -247,8 +259,8 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
-        private void AddControlTreeItemsRecursive(InputControlLayout layout, DeviceDropdownItem parent,
-            string device, string usage, bool searchable, ControlDropdownItem parentControl = null)
+        private void AddControlTreeItemsRecursive(IInputControlPickerLayout controlPickerLayout, InputControlLayout layout,
+            DeviceDropdownItem parent, string device, string usage, bool searchable, ControlDropdownItem parentControl = null)
         {
             foreach (var control in layout.controls.OrderBy(a => a.name))
             {
@@ -262,7 +274,7 @@ namespace UnityEngine.InputSystem.Editor
                     continue;
                 }
 
-                AddControlItem(parent, parentControl, control, device, usage, searchable);
+                controlPickerLayout.AddControlItem(this, parent, parentControl, control, device, usage, searchable);
             }
 
             // Add optional controls for devices.
@@ -292,13 +304,17 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
-        private void AddControlItem(DeviceDropdownItem parent, ControlDropdownItem parentControl,
-            InputControlLayout.ControlItem control, string device, string usage, bool searchable)
+        internal void AddControlItem(IInputControlPickerLayout controlPickerLayout,
+            DeviceDropdownItem parent, ControlDropdownItem parentControl,
+            InputControlLayout.ControlItem control, string device, string usage, bool searchable,
+            string controlNameOverride = default)
         {
+            var controlName = controlNameOverride ?? control.name;
+
             // If it's an array, generate a control entry for each array element.
             for (var i = 0; i < (control.isArray ? control.arraySize : 1); ++i)
             {
-                var name = control.isArray ? control.name + i : control.name;
+                var name = control.isArray ? controlName + i : controlName;
                 var displayName = !string.IsNullOrEmpty(control.displayName)
                     ? (control.isArray ? $"{control.displayName} #{i}" : control.displayName)
                     : name;
@@ -317,7 +333,7 @@ namespace UnityEngine.InputSystem.Editor
                 }
                 // Add children.
                 if (controlLayout != null)
-                    AddControlTreeItemsRecursive(controlLayout, parent, device, usage,
+                    AddControlTreeItemsRecursive(controlPickerLayout, controlLayout, parent, device, usage,
                         searchable, child);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b630b769a2a8aa499ce2d2093f40500
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/DefaultInputControlPickerLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/DefaultInputControlPickerLayout.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine.InputSystem.Layouts;
 
 namespace UnityEngine.InputSystem.Editor
@@ -12,3 +13,4 @@ namespace UnityEngine.InputSystem.Editor
         }
     }
 }
+#endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/DefaultInputControlPickerLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/DefaultInputControlPickerLayout.cs
@@ -1,0 +1,14 @@
+using UnityEngine.InputSystem.Layouts;
+
+namespace UnityEngine.InputSystem.Editor
+{
+    internal class DefaultInputControlPickerLayout : IInputControlPickerLayout
+    {
+        public void AddControlItem(InputControlPickerDropdown dropdown, DeviceDropdownItem parent,
+            ControlDropdownItem parentControl,
+            InputControlLayout.ControlItem control, string device, string usage, bool searchable)
+        {
+            dropdown.AddControlItem(this, parent, parentControl, control, device, usage, searchable);
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/DefaultInputControlPickerLayout.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/DefaultInputControlPickerLayout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7717bf968da90024b9c047ba1a3394ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/TouchscreenControlPickerLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/TouchscreenControlPickerLayout.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 
@@ -32,3 +33,4 @@ namespace UnityEngine.InputSystem.Editor
         }
     }
 }
+#endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/TouchscreenControlPickerLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/TouchscreenControlPickerLayout.cs
@@ -1,0 +1,34 @@
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.Utilities;
+
+namespace UnityEngine.InputSystem.Editor
+{
+    internal class TouchscreenControlPickerLayout : IInputControlPickerLayout
+    {
+        public void AddControlItem(InputControlPickerDropdown dropdown, DeviceDropdownItem parent, ControlDropdownItem parentControl,
+            InputControlLayout.ControlItem control, string device, string usage, bool searchable)
+        {
+            // for the Press control, show two variants, one for single touch presses, and another for multi-touch presses
+            if (control.displayName == "Press")
+            {
+                dropdown.AddControlItem(this, parent, parentControl, new InputControlLayout.ControlItem
+                {
+                    name = new InternedString("Press"),
+                    displayName = new InternedString("Press (Single touch)"),
+                    layout = control.layout
+                }, device, usage, searchable);
+
+                dropdown.AddControlItem(this, parent, parentControl, new InputControlLayout.ControlItem
+                {
+                    name = new InternedString("Press"),
+                    displayName = new InternedString("Press (Multi-touch)"),
+                    layout = control.layout
+                }, device, usage, searchable, "touch*/Press");
+            }
+            else
+            {
+                dropdown.AddControlItem(this, parent, parentControl, control, device, usage, searchable);
+            }
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/TouchscreenControlPickerLayout.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/Layouts/TouchscreenControlPickerLayout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 224236193350c244abab484f4514df16
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[case 1357664](https://fogbugz.unity3d.com/f/cases/1357664/)

### Description

The input action asset editor doesn't allow for selecting a binding that supports multi-touch, and new users find it difficult to impossible to know the touch*/press path binding syntax.

### Changes made

Replaced the Press option in the input action dropdown editor with two new options:
* Press (Single touch)
* Press (Multi-touch)

The second option generates the touch*/press binding path.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.
