### PR TITLE
Resync all devices after entering play mode

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Changed
 
 - The artificial `ctrl`, `shift`, and `alt` controls (which combine the left and right controls into one) on the keyboard can now be written to and no longer throw `NotSupportedException` when trying to do so ([case 1340793](https://issuetracker.unity3d.com/issues/on-screen-button-errors-on-mouse-down-slash-up-when-its-control-path-is-set-to-control-keyboard)).
+- All devices are now resynced/reset in next update after entering play mode, this is needed to read current state of devices before any intentional input is provided ([case 1231907](https://issuetracker.unity3d.com/issues/mouse-coordinates-reported-as-00-until-the-first-move)).
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2526,27 +2526,40 @@ namespace UnityEngine.InputSystem
             #endif
         }
 
+#if UNITY_EDITOR
         private void SyncAllDevicesWhenEditorIsActivated()
         {
-            #if UNITY_EDITOR
             var isActive = m_Runtime.isEditorActive;
             if (isActive == m_EditorIsActive)
                 return;
 
             m_EditorIsActive = isActive;
             if (m_EditorIsActive)
-            {
-                for (var i = 0; i < m_DevicesCount; ++i)
-                {
-                    // When the editor comes back into focus, we actually do want resets to happen
-                    // for devices that don't support syncs as they will likely have missed input while
-                    // we were in the background.
-                    if (!m_Devices[i].RequestSync())
-                        ResetDevice(m_Devices[i], issueResetCommand: true);
-                }
-            }
-            #endif
+                SyncAllDevices();
         }
+
+        private void SyncAllDevices()
+        {
+            for (var i = 0; i < m_DevicesCount; ++i)
+            {
+                // When the editor comes back into focus, we actually do want resets to happen
+                // for devices that don't support syncs as they will likely have missed input while
+                // we were in the background.
+                if (!m_Devices[i].RequestSync())
+                    ResetDevice(m_Devices[i], issueResetCommand: true);
+            }
+        }
+
+        internal void SyncAllDevicesAfterEnteringPlayMode()
+        {
+            // Because we ignore all events between exiting edit mode and entering play mode,
+            // that includes any potential device resets/syncs/etc,
+            // we need to resync all devices after we're in play mode proper.
+            ////TODO: this is a hacky workaround, implement a proper solution where events from sync/resets are not ignored.
+            SyncAllDevices();
+        }
+
+#endif
 
         private void WarnAboutDevicesFailingToRecreateAfterDomainReload()
         {
@@ -2943,7 +2956,9 @@ namespace UnityEngine.InputSystem
             RestoreDevicesAfterDomainReloadIfNecessary();
 
             // In the editor, we issue a sync on all devices when the editor comes back to the foreground.
+            #if UNITY_EDITOR
             SyncAllDevicesWhenEditorIsActivated();
+            #endif
 
             if ((updateType & m_UpdateMask) == 0)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3277,6 +3277,7 @@ namespace UnityEngine.InputSystem
 
                 case PlayModeStateChange.EnteredPlayMode:
                     s_SystemObject.enterPlayModeTime = InputRuntime.s_Instance.currentTime;
+                    s_Manager.SyncAllDevicesAfterEnteringPlayMode();
                     break;
 
                 case PlayModeStateChange.ExitingPlayMode:


### PR DESCRIPTION
### Description

As part of fixing [case 1231907](https://issuetracker.unity3d.com/issues/mouse-coordinates-reported-as-00-until-the-first-move) I've noticed that even if I implemented sync for the mouse it still doesn't work, it's because we are dropping all events generated between exiting edit mode and entering play mode here:

```
                    // In the editor, we discard all input events that occur in-between exiting edit mode and having
                    // entered play mode as otherwise we'll spill a bunch of UI events that have occurred while the
                    // UI was sort of neither in this mode nor in that mode. This would usually lead to the game receiving
                    // an accumulation of spurious inputs right in one of its first updates.
                    //
                    // NOTE: There's a chance the solution here will prove inadequate on the long run. We may do things
                    //       here such as throwing partial touches away and then letting the rest of a touch go through.
                    //       Could be that ultimately we need to issue a full reset of all devices at the beginning of
                    //       play mode in the editor.
#if UNITY_EDITOR
                    if ((updateType & InputUpdateType.Editor) == 0 &&
                        InputSystem.s_SystemObject.exitEditModeTime > 0 &&
                        currentEventTimeInternal >= InputSystem.s_SystemObject.exitEditModeTime &&
                        (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
                         InputSystem.s_SystemObject.enterPlayModeTime == 0))
                    {
                        m_InputEventStream.Advance(false);
                        continue;
                    }
#endif
```

Currently devices are only resynced when they're recreating during domain reload, and that means the resync state event currently is generated during domain reload, hence it's ignored.

### Changes made

Ideally the ignoring logic should not ignore resyncs, but that implies some sort of flag or metadata added to events. But even if we do this, it's unclear what to do with a proper input event that might come after resync event. Maybe instead all listeners should be skipped during domain reload? Likely something else will break then.

I couldn't really figure out how to properly fix it at this stage, feels like we need to separate "calculating control values" step from "calling callbacks" step more cleanly, then we could store all updates but not trigger any UI stuff.

So for now I did a very hacky fix to just resync the universe in a frame after play mode, I think this effectively means that first scene update after play mode will have no data. Not ideal, but almost fixes the problem.

