### PR TITLE
FIX: New Input system registering Active Touches when app loses focus (case 1364017)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -1140,4 +1140,17 @@ internal class EnhancedTouchTests : CoreTestsFixture
         Assert.That(Touchscreen.current.touches[0].isInProgress, Is.True);
         Assert.That(Touchscreen.current.touches[0].position.ReadValue(), Is.EqualTo(new Vector2(123, 234)));
     }
+
+    [Test]
+    [Category("EnhancedTouch")]
+    public unsafe void EnhancedTouch_ClearsActiveTouchesOnFocusLost()
+    {
+        BeginTouch(1, new Vector2(0.123f, 0.456f), queueEventOnly: true);
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
+        runtime.PlayerFocusLost();
+        runtime.PlayerFocusGained();
+        InputSystem.Update();
+        Assert.That(Touch.activeTouches, Is.Empty);
+    }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue where touches were being retained on focus loss ([case 1364017](https://issuetracker.unity3d.com/issues/input-system-new-input-system-registering-active-touches-when-app-loses-focus)).
+
 ## [1.2.0] - 2021-10-22
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -725,7 +725,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
                     var history = finger.m_StateHistory;
                     var touchRecordCount = history.Count;
-                    if (touchRecordCount == 0)
+                    if (touchRecordCount == 0 || !finger.currentTouch.valid)
                         continue;
 
                     // We're walking newest-first through the touch history but want the resulting list of


### PR DESCRIPTION
Fixes [1364017](https://issuetracker.unity3d.com/issues/input-system-new-input-system-registering-active-touches-when-app-loses-focus) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1364017/)).

### Description

activeTouches were > 0 when the player lost focus, fingers removed from screen, then regained focus. This ensures that activeTouches resets to 0.

### Changes made

The issue was a regression, and the line that caused the issue was the `finger.currentTouch.valid` check in `UpdateActiveTouches()` in `Touch.cs`. Restoring this fixed the issue.

Added a test that confirms activeTouches are 0 when a player loses then regains focus. Test fails without the fix.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
