### PR TITLE
Added ToString() override based on PointerInputModule

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -31,8 +31,6 @@ using UnityEditor;
 ////TODO: add ability to query which device was last used with any of the actions
 ////REVIEW: also give access to the last/current UI event?
 
-////TODO: ToString() method a la PointerInputModule
-
 namespace UnityEngine.InputSystem.UI
 {
     /// <summary>
@@ -2614,6 +2612,22 @@ namespace UnityEngine.InputSystem.UI
                     HookActions();
                 }
             }
+        }
+
+        public override string ToString()
+        {
+             System.Text.StringBuilder stringBuilder = new System.Text.StringBuilder("<b>Pointer Input Module of type: </b>" + (object) this.GetType());
+             stringBuilder.AppendLine();
+
+             foreach (PointerModel keyValuePair in this.m_PointerStates)
+             {
+               if (keyValuePair.eventData != null)
+               {
+                 stringBuilder.AppendLine("<B>Pointer:</b> " + (object) keyValuePair.screenPosition);
+                 stringBuilder.AppendLine(keyValuePair.eventData.ToString());
+               }
+             }
+             return stringBuilder.ToString();
         }
 
         [SerializeField, HideInInspector] private InputActionAsset m_ActionsAsset;


### PR DESCRIPTION
### Description

PreviewGUI is missing in new Input System so i added toString Method based on PointerInputModule
### Changes made

Added ToString override to InputSystemUIInputModule

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
