### PR TITLE
fix: tracked device raycaster 3d occlusion hit distance calculation

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed writing values into the half-axis controls of sticks (such as `Gamepad.leftStick.left`) producing incorrect values on the stick ([case 1336240](https://issuetracker.unity3d.com/issues/inputtestfixture-tests-return-inverted-values-when-pressing-gamepads-left-or-down-joystick-buttons)).
 - Fixed setting size of event trace in input debugger always growing back to largest size set before.
+- Fixed `TrackedDeviceRaycaster.cs` 3D occlusion check not working correctly. Issue unity forums thread link: https://forum.unity.com/threads/input-system-trackeddeviceraycaster-cs-3d-occlusion-check-not-working-correctly.1193089/
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/TrackedDeviceRaycaster.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/TrackedDeviceRaycaster.cs
@@ -116,9 +116,10 @@ namespace UnityEngine.InputSystem.UI
             {
                 var hits = Physics.RaycastAll(ray, hitDistance, m_BlockingMask);
 
-                if (hits.Length > 0 && hits[0].distance < hitDistance)
+                if (hits.Length > 0)
                 {
-                    hitDistance = hits[0].distance;
+                    // Distance to the closest 3D object on the ray's way
+                    hitDistance = hits.Select(hit => hit.distance).Min();
                 }
             }
             #endif


### PR DESCRIPTION
### Description

Here i made a short fix in TrackedDeviceRaycaster.cs. The issue described here https://forum.unity.com/threads/input-system-trackeddeviceraycaster-cs-3d-occlusion-check-not-working-correctly.1193089/. In two words: there was a bug in 3d occlusion check while raycasting UI.

### Changes made

Changed calculation of hitDistance local variable in internal PerformRaycast method of TrackedDeviceRaycaster.cs

### Notes

It was my first fork and PR ever. Hope it will be applied!)

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
