### PR TITLE
FIX: VirtualMouseInput works correctly in the editor again

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2958,6 +2958,18 @@ partial class CoreTests
         EditorHelpers.RestartEditorAndRecompileScripts(dryRun: true);
     }
 
+    [Test]
+    [Category("Editor")]
+    public void Editor_AfterUpdateCallbackIsNotCalledDuringEditorUpdates()
+    {
+        var receivedCalls = 0;
+        InputSystem.onAfterUpdate += () => ++ receivedCalls;
+
+        InputSystem.Update(InputUpdateType.Editor);
+
+        Assert.That(receivedCalls, Is.Zero);
+    }
+
     ////TODO: tests for InputAssetImporter; for this we need C# mocks to be able to cut us off from the actual asset DB
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a performance issue on entering/exiting playmode where HID device capabilities JSON could be parsed multiple times for a single device([case 1362733](https://issuetracker.unity3d.com/issues/input-package-deserializing-json-multiple-times-when-entering-slash-exiting-playmode)).
 - Fixed a problem where explicitly switching to the already active control scheme and device set for PlayerInput would cancel event callbacks for no reason when the control scheme switch would have no practical effect. This fix detects and skips device unpairing and re-pairing if the switch is detected to not be a change to scheme or devices. ([case 1342297](https://fogbugz.unity3d.com/f/cases/1342297/))
 - Any unhandled exception in `InputManager.OnUpdate` failing latter updates with `InvalidOperationException: Already have an event buffer set! Was OnUpdate() called recursively?`. Instead the system will try to handle the exception and recover into a working state.
+- Fixed an issue that broke the VirtualMouseInput component in the editor ([case 1367553](https://fogbugz.unity3d.com/f/cases/1367553/)).
 
 ## [1.1.1] - 2021-09-03
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3397,9 +3397,10 @@ namespace UnityEngine.InputSystem
 
         private void InvokeAfterUpdateCallback(InputUpdateType updateType)
         {
-            // don't invoke the after update callback if this is an editor update. Otherwise, any
-            // handlers for this delegate that query input state will get stale values.
-            if (updateType == InputUpdateType.Editor)
+            // don't invoke the after update callback if this is an editor update and the game is playing. We
+            // skip event processing when playing in the editor and the game has focus, which means that any
+            // handlers for this delegate that query input state during this update will get no values.
+            if (updateType == InputUpdateType.Editor && gameIsPlaying)
                 return;
 
             DelegateHelpers.InvokeCallbacksSafe(ref m_AfterUpdateListeners,

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2968,7 +2968,7 @@ namespace UnityEngine.InputSystem
                     ProcessStateChangeMonitorTimeouts();
 
                 Profiler.EndSample();
-                InvokeAfterUpdateCallback();
+                InvokeAfterUpdateCallback(updateType);
                 if (canFlushBuffer)
                     eventBuffer.Reset();
                 m_CurrentUpdate = default;
@@ -3378,12 +3378,17 @@ namespace UnityEngine.InputSystem
             ////FIXME: need to ensure that if someone calls QueueEvent() from an onAfterUpdate callback, we don't end up with a
             ////       mess in the event buffer
             ////       same goes for events that someone may queue from a change monitor callback
-            InvokeAfterUpdateCallback();
+            InvokeAfterUpdateCallback(updateType);
             m_CurrentUpdate = default;
         }
 
-        private void InvokeAfterUpdateCallback()
+        private void InvokeAfterUpdateCallback(InputUpdateType updateType)
         {
+            // don't invoke the after update callback if this is an editor update. Otherwise, any
+            // handlers for this delegate that query input state will get stale values.
+            if (updateType == InputUpdateType.Editor)
+                return;
+
             DelegateHelpers.InvokeCallbacksSafe(ref m_AfterUpdateListeners,
                 "InputSystem.onAfterUpdate");
         }


### PR DESCRIPTION
[case 1367553](https://fogbugz.unity3d.com/f/cases/1367553/)

### Description

VirtualMouseInput uses OnAfterUpdate callback to query the state of the device. This works well during dynamic or fixed updates but doesn't work so well for editor updates. This is because the state of the device in the editor state buffers will not have been updated when the game view has focus due to how we short circuit the event processing loop in focus code.

### Changes made

After update callbacks are no longer called during editor mode updates.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
