### PR TITLE
NEW: Actions can now apply processors to control values even when a control is not actuated

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -30,6 +30,10 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed an issue where `InputAction.Enable` would not reuse memory allocated prior and thus lead to memory leaks ([case 1367442](https://issuetracker.unity3d.com/issues/input-system-puts-a-lot-of-pressure-on-the-garbage-collector-when-enabling-and-disabling-inputactionmaps)).
 
+#### Added
+
+- Actions now have a switch (Always Run Processors) to enable them to always apply processors to a binding even if the control for the binding is not actuated. This is useful for any binding that normalizes input ranges in such a way that the default input value should not be zero ([case 1293728](https://issuetracker.unity3d.com/product/unity/issues/guid/1293728/)).
+
 ## [1.2.0] - 2021-10-22
 
 ### Changed

--- a/Packages/com.unity.inputsystem/Documentation~/HowDoI.md
+++ b/Packages/com.unity.inputsystem/Documentation~/HowDoI.md
@@ -593,3 +593,6 @@ Use this code:
 Go to __Windows > Analysis > Input Debugger__(Debugging.md), then double click on a Device to see its Controls. You can also click the __Remote Devices__ button to remotely see Devices from Unity Players deployed to any connected computers or devices.
 
 [//]: # (TODO: working on having device setups from players mirrored 1:1 into the running input system in the editor (including having their input available in the editor))
+
+# …normalize input even when my control is in its default position?
+If you have a normalization processor attached to an axis control, say gamepad left stick X axis, that makes the axis range go from 0 to 1, you can make the `InputAction.ReadValue` method return 0.5 for the default, non-actuated, position by turning on the Always Run Processors option for your action. This option will force even default control values to be processed by all processors attached to the most recently actuated binding on that action. This of course applies to all types of processors, not just normalization.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1368,6 +1368,7 @@ namespace UnityEngine.InputSystem
             public string interactions;
             public bool passThrough;
             public bool initialStateCheck;
+            public bool alwaysRunProcessors;
 
             // Bindings can either be on the action itself (in which case the action name
             // for each binding is implied) or listed separately in the action file.
@@ -1406,6 +1407,7 @@ namespace UnityEngine.InputSystem
                     m_Processors = processors,
                     m_Interactions = interactions,
                     wantsInitialStateCheck = initialStateCheck,
+                    alwaysRunProcessors = alwaysRunProcessors
                 };
             }
         }
@@ -1420,6 +1422,7 @@ namespace UnityEngine.InputSystem
             public string processors;
             public string interactions;
             public bool initialStateCheck;
+            public bool alwaysRunProcessors;
 
             public static WriteActionJson FromAction(InputAction action)
             {
@@ -1432,6 +1435,7 @@ namespace UnityEngine.InputSystem
                     processors = action.processors,
                     interactions = action.interactions,
                     initialStateCheck = action.wantsInitialStateCheck,
+                    alwaysRunProcessors = action.alwaysRunProcessors,
                 };
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -2384,16 +2384,24 @@ namespace UnityEngine.InputSystem
                 value = controlOfType.ReadValue();
             }
 
+            value = ApplyBindingProcessors(bindingIndex, value, controlOfType);
+
+            return value;
+        }
+
+        internal TValue ApplyBindingProcessors<TValue>(int bindingIndex, TValue value, InputControl<TValue> control) where TValue : struct
+        {
+            Debug.Assert(bindingIndex >= 0 && bindingIndex < totalBindingCount, "Binding index is out of range");
+
             // Run value through processors, if any.
             var processorCount = bindingStates[bindingIndex].processorCount;
-            if (processorCount > 0)
+            if (processorCount <= 0) return value;
+
+            var processorStartIndex = bindingStates[bindingIndex].processorStartIndex;
+            for (var i = 0; i < processorCount; ++i)
             {
-                var processorStartIndex = bindingStates[bindingIndex].processorStartIndex;
-                for (var i = 0; i < processorCount; ++i)
-                {
-                    if (processors[processorStartIndex + i] is InputProcessor<TValue> processor)
-                        value = processor.Process(value, controlOfType);
-                }
+                if (processors[processorStartIndex + i] is InputProcessor<TValue> processor)
+                    value = processor.Process(value, control);
             }
 
             return value;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionPropertiesView.cs
@@ -27,6 +27,7 @@ namespace UnityEngine.InputSystem.Editor
 
             m_SelectedActionType = (InputActionType)m_ActionTypeProperty.intValue;
             m_WantsInitialStateCheck = (m_ActionFlagsProperty.intValue & (int)InputAction.ActionFlags.WantsInitialStateCheck) != 0;
+            m_AlwaysProcessControlValue = (m_ActionFlagsProperty.intValue & (int)InputAction.ActionFlags.AlwaysProcessControlValue) != 0;
 
             BuildControlTypeList();
             m_SelectedControlType = Array.IndexOf(m_ControlTypeList, m_ExpectedControlTypeProperty.stringValue);
@@ -42,6 +43,12 @@ namespace UnityEngine.InputSystem.Editor
                     "Whether in the next input update after the action was enabled, the action should "
                     + "immediately trigger if any of its bound controls are currently in a non-default state. "
                     + "This check happens implicitly for Value actions but can be explicitly enabled for Button and Pass-Through actions.");
+            if (s_AlwaysProcessControlValueLabel == null)
+                s_AlwaysProcessControlValueLabel = EditorGUIUtility.TrTextContent("Always Run Processors",
+                    "Run binding processors even when the associated control is not actuated. This is useful in "
+                    + "several circumstances. For example, normalizing the range of an axis control using a Normalize " +
+                    " processor so that the non-actuated default value is 0.5 instead of 0. Note that only the bindings "
+                    + "from the most recently actuated control are applied.");
         }
 
         protected override void DrawGeneralProperties()
@@ -54,6 +61,8 @@ namespace UnityEngine.InputSystem.Editor
 
             if ((InputActionType)m_SelectedActionType != InputActionType.Value)
                 m_WantsInitialStateCheck = EditorGUILayout.Toggle(s_WantsInitialStateCheckLabel, m_WantsInitialStateCheck);
+
+            m_AlwaysProcessControlValue = EditorGUILayout.Toggle(s_AlwaysProcessControlValueLabel, m_AlwaysProcessControlValue);
 
             if (EditorGUI.EndChangeCheck())
             {
@@ -70,6 +79,11 @@ namespace UnityEngine.InputSystem.Editor
                     m_ActionFlagsProperty.intValue |= (int)InputAction.ActionFlags.WantsInitialStateCheck;
                 else
                     m_ActionFlagsProperty.intValue &= ~(int)InputAction.ActionFlags.WantsInitialStateCheck;
+
+                if (m_AlwaysProcessControlValue)
+                    m_ActionFlagsProperty.intValue |= (int)InputAction.ActionFlags.AlwaysProcessControlValue;
+                else
+                    m_ActionFlagsProperty.intValue &= ~(int)InputAction.ActionFlags.AlwaysProcessControlValue;
 
                 m_ActionTypeProperty.serializedObject.ApplyModifiedProperties();
                 UpdateProcessors(m_ExpectedControlTypeProperty.stringValue);
@@ -121,10 +135,12 @@ namespace UnityEngine.InputSystem.Editor
         private int m_SelectedControlType;
         private Enum m_SelectedActionType;
         private bool m_WantsInitialStateCheck;
+        private bool m_AlwaysProcessControlValue;
 
         private static GUIContent s_ActionTypeLabel;
         private static GUIContent s_ControlTypeLabel;
         private static GUIContent s_WantsInitialStateCheckLabel;
+        private static GUIContent s_AlwaysProcessControlValueLabel;
     }
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions
@@ -12,7 +12,8 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": true
+                    "initialStateCheck": true,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "Look",
@@ -21,7 +22,8 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": true
+                    "initialStateCheck": true,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "Fire",
@@ -30,7 +32,8 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 }
             ],
             "bindings": [
@@ -267,7 +270,8 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "Submit",
@@ -276,7 +280,8 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "Cancel",
@@ -285,7 +290,8 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "Point",
@@ -294,7 +300,8 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": true
+                    "initialStateCheck": true,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "Click",
@@ -303,7 +310,8 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": true
+                    "initialStateCheck": true,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "ScrollWheel",
@@ -312,7 +320,8 @@
                     "expectedControlType": "Vector2",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "MiddleClick",
@@ -321,7 +330,8 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "RightClick",
@@ -330,7 +340,8 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "TrackedDevicePosition",
@@ -339,7 +350,8 @@
                     "expectedControlType": "Vector3",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 },
                 {
                     "name": "TrackedDeviceOrientation",
@@ -348,7 +360,8 @@
                     "expectedControlType": "Quaternion",
                     "processors": "",
                     "interactions": "",
-                    "initialStateCheck": false
+                    "initialStateCheck": false,
+                    "alwaysRunProcessors": false
                 }
             ],
             "bindings": [


### PR DESCRIPTION
Case [1293728](https://issuetracker.unity3d.com/product/unity/issues/guid/1293728/)([Fogbugz](https://fogbugz.unity3d.com/f/cases/1293728/))

### Description

The original bug report suggested that the dead zone processor was interacting with the normalize processor and causing it to malfunction. The actual issue, as far as I can tell, was that calling InputAction.ReadValue() when no binding/control is actuated always returns default(T), where in this case, the user had a normalize processor on a stick X axis binding that they wanted to return 0.5 at the default state, instead of 0.

### Changes made

Added a new option to InputAction called Always Run Processors that will force the ReadValue call to always run the default control value through the binding processors of the most recently actuated control if there is no binding in progress.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.
