### PR TITLE
Resolved syntax error in code example

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - The artificial `ctrl`, `shift`, and `alt` controls (which combine the left and right controls into one) on the keyboard can now be written to and no longer throw `NotSupportedException` when trying to do so ([case 1340793](https://issuetracker.unity3d.com/issues/on-screen-button-errors-on-mouse-down-slash-up-when-its-control-path-is-set-to-control-keyboard)).
 - All devices are now resynced/reset in next update after entering play mode, this is needed to read current state of devices before any intentional input is provided ([case 1231907](https://issuetracker.unity3d.com/issues/mouse-coordinates-reported-as-00-until-the-first-move)).
+- Resolved a syntax error within the code examples in the documentation.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/Documentation~/Devices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Devices.md
@@ -299,7 +299,7 @@ public struct MyDeviceState : IInputStateTypeInfo
     // You must tag every state with a FourCC code for type
     // checking. The characters can be anything. Choose something that allows
     // you to easily recognize memory that belongs to your own Device.
-    public FourCC format => return new FourCC('M', 'Y', 'D', 'V');
+    public FourCC format => new FourCC('M', 'Y', 'D', 'V');
 
     // InputControlAttributes on fields tell the Input System to create Controls
     // for the public fields found in the struct.


### PR DESCRIPTION
### Description

Resolved syntax error in code example.

### Changes made

Removed "return" keyword from array function.

### Notes

/

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
