### PR TITLE
Allow World Space UI interactions while in CursorLockMode.Locked

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -247,13 +247,7 @@ namespace UnityEngine.InputSystem.UI
 
             // Sync position.
             var pointerType = eventData.pointerType;
-            if (pointerType == UIPointerType.MouseOrPen && Cursor.lockState == CursorLockMode.Locked)
-            {
-                eventData.position = new Vector2(-1, -1);
-                ////REVIEW: This is consistent with StandaloneInputModule but having no deltas in locked mode seems wrong
-                eventData.delta = default;
-            }
-            else if (pointerType == UIPointerType.Tracked)
+            if (pointerType == UIPointerType.Tracked)
             {
                 var position = state.worldPosition;
                 var rotation = state.worldOrientation;
@@ -341,8 +335,7 @@ namespace UnityEngine.InputSystem.UI
             var currentPointerTarget =
                 // If the pointer is a touch that was released the *previous* frame, we generate pointer-exit events
                 // and then later remove the pointer.
-                (eventData.pointerType == UIPointerType.Touch && !pointer.leftButton.isPressed && !pointer.leftButton.wasReleasedThisFrame) ||
-                (eventData.pointerType == UIPointerType.MouseOrPen && Cursor.lockState == CursorLockMode.Locked)
+                (eventData.pointerType == UIPointerType.Touch && !pointer.leftButton.isPressed && !pointer.leftButton.wasReleasedThisFrame) 
                 ? null
                 : eventData.pointerCurrentRaycast.gameObject;
 
@@ -527,7 +520,6 @@ namespace UnityEngine.InputSystem.UI
         private void ProcessPointerButtonDrag(ref PointerModel.ButtonState button, ExtendedPointerEventData eventData)
         {
             if (!eventData.IsPointerMoving() ||
-                (eventData.pointerType == UIPointerType.MouseOrPen && Cursor.lockState == CursorLockMode.Locked) ||
                 eventData.pointerDrag == null)
                 return;
 


### PR DESCRIPTION
### Description

Current InputSystemUIInputModule.cs wouldn't allow any UI interaction while in CursorLockMode.Locked.
People used to hack the old StandaloneInputModule for that reason but such trick is no longer possible with InputSystem.

### Changes made

Removed conditions for CursorLockMode.Locked

## Notes

https://gist.github.com/EmmaEwert/fad38a248f62e1c7267daa4e778468b1
https://forum.unity.com/threads/cursor-lockstate-cursorlockmode-locked-not-working-in-editor.623071/
https://www.reddit.com/r/Unity3D/comments/9g4hjk/having_issues_with_world_space_ui_and_first/
