### PR TITLE
FIX: Calling IsPressed() on device being true (case 1374024).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1034,6 +1034,35 @@ partial class CoreTests
 
     [Test]
     [Category("Controls")]
+    public void Controls_CanDetermineIfControlIsPressed()
+    {
+        InputSystem.settings.defaultButtonPressPoint = 0.5f;
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        Set(gamepad.leftStick, Vector2.one);
+        Set(gamepad.leftTrigger, 0.6f);
+        Press(gamepad.buttonSouth);
+
+        //// https://jira.unity3d.com/browse/ISX-926
+        ////REVIEW: IsPressed() should probably be renamed. As is apparent from the calls here, it's not always
+        ////        readily apparent that the way it is defined ("actuation level at least at button press threshold")
+        ////        does not always connect to what it intuitively means for the specific control.
+
+        Assert.That(gamepad.leftTrigger.IsPressed(), Is.True);
+        Assert.That(gamepad.rightTrigger.IsPressed(), Is.False);
+        Assert.That(gamepad.buttonSouth.IsPressed(), Is.True);
+        Assert.That(gamepad.buttonNorth.IsPressed(), Is.False);
+        Assert.That(gamepad.leftStick.IsPressed(), Is.True); // Note how this diverges from the actual meaning of "is the left stick pressed?"
+        Assert.That(gamepad.rightStick.IsPressed(), Is.False);
+
+        // https://fogbugz.unity3d.com/f/cases/1374024/
+        // Calling it on the entire device should be false.
+        Assert.That(gamepad.IsPressed(), Is.False);
+    }
+
+    [Test]
+    [Category("Controls")]
     public void Controls_CanCustomizeDefaultButtonPressPoint()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,12 +18,13 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed writing values into the half-axis controls of sticks (such as `Gamepad.leftStick.left`) producing incorrect values on the stick ([case 1336240](https://issuetracker.unity3d.com/issues/inputtestfixture-tests-return-inverted-values-when-pressing-gamepads-left-or-down-joystick-buttons)).
 - Fixed setting size of event trace in input debugger always growing back to largest size set before.
-- Fixed an issue where serialized `InputAction` properties would have display name "Input Action" in the Inspector window instead of their given name. ([case 1367240](https://issuetracker.unity3d.com/product/unity/issues/guid/1367240)).
 - Fixed an issue where UI button clicks could be ignored by `InputSystemUIInputModule` if modifying on-screen devices from Update() callbacks [1365070](https://issuetracker.unity3d.com/product/unity/issues/guid/1365070).
+- Fixed calling `IsPressed` on an entire device returning `true` ([case 1374024](https://issuetracker.unity3d.com/issues/inputcontrol-dot-ispressed-always-returns-true-when-using-new-input-system)).
 
 #### Actions
 
 - Fixed an issue where `InputAction.Enable` would not reuse memory allocated prior and thus lead to memory leaks ([case 1367442](https://issuetracker.unity3d.com/issues/input-system-puts-a-lot-of-pressure-on-the-garbage-collector-when-enabling-and-disabling-inputactionmaps)).
+- Fixed an issue where serialized `InputAction` properties would have display name "Input Action" in the Inspector window instead of their given name. ([case 1367240](https://issuetracker.unity3d.com/product/unity/issues/guid/1367240)).
 
 ## [1.2.0] - 2021-10-22
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -41,6 +41,7 @@ namespace UnityEngine.InputSystem
             return null;
         }
 
+        ////REVIEW: This ist too high up in the class hierarchy; can be applied to any kind of control without it being readily apparent what exactly it means
         /// <summary>
         /// Check whether the given control is considered pressed according to the button press threshold.
         /// </summary>
@@ -99,8 +100,14 @@ namespace UnityEngine.InputSystem
             var magnitude = control.EvaluateMagnitude();
             if (magnitude < 0)
             {
-                ////REVIEW: we probably want to do a value comparison on this path to compare it to the default value
-                return true;
+                // We know the control is not in default state but we also know it doesn't support
+                // magnitude. So, all we can say is that it is actuated. Not how much it is actuated.
+                //
+                // If we're looking for a specific threshold here, consider the control to always
+                // be under. But if not, consider it actuated "by virtue of not being in default state".
+                if (Mathf.Approximately(threshold, 0))
+                    return true;
+                return false;
             }
 
             if (Mathf.Approximately(threshold, 0))


### PR DESCRIPTION
Fixes [1374024](https://issuetracker.unity3d.com/issues/inputcontrol-dot-ispressed-always-returns-true-when-using-new-input-system) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1374024/)).

### Description

`IsPressed` is an extension method for `InputControl`s that checks whether actuation levels are above button press thresholds. As it is defined for any `InputControl`, it also works for an `InputDevice`. The current implementation returns true as long as the device is not in its default state.

### Changes made

Made the check more nuanced to handle "EvaluateMagnitude() has no defined result" better.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
