### PR TITLE
Replacing inputDirectory with "Temp" for InputSystemLink.xml

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - The artificial `ctrl`, `shift`, and `alt` controls (which combine the left and right controls into one) on the keyboard can now be written to and no longer throw `NotSupportedException` when trying to do so ([case 1340793](https://issuetracker.unity3d.com/issues/on-screen-button-errors-on-mouse-down-slash-up-when-its-control-path-is-set-to-control-keyboard)).
 - All devices are now resynced/reset in next update after entering play mode, this is needed to read current state of devices before any intentional input is provided ([case 1231907](https://issuetracker.unity3d.com/issues/mouse-coordinates-reported-as-00-until-the-first-move)).
+- Replaced `UnityLinkerBuildPipelineData.inputDirectory` with hardcoded `Temp` folder because `inputDirectory` is deprecated.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/BuildPipeline/LinkFileGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/BuildPipeline/LinkFileGenerator.cs
@@ -77,7 +77,7 @@ namespace UnityEngine.InputSystem.Editor
 
             sb.AppendLine("</linker>");
 
-            var filePathName = Path.Combine(data.inputDirectory, "InputSystemLink.xml");
+            var filePathName = Path.Combine(Application.dataPath, "..", "Temp", "InputSystemLink.xml");
             File.WriteAllText(filePathName, sb.ToString());
             return filePathName;
         }


### PR DESCRIPTION
### Description

`UnityLinkerBuildPipelineData.inputDirectory` is deprecated on trunk, after consulting with @jechter it seems placing link.xml in Temp is the next best thing

