### PR TITLE
FIX: Incorrect writes into stick half-axes (case 1336240).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -317,6 +317,36 @@ partial class CoreTests
             Is.EqualTo(new AxisDeadzoneProcessor().Process(0.5f)));
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1336240/
+    [Test]
+    [Category("Controls")]
+    public void Controls_CanWriteIntoHalfAxesOfSticks()
+    {
+        // Disable deadzoning.
+        InputSystem.settings.defaultDeadzoneMax = 1;
+        InputSystem.settings.defaultDeadzoneMin = 0;
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        Set(gamepad.leftStick.left, 1f);
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(Vector2.left));
+
+        // Set "right" to 1 as well. This is a conflicting state. Result should
+        // be that left is 0 and right is 1.
+        Set(gamepad.leftStick.right, 1f);
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(Vector2.right));
+
+        Set(gamepad.leftStick.up, 1f);
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo((Vector2.right + Vector2.up).normalized));
+
+        Set(gamepad.leftStick.down, 1f);
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo((Vector2.right + Vector2.down).normalized));
+    }
+
     [Test]
     [Category("Controls")]
     public void Controls_CanEvaluateMagnitude()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed writing values into the half-axis controls of sticks (such as `Gamepad.leftStick.left`) producing incorrect values on the stick ([case 1336240](https://issuetracker.unity3d.com/issues/inputtestfixture-tests-return-inverted-values-when-pressing-gamepads-left-or-down-joystick-buttons)).
+
 ## [1.2.0] - 2021-10-22
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -197,6 +197,19 @@ namespace UnityEngine.InputSystem.Controls
             return value;
         }
 
+        private float Unpreprocess(float value)
+        {
+            // Does not reverse the effect of clamping (we don't know what the unclamped value should be).
+
+            if (invert)
+                value *= -1f;
+            if (normalize)
+                value = NormalizeProcessor.Denormalize(value, normalizeMin, normalizeMax, normalizeZero);
+            if (scale)
+                value /= scaleFactor;
+            return value;
+        }
+
         /// <summary>
         /// Default-initialize the control.
         /// </summary>
@@ -229,6 +242,7 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(float value, void* statePtr)
         {
+            value = Unpreprocess(value);
             stateBlock.WriteFloat(statePtr, value);
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/NormalizeProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/NormalizeProcessor.cs
@@ -97,6 +97,21 @@ namespace UnityEngine.InputSystem.Processors
             return percentage;
         }
 
+        internal static float Denormalize(float value, float min, float max, float zero)
+        {
+            if (zero < min)
+                zero = min;
+
+            if (min < zero)
+            {
+                if (value < 0)
+                    return min + (zero - min) * (value * -1f);
+                return zero + (max - zero) * value;
+            }
+
+            return min + (max - min) * value;
+        }
+
         /// <inheritdoc/>
         public override string ToString()
         {


### PR DESCRIPTION
Fixes [1336240](https://issuetracker.unity3d.com/issues/inputtestfixture-tests-return-inverted-values-when-pressing-gamepads-left-or-down-joystick-buttons) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1336240/)).

### Description

We don't "unprocess" values when we write them. This is a general problem. So if you do this in a test on current `develop`

```CSharp
Set(gamepad.leftStick.left, 1f);
```

the resulting stick value will be `Vector2.right` instead of `Vector2.left`.

### Changes made

Decided to not tackle the bigger issue but rather just fix this for `AxisControl` only. Unlike some other controls, `AxisControl` does most of its processing through built-in parameters rather than relying on processor stacks. So I just added code to do "unprocessing" based on those parameters (minus clamping as we don't know what the unclamped value should be).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
