### PR TITLE
Updated conditional compilation flags

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -476,6 +476,9 @@ class APIVerificationTests
     [Test]
     [Category("API")]
     [Ignore("Still needs a lot of documentation work to happen")]
+    #if UNITY_EDITOR_OSX
+    [Explicit]     // Fails due to file system permissions on yamato, but works locally.
+    #endif
     #if !HAVE_DOCTOOLS_INSTALLED
     //[Ignore("Must install com.unity.package-manager-doctools package to be able to run this test")]
     #endif
@@ -567,6 +570,9 @@ class APIVerificationTests
 
     [Test]
     [Category("API")]
+    #if UNITY_EDITOR_OSX
+    [Explicit] // Fails due to file system permissions on yamato, but works locally.
+    #endif
     public void API_MonoBehavioursHaveHelpUrls()
     {
         // We exclude abstract MonoBehaviours as these can't show up in the Unity inspector.

--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -162,7 +162,6 @@ internal class OnScreenTests : CoreTestsFixture
         Assert.That(InputSystem.devices, Has.None.InstanceOf<Keyboard>());
     }
 
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     // https://fogbugz.unity3d.com/f/cases/1271942
     [UnityTest]
     [Category("Devices")]
@@ -263,8 +262,6 @@ internal class OnScreenTests : CoreTestsFixture
 
         Assert.That(Gamepad.all[0].buttonSouth.isPressed, Is.False);
     }
-
-#endif
 
     // https://fogbugz.unity3d.com/f/cases/1305016/
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3415,7 +3415,12 @@ internal class UITests : CoreTestsFixture
     [UnityTest]
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
-    [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1)]
+    [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
+    #if UNITY_STANDALONE_OSX && TEMP_DISABLE_UITOOLKIT_TEST
+            // temporarily disable this test case on OSX player for 2021.2. It only intermittently works and I don't know why!
+        , Ignore = "Currently fails on OSX IL2CPP player on Unity version 2021.2"
+    #endif
+     )]
     [TestCase(UIPointerBehavior.SingleUnifiedPointer, ExpectedResult = 1)]
 #if UNITY_ANDROID || UNITY_IOS || UNITY_TVOS
     [Ignore("Currently fails on the farm but succeeds locally on Note 10+; needs looking into.")]

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -232,7 +232,6 @@ internal class UITests : CoreTestsFixture
     //       click like the docs say) and also has some questionable behaviors that we opt to do different (for example, we perform
     //       click detection *before* invoking click handlers so that clickCount and clickTime correspond to the current click instead
     //       of to the previous click).
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
 #if UNITY_IOS || UNITY_TVOS
@@ -1111,10 +1110,7 @@ internal class UITests : CoreTestsFixture
         }
     }
 
-#endif
-
     // https://fogbugz.unity3d.com/f/cases/1232705/
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanReceivePointerExitsWhenChangingUIStateWithoutMovingPointer()
@@ -1147,9 +1143,6 @@ internal class UITests : CoreTestsFixture
         );
     }
 
-#endif
-
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     [TestCase(UIPointerBehavior.SingleUnifiedPointer, ExpectedResult = -1)]
@@ -1368,9 +1361,6 @@ internal class UITests : CoreTestsFixture
         }
     }
 
-#endif
-
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanDriveUIFromMultipleTouches()
@@ -1575,10 +1565,7 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.leftChildReceiver.events, Is.Empty);
     }
 
-#endif
-
     // https://fogbugz.unity3d.com/f/cases/1190150/
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanUseTouchSimulationWithUI()
@@ -1699,8 +1686,6 @@ internal class UITests : CoreTestsFixture
             TouchSimulation.Disable();
         }
     }
-
-#endif
 
     #if UNITY_IOS || UNITY_TVOS
     [Ignore("Failing on iOS https://jira.unity3d.com/browse/ISX-448")]
@@ -1886,7 +1871,6 @@ internal class UITests : CoreTestsFixture
     // from non-pointer devices, we need to decide what to do. What the UI input module does is try to find a pointer (classic
     // or tracked) into which to route the input. Only if it can't find an existing pointer to route the input into will it
     // resort to turning the non-pointer device into a (likely non-functional) pointer.
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanTriggerPointerClicksFromNonPointerDevices()
@@ -1925,10 +1909,7 @@ internal class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event eventRecord) => eventRecord.pointerData.clickCount == 0));
     }
 
-#endif
-
     // https://fogbugz.unity3d.com/f/cases/1317239/
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanDetectClicks_WithSuccessiveClicksReflectedInClickCount()
@@ -2102,14 +2083,11 @@ internal class UITests : CoreTestsFixture
         );
     }
 
-#endif
-
     // The UI input module needs to return true from IsPointerOverGameObject() for touches
     // that have ended in the current frame. I.e. even though the touch is already concluded
     // at the InputDevice level, the UI module needs to maintain state for one more frame.
     //
     // https://fogbugz.unity3d.com/f/cases/1347048/
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_TouchPointersAreKeptForOneFrameAfterRelease()
@@ -2144,8 +2122,6 @@ internal class UITests : CoreTestsFixture
 
         Assert.That(EventSystem.current.IsPointerOverGameObject(), Is.False);
     }
-
-#endif
 
     [UnityTest]
     [Category("UI")]
@@ -2373,7 +2349,6 @@ internal class UITests : CoreTestsFixture
         }, Is.Not.AllocatingGCMemory());
     }
 
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     // Check that two players can have separate UI, and that both selections will stay active when
@@ -2454,8 +2429,6 @@ internal class UITests : CoreTestsFixture
         Assert.That(players[0].eventSystem.currentSelectedGameObject, Is.SameAs(players[0].rightGameObject));
         Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.SameAs(players[1].rightGameObject));
     }
-
-#endif
 
     // Check that two players can have separate UI and control it using separate gamepads, using
     // MultiplayerEventSystem.
@@ -2774,7 +2747,6 @@ internal class UITests : CoreTestsFixture
         Assert.That(uiModule.point?.action, Is.Null);
     }
 
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanChangeControlsOnActions()
@@ -2818,8 +2790,6 @@ internal class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerExit).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == mouse));
     }
-
-#endif
 
     private class InputSystemUIInputModuleTestScene_Setup : IPrebuildSetup, IPostBuildCleanup
     {
@@ -3094,7 +3064,6 @@ internal class UITests : CoreTestsFixture
     }
 
     // https://forum.unity.com/threads/feature-request-option-to-disable-deselect-in-ui-input-module.761531
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_CanPreventAutomaticDeselectionOfGameObjects()
@@ -3155,9 +3124,6 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.leftGameObject));
     }
 
-#endif
-
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_WhenBindingsAreReResolved_PointerStatesAreKeptInSync()
@@ -3207,8 +3173,6 @@ internal class UITests : CoreTestsFixture
 
         Assert.That(EventSystem.current.IsPointerOverGameObject(), Is.True);
     }
-
-#endif
 
     ////REVIEW: While `deselectOnBackgroundClick` does solve the problem of breaking keyboard and gamepad navigation, the question
     ////        IMO is whether navigation should even be affected that way by not having a current selection. Seems to me that the
@@ -3447,7 +3411,7 @@ internal class UITests : CoreTestsFixture
     // to our manifest without breaking test runs with previous versions of Unity. However, in 2021.2, all the UITK functionality
     // has moved into the com.unity.modules.uielements module which is also available in previous versions of Unity. This way we
     // can have a reference to UITK that doesn't break things in previous versions of Unity.
-#if UNITY_2021_2_OR_NEWER && !TEMP_DISABLE_UI_TESTS_ON_TRUNK
+#if UNITY_2021_2_OR_NEWER
     [UnityTest]
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
@@ -3602,7 +3566,6 @@ internal class UITests : CoreTestsFixture
     }
 #endif
 
-#if !TEMP_DISABLE_UI_TESTS_ON_TRUNK
     static bool[] canRunInBackgroundValueSource = new[] { false, true };
 
     [UnityTest]
@@ -3696,8 +3659,6 @@ internal class UITests : CoreTestsFixture
         Assert.That(mouse.leftButton.isPressed, Is.False);
         Assert.That(clicked, Is.EqualTo(canRunInBackground));
     }
-
-#endif
 
     public class MyButton : UnityEngine.UI.Button
     {

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Unity.InputSystem.Tests",
+    "rootNamespace": "",
     "references": [
         "Unity.InputSystem",
         "Unity.InputSystem.TestFramework",
@@ -31,12 +32,7 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1.0a12,2022.1.0a17)",
-            "define": "TEMP_DISABLE_UI_TESTS_ON_TRUNK"
-        },
-        {
-            "name": "Unity",
-            "expression": "[2022.1.0a15,2022.1.0a17)",
+            "expression": "[2022.2.0a1,2022.2.0a10)",
             "define": "TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK"
         }
     ],

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -34,6 +34,11 @@
             "name": "Unity",
             "expression": "[2022.2.0a1,2022.2.0a10)",
             "define": "TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2021.2,2021.3)",
+            "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
* Trunk has now moved to 2022.2.0a1 where the UI issue that TEMP_DISABLE_UI_TESTS_ON_TRUNK helped us deal with has apparently been fixed.
* Updated TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK to skip the next 10 alpha versions.