### PR TITLE
Fixing device current getting set when a state event with no changes is sent

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -768,6 +768,10 @@ class APIVerificationTests
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem.Editor", "public sealed class InputControlPathEditor : System.IDisposable", "public void OnGUI(UnityEngine.Rect rect);")]
     // InputEventTrace.Resize() has a new parameter with a default value.
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem.LowLevel", "public sealed class InputEventTrace : System.Collections.Generic.IEnumerable<UnityEngine.InputSystem.LowLevel.InputEventPtr>, System.Collections.IEnumerable, System.IDisposable", "public bool Resize(long newBufferSize);")]
+    // filterNoiseOnCurrent is Obsolete since 1.3.0
+    [Property("Exclusions", @"1.0.0
+        public bool filterNoiseOnCurrent { get; set; }
+    ")]
     public void API_MinorVersionsHaveNoBreakingChanges()
     {
         var currentVersion = CoreTests.PackageJson.ReadVersion();

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4033,15 +4033,6 @@ partial class CoreTests
         Assert.That(gamepad1.rightTrigger.noisy, Is.False);
         Assert.That(Gamepad.current, Is.SameAs(gamepad2));
 
-        var receivedSettingsChange = false;
-        InputSystem.onSettingsChange += () => receivedSettingsChange = true;
-
-        // Enable filtering. Off by default.
-        InputSystem.settings.filterNoiseOnCurrent = true;
-
-        Assert.That(InputSystem.settings.filterNoiseOnCurrent, Is.True);
-        Assert.That(receivedSettingsChange, Is.True);
-
         // Send delta state without noise on first gamepad.
         InputSystem.QueueDeltaStateEvent(gamepad1.leftStick, new Vector2(0.123f, 0.234f));
         InputSystem.Update();
@@ -4075,13 +4066,6 @@ partial class CoreTests
         Assert.That(Gamepad.current, Is.SameAs(gamepad1));
     }
 
-    [Test]
-    [Category("Devices")]
-    public void Devices_FilteringNoiseOnCurrentIsTurnedOffByDefault()
-    {
-        Assert.That(InputSystem.settings.filterNoiseOnCurrent, Is.False);
-    }
-
     // We currently do not read out actual values during noise detection. This means that any state change on a control
     // that isn't marked as noisy will pass the noise filter. If, for example, the sticks are wiggled but they are still
     // below deadzone threshold, they will still classify as carrying signal. To do that differently, we would have to
@@ -4092,8 +4076,6 @@ partial class CoreTests
     {
         var gamepad1 = InputSystem.AddDevice<Gamepad>();
         InputSystem.AddDevice<Gamepad>();
-
-        InputSystem.settings.filterNoiseOnCurrent = true;
 
         // Actuate leftStick below deadzone threshold.
         InputSystem.QueueStateEvent(gamepad1, new GamepadState { leftStick = new Vector2(0.001f, 0.001f)});

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -3975,7 +3975,7 @@ partial class CoreTests
 
         Assert.That(Gamepad.current, Is.Not.SameAs(gamepad1));
 
-        InputSystem.QueueStateEvent(gamepad1, new GamepadState());
+        InputSystem.QueueStateEvent(gamepad1, new GamepadState().WithButton(GamepadButton.A));
         InputSystem.Update();
 
         Assert.That(Gamepad.current, Is.SameAs(gamepad1));
@@ -3985,6 +3985,28 @@ partial class CoreTests
         InputSystem.Update();
 
         Assert.That(Gamepad.current, Is.SameAs(gamepad1));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_AreNotMadeCurrentWhenReceivingStateEventWithNoControlsChanged()
+    {
+        var gamepad1 = InputSystem.AddDevice<Gamepad>();
+        var gamepad2 = InputSystem.AddDevice<Gamepad>();
+
+        InputSystem.QueueStateEvent(gamepad1, new GamepadState().WithButton(GamepadButton.A));
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.SameAs(gamepad1));
+
+        InputSystem.QueueStateEvent(gamepad2, new GamepadState().WithButton(GamepadButton.B));
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.SameAs(gamepad2));
+
+        InputSystem.QueueStateEvent(gamepad1, new GamepadState().WithButton(GamepadButton.A));
+        InputSystem.Update();
+
+        // If none of the controls changed, a state event shouldn't switch current gamepad.
+        Assert.That(Gamepad.current, Is.SameAs(gamepad2));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -27,6 +27,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed a problem with UI Toolkit buttons remaining active when multiple fingers are used on a touchscreen, using `InputSystemUIInputModule` with pointerBehavior set to `UIPointerBehavior.SingleUnifiedPointer`. UI Toolkit will now always receive the same pointerId when that option is in use, regardless of the hardware component that produced the pointer event. ([case 1369081](https://issuetracker.unity3d.com/issues/transitions-get-stuck-when-pointer-behavior-is-set-to-single-unified-pointer-and-multiple-touches-are-made)).
 - Fixed DualSense on iOS not inheriting from `DualShockGamepad` ([case 1378308](https://issuetracker.unity3d.com/issues/input-dualsense-detection-ios)).
 - Fixed Input System UI Input Module inspector showing all action bindings as "None" when assigned a runtime created actions asset ([case 1304943](https://issuetracker.unity3d.com/issues/input-system-ui-input-module-loses-prefab-action-mapping-in-local-co-op)).
+- Fixed a device becoming `.current` (e.g. `Gamepad.current`, etc) when sending a new state event that contains no control changes (case 1377952).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - The artificial `ctrl`, `shift`, and `alt` controls (which combine the left and right controls into one) on the keyboard can now be written to and no longer throw `NotSupportedException` when trying to do so ([case 1340793](https://issuetracker.unity3d.com/issues/on-screen-button-errors-on-mouse-down-slash-up-when-its-control-path-is-set-to-control-keyboard)).
 - All devices are now resynced/reset in next update after entering play mode, this is needed to read current state of devices before any intentional input is provided ([case 1231907](https://issuetracker.unity3d.com/issues/mouse-coordinates-reported-as-00-until-the-first-move)).
 - Replaced `UnityLinkerBuildPipelineData.inputDirectory` with hardcoded `Temp` folder because `inputDirectory` is deprecated.
+- Deprecated `InputSettings.filterNoiseOnCurrent`. Now noise filtering is always enabled. Device only will become `.current` if any non-noise control have changed state.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -590,13 +590,12 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// When added, a device is automatically made current (see <see cref="InputDevice.MakeCurrent"/>), so
         /// when connecting a gamepad, it will also become current. After that, it will only become current again
-        /// when input on non-noisy controls (see <see cref="InputControl.noisy"/>) is received.
+        /// when input change on non-noisy controls (see <see cref="InputControl.noisy"/>) is received.
         ///
         /// For local multiplayer scenarios (or whenever there are multiple gamepads that need to be usable
         /// in a concurrent fashion), it is not recommended to rely on this property. Instead, it is recommended
         /// to use <see cref="PlayerInput"/> or <see cref="Users.InputUser"/>.
         /// </remarks>
-        /// <seealso cref="InputSettings.filterNoiseOnCurrent"/>
         /// <seealso cref="InputDevice.MakeCurrent"/>
         /// <seealso cref="all"/>
         public static Gamepad current { get; private set; }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -476,13 +476,10 @@ namespace UnityEngine.InputSystem
         /// feed events into the input system even if not being actually in use. If, for example, an
         /// Xbox gamepad and PS4 gamepad are both connected to a PC and the user is playing with the
         /// Xbox gamepad, the PS4 gamepad would still constantly make itself <see cref="Gamepad.current"/>
-        /// by simply flooding the system with events.
-        ///
-        /// By enabling <see cref="InputSettings.filterNoiseOnCurrent"/> (disabled by default),
-        /// noise on <c>.current</c> getters will be filtered out and a device will only see <c>MakeCurrent</c>
-        /// getting called if there input was detected on non-noisy controls.
+        /// by simply flooding the system with events. Hence why by default,  noise on <c>.current</c> getters
+        /// will be filtered out and a device will only see <c>MakeCurrent</c> getting called if there input
+        /// was detected on non-noisy controls.
         /// </remarks>
-        /// <seealso cref="InputSettings.filterNoiseOnCurrent"/>
         /// <seealso cref="Pointer.current"/>
         /// <seealso cref="Gamepad.current"/>
         /// <seealso cref="Mouse.current"/>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -595,7 +595,6 @@ namespace UnityEngine.InputSystem.Editor
                 settingsItem = AddChild(root, settingsLabel, ref id);
                 AddValueItem(settingsItem, "Update Mode", settings.updateMode, ref id);
                 AddValueItem(settingsItem, "Compensate For Screen Orientation", settings.compensateForScreenOrientation, ref id);
-                AddValueItem(settingsItem, "Filter Noise On .current", settings.filterNoiseOnCurrent, ref id);
                 AddValueItem(settingsItem, "Default Button Press Point", settings.defaultButtonPressPoint, ref id);
                 AddValueItem(settingsItem, "Default Deadzone Min", settings.defaultDeadzoneMin, ref id);
                 AddValueItem(settingsItem, "Default Deadzone Max", settings.defaultDeadzoneMax, ref id);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -105,7 +105,6 @@ namespace UnityEngine.InputSystem.Editor
                     EditorGUILayout.HelpBox("Focus change behavior can only be changed if 'Run In Background' is enabled in Player Settings.", MessageType.Info);
 
                 EditorGUILayout.Space();
-                EditorGUILayout.PropertyField(m_FilterNoiseOnCurrent, m_FilterNoiseOnCurrentContent);
                 EditorGUILayout.PropertyField(m_CompensateForScreenOrientation, m_CompensateForScreenOrientationContent);
 
                 // NOTE: We do NOT make showing this one conditional on whether runInBackground is actually set in the
@@ -260,7 +259,6 @@ namespace UnityEngine.InputSystem.Editor
             m_CompensateForScreenOrientation = m_SettingsObject.FindProperty("m_CompensateForScreenOrientation");
             m_BackgroundBehavior = m_SettingsObject.FindProperty("m_BackgroundBehavior");
             m_EditorInputBehaviorInPlayMode = m_SettingsObject.FindProperty("m_EditorInputBehaviorInPlayMode");
-            m_FilterNoiseOnCurrent = m_SettingsObject.FindProperty("m_FilterNoiseOnCurrent");
             m_DefaultDeadzoneMin = m_SettingsObject.FindProperty("m_DefaultDeadzoneMin");
             m_DefaultDeadzoneMax = m_SettingsObject.FindProperty("m_DefaultDeadzoneMax");
             m_DefaultButtonPressPoint = m_SettingsObject.FindProperty("m_DefaultButtonPressPoint");
@@ -272,7 +270,6 @@ namespace UnityEngine.InputSystem.Editor
             m_MultiTapDelayTime = m_SettingsObject.FindProperty("m_MultiTapDelayTime");
 
             m_UpdateModeContent = new GUIContent("Update Mode", "When should the Input System be updated?");
-            m_FilterNoiseOnCurrentContent = new GUIContent("Filter Noise on .current", "If enabled, input from noisy controls will not cause a device to become '.current'.");
             m_CompensateForScreenOrientationContent = new GUIContent("Compensate Orientation", "Whether sensor input on mobile devices should be transformed to be relative to the current device orientation.");
             m_BackgroundBehaviorContent = new GUIContent("Background Behavior", "If runInBackground is true (and in standalone *development* players and the editor), "
                 + "determines what happens to InputDevices and events when the application moves in and out of running in the foreground.\n\n"
@@ -398,7 +395,6 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private SerializedProperty m_CompensateForScreenOrientation;
         [NonSerialized] private SerializedProperty m_BackgroundBehavior;
         [NonSerialized] private SerializedProperty m_EditorInputBehaviorInPlayMode;
-        [NonSerialized] private SerializedProperty m_FilterNoiseOnCurrent;
         [NonSerialized] private SerializedProperty m_DefaultDeadzoneMin;
         [NonSerialized] private SerializedProperty m_DefaultDeadzoneMax;
         [NonSerialized] private SerializedProperty m_DefaultButtonPressPoint;
@@ -418,7 +414,6 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private GUIStyle m_NewAssetButtonStyle;
 
         private GUIContent m_UpdateModeContent;
-        private GUIContent m_FilterNoiseOnCurrentContent;
         private GUIContent m_CompensateForScreenOrientationContent;
         private GUIContent m_BackgroundBehaviorContent;
         private GUIContent m_EditorInputBehaviorInPlayModeContent;

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3717,7 +3717,7 @@ namespace UnityEngine.InputSystem
             ////REVIEW: Should we do this only for events but not for InputState.Change()?
             // If noise filtering on .current is turned on and the device may have noise,
             // determine if the event carries signal or not.
-            var noiseMask = device.noisy && m_Settings.filterNoiseOnCurrent
+            var noiseMask = device.noisy
                 ? (byte*)InputStateBuffers.s_NoiseMaskBuffer + deviceStateOffset
                 : null;
             // Compare the current state of the device to the newly received state but overlay

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3717,18 +3717,13 @@ namespace UnityEngine.InputSystem
             ////REVIEW: Should we do this only for events but not for InputState.Change()?
             // If noise filtering on .current is turned on and the device may have noise,
             // determine if the event carries signal or not.
-            var makeDeviceCurrent = true;
-            if (device.noisy && m_Settings.filterNoiseOnCurrent)
-            {
-                // Compare the current state of the device to the newly received state but overlay
-                // the comparison by the noise mask.
-
-                var noiseMask = (byte*)InputStateBuffers.s_NoiseMaskBuffer + deviceStateOffset;
-
-                makeDeviceCurrent =
-                    !MemoryHelpers.MemCmpBitRegion(deviceStatePtr, statePtr,
-                        0, stateSize * 8, mask: noiseMask);
-            }
+            var noiseMask = device.noisy && m_Settings.filterNoiseOnCurrent
+                ? (byte*)InputStateBuffers.s_NoiseMaskBuffer + deviceStateOffset
+                : null;
+            // Compare the current state of the device to the newly received state but overlay
+            // the comparison by the noise mask.
+            var makeDeviceCurrent = !MemoryHelpers.MemCmpBitRegion(deviceStatePtr, statePtr,
+                0, stateSize * 8, mask: noiseMask);
 
             // Buffer flip.
             var flipped = FlipBuffersForDeviceIfNecessary(device, updateType);

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -112,14 +112,12 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Whether to not make a device <c>.current</c> (see <see cref="InputDevice.MakeCurrent"/>)
+        /// Currently: Option is deprecated and has no influence on the system. Filtering on noise is always enabled.
+        /// Previously: Whether to not make a device <c>.current</c> (see <see cref="InputDevice.MakeCurrent"/>)
         /// when there is only noise in the input.
         /// </summary>
-        /// <value>Whether to check input on devices for noise.</value>
         /// <remarks>
-        /// This is <em>disabled by default</em>.
-        ///
-        /// When toggled on, this property adds extra processing every time input is
+        /// We add extra processing every time input is
         /// received on a device that is considered noisy. These devices are those that
         /// have at least one control that is marked as <see cref="InputControl.noisy"/>.
         /// A good example is the PS4 controller which has a gyroscope sensor built into
@@ -141,15 +139,13 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="InputDevice.MakeCurrent"/>
         /// <seealso cref="InputControl.noisy"/>
+        [Obsolete("filterNoiseOnCurrent is deprecated, filtering of noise is always enabled now.", false)]
         public bool filterNoiseOnCurrent
         {
-            get => m_FilterNoiseOnCurrent;
+            get => false;
             set
             {
-                if (m_FilterNoiseOnCurrent == value)
-                    return;
-                m_FilterNoiseOnCurrent = value;
-                OnChange();
+                /* no op */
             }
         }
 
@@ -649,7 +645,6 @@ namespace UnityEngine.InputSystem
         [SerializeField] private int m_MaxQueuedEventsPerUpdate = 1000;
 
         [SerializeField] private bool m_CompensateForScreenOrientation = true;
-        [SerializeField] private bool m_FilterNoiseOnCurrent = false;
         [SerializeField] private BackgroundBehavior m_BackgroundBehavior = BackgroundBehavior.ResetAndDisableNonBackgroundDevices;
         [SerializeField] private EditorInputBehaviorInPlayMode m_EditorInputBehaviorInPlayMode;
         [SerializeField] private float m_DefaultDeadzoneMin = 0.125f;


### PR DESCRIPTION
### Description

Some backends send a state event every once in a while (every frame, twice a frame, etc) without even checking if anything changed. That is currently making devices from these backends as `.current`.

### Changes made

Always memcmp new state with previous one, and only make device current if anything changed (or non-noisy data changed for noisy devices).

