### PR TITLE
Swapping InputManager state buffers and update step counts back to latest player update after editor update

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -490,7 +490,7 @@ partial class CoreTests
         Assert.That(receivedEvents[2].time, Is.EqualTo(2.9).Within(0.00001));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.3456).Within(0.00001));
 
-        Assert.That(InputUpdate.s_LastUpdateRetainedEventCount, Is.Zero);
+        Assert.That(runtime.eventCount, Is.Zero);
 
         receivedEvents.Clear();
 
@@ -509,7 +509,7 @@ partial class CoreTests
         Assert.That(receivedEvents[1].time, Is.EqualTo(3 + 0.002).Within(0.00001));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.2345).Within(0.00001));
 
-        Assert.That(InputUpdate.s_LastUpdateRetainedEventCount, Is.EqualTo(2));
+        Assert.That(runtime.eventCount, Is.EqualTo(2));
 
         receivedEvents.Clear();
 
@@ -521,7 +521,7 @@ partial class CoreTests
         Assert.That(receivedEvents[0].time, Is.EqualTo(3 + 1.0 / 60 + 0.001).Within(0.00001));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.3456).Within(0.00001));
 
-        Assert.That(InputUpdate.s_LastUpdateRetainedEventCount, Is.EqualTo(1));
+        Assert.That(runtime.eventCount, Is.EqualTo(1));
 
         receivedEvents.Clear();
 
@@ -533,7 +533,7 @@ partial class CoreTests
         Assert.That(receivedEvents[0].time, Is.EqualTo(3 + 2 * (1.0 / 60) + 0.001).Within(0.00001));
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.4567).Within(0.00001));
 
-        Assert.That(InputUpdate.s_LastUpdateRetainedEventCount, Is.Zero);
+        Assert.That(runtime.eventCount, Is.Zero);
 
         receivedEvents.Clear();
 
@@ -544,7 +544,7 @@ partial class CoreTests
         Assert.That(receivedEvents, Has.Count.Zero);
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.4567).Within(0.00001));
 
-        Assert.That(InputUpdate.s_LastUpdateRetainedEventCount, Is.Zero);
+        Assert.That(runtime.eventCount, Is.Zero);
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 - Generic gamepad short display button names where incorrectly mapped on Switch (`A` instead of `B`, etc).
 - Fixed an issue where resetting an action via `InputAction.Reset()` while being in disabled state would prevent the action from being enabled again. ([case 1370732](https://issuetracker.unity3d.com/product/unity/issues/guid/1370732/)).
 - Fixed "Default constructor not found for type UnityEngine.InputSystem.iOS.LowLevel.iOSStepCounter" any other potential exceptions due to classes, methods, fields and properties being stripped when managed stripping setting set to medium or high ([case 1368761](https://issuetracker.unity3d.com/issues/ios-new-input-system-iosstepcounter-crash-on-launch-with-managed-stripping)).
+- Fixed `action.ReadValue` and others returning invalid data when used from `FixedUpdate` or early update when running in play mode in the editor ([case 1368559](https://issuetracker.unity3d.com/issues/enter-key-is-not-registered-when-using-waspressedthisframe-with-input-system-1-dot-1-1) [case 1367556](https://issuetracker.unity3d.com/issues/input-action-readvalue-always-returns-zero-when-called-from-fixedupdate) [case 1372830](https://issuetracker.unity3d.com/issues/querying-inputs-before-preupdate-dot-newinputupdate-returns-invalid-data-when-running-in-play-mode-in-editor)).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -89,6 +89,13 @@ namespace UnityEngine.InputSystem.LowLevel
 
         Func<InputUpdateType, bool> onShouldRunUpdate { get; set; }
 
+        #if UNITY_EDITOR
+        /// <summary>
+        /// Set delegate to be called during player loop initialization callbacks.
+        /// </summary>
+        Action onPlayerLoopInitialization { get; set; }
+        #endif
+
         /// <summary>
         /// Set delegate to be called when a new device is discovered.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1901,6 +1901,9 @@ namespace UnityEngine.InputSystem
                 m_Runtime.onDeviceDiscovered = null;
                 m_Runtime.onPlayerFocusChanged = null;
                 m_Runtime.onShouldRunUpdate = null;
+                #if UNITY_EDITOR
+                m_Runtime.onPlayerLoopInitialization = null;
+                #endif
             }
 
             m_Runtime = runtime;
@@ -1908,6 +1911,9 @@ namespace UnityEngine.InputSystem
             m_Runtime.onDeviceDiscovered = OnNativeDeviceDiscovered;
             m_Runtime.onPlayerFocusChanged = OnFocusChanged;
             m_Runtime.onShouldRunUpdate = ShouldRunUpdate;
+            #if UNITY_EDITOR
+            m_Runtime.onPlayerLoopInitialization = OnPlayerLoopInitialization;
+            #endif
             m_Runtime.pollingFrequency = pollingFrequency;
             m_HasFocus = m_Runtime.isPlayerFocused;
 
@@ -2010,6 +2016,11 @@ namespace UnityEngine.InputSystem
         internal InputUpdateType m_UpdateMask; // Which of our update types are enabled.
         private InputUpdateType m_CurrentUpdate;
         internal InputStateBuffers m_StateBuffers;
+
+        #if UNITY_EDITOR
+        // remember time offset to correctly restore it after editor mode is done
+        private double latestNonEditorTimeOffsetToRealtimeSinceStartup;
+        #endif
 
         // We don't use UnityEvents and thus don't persist the callbacks during domain reloads.
         // Restoration of UnityActions is unreliable and it's too easy to end up with double
@@ -2211,7 +2222,7 @@ namespace UnityEngine.InputSystem
 
             // Switch to buffers.
             InputStateBuffers.SwitchTo(m_StateBuffers,
-                InputUpdate.s_LastUpdateType != InputUpdateType.None ? InputUpdate.s_LastUpdateType : defaultUpdateType);
+                InputUpdate.s_LatestUpdateType != InputUpdateType.None ? InputUpdate.s_LatestUpdateType : defaultUpdateType);
 
             ////TODO: need to update state change monitors
         }
@@ -2829,6 +2840,18 @@ namespace UnityEngine.InputSystem
             m_CurrentUpdate = default;
         }
 
+        private void OnPlayerLoopInitialization()
+        {
+            if (!gameIsPlaying || // if game is not playing
+                !InputUpdate.s_LatestUpdateType.IsEditorUpdate() || // or last update was not editor update
+                !InputUpdate.s_LatestNonEditorUpdateType.IsPlayerUpdate()) // or update before that was not player update
+                return; // then no need to restore anything
+
+            InputUpdate.RestoreStateAfterEditorUpdate();
+            InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup = latestNonEditorTimeOffsetToRealtimeSinceStartup;
+            InputStateBuffers.SwitchTo(m_StateBuffers, InputUpdate.s_LatestUpdateType);
+        }
+
 #endif
 
         internal bool ShouldRunUpdate(InputUpdateType updateType)
@@ -2908,8 +2931,13 @@ namespace UnityEngine.InputSystem
             // Update metrics.
             ++m_Metrics.totalUpdateCount;
 
-            InputUpdate.s_LastUpdateRetainedEventCount = 0;
-            InputUpdate.s_LastUpdateRetainedEventBytes = 0;
+            #if UNITY_EDITOR
+            // If current update is editor update and previous update was non-editor,
+            // store the time offset so we can restore it right after editor update is complete
+            if (((updateType & InputUpdateType.Editor) == InputUpdateType.Editor) && (m_CurrentUpdate & InputUpdateType.Editor) == 0)
+                latestNonEditorTimeOffsetToRealtimeSinceStartup =
+                    InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
+            #endif
 
             // Store current time offset.
             InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup = m_Runtime.currentTimeOffsetToRealtimeSinceStartup;
@@ -3367,11 +3395,6 @@ namespace UnityEngine.InputSystem
                 m_Metrics.totalEventProcessingTime +=
                     ((double)(Stopwatch.GetTimestamp() - processingStartTime)) / Stopwatch.Frequency;
                 m_Metrics.totalEventLagTime += totalEventLag;
-
-                // Remember how much data we retained so that we don't count it against the next
-                // batch of events that we receive.
-                InputUpdate.s_LastUpdateRetainedEventCount = (uint)m_InputEventStream.numEventsRetainedInBuffer;
-                InputUpdate.s_LastUpdateRetainedEventBytes = m_InputEventStream.numBytesRetainedInBuffer;
 
                 m_InputEventStream.Close(ref eventBuffer);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -71,13 +71,12 @@ namespace UnityEngine.InputSystem.LowLevel
     internal static class InputUpdate
     {
         public static uint s_UpdateStepCount; // read only, but kept as a variable for performance reasons
-        public static InputUpdateType s_LastUpdateType;
+        public static InputUpdateType s_LatestUpdateType;
         public static UpdateStepCount s_PlayerUpdateStepCount;
         #if UNITY_EDITOR
+        public static InputUpdateType s_LatestNonEditorUpdateType;
         public static UpdateStepCount s_EditorUpdateStepCount;
         #endif
-        public static uint s_LastUpdateRetainedEventBytes;
-        public static uint s_LastUpdateRetainedEventCount;
 
         [Serializable]
         public struct UpdateStepCount
@@ -107,15 +106,14 @@ namespace UnityEngine.InputSystem.LowLevel
             public InputUpdateType lastUpdateType;
             public UpdateStepCount playerUpdateStepCount;
             #if UNITY_EDITOR
+            public InputUpdateType lastNonEditorUpdateType;
             public UpdateStepCount editorUpdateStepCount;
             #endif
-            public uint lastUpdateRetainedEventBytes;
-            public uint lastUpdateRetainedEventCount;
         }
 
         internal static void OnBeforeUpdate(InputUpdateType type)
         {
-            s_LastUpdateType = type;
+            s_LatestUpdateType = type;
             switch (type)
             {
                 case InputUpdateType.Dynamic:
@@ -123,6 +121,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 case InputUpdateType.Fixed:
                     s_PlayerUpdateStepCount.OnBeforeUpdate();
                     s_UpdateStepCount = s_PlayerUpdateStepCount.value;
+                    s_LatestNonEditorUpdateType = type;
                     break;
                 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
@@ -135,7 +134,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         internal static void OnUpdate(InputUpdateType type)
         {
-            s_LastUpdateType = type;
+            s_LatestUpdateType = type;
             switch (type)
             {
                 case InputUpdateType.Dynamic:
@@ -143,6 +142,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 case InputUpdateType.Fixed:
                     s_PlayerUpdateStepCount.OnUpdate();
                     s_UpdateStepCount = s_PlayerUpdateStepCount.value;
+                    s_LatestNonEditorUpdateType = type;
                     break;
                 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
@@ -153,31 +153,38 @@ namespace UnityEngine.InputSystem.LowLevel
             }
         }
 
+        #if UNITY_EDITOR
+        internal static void RestoreStateAfterEditorUpdate()
+        {
+            s_LatestUpdateType = s_LatestNonEditorUpdateType;
+            s_UpdateStepCount = s_PlayerUpdateStepCount.value;
+        }
+
+        #endif
+
         public static SerializedState Save()
         {
             return new SerializedState
             {
-                lastUpdateType = s_LastUpdateType,
+                lastUpdateType = s_LatestUpdateType,
                 playerUpdateStepCount = s_PlayerUpdateStepCount,
                 #if UNITY_EDITOR
-                editorUpdateStepCount = s_EditorUpdateStepCount,
+                lastNonEditorUpdateType = s_LatestNonEditorUpdateType,
+                editorUpdateStepCount = s_EditorUpdateStepCount
                 #endif
-                lastUpdateRetainedEventBytes = s_LastUpdateRetainedEventBytes,
-                lastUpdateRetainedEventCount = s_LastUpdateRetainedEventCount,
             };
         }
 
         public static void Restore(SerializedState state)
         {
-            s_LastUpdateType = state.lastUpdateType;
+            s_LatestUpdateType = state.lastUpdateType;
             s_PlayerUpdateStepCount = state.playerUpdateStepCount;
-            s_LastUpdateRetainedEventBytes = state.lastUpdateRetainedEventBytes;
-            s_LastUpdateRetainedEventCount = state.lastUpdateRetainedEventCount;
             #if UNITY_EDITOR
+            s_LatestNonEditorUpdateType = state.lastNonEditorUpdateType;
             s_EditorUpdateStepCount = state.editorUpdateStepCount;
             #endif
 
-            switch (s_LastUpdateType)
+            switch (s_LatestUpdateType)
             {
                 case InputUpdateType.Dynamic:
                 case InputUpdateType.Manual:
@@ -216,5 +223,13 @@ namespace UnityEngine.InputSystem.LowLevel
                 return false;
             return updateType != default;
         }
+
+        #if UNITY_EDITOR
+        public static bool IsEditorUpdate(this InputUpdateType updateType)
+        {
+            return updateType == InputUpdateType.Editor;
+        }
+
+        #endif
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputUpdateType.cs
@@ -121,7 +121,9 @@ namespace UnityEngine.InputSystem.LowLevel
                 case InputUpdateType.Fixed:
                     s_PlayerUpdateStepCount.OnBeforeUpdate();
                     s_UpdateStepCount = s_PlayerUpdateStepCount.value;
+                    #if UNITY_EDITOR
                     s_LatestNonEditorUpdateType = type;
+                    #endif
                     break;
                 #if UNITY_EDITOR
                 case InputUpdateType.Editor:
@@ -142,7 +144,9 @@ namespace UnityEngine.InputSystem.LowLevel
                 case InputUpdateType.Fixed:
                     s_PlayerUpdateStepCount.OnUpdate();
                     s_UpdateStepCount = s_PlayerUpdateStepCount.value;
+                    #if UNITY_EDITOR
                     s_LatestNonEditorUpdateType = type;
+                    #endif
                     break;
                 #if UNITY_EDITOR
                 case InputUpdateType.Editor:

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// that queries input state will receive. For example, during editor updates, this will be
         /// <see cref="InputUpdateType.Editor"/> and the state buffers for the editor will be active.
         /// </remarks>
-        public static InputUpdateType currentUpdateType => InputUpdate.s_LastUpdateType;
+        public static InputUpdateType currentUpdateType => InputUpdate.s_LatestUpdateType;
 
         ////FIXME: ATM this does not work for editor updates
         /// <summary>

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -350,6 +350,9 @@ namespace UnityEngine.InputSystem
         public InputUpdateDelegate onUpdate { get; set; }
         public Action<InputUpdateType> onBeforeUpdate { get; set; }
         public Func<InputUpdateType, bool> onShouldRunUpdate { get; set; }
+#if UNITY_EDITOR
+        public Action onPlayerLoopInitialization { get; set; }
+#endif
         public Action<int, string> onDeviceDiscovered { get; set; }
         public Action onShutdown { get; set; }
         public Action<bool> onPlayerFocusChanged { get; set; }


### PR DESCRIPTION
### Description

When reading actions or device states from FixedUpdate or early update, the values are incorrect in play mode because we're reading from last frames editor update. This was not a case <1.1.0-pre.6 because editor updates were ignored in play mode when game view had focus.

### Changes made

- Injected a callback in Unity PlayerLoop.Initialization system which runs before early update / FixedUpdate.
- Swap state buffers, update step counts and time offset if previous frame last update was editor update, and update before that was player update.
