### PR TITLE
FIX: Touch.activeTouches not canceled on focus loss (case 1364017).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -1960,6 +1960,39 @@ partial class CoreTests
         Assert.That(gyro.angularVelocity.ReadValue(), Is.EqualTo(Vector3.zero));
     }
 
+    class DeviceWithCustomReset : InputDevice, ICustomDeviceReset
+    {
+        [InputControl]
+        public AxisControl axis { get; private set; }
+
+        protected override void FinishSetup()
+        {
+            axis = GetChildControl<AxisControl>("axis");
+        }
+
+        public unsafe void Reset()
+        {
+            InputState.Change(axis, 1f);
+        }
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_CanCustomizeResetOfDevice()
+    {
+        var device = InputSystem.AddDevice<DeviceWithCustomReset>();
+
+        Set(device.axis, 0.45f);
+
+        InputSystem.ResetDevice(device);
+
+        Assert.That(device.axis.ReadValue(), Is.EqualTo(1f));
+
+        InputSystem.ResetDevice(device, alsoResetDontResetControls: true);
+
+        Assert.That(device.axis.ReadValue(), Is.Zero);
+    }
+
     [Test]
     [Category("Devices")]
     public void Devices_WhenDeviceIsReset_AndResetsAreObservableStateChanges()

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -1160,30 +1160,20 @@ internal class EnhancedTouchTests : CoreTestsFixture
         {
             // When running in the background, next update after focus loss sees touches cancelled
             // and update after that sees them gone.
-
             InputSystem.Update(InputUpdateType.Dynamic);
-
-            Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
-            Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Canceled));
-
-            InputSystem.Update();
-
-            Assert.That(Touch.activeTouches, Is.Empty);
         }
         else
         {
             // When not running in the background, the same thing happens but only on focus gain.
-
             runtime.PlayerFocusGained();
-
             InputSystem.Update();
-
-            Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
-            Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Canceled));
-
-            InputSystem.Update();
-
-            Assert.That(Touch.activeTouches, Is.Empty);
         }
+
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Canceled));
+
+        InputSystem.Update();
+
+        Assert.That(Touch.activeTouches, Is.Empty);
     }
 }

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -1140,4 +1140,50 @@ internal class EnhancedTouchTests : CoreTestsFixture
         Assert.That(Touchscreen.current.touches[0].isInProgress, Is.True);
         Assert.That(Touchscreen.current.touches[0].position.ReadValue(), Is.EqualTo(new Vector2(123, 234)));
     }
+
+    [Test]
+    [Category("EnhancedTouch")]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void EnhancedTouch_ActiveTouchesGetCanceledOnFocusLoss_WithRunInBackgroundBeing(bool runInBackground)
+    {
+        runtime.runInBackground = runInBackground;
+
+        BeginTouch(1, new Vector2(123, 456));
+
+        Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
+        Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Began));
+
+        runtime.PlayerFocusLost();
+
+        if (runInBackground)
+        {
+            // When running in the background, next update after focus loss sees touches cancelled
+            // and update after that sees them gone.
+
+            InputSystem.Update(InputUpdateType.Dynamic);
+
+            Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
+            Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Canceled));
+
+            InputSystem.Update();
+
+            Assert.That(Touch.activeTouches, Is.Empty);
+        }
+        else
+        {
+            // When not running in the background, the same thing happens but only on focus gain.
+
+            runtime.PlayerFocusGained();
+
+            InputSystem.Update();
+
+            Assert.That(Touch.activeTouches, Has.Count.EqualTo(1));
+            Assert.That(Touch.activeTouches[0].phase, Is.EqualTo(TouchPhase.Canceled));
+
+            InputSystem.Update();
+
+            Assert.That(Touch.activeTouches, Is.Empty);
+        }
+    }
 }

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3413,10 +3413,10 @@ internal class UITests : CoreTestsFixture
 #endif
 
 #if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
-    static bool[] canRunInBackgroundValueSource = new bool[] { false, true };
+    static bool[] canRunInBackgroundValueSource = new[] { false, true };
 
     [UnityTest]
-    public IEnumerator Run_UI_WhenAppLosesAndRegainsFocus_WhileUIButtonIsPressed_UIButtonClickBehaviorShouldDependOnIfDeviceCanRunInBackground(
+    public IEnumerator UI_WhenAppLosesAndRegainsFocus_WhileUIButtonIsPressed_UIButtonClickBehaviorShouldDependOnIfDeviceCanRunInBackground(
         [ValueSource(nameof(canRunInBackgroundValueSource))] bool canRunInBackground)
     {
         // Whether we run in the background or not should only move the reset of the mouse button

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,17 +13,19 @@ however, it has to be formatted properly to pass verification tests.
 ### Changed
 
 - The artificial `ctrl`, `shift`, and `alt` controls (which combine the left and right controls into one) on the keyboard can now be written to and no longer throw `NotSupportedException` when trying to do so ([case 1340793](https://issuetracker.unity3d.com/issues/on-screen-button-errors-on-mouse-down-slash-up-when-its-control-path-is-set-to-control-keyboard)).
+- A device reset (such as when focus is lost) on `Touchscreen` will now result in all ongoing touches getting cancelled instead of all touches being simply reset to default state.
 
 ### Fixed
 
 - Fixed writing values into the half-axis controls of sticks (such as `Gamepad.leftStick.left`) producing incorrect values on the stick ([case 1336240](https://issuetracker.unity3d.com/issues/inputtestfixture-tests-return-inverted-values-when-pressing-gamepads-left-or-down-joystick-buttons)).
 - Fixed setting size of event trace in input debugger always growing back to largest size set before.
-- Fixed an issue where serialized `InputAction` properties would have display name "Input Action" in the Inspector window instead of their given name. ([case 1367240](https://issuetracker.unity3d.com/product/unity/issues/guid/1367240)).
 - Fixed an issue where UI button clicks could be ignored by `InputSystemUIInputModule` if modifying on-screen devices from Update() callbacks [1365070](https://issuetracker.unity3d.com/product/unity/issues/guid/1365070).
+- Fixed `Touch.activeTouches` still registering touches after the app loses focus ([case 1364017](https://issuetracker.unity3d.com/issues/input-system-new-input-system-registering-active-touches-when-app-loses-focus)).
 
 #### Actions
 
 - Fixed an issue where `InputAction.Enable` would not reuse memory allocated prior and thus lead to memory leaks ([case 1367442](https://issuetracker.unity3d.com/issues/input-system-puts-a-lot-of-pressure-on-the-garbage-collector-when-enabling-and-disabling-inputactionmaps)).
+- Fixed an issue where serialized `InputAction` properties would have display name "Input Action" in the Inspector window instead of their given name. ([case 1367240](https://issuetracker.unity3d.com/product/unity/issues/guid/1367240)).
 
 ## [1.2.0] - 2021-10-22
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -25,7 +25,6 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed an issue where `InputAction.Enable` would not reuse memory allocated prior and thus lead to memory leaks ([case 1367442](https://issuetracker.unity3d.com/issues/input-system-puts-a-lot-of-pressure-on-the-garbage-collector-when-enabling-and-disabling-inputactionmaps)).
-- Fixed an issue where serialized `InputAction` properties would have display name "Input Action" in the Inspector window instead of their given name. ([case 1367240](https://issuetracker.unity3d.com/product/unity/issues/guid/1367240)).
 
 ## [1.2.0] - 2021-10-22
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/ICustomDeviceReset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/ICustomDeviceReset.cs
@@ -1,0 +1,14 @@
+namespace UnityEngine.InputSystem.LowLevel
+{
+    /// <summary>
+    /// A device that implements its own reset logic for when <see cref="InputSystem.ResetDevice"/>
+    /// is called.
+    /// </summary>
+    internal interface ICustomDeviceReset
+    {
+        /// <summary>
+        /// Reset the current device state.
+        /// </summary>
+        void Reset();
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/ICustomDeviceReset.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/ICustomDeviceReset.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 08dab706fb9641539767891cee0c7d3c
+timeCreated: 1636546307

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventMerger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventMerger.cs
@@ -1,6 +1,4 @@
-using UnityEngine.InputSystem.LowLevel;
-
-namespace UnityEngine.InputSystem
+namespace UnityEngine.InputSystem.LowLevel
 {
     internal interface IEventMerger
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/IEventPreProcessor.cs
@@ -1,6 +1,4 @@
-using UnityEngine.InputSystem.LowLevel;
-
-namespace UnityEngine.InputSystem
+namespace UnityEngine.InputSystem.LowLevel
 {
     /// <summary>
     /// Gives an opportunity for device to modify event data in-place before it gets propagated to the rest of the system.

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEvent.cs
@@ -48,8 +48,6 @@ namespace UnityEngine.InputSystem.LowLevel
     /// some device (which, however, may or may not translate to an <see cref="InputDevice"/>; that
     /// part depends on whether the input system was able to create an <see cref="InputDevice"/>
     /// based on the information received from the backend).
-    ///
-    /// To implement your own type of event, TODO (manual?)
     /// </remarks>
     /// <seealso cref="InputEventPtr"/>
     // NOTE: This has to be layout compatible with native events.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1344,87 +1344,95 @@ namespace UnityEngine.InputSystem
             InputActionState.OnDeviceChange(device, change);
             DelegateHelpers.InvokeCallbacksSafe(ref m_DeviceChangeListeners, device, change, "onDeviceChange");
 
-            var defaultStatePtr = device.defaultStatePtr;
-            var deviceStateBlockSize = device.stateBlock.alignedSizeInBytes;
-
-            // Allocate temp memory to hold one state event.
-            ////REVIEW: the need for an event here is sufficiently obscure to warrant scrutiny; likely, there's a better way
-            ////        to tell synthetic input (or input sources in general) apart
-            // NOTE: We wrap the reset in an artificial state event so that it appears to the rest of the system
-            //       like any other input. If we don't do that but rather just call UpdateState() with a null event
-            //       pointer, the change will be considered an internal state change and will get ignored by some
-            //       pieces of code (such as EnhancedTouch which filters out internal state changes of Touchscreen
-            //       by ignoring any change that is not coming from an input event).
-            using (var tempBuffer =
-                       new NativeArray<byte>(InputEvent.kBaseEventSize + sizeof(int) + (int)deviceStateBlockSize, Allocator.Temp))
+            // If the device implements its own reset, let it handle it.
+            if (!alsoResetDontResetControls && device is ICustomDeviceReset customReset)
             {
-                var stateEventPtr = (StateEvent*)tempBuffer.GetUnsafePtr();
-                var statePtr = stateEventPtr->state;
-                var currentTime = m_Runtime.currentTime;
-
-                // Set up the state event.
-                ref var stateBlock = ref device.m_StateBlock;
-                stateEventPtr->baseEvent.type = StateEvent.Type;
-                stateEventPtr->baseEvent.sizeInBytes = InputEvent.kBaseEventSize + sizeof(int) + deviceStateBlockSize;
-                stateEventPtr->baseEvent.time = currentTime;
-                stateEventPtr->baseEvent.deviceId = device.deviceId;
-                stateEventPtr->baseEvent.eventId = -1;
-                stateEventPtr->stateFormat = device.m_StateBlock.format;
-
-                // Decide whether we perform a soft reset or a hard reset.
-                if (isHardReset)
-                {
-                    // Perform a hard reset where we wipe the entire device and set a full
-                    // reset request to the backend.
-                    UnsafeUtility.MemCpy(statePtr,
-                        (byte*)defaultStatePtr + stateBlock.byteOffset,
-                        deviceStateBlockSize);
-                }
-                else
-                {
-                    // Perform a soft reset where we exclude any dontReset control (which is automatically
-                    // toggled on for noisy controls) and do *NOT* send a reset request to the backend.
-
-                    var currentStatePtr = device.currentStatePtr;
-                    var resetMaskPtr = m_StateBuffers.resetMaskBuffer;
-
-                    // To preserve values from dontReset controls, we need to first copy their current values.
-                    UnsafeUtility.MemCpy(statePtr,
-                        (byte*)currentStatePtr + stateBlock.byteOffset,
-                        deviceStateBlockSize);
-
-                    // And then we copy over default values masked by dontReset bits.
-                    MemoryHelpers.MemCpyMasked(statePtr,
-                        (byte*)defaultStatePtr + stateBlock.byteOffset,
-                        (int)deviceStateBlockSize,
-                        (byte*)resetMaskPtr + stateBlock.byteOffset);
-                }
-
-                UpdateState(device, defaultUpdateType, statePtr, 0, deviceStateBlockSize, currentTime,
-                    new InputEventPtr((InputEvent*)stateEventPtr));
-
-                // In the editor, we don't want to issue RequestResetCommand to devices based on focus of the game view
-                // as this would also reset device state for the editor. And we don't need the reset commands in this case
-                // as -- unlike in the player --, Unity keeps running and we will keep seeing OS messages for these devices.
-                // So, in the editor, we generally suppress reset commands.
-                //
-                // The only exception is when the editor itself loses focus. We issue sync requests to all devices when
-                // coming back into focus. But for any device that doesn't support syncs, we actually do want to have a
-                // reset command reach the background.
-                //
-                // Finally, in the player, we also avoid reset commands when disabling a device as these are pointless.
-                // We sync/reset when enabling a device in the backend.
-                var doIssueResetCommand = isHardReset;
-                if (issueResetCommand != null)
-                    doIssueResetCommand = issueResetCommand.Value;
-                #if UNITY_EDITOR
-                else if (m_Settings.editorInputBehaviorInPlayMode != InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView)
-                    doIssueResetCommand = false;
-                #endif
-
-                if (doIssueResetCommand)
-                    device.RequestReset();
+                customReset.Reset();
             }
+            else
+            {
+                var defaultStatePtr = device.defaultStatePtr;
+                var deviceStateBlockSize = device.stateBlock.alignedSizeInBytes;
+
+                // Allocate temp memory to hold one state event.
+                ////REVIEW: the need for an event here is sufficiently obscure to warrant scrutiny; likely, there's a better way
+                ////        to tell synthetic input (or input sources in general) apart
+                // NOTE: We wrap the reset in an artificial state event so that it appears to the rest of the system
+                //       like any other input. If we don't do that but rather just call UpdateState() with a null event
+                //       pointer, the change will be considered an internal state change and will get ignored by some
+                //       pieces of code (such as EnhancedTouch which filters out internal state changes of Touchscreen
+                //       by ignoring any change that is not coming from an input event).
+                using (var tempBuffer =
+                           new NativeArray<byte>(InputEvent.kBaseEventSize + sizeof(int) + (int)deviceStateBlockSize, Allocator.Temp))
+                {
+                    var stateEventPtr = (StateEvent*)tempBuffer.GetUnsafePtr();
+                    var statePtr = stateEventPtr->state;
+                    var currentTime = m_Runtime.currentTime;
+
+                    // Set up the state event.
+                    ref var stateBlock = ref device.m_StateBlock;
+                    stateEventPtr->baseEvent.type = StateEvent.Type;
+                    stateEventPtr->baseEvent.sizeInBytes = InputEvent.kBaseEventSize + sizeof(int) + deviceStateBlockSize;
+                    stateEventPtr->baseEvent.time = currentTime;
+                    stateEventPtr->baseEvent.deviceId = device.deviceId;
+                    stateEventPtr->baseEvent.eventId = -1;
+                    stateEventPtr->stateFormat = device.m_StateBlock.format;
+
+                    // Decide whether we perform a soft reset or a hard reset.
+                    if (isHardReset)
+                    {
+                        // Perform a hard reset where we wipe the entire device and set a full
+                        // reset request to the backend.
+                        UnsafeUtility.MemCpy(statePtr,
+                            (byte*)defaultStatePtr + stateBlock.byteOffset,
+                            deviceStateBlockSize);
+                    }
+                    else
+                    {
+                        // Perform a soft reset where we exclude any dontReset control (which is automatically
+                        // toggled on for noisy controls) and do *NOT* send a reset request to the backend.
+
+                        var currentStatePtr = device.currentStatePtr;
+                        var resetMaskPtr = m_StateBuffers.resetMaskBuffer;
+
+                        // To preserve values from dontReset controls, we need to first copy their current values.
+                        UnsafeUtility.MemCpy(statePtr,
+                            (byte*)currentStatePtr + stateBlock.byteOffset,
+                            deviceStateBlockSize);
+
+                        // And then we copy over default values masked by dontReset bits.
+                        MemoryHelpers.MemCpyMasked(statePtr,
+                            (byte*)defaultStatePtr + stateBlock.byteOffset,
+                            (int)deviceStateBlockSize,
+                            (byte*)resetMaskPtr + stateBlock.byteOffset);
+                    }
+
+                    UpdateState(device, defaultUpdateType, statePtr, 0, deviceStateBlockSize, currentTime,
+                        new InputEventPtr((InputEvent*)stateEventPtr));
+                }
+            }
+
+            // In the editor, we don't want to issue RequestResetCommand to devices based on focus of the game view
+            // as this would also reset device state for the editor. And we don't need the reset commands in this case
+            // as -- unlike in the player --, Unity keeps running and we will keep seeing OS messages for these devices.
+            // So, in the editor, we generally suppress reset commands.
+            //
+            // The only exception is when the editor itself loses focus. We issue sync requests to all devices when
+            // coming back into focus. But for any device that doesn't support syncs, we actually do want to have a
+            // reset command reach the background.
+            //
+            // Finally, in the player, we also avoid reset commands when disabling a device as these are pointless.
+            // We sync/reset when enabling a device in the backend.
+            var doIssueResetCommand = isHardReset;
+            if (issueResetCommand != null)
+                doIssueResetCommand = issueResetCommand.Value;
+            #if UNITY_EDITOR
+            else if (m_Settings.editorInputBehaviorInPlayMode != InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView)
+                doIssueResetCommand = false;
+            #endif
+
+            if (doIssueResetCommand)
+                device.RequestReset();
         }
 
         public InputDevice TryGetDevice(string nameOrLayout)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -134,7 +134,6 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         {
             // We only want to record changes that come from events. We ignore internal state
             // changes that Touchscreen itself generates. This includes the resetting of deltas.
-            // NOTE: This means we are ignoring delta resets happening in Touchscreen.
             if (!eventPtr.valid)
                 return false;
 

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -614,7 +614,7 @@ namespace UnityEngine.InputSystem
             {
                 screen = Touchscreen.current;
                 if (screen == null)
-                    throw new InvalidOperationException("No touchscreen has been added");
+                    screen = InputSystem.AddDevice<Touchscreen>();
             }
 
             InputSystem.QueueStateEvent(screen, new TouchState


### PR DESCRIPTION
Fixes [1364017](https://issuetracker.unity3d.com/issues/input-system-new-input-system-registering-active-touches-when-app-loses-focus) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1364017/)).

### Description

When focus is lost, devices are reset and thus get reset to default state. However, for `Touchscreen` this is undesirable as touches should cancel cleanly, not just disappear.

### Changes made

Modified `Touchscreen` to have its own reset logic.

### Notes

There's a bigger problem in here around how we cannot tell why a specific state change happens. So `Touchscreen.Reset()` has to jump through some hoops an actually construct an event that, in the end, isn't actually used other than to check whether there is an event.

Recorded a Tech Debt ticket for this ([ISX-930](https://jira.unity3d.com/browse/ISX-930)).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
