### PR TITLE
FIX: InputSystem.onAnyButtonPress now filters out non-state or delta state events

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -181,6 +181,23 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
+    public void Events_OnAnyButtonPressed_FiltersOutNonStateEvents()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        var callCount = 0;
+
+        InputSystem.onAnyButtonPress
+            .CallOnce(_ => { ++callCount; });
+
+        InputSystem.QueueTextEvent(keyboard, ' ');
+        InputSystem.Update();
+
+        Assert.That(callCount, Is.EqualTo(0));
+    }
+
+    [Test]
+    [Category("Events")]
     public void Events_CanGetAllButtonPressesInEvent()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -198,6 +198,20 @@ partial class CoreTests
 
     [Test]
     [Category("Events")]
+    public unsafe void Events_GetAllButtonPressesInEvent_ReturnsEmptyEnumerableForNonStateOrDeltaStateEvents()
+    {
+        var inputEvent = TextEvent.Create(InputSystem.AddDevice<Keyboard>().deviceId, ' ');
+
+        IEnumerable<InputControl> controls = null;
+        Assert.That(() =>
+        {
+            controls = InputControlExtensions.GetAllButtonPresses((InputEvent*)UnsafeUtility.AddressOf(ref inputEvent));
+        }, Throws.Nothing);
+        Assert.That(controls, Is.Empty);
+    }
+
+    [Test]
+    [Category("Events")]
     public void Events_CanGetAllButtonPressesInEvent()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
 - Fixed `InvalidCastException: Specified cast is not valid.` being thrown when clicking on menu separators in the control picker ([case 1388049](https://issuetracker.unity3d.com/issues/invalidcastexception-is-thrown-when-selecting-the-header-of-an-advanceddropdown)).
 - Fixed DualShock 4 controller not allowing input from other devices due to noisy input from its unmapped sensors ([case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)).
+- Fixed `InputSystem.onAnyButtonPress` so that it doesn't throw exceptions when trying to process non state or delta events ([case 1376034](https://issuetracker.unity3d.com/product/unity/issues/guid/1376034/)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1099,6 +1099,9 @@ namespace UnityEngine.InputSystem
         /// east (bit position 5), so if both buttons were pressed in the given event, button north would be returned.</remarks>
         public static InputControl GetFirstButtonPressOrNull(this InputEventPtr eventPtr, float magnitude = -1, bool buttonControlsOnly = true)
         {
+            if (eventPtr.type != StateEvent.Type || eventPtr.type != DeltaStateEvent.Type)
+                return null;
+
             if (magnitude < 0)
                 magnitude = InputSystem.settings.defaultButtonPressPoint;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1068,9 +1068,9 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Return true if the given <paramref name="eventPtr"/> has any <see cref="Input"/>
         /// </summary>
-        /// <param name="eventPtr"></param>
-        /// <param name="magnitude"></param>
-        /// <param name="buttonControlsOnly"></param>
+        /// <param name="eventPtr">An event. Must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</param>
+        /// <param name="magnitude">The threshold value that a button must be actuated by to be considered pressed.</param>
+        /// <param name="buttonControlsOnly">Whether the method should only consider button controls. See <see cref="InputControl.isButton"/>.</param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"><paramref name="eventPtr"/> is a <c>null</c> pointer.</exception>
         /// <exception cref="ArgumentException"><paramref name="eventPtr"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> -or-
@@ -1085,9 +1085,9 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Get the first pressed button from the given event or null if the event doesn't contain a new button press.
         /// </summary>
-        /// <param name="eventPtr"></param>
-        /// <param name="magnitude"></param>
-        /// <param name="buttonControlsOnly"></param>
+        /// <param name="eventPtr">An event. Must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</param>
+        /// <param name="magnitude">The threshold value that a button must be actuated by to be considered pressed.</param>
+        /// <param name="buttonControlsOnly">Whether the method should only consider button controls. See <see cref="InputControl.isButton"/>.</param>
         /// <returns>The control that was pressed.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="eventPtr"/> is a <c>null</c> pointer.</exception>
         /// <exception cref="ArgumentException"><paramref name="eventPtr"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> -or-
@@ -1099,7 +1099,7 @@ namespace UnityEngine.InputSystem
         /// east (bit position 5), so if both buttons were pressed in the given event, button north would be returned.</remarks>
         public static InputControl GetFirstButtonPressOrNull(this InputEventPtr eventPtr, float magnitude = -1, bool buttonControlsOnly = true)
         {
-            if (eventPtr.type != StateEvent.Type || eventPtr.type != DeltaStateEvent.Type)
+            if (eventPtr.type != StateEvent.Type && eventPtr.type != DeltaStateEvent.Type)
                 return null;
 
             if (magnitude < 0)
@@ -1118,8 +1118,8 @@ namespace UnityEngine.InputSystem
         /// Enumerate all pressed buttons in the given event.
         /// </summary>
         /// <param name="eventPtr">An event. Must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</param>
-        /// <param name="magnitude"></param>
-        /// <param name="buttonControlsOnly"></param>
+        /// <param name="magnitude">The threshold value that a button must be actuated by to be considered pressed.</param>
+        /// <param name="buttonControlsOnly">Whether the method should only consider button controls. See <see cref="InputControl.isButton"/>.</param>
         /// <returns>An enumerable collection containing all buttons that were pressed in the given event.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="eventPtr"/> is a <c>null</c> pointer.</exception>
         /// <exception cref="ArgumentException"><paramref name="eventPtr"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> -or-

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1086,17 +1086,23 @@ namespace UnityEngine.InputSystem
         /// Get the first pressed button from the given event or null if the event doesn't contain a new button press.
         /// </summary>
         /// <param name="eventPtr">An event. Must be a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/>.</param>
-        /// <param name="magnitude">The threshold value that a button must be actuated by to be considered pressed.</param>
-        /// <param name="buttonControlsOnly">Whether the method should only consider button controls. See <see cref="InputControl.isButton"/>.</param>
+        /// <param name="magnitude">The threshold value that a control must be actuated by (see
+        /// <see cref="InputControl.EvaluateMagnitude()"/>) to be considered pressed. If not given, defaults to <see
+        /// cref="InputSettings.defaultButtonPressPoint"/>.</param>
+        /// <param name="buttonControlsOnly">Whether the method should only consider <see cref="ButtonControl"/>s. Otherwise,
+        /// any <see cref="InputControl"/> that has an actuation (see <see cref="InputControl.EvaluateMagnitude()"/>) equal to
+        /// or greater than the given <paramref name="magnitude"/> will be considered a pressed button. This is 'true' by
+        /// default.</param>
         /// <returns>The control that was pressed.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="eventPtr"/> is a <c>null</c> pointer.</exception>
-        /// <exception cref="ArgumentException"><paramref name="eventPtr"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> -or-
-        /// the <see cref="InputDevice"/> referenced by the <see cref="InputEvent.deviceId"/> in the event cannot be found.</exception>
+        /// <exception cref="ArgumentException">The <see cref="InputDevice"/> referenced by the <see cref="InputEvent.deviceId"/> in the event cannot
+        /// be found.</exception>
         /// <seealso cref="EnumerateChangedControls"/>
         /// <seealso cref="ButtonControl.isPressed"/>
         /// <remarks>Buttons will be evaluated in the order that they appear in the devices layout i.e. the bit position of each control
         /// in the devices state memory. For example, in the gamepad state, button north (bit position 4) will be evaluated before button
-        /// east (bit position 5), so if both buttons were pressed in the given event, button north would be returned.</remarks>
+        /// east (bit position 5), so if both buttons were pressed in the given event, button north would be returned.
+        /// Note that the function returns null if the <paramref name="eventPtr"/> is not a StateEvent or DeltaStateEvent.</remarks>
         public static InputControl GetFirstButtonPressOrNull(this InputEventPtr eventPtr, float magnitude = -1, bool buttonControlsOnly = true)
         {
             if (eventPtr.type != StateEvent.Type && eventPtr.type != DeltaStateEvent.Type)
@@ -1122,12 +1128,15 @@ namespace UnityEngine.InputSystem
         /// <param name="buttonControlsOnly">Whether the method should only consider button controls. See <see cref="InputControl.isButton"/>.</param>
         /// <returns>An enumerable collection containing all buttons that were pressed in the given event.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="eventPtr"/> is a <c>null</c> pointer.</exception>
-        /// <exception cref="ArgumentException"><paramref name="eventPtr"/> is not a <see cref="StateEvent"/> or <see cref="DeltaStateEvent"/> -or-
-        /// the <see cref="InputDevice"/> referenced by the <see cref="InputEvent.deviceId"/> in the event cannot be found.</exception>
+        /// <exception cref="ArgumentException">The <see cref="InputDevice"/> referenced by the <see cref="InputEvent.deviceId"/> in the event cannot be found.</exception>
+        /// <remarks>Returns an empty enumerable if the <paramref name="eventPtr"/> is not a StateEvent or DeltaStateEvent.</remarks>
         /// <seealso cref="EnumerateChangedControls"/>
         /// <seealso cref="ButtonControl.isPressed"/>
         public static IEnumerable<InputControl> GetAllButtonPresses(this InputEventPtr eventPtr, float magnitude = -1, bool buttonControlsOnly = true)
         {
+            if (eventPtr.type != StateEvent.Type && eventPtr.type != DeltaStateEvent.Type)
+                yield break;
+
             if (magnitude < 0)
                 magnitude = InputSystem.settings.defaultButtonPressPoint;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2402,7 +2402,6 @@ namespace UnityEngine.InputSystem
         /// <seealso cref="onEvent"/>
         public static IObservable<InputControl> onAnyButtonPress =>
             onEvent
-                .Where(evt => evt.type == StateEvent.Type || evt.type == DeltaStateEvent.Type)
                 .Select(e => e.GetFirstButtonPressOrNull()).Where(c => c != null);
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -2401,7 +2401,9 @@ namespace UnityEngine.InputSystem
         /// <seealso cref="ButtonControl.isPressed"/>
         /// <seealso cref="onEvent"/>
         public static IObservable<InputControl> onAnyButtonPress =>
-            onEvent.Select(e => e.GetFirstButtonPressOrNull()).Where(c => c != null);
+            onEvent
+                .Where(evt => evt.type == StateEvent.Type || evt.type == DeltaStateEvent.Type)
+                .Select(e => e.GetFirstButtonPressOrNull()).Where(c => c != null);
 
         /// <summary>
         /// Add an event to the internal event queue.


### PR DESCRIPTION
Case [1376034](https://issuetracker.unity3d.com/product/unity/issues/guid/1376034/) [(Fogbugz)](https://fogbugz.unity3d.com/f/cases/1376034/)

### Description

InputSystem.onAnyButtonPress relies on EnumerateControls, which only works with state and delta state events, and throws exceptions otherwise. When onAnyButtonPress is hooked up and any other type of event comes through, players get exceptions.

### Changes made

Changed onAnyButtonPress to filter out everything except state and delta state events.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.