### PR TITLE
FIX: Input Action drawer doesn't indent bindings properly

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed InputSystemUIInputModule showing incorrect bindings after pressing the 'Fix UI Input Module' button in PlayerInput component([case 1319968](https://issuetracker.unity3d.com/product/unity/issues/guid/1319968/)).
 - Fixed an issue where serialized `InputAction` properties would have display name "Input Action" in the Inspector window instead of their given name. ([case 1367240](https://issuetracker.unity3d.com/product/unity/issues/guid/1367240)).
 - Fixed an issue where UI button clicks could be ignored by `InputSystemUIInputModule` if modifying on-screen devices from Update() callbacks [1365070](https://issuetracker.unity3d.com/product/unity/issues/guid/1365070).
+- Fixed incorrect indentation of input actions in the inspector ([case 1285546](https://issuetracker.unity3d.com/product/unity/issues/guid/1285546/)).
 - Fixed a problem with UI Toolkit buttons remaining active when multiple fingers are used on a touchscreen, using `InputSystemUIInputModule` with pointerBehavior set to `UIPointerBehavior.SingleUnifiedPointer`. UI Toolkit will now always receive the same pointerId when that option is in use, regardless of the hardware component that produced the pointer event. ([case 1369081](https://issuetracker.unity3d.com/issues/transitions-get-stuck-when-pointer-behavior-is-set-to-single-unified-pointer-and-multiple-touches-are-made)).
 
 #### Actions

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -1261,9 +1261,29 @@ namespace UnityEngine.InputSystem.Editor
             // We don't get the depth of the item we're drawing the foldout for but we can
             // infer it by the amount that the given rectangle was indented.
             var indent = (int)(position.x / kFoldoutWidth);
-            position.x = foldoutOffset + (indent + 1) * kColorTagWidth + 2;
+            var indentLevel = EditorGUI.indentLevel;
+
+            // When drawing input actions in the input actions editor, we don't want to offset the foldout
+            // icon any further than the position that's passed in to this function, so take advantage of
+            // the fact that indentLevel is always zero in that editor.
+            position.x = EditorGUI.IndentedRect(position).x * Mathf.Clamp01(indentLevel) + kColorTagWidth + 2 + indent * kColorTagWidth;
+
             position.width = kFoldoutWidth;
-            return EditorGUI.Foldout(position, expandedState, GUIContent.none, true, style);
+
+            var hierarchyMode = EditorGUIUtility.hierarchyMode;
+
+            // We remove the editor indent level and set hierarchy mode to false when drawing the foldout
+            // arrow so that in the inspector we don't get additional padding on the arrow for the inspector
+            // gutter, and so that the indent level doesn't apply because we've done that ourselves.
+            EditorGUI.indentLevel = 0;
+            EditorGUIUtility.hierarchyMode = false;
+
+            var foldoutExpanded = EditorGUI.Foldout(position, expandedState, GUIContent.none, true, style);
+
+            EditorGUI.indentLevel = indentLevel;
+            EditorGUIUtility.hierarchyMode = hierarchyMode;
+
+            return foldoutExpanded;
         }
 
         protected override void RowGUI(RowGUIArgs args)
@@ -1272,7 +1292,7 @@ namespace UnityEngine.InputSystem.Editor
             var isRepaint = Event.current.type == EventType.Repaint;
 
             // Color tag at beginning of line.
-            var colorTagRect = args.rowRect;
+            var colorTagRect = EditorGUI.IndentedRect(args.rowRect);
             colorTagRect.x += item.depth * kColorTagWidth;
             colorTagRect.width = kColorTagWidth;
             if (isRepaint)
@@ -1292,7 +1312,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Bottom line.
-            var lineRect = args.rowRect;
+            var lineRect = EditorGUI.IndentedRect(args.rowRect);
             lineRect.y += lineRect.height - 1;
             lineRect.height = 1;
             if (isRepaint)
@@ -1320,16 +1340,16 @@ namespace UnityEngine.InputSystem.Editor
 
         protected override Rect GetRenameRect(Rect rowRect, int row, TreeViewItem item)
         {
-            var textRect = GetTextRect(rowRect, item);
+            var textRect = GetTextRect(rowRect, item, false);
             textRect.x += 2;
             textRect.height -= 2;
             return textRect;
         }
 
-        private static Rect GetTextRect(Rect rowRect, TreeViewItem item)
+        private Rect GetTextRect(Rect rowRect, TreeViewItem item, bool applyIndent = true)
         {
             var indent = (item.depth + 1) * kColorTagWidth + kFoldoutWidth;
-            var textRect = rowRect;
+            var textRect = applyIndent ? EditorGUI.IndentedRect(rowRect) : rowRect;
             textRect.x += indent;
             return textRect;
         }
@@ -1395,7 +1415,6 @@ namespace UnityEngine.InputSystem.Editor
         public bool drawPlusButton { get; set; }
         public bool drawMinusButton { get; set; }
         public bool drawActionPropertiesButton { get; set; }
-        public float foldoutOffset { get; set; }
 
         public Action<SerializedProperty> onHandleAddNewAction { get; set; }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -52,9 +52,6 @@ namespace UnityEngine.InputSystem.Editor
             {
                 onBuildTree = () => BuildTree(property),
                 onDoubleClick = item => OnItemDoubleClicked(item, property),
-                // With the tree in the inspector, the foldouts are drawn too far to the left. I don't
-                // really know where this is coming from. This works around it by adding an arbitrary offset...
-                foldoutOffset = 14,
                 drawActionPropertiesButton = true,
                 title = (GetPropertyTitle(property), property.GetTooltip())
             };


### PR DESCRIPTION
Fixes [1285546](https://issuetracker.unity3d.com/product/unity/issues/guid/1285546/)  ([FogBugz](https://fogbugz.unity3d.com/f/cases/1285546/))

### Description
Input action bindings were drawn at the wrong indentation level in the inspector when the input action itself was indented due to belonging to a parent serializable object.

### Changes made
Modified InputActionTreeView to use the EditorGUI.IndentRect method to get correct positioning for items in the tree.

### Notes
Removed the 14 pixel offset hack from InputActionDrawerBase. The offset that that worked around was caused by the inspector gutter, and is removed by setting EditorGUIUtility.hierarchyMode to false and EditorGUI.indentLevel to 0 while drawing the foldout icon.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.
