### PR TITLE
Fixing the problem with ui input inspector not showing action references for runtime asset

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -25,6 +25,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed incorrect indentation of input actions in the inspector ([case 1285546](https://issuetracker.unity3d.com/product/unity/issues/guid/1285546/)).
 - Fixed a problem with UI Toolkit buttons remaining active when multiple fingers are used on a touchscreen, using `InputSystemUIInputModule` with pointerBehavior set to `UIPointerBehavior.SingleUnifiedPointer`. UI Toolkit will now always receive the same pointerId when that option is in use, regardless of the hardware component that produced the pointer event. ([case 1369081](https://issuetracker.unity3d.com/issues/transitions-get-stuck-when-pointer-behavior-is-set-to-single-unified-pointer-and-multiple-touches-are-made)).
 - Fixed DualSense on iOS not inheriting from `DualShockGamepad` ([case 1378308](https://issuetracker.unity3d.com/issues/input-dualsense-detection-ios)).
+- Fixed Input System UI Input Module inspector showing all action bindings as "None" when assigned a runtime created actions asset ([case 1304943](https://issuetracker.unity3d.com/issues/input-system-ui-input-module-loses-prefab-action-mapping-in-local-co-op)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
@@ -135,6 +135,7 @@ namespace UnityEngine.InputSystem
 
             m_Asset = asset;
             m_ActionId = action.id.ToString();
+            name = GetDisplayName(action);
 
             ////REVIEW: should this dirty the asset if IDs had not been generated yet?
         }
@@ -157,6 +158,19 @@ namespace UnityEngine.InputSystem
             }
 
             return base.ToString();
+        }
+
+        private static string GetDisplayName(InputAction action)
+        {
+            return !string.IsNullOrEmpty(action?.actionMap?.name) ? $"{action.actionMap?.name}/{action.name}" : action?.name;
+        }
+
+        /// <summary>
+        /// Return a string representation useful for showing in UI.
+        /// </summary>
+        internal string ToDisplayName()
+        {
+            return string.IsNullOrEmpty(name) ? GetDisplayName(action) : name;
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -123,18 +123,10 @@ namespace UnityEngine.InputSystem.Editor
             // Create subasset for each action.
             foreach (var map in maps)
             {
-                var haveSetName = !string.IsNullOrEmpty(map.name);
-
                 foreach (var action in map.actions)
                 {
                     var actionReference = ScriptableObject.CreateInstance<InputActionReference>();
                     actionReference.Set(action);
-
-                    var objectName = action.name;
-                    if (haveSetName)
-                        objectName = $"{map.name}/{action.name}";
-
-                    actionReference.name = objectName;
                     ctx.AddObjectToAsset(action.m_Id, actionReference, actionIcon);
 
                     // Backwards-compatibility (added for 1.0.0-preview.7).
@@ -149,9 +141,9 @@ namespace UnityEngine.InputSystem.Editor
                     //
                     // Case: https://fogbugz.unity3d.com/f/cases/1229145/
                     var backcompatActionReference = Instantiate(actionReference);
-                    backcompatActionReference.name = objectName; // Get rid of the (Clone) suffix.
+                    backcompatActionReference.name = actionReference.name; // Get rid of the (Clone) suffix.
                     backcompatActionReference.hideFlags = HideFlags.HideInHierarchy;
-                    ctx.AddObjectToAsset(objectName, backcompatActionReference, actionIcon);
+                    ctx.AddObjectToAsset(actionReference.name, backcompatActionReference, actionIcon);
                 }
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -161,7 +161,7 @@ namespace UnityEngine.InputSystem.UI.Editor
                     if (m_ReferenceProperties[i].objectReferenceValue != null &&
                         (m_ReferenceProperties[i].objectReferenceValue is InputActionReference reference))
                         retrievedName = MakeActionReferenceNameUsableInGenericMenu(reference.ToDisplayName());
-                
+
                     EditorGUILayout.Popup(s_ActionNiceNames[i], 0, new[] {retrievedName});
                 }
                 EditorGUI.EndDisabledGroup();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -23,15 +23,17 @@ namespace UnityEngine.InputSystem.UI.Editor
             return null;
         }
 
-        private static InputActionReference[] GetAllActionsFromAsset(InputActionAsset actions)
+        private static InputActionReference[] GetAllAssetReferencesFromAssetDatabase(InputActionAsset actions)
         {
-            if (actions != null)
-            {
-                var path = AssetDatabase.GetAssetPath(actions);
-                var assets = AssetDatabase.LoadAllAssetsAtPath(path);
-                return assets.Where(asset => asset is InputActionReference).Cast<InputActionReference>().OrderBy(x => x.name).ToArray();
-            }
-            return null;
+            if (actions == null)
+                return null;
+
+            var path = AssetDatabase.GetAssetPath(actions);
+            var assets = AssetDatabase.LoadAllAssetsAtPath(path);
+            return assets.Where(asset => asset is InputActionReference)
+                .Cast<InputActionReference>()
+                .OrderBy(x => x.name)
+                .ToArray();
         }
 
         private static readonly string[] s_ActionNames =
@@ -64,8 +66,14 @@ namespace UnityEngine.InputSystem.UI.Editor
 
         private SerializedProperty[] m_ReferenceProperties;
         private SerializedProperty m_ActionsAsset;
-        private InputActionReference[] m_AvailableActionsInAsset;
+        private InputActionReference[] m_AvailableActionReferencesInAssetDatabase;
         private string[] m_AvailableActionsInAssetNames;
+
+        private string MakeActionReferenceNameUsableInGenericMenu(string name)
+        {
+            // Ugly hack: GenericMenu interprets "/" as a submenu path. But luckily, "/" is not the only slash we have in Unicode.
+            return name.Replace("/", "\uFF0F");
+        }
 
         public void OnEnable()
         {
@@ -75,15 +83,15 @@ namespace UnityEngine.InputSystem.UI.Editor
                 m_ReferenceProperties[i] = serializedObject.FindProperty($"m_{s_ActionNames[i]}Action");
 
             m_ActionsAsset = serializedObject.FindProperty("m_ActionsAsset");
-            m_AvailableActionsInAsset = GetAllActionsFromAsset(m_ActionsAsset.objectReferenceValue as InputActionAsset);
-            // Ugly hack: GenericMenu interprets "/" as a submenu path. But luckily, "/" is not the only slash we have in Unicode.
-            m_AvailableActionsInAssetNames = new[] { "None" }.Concat(m_AvailableActionsInAsset?.Select(x => x.name.Replace("/", "\uFF0F")) ?? new string[0]).ToArray();
+            m_AvailableActionReferencesInAssetDatabase = GetAllAssetReferencesFromAssetDatabase(m_ActionsAsset.objectReferenceValue as InputActionAsset);
+            m_AvailableActionsInAssetNames = new[] { "None" }
+                .Concat(m_AvailableActionReferencesInAssetDatabase?.Select(x => MakeActionReferenceNameUsableInGenericMenu(x.name)) ?? new string[0]).ToArray();
         }
 
         public static void ReassignActions(InputSystemUIInputModule module, InputActionAsset action)
         {
             module.actionsAsset = action;
-            var assets = GetAllActionsFromAsset(action);
+            var assets = GetAllAssetReferencesFromAssetDatabase(action);
             if (assets != null)
             {
                 module.point = GetActionReferenceFromAssets(assets, module.point?.action?.name, "Point", "MousePosition", "Mouse Position");
@@ -122,22 +130,41 @@ namespace UnityEngine.InputSystem.UI.Editor
             }
 
             var numActions = s_ActionNames.Length;
-            for (var i = 0; i < numActions; i++)
+            if ((m_AvailableActionReferencesInAssetDatabase != null && m_AvailableActionReferencesInAssetDatabase.Length > 0) || m_ActionsAsset.objectReferenceValue == null)
             {
-                if (m_AvailableActionsInAsset == null)
-                    continue;
+                for (var i = 0; i < numActions; i++)
+                {
+                    // find the input action reference from the asset that matches the input action reference from the
+                    // InputSystemUIInputModule that is currently selected. Note we can't use reference equality of the
+                    // two InputActionReference objects here because in ReassignActions above, we create new instances
+                    // every time it runs.
+                    var index = IndexOfInputActionInAsset(
+                        ((InputActionReference)m_ReferenceProperties[i]?.objectReferenceValue)?.action);
 
-                // find the input action reference from the asset that matches the input action reference from the
-                // InputSystemUIInputModule that is currently selected. Note we can't use reference equality of the
-                // two InputActionReference objects here because in ReassignActions above, we create new instances
-                // every time it runs.
-                var index = IndexOfInputActionInAsset(((InputActionReference)m_ReferenceProperties[i]?.objectReferenceValue)?.action);
+                    EditorGUI.BeginChangeCheck();
+                    index = EditorGUILayout.Popup(s_ActionNiceNames[i], index, m_AvailableActionsInAssetNames);
 
-                EditorGUI.BeginChangeCheck();
-                index = EditorGUILayout.Popup(s_ActionNiceNames[i], index, m_AvailableActionsInAssetNames);
+                    if (EditorGUI.EndChangeCheck())
+                        m_ReferenceProperties[i].objectReferenceValue =
+                            index > 0 ? m_AvailableActionReferencesInAssetDatabase[index - 1] : null;
+                }
+            }
+            else
+            {
+                // Somehow we have an asset but no asset references from the database, pull out references manually and show them in read only UI
+                EditorGUILayout.HelpBox("Showing fields as read-only because current action asset seems to be created by a script and assigned programmatically.", MessageType.Info);
 
-                if (EditorGUI.EndChangeCheck())
-                    m_ReferenceProperties[i].objectReferenceValue = index > 0 ? m_AvailableActionsInAsset[index - 1] : null;
+                EditorGUI.BeginDisabledGroup(true);
+                for (var i = 0; i < numActions; i++)
+                {
+                    var retrievedName = "None";
+                    if (m_ReferenceProperties[i].objectReferenceValue != null &&
+                        (m_ReferenceProperties[i].objectReferenceValue is InputActionReference reference))
+                        retrievedName = MakeActionReferenceNameUsableInGenericMenu(reference.ToDisplayName());
+                
+                    EditorGUILayout.Popup(s_ActionNiceNames[i], 0, new[] {retrievedName});
+                }
+                EditorGUI.EndDisabledGroup();
             }
 
             if (GUI.changed)
@@ -151,10 +178,10 @@ namespace UnityEngine.InputSystem.UI.Editor
                 return 0;
 
             var index = 0;
-            for (var j = 0; j < m_AvailableActionsInAsset.Length; j++)
+            for (var j = 0; j < m_AvailableActionReferencesInAssetDatabase.Length; j++)
             {
-                if (m_AvailableActionsInAsset[j].action != null &&
-                    m_AvailableActionsInAsset[j].action == inputAction)
+                if (m_AvailableActionReferencesInAssetDatabase[j].action != null &&
+                    m_AvailableActionReferencesInAssetDatabase[j].action == inputAction)
                 {
                     index = j + 1;
                     break;


### PR DESCRIPTION
### Description

When two player inputs with two ui input modules point to the same asset, one of them will get a runtime created copy of actions asset (because of `m_Actions = Instantiate(m_Actions);`). That makes one of ui input modules inspector showing everything as "None" because `GetAllActionsFromAsset` was returning empty array.

### Changes made

I've thought about it, and it doesn't seem to make sense to resolve `InputActionReference` for a runtime created asset, because to be able to resolve it later on one would need the asset instance. So I made inspector to fallback to "read-only" mode.
