### PR TITLE
Updating our CI to latest versions

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,7 +1,7 @@
 editors:
   - version: 2019.4
   - version: 2020.3
-  - version: 2021.1
+  - version: 2021.2
   - version: trunk
 platforms:
   - name: win


### PR DESCRIPTION
### Description

Updating our CI to latest versions: 2021.1 is EOL and no longer supported

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
