### PR TITLE
Bump Unity version to avoid codedom failures temporarily

### DIFF
--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -36,7 +36,7 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1.0a15,2022.1.0a16)",
+            "expression": "[2022.1.0a15,2022.1.0a17)",
             "define": "TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK"
         }
     ],

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -31,7 +31,7 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1.0a12,2022.1.0a16)",
+            "expression": "[2022.1.0a12,2022.1.0a17)",
             "define": "TEMP_DISABLE_UI_TESTS_ON_TRUNK"
         },
         {


### PR DESCRIPTION
### Description

Bump editor version to avoid codedom failures for trunk version not respecting .NET version

### Changes made

Bumped version for disabling tests.

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
