### PR TITLE
FIX: InputAction.GetTimeoutCompletionPercentage() skipping to 100% (case 1377009).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTestsFixture.cs
+++ b/Assets/Tests/InputSystem/CoreTestsFixture.cs
@@ -3,6 +3,18 @@ using UnityEngine.SceneManagement;
 
 public class CoreTestsFixture : InputTestFixture
 {
+    public override void Setup()
+    {
+        base.Setup();
+
+        // https://fogbugz.unity3d.com/f/cases/1377009/
+        // Make sure the runtime's timeline has an offset compared to the input timeline.
+        // This ensures that we're tapping the right timeline in the code as in practice,
+        // the runtime's timeline will always have an offset.
+        runtime.currentTimeOffsetToRealtimeSinceStartup += 10;
+        runtime.currentTime = 20;
+    }
+
     public override void TearDown()
     {
         // Unload any additional scenes.
@@ -30,5 +42,12 @@ public class CoreTestsFixture : InputTestFixture
         }
 
         base.TearDown();
+    }
+
+    public void ResetTime()
+    {
+        runtime.currentTimeOffsetToRealtimeSinceStartup = default;
+        runtime.currentTimeForFixedUpdate = default;
+        currentTime = default;
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -52,6 +52,8 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_TimeoutsDoNotGetTriggeredInEditorUpdates()
     {
+        ResetTime();
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         // Devices get reset when losing focus so when we switch from the player to the editor,
@@ -74,7 +76,7 @@ partial class CoreTests
             trace.Clear();
 
             runtime.PlayerFocusLost();
-            runtime.currentTime = 10;
+            currentTime = 10;
 
             InputSystem.Update(InputUpdateType.Editor);
 
@@ -290,6 +292,8 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_WhenDisabled_CancelAllStartedInteractions()
     {
+        ResetTime();
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         var action1 = new InputAction("action1", InputActionType.Button, binding: "<Gamepad>/buttonSouth", interactions: "Hold");
@@ -309,7 +313,7 @@ partial class CoreTests
             trace.SubscribeTo(action2);
             trace.SubscribeTo(action3);
 
-            runtime.currentTime = 0.234f;
+            currentTime = 0.234f;
             runtime.advanceTimeEachDynamicUpdate = 0;
 
             action1.Disable();
@@ -338,7 +342,7 @@ partial class CoreTests
 
             Assert.That(action1.phase, Is.EqualTo(InputActionPhase.Waiting));
 
-            runtime.currentTime = 0.345f;
+            currentTime = 0.345f;
 
             Release(gamepad.buttonSouth);
             Press(gamepad.buttonSouth);
@@ -354,7 +358,7 @@ partial class CoreTests
 
             trace.Clear();
 
-            runtime.currentTime = 1;
+            currentTime = 1;
             InputSystem.Update();
 
             actions = trace.ToArray();
@@ -1626,6 +1630,7 @@ partial class CoreTests
         asset.AddActionMap(map3);
         asset.AddActionMap(map4);
 
+        var startTime = currentTime;
         using (var trace = new InputActionTrace())
         {
             trace.SubscribeToAll();
@@ -1633,103 +1638,50 @@ partial class CoreTests
             // Enable only map1.
             map1.Enable();
 
-            Set(gamepad.leftStick, new Vector2(0.123f, 0.234f), 0.123);
-
-            var actions = trace.ToArray();
+            Set(gamepad.leftStick, new Vector2(0.123f, 0.234f), startTime + 0.123);
 
             // map1/action1 should have been started and performed.
-            Assert.That(actions.Length, Is.EqualTo(2));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[0].action, Is.SameAs(action1));
-            Assert.That(actions[0].ReadValue<Vector2>,
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(-1, 1))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[0].interaction, Is.Null);
-            Assert.That(actions[0].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[0].time, Is.EqualTo(0.123).Within(0.00001));
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[1].action, Is.SameAs(action1));
-            Assert.That(actions[1].ReadValue<Vector2>,
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(-1, 1))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[1].interaction, Is.Null);
-            Assert.That(actions[1].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[1].time, Is.EqualTo(0.123).Within(0.00001));
+            Assert.That(trace,
+                Started(action1, value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(-1, 1),
+                    control: gamepad.leftStick, time: startTime + 0.123)
+                    .AndThen(Performed(action1,
+                    value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(-1, 1),
+                    control: gamepad.leftStick, time: startTime + 0.123)));
 
             trace.Clear();
 
-            runtime.currentTime = 0.234f;
+            currentTime = startTime + 0.234f;
 
             // Disable map1 and enable map2+map3.
             map1.Disable();
             map2.Enable();
             map3.Enable();
 
-            Press(gamepad.buttonSouth, 0.345f);
-            Set(gamepad.leftStick, new Vector2(0.234f, 0.345f), 0.456f);
+            Press(gamepad.buttonSouth, startTime + 0.345f);
+            Set(gamepad.leftStick, new Vector2(0.234f, 0.345f), startTime + 0.456f);
 
-            actions = trace.ToArray();
-            Assert.That(actions.Length, Is.EqualTo(6));
-
-            // map1/action1 should have been canceled.
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[0].action, Is.SameAs(action1));
-            Assert.That(actions[0].ReadValue<Vector2>(),
-                Is.EqualTo(default(Vector2))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[0].interaction, Is.Null);
-            Assert.That(actions[0].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[0].time, Is.EqualTo(0.234f));
-
-            // map3/action4 should immediately start as the stick was already actuated
-            // when we enabled the action.
-            // NOTE: We get a different value here than what action1 got as we have a different
-            //       processor on the binding.
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[1].action, Is.SameAs(action4));
-            Assert.That(actions[1].ReadValue<Vector2>,
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(1, -1))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[1].interaction, Is.Null);
-            Assert.That(actions[1].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[1].time, Is.EqualTo(0.234).Within(0.00001));
-
-            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[2].action, Is.SameAs(action4));
-            Assert.That(actions[2].ReadValue<Vector2>,
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(1, -1))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[2].interaction, Is.Null);
-            Assert.That(actions[2].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[2].time, Is.EqualTo(0.234).Within(0.00001));
-
-            // map2/action3 should have been started.
-            Assert.That(actions[3].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[3].action, Is.SameAs(action3));
-            Assert.That(actions[3].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
-            Assert.That(actions[3].interaction, Is.TypeOf<TapInteraction>());
-            Assert.That(actions[3].control, Is.SameAs(gamepad.buttonSouth));
-            Assert.That(actions[3].time, Is.EqualTo(0.345).Within(0.00001));
-
-            // map3/action5 should have been started.
-            Assert.That(actions[4].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[4].action, Is.SameAs(action5));
-            Assert.That(actions[4].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
-            Assert.That(actions[4].interaction, Is.TypeOf<TapInteraction>());
-            Assert.That(actions[4].interaction, Is.Not.SameAs(actions[1].interaction));
-            Assert.That(actions[4].control, Is.SameAs(gamepad.buttonSouth));
-            Assert.That(actions[4].time, Is.EqualTo(0.345).Within(0.00001));
-
-            // map3/action4 should have been performed as the stick has been moved
-            // beyond where it had already moved.
-            Assert.That(actions[5].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[5].action, Is.SameAs(action4));
-            Assert.That(actions[5].ReadValue<Vector2>,
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.234f, 0.345f)) * new Vector2(1, -1))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[5].interaction, Is.Null);
-            Assert.That(actions[5].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[5].time, Is.EqualTo(0.456).Within(0.00001));
+            Assert.That(trace,
+                // map1/action1 should have been canceled.
+                Canceled(action1, value: default(Vector2), control: gamepad.leftStick, time: startTime + 0.234)
+                // map3/action4 should immediately start as the stick was already actuated
+                // when we enabled the action.
+                // NOTE: We get a different value here than what action1 got as we have a different
+                //       processor on the binding.
+                    .AndThen(Started(action4,
+                    value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(1, -1),
+                    control: gamepad.leftStick, time: startTime + 0.234))
+                    .AndThen(Performed(action4,
+                        value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(1, -1),
+                        control: gamepad.leftStick, time: startTime + 0.234))
+                    // map2/action3 should have been started.
+                    .AndThen(Started<TapInteraction>(action3, value: 1f, control: gamepad.buttonSouth, time: startTime + 0.345))
+                    // map3/action5 should have been started.
+                    .AndThen(Started<TapInteraction>(action5, value: 1f, control: gamepad.buttonSouth, time: startTime + 0.345))
+                    // map3/action4 should have been performed as the stick has been moved
+                    // beyond where it had already moved.
+                    .AndThen(Performed(action4,
+                        value: new StickDeadzoneProcessor().Process(new Vector2(0.234f, 0.345f)) * new Vector2(1, -1),
+                        control: gamepad.leftStick, time: startTime + 0.456)));
 
             trace.Clear();
 
@@ -1737,40 +1689,19 @@ partial class CoreTests
             map2.Disable();
             map3.Disable();
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(3));
-
-            // map2/action3 should have been canceled.
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[0].action, Is.SameAs(action3));
-            Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(0));
-            Assert.That(actions[0].interaction, Is.TypeOf<TapInteraction>());
-            Assert.That(actions[0].control, Is.SameAs(gamepad.buttonSouth));
-            Assert.That(actions[0].time, Is.EqualTo(runtime.currentTime).Within(0.00001));
-
-            // map3/action3 should have been canceled.
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[1].action, Is.SameAs(action4));
-            Assert.That(actions[1].ReadValue<Vector2>,
-                Is.EqualTo(default(Vector2))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions[1].interaction, Is.Null);
-            Assert.That(actions[1].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions[1].time, Is.EqualTo(runtime.currentTime).Within(0.00001));
-
-            // map3/action5 should have been canceled.
-            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[2].action, Is.SameAs(action5));
-            Assert.That(actions[2].ReadValue<float>(), Is.EqualTo(0));
-            Assert.That(actions[2].interaction, Is.TypeOf<TapInteraction>());
-            Assert.That(actions[2].interaction, Is.Not.SameAs(actions[1].interaction));
-            Assert.That(actions[2].control, Is.SameAs(gamepad.buttonSouth));
-            Assert.That(actions[2].time, Is.EqualTo(runtime.currentTime).Within(0.00001));
+            Assert.That(trace,
+                // map2/action3 should have been canceled.
+                Canceled<TapInteraction>(action3, value: 0f, control: gamepad.buttonSouth, time: currentTime)
+                // map3/action4 should have been canceled.
+                    .AndThen(Canceled(action4, value: default(Vector2), control: gamepad.leftStick,
+                    time: currentTime))
+                    // map3/action5 should have been canceled.
+                    .AndThen(Canceled<TapInteraction>(action5, value: 0f, control: gamepad.buttonSouth, time: currentTime)));
 
             trace.Clear();
 
-            Set(gamepad.buttonSouth, 0, 1.23);
-            Set(gamepad.buttonSouth, 0, 1.34);
+            Set(gamepad.buttonSouth, 0, startTime + 1.23);
+            Set(gamepad.buttonSouth, 0, startTime + 1.34);
 
             Assert.That(trace, Is.Empty);
         }
@@ -3537,8 +3468,9 @@ partial class CoreTests
             wasPerformed = true;
         };
 
-        Press(gamepad.buttonSouth, time: 0);
-        Release(gamepad.buttonSouth, time: 0.1);
+        Press(gamepad.buttonSouth);
+        currentTime += 0.1f;
+        Release(gamepad.buttonSouth);
 
         Assert.That(wasPerformed, Is.True);
     }
@@ -4204,6 +4136,8 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_CanPerformHoldOnTrigger()
     {
+        ResetTime();
+
         InputSystem.settings.defaultButtonPressPoint = 0.1f;
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -4211,35 +4145,23 @@ partial class CoreTests
         var action = new InputAction(binding: "<Gamepad>/leftTrigger", interactions: "hold(duration=0.4)");
         action.Enable();
 
-        runtime.advanceTimeEachDynamicUpdate = 0;
-
         using (var trace = new InputActionTrace())
         {
             trace.SubscribeTo(action);
 
-            runtime.currentTime = 0.1f;
-            Set(gamepad.leftTrigger, 0.123f);
-            runtime.currentTime = 0.2f;
-            Set(gamepad.leftTrigger, 0.234f);
+            Set(gamepad.leftTrigger, 0.123f, time: 0.1f);
+            Set(gamepad.leftTrigger, 0.234f, time: 0.2f);
 
-            var actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[0].time, Is.EqualTo(0.1).Within(0.00001));
-            Assert.That(actions[0].ReadValue<float>, Is.EqualTo(0.123).Within(0.00001));
+            Assert.That(trace,
+                Started<HoldInteraction>(action, time: 0.1, value: 0.123f));
 
             trace.Clear();
 
-            runtime.currentTime = 0.6f;
-            Set(gamepad.leftTrigger, 0.345f);
-            runtime.currentTime = 0.7f;
-            Set(gamepad.leftTrigger, 0.456f);
+            Set(gamepad.leftTrigger, 0.345f, time: 0.6f);
+            Set(gamepad.leftTrigger, 0.456f, time: 0.7f);
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[0].time, Is.EqualTo(0.6).Within(0.00001));
-            Assert.That(actions[0].ReadValue<float>, Is.EqualTo(0.345).Within(0.00001));
+            Assert.That(trace,
+                Performed<HoldInteraction>(action, time: 0.6, value: 0.345));
             Assert.That(action.phase, Is.EqualTo(InputActionPhase.Performed));
         }
     }

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -198,8 +198,10 @@ internal partial class CoreTests
 
     [Test]
     [Category("Actions")]
-    public void Actions_WhenTransitionFromOneInteractionToNext_GetCallbacks()
+    public void Actions_WhenTransitioningFromOneInteractionToNext_GetCallbacks()
     {
+        ResetTime();
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         var action = new InputAction("test", InputActionType.Button, binding: "<Gamepad>/buttonSouth",
@@ -217,7 +219,7 @@ internal partial class CoreTests
 
             // Expire the tap. The system should transitioning from the tap to a slowtap.
             // Note the starting time of the slowTap will be 0 not 2.
-            runtime.currentTime = 2;
+            currentTime = 2;
             InputSystem.Update();
 
             Assert.That(trace,
@@ -230,6 +232,8 @@ internal partial class CoreTests
     [Category("Actions")]
     public void Actions_CanPerformPressInteraction()
     {
+        ResetTime();
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         // We add a second input device (and bind to it), to test that the binding
@@ -252,7 +256,7 @@ internal partial class CoreTests
         using (var releaseOnly = new InputActionTrace(releaseOnlyAction))
         using (var pressAndRelease = new InputActionTrace(pressAndReleaseAction))
         {
-            runtime.currentTime = 1;
+            currentTime = 1;
             Press(gamepad.buttonSouth);
 
             Assert.That(pressOnly,
@@ -267,7 +271,7 @@ internal partial class CoreTests
             releaseOnly.Clear();
             pressAndRelease.Clear();
 
-            runtime.currentTime = 2;
+            currentTime = 2;
             Release(gamepad.buttonSouth);
 
             Assert.That(pressOnly, Canceled<PressInteraction>(pressOnlyAction, gamepad.buttonSouth, value: 0.0, time: 2, duration: 1));
@@ -282,7 +286,7 @@ internal partial class CoreTests
             releaseOnly.Clear();
             pressAndRelease.Clear();
 
-            runtime.currentTime = 5;
+            currentTime = 5;
             Press(gamepad.buttonSouth);
 
             Assert.That(pressOnly,
@@ -565,6 +569,8 @@ internal partial class CoreTests
     [Category("Actions")]
     public void Actions_CanPerformTapInteraction()
     {
+        ResetTime();
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         var performedReceivedCalls = 0;
@@ -633,7 +639,7 @@ internal partial class CoreTests
             trace.SubscribeTo(action);
 
             // Press button.
-            runtime.currentTime = 1;
+            currentTime = 1;
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 1);
             InputSystem.Update();
 
@@ -647,7 +653,7 @@ internal partial class CoreTests
             trace.Clear();
 
             // Release before tap time and make sure the double tap cancels.
-            runtime.currentTime = 12;
+            currentTime = 12;
             InputSystem.QueueStateEvent(gamepad, new GamepadState(), 1.75);
             InputSystem.Update();
 
@@ -662,7 +668,7 @@ internal partial class CoreTests
 
             // Press again and then release before tap time. Should see only the start from
             // the initial press.
-            runtime.currentTime = 2.5;
+            currentTime = 2.5;
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 2);
             InputSystem.QueueStateEvent(gamepad, new GamepadState(), 2.25);
             InputSystem.Update();
@@ -678,7 +684,7 @@ internal partial class CoreTests
             trace.Clear();
 
             // Wait for longer than tapDelay and make sure we're seeing a cancellation.
-            runtime.currentTime = 4;
+            currentTime = 4;
             InputSystem.Update();
 
             actions = trace.ToArray();
@@ -693,7 +699,7 @@ internal partial class CoreTests
 
             // Now press and release within tap time. Then press again within delay time but release
             // only after tap time. Should we started and canceled.
-            runtime.currentTime = 6;
+            currentTime = 6;
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 4.7);
             InputSystem.QueueStateEvent(gamepad, new GamepadState(), 4.9);
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 5);
@@ -716,7 +722,7 @@ internal partial class CoreTests
             trace.Clear();
 
             // Finally perform a full, proper double tap cycle.
-            runtime.currentTime = 8;
+            currentTime = 8;
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 7);
             InputSystem.QueueStateEvent(gamepad, new GamepadState(), 7.25);
             InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South), 7.5);

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -641,7 +641,7 @@ partial class CoreTests
         InputSystem.Update();
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0).Within(0.00001));
 
-        runtime.currentTimeForFixedUpdate = 1;
+        runtime.currentTimeForFixedUpdate = runtime.currentTime + 1;
         InputSystem.Update();
         Assert.That(gamepad.leftTrigger.ReadValue(), Is.EqualTo(0.123).Within(0.00001));
     }

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -3082,21 +3082,21 @@ partial class CoreTests
         BeginTouch(4, new Vector2(0.123f, 0.234f), time: 0.1);
         BeginTouch(5, new Vector2(0.234f, 0.345f), time: 0.2);
 
-        Assert.That(touchscreen.touches[0].startTime.ReadValue(), Is.EqualTo(0.1));
-        Assert.That(touchscreen.touches[1].startTime.ReadValue(), Is.EqualTo(0.2));
+        Assert.That(touchscreen.touches[0].startTime.ReadValue(), Is.EqualTo(0.1).Within(0.0001));
+        Assert.That(touchscreen.touches[1].startTime.ReadValue(), Is.EqualTo(0.2).Within(0.0001));
 
         MoveTouch(4, new Vector2(0.345f, 0.456f), time: 0.3);
         MoveTouch(4, new Vector2(0.456f, 0.567f), time: 0.3);
         MoveTouch(5, new Vector2(0.567f, 0.678f), time: 0.4);
 
-        Assert.That(touchscreen.touches[0].startTime.ReadValue(), Is.EqualTo(0.1));
-        Assert.That(touchscreen.touches[1].startTime.ReadValue(), Is.EqualTo(0.2));
+        Assert.That(touchscreen.touches[0].startTime.ReadValue(), Is.EqualTo(0.1).Within(0.0001));
+        Assert.That(touchscreen.touches[1].startTime.ReadValue(), Is.EqualTo(0.2).Within(0.0001));
 
         EndTouch(4, new Vector2(0.123f, 0.234f), time: 0.5);
         EndTouch(5, new Vector2(0.234f, 0.345f), time: 0.5);
 
-        Assert.That(touchscreen.touches[0].startTime.ReadValue(), Is.EqualTo(0.1));
-        Assert.That(touchscreen.touches[1].startTime.ReadValue(), Is.EqualTo(0.2));
+        Assert.That(touchscreen.touches[0].startTime.ReadValue(), Is.EqualTo(0.1).Within(0.0001));
+        Assert.That(touchscreen.touches[1].startTime.ReadValue(), Is.EqualTo(0.2).Within(0.0001));
     }
 
     [Test]
@@ -3132,14 +3132,14 @@ partial class CoreTests
             Assert.That(allTouchTaps[1].control, Is.SameAs(touchscreen.touches[0].tap));
             Assert.That(allTouchTaps[0].ReadValue(), Is.EqualTo(1));
             Assert.That(allTouchTaps[1].ReadValue(), Is.EqualTo(0));
-            Assert.That(allTouchTaps[0].time, Is.EqualTo(0.3));
-            Assert.That(allTouchTaps[1].time, Is.EqualTo(0.3));
+            Assert.That(allTouchTaps[0].time, Is.EqualTo(0.3).Within(0.0001));
+            Assert.That(allTouchTaps[1].time, Is.EqualTo(0.3).Within(0.0001));
             Assert.That(allTouchTaps[2].control, Is.SameAs(touchscreen.touches[1].tap));
             Assert.That(allTouchTaps[3].control, Is.SameAs(touchscreen.touches[1].tap));
             Assert.That(allTouchTaps[2].ReadValue(), Is.EqualTo(1));
             Assert.That(allTouchTaps[3].ReadValue(), Is.EqualTo(0));
-            Assert.That(allTouchTaps[2].time, Is.EqualTo(0.3));
-            Assert.That(allTouchTaps[3].time, Is.EqualTo(0.3));
+            Assert.That(allTouchTaps[2].time, Is.EqualTo(0.3).Within(0.0001));
+            Assert.That(allTouchTaps[3].time, Is.EqualTo(0.3).Within(0.0001));
 
             // The primary touch switched from touch #0 to touch #1 when we released
             // touch #0 while touch #1 was still ongoing. Even though touch #1 then
@@ -3166,16 +3166,16 @@ partial class CoreTests
             Assert.That(allTouchTaps[1].control, Is.SameAs(touchscreen.touches[0].tap));
             Assert.That(allTouchTaps[0].ReadValue(), Is.EqualTo(1));
             Assert.That(allTouchTaps[1].ReadValue(), Is.EqualTo(0));
-            Assert.That(allTouchTaps[0].time, Is.EqualTo(0.8));
-            Assert.That(allTouchTaps[1].time, Is.EqualTo(0.8));
+            Assert.That(allTouchTaps[0].time, Is.EqualTo(0.8).Within(0.0001));
+            Assert.That(allTouchTaps[1].time, Is.EqualTo(0.8).Within(0.0001));
 
             Assert.That(primaryTouchTap, Has.Count.EqualTo(2));
             Assert.That(primaryTouchTap[0].control, Is.SameAs(touchscreen.primaryTouch.tap));
             Assert.That(primaryTouchTap[1].control, Is.SameAs(touchscreen.primaryTouch.tap));
             Assert.That(primaryTouchTap[0].ReadValue(), Is.EqualTo(1));
             Assert.That(primaryTouchTap[1].ReadValue(), Is.EqualTo(0));
-            Assert.That(primaryTouchTap[0].time, Is.EqualTo(0.8));
-            Assert.That(primaryTouchTap[1].time, Is.EqualTo(0.8));
+            Assert.That(primaryTouchTap[0].time, Is.EqualTo(0.8).Within(0.0001));
+            Assert.That(primaryTouchTap[1].time, Is.EqualTo(0.8).Within(0.0001));
         }
     }
 
@@ -3183,6 +3183,8 @@ partial class CoreTests
     [Category("Devices")]
     public void Devices_CanDetectTouchTaps_AndKeepTrackOfTapCounts()
     {
+        ResetTime();
+
         // Give us known tap settings.
         InputSystem.settings.defaultTapTime = 0.5f;
         InputSystem.settings.tapRadius = 5;
@@ -3202,7 +3204,7 @@ partial class CoreTests
         Assert.That(touchscreen.touches[0].tapCount.ReadValue(), Is.EqualTo(2));
         Assert.That(touchscreen.primaryTouch.tapCount.ReadValue(), Is.EqualTo(2));
 
-        runtime.currentTime = 10;
+        currentTime = 10;
         InputSystem.Update();
 
         Assert.That(touchscreen.touches[0].tapCount.ReadValue(), Is.Zero);

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -416,6 +416,8 @@ partial class CoreTests
     [Category("Events")]
     public void Events_CanSwitchToProcessingInFixedUpdates()
     {
+        ResetTime();
+
         var mouse = InputSystem.AddDevice<Mouse>();
 
         var receivedOnChange = true;
@@ -468,6 +470,7 @@ partial class CoreTests
         InputSystem.settings.updateMode = InputSettings.UpdateMode.ProcessEventsInFixedUpdate;
 
         runtime.currentTimeForFixedUpdate = 1;
+        runtime.currentTimeOffsetToRealtimeSinceStartup = 0;
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
@@ -555,7 +558,7 @@ partial class CoreTests
         var keyboard = InputSystem.AddDevice<Keyboard>();
 
         runtime.advanceTimeEachDynamicUpdate = 0;
-        runtime.currentTime = 10;
+        currentTime = 10;
 
         InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A), 6);
         InputSystem.QueueStateEvent(gamepad, new GamepadState {leftStick = new Vector2(0.123f, 0.234f)}, 1);
@@ -590,7 +593,7 @@ partial class CoreTests
             var stateEventPtr = StateEvent.From(eventPtr);
 
             Assert.That(stateEventPtr->baseEvent.deviceId, Is.EqualTo(mouse.deviceId));
-            Assert.That(stateEventPtr->baseEvent.time, Is.EqualTo(runtime.currentTime));
+            Assert.That(stateEventPtr->baseEvent.time, Is.EqualTo(InputState.currentTime));
             Assert.That(stateEventPtr->baseEvent.sizeInBytes.AlignToMultipleOf(4), Is.EqualTo(buffer.Length));
             Assert.That(stateEventPtr->baseEvent.sizeInBytes,
                 Is.EqualTo(InputEvent.kBaseEventSize + sizeof(FourCC) + mouse.stateBlock.alignedSizeInBytes));

--- a/Assets/Tests/InputSystem/CoreTests_Remoting.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Remoting.cs
@@ -120,6 +120,8 @@ partial class CoreTests
     [Category("Remote")]
     public void Remote_EventsAreSentToRemotes()
     {
+        ResetTime();
+
         var gamepad = InputSystem.AddDevice<Gamepad>();
 
         using (var remote = new FakeRemote())

--- a/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/EnhancedTouchTests.cs
@@ -121,6 +121,8 @@ internal class EnhancedTouchTests : CoreTestsFixture
     [TestCase(InputSettings.UpdateMode.ProcessEventsInFixedUpdate, InputUpdateType.Fixed)]
     public void EnhancedTouch_SupportsInputUpdateIn(InputSettings.UpdateMode updateMode, InputUpdateType updateType)
     {
+        ResetTime();
+
         InputSystem.settings.updateMode = updateMode;
         runtime.currentTimeForFixedUpdate += Time.fixedDeltaTime;
         BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
@@ -139,6 +141,8 @@ internal class EnhancedTouchTests : CoreTestsFixture
     [TestCase(InputSettings.UpdateMode.ProcessEventsInFixedUpdate)]
     public void EnhancedTouch_SupportsEditorUpdates(InputSettings.UpdateMode updateMode)
     {
+        ResetTime();
+
         InputSystem.settings.editorInputBehaviorInPlayMode = default;
 
         // To better observe that play mode and edit mode state is indeed independent and handled
@@ -502,13 +506,13 @@ internal class EnhancedTouchTests : CoreTestsFixture
     [Category("EnhancedTouch")]
     public void EnhancedTouch_CanGetStartPositionAndTimeOfTouch()
     {
-        runtime.currentTime = 0.111;
+        currentTime = 0.111;
         BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
         MoveTouch(1, new Vector2(0.234f, 0.345f), queueEventOnly: true);
-        runtime.currentTime = 0.222;
+        currentTime = 0.222;
         MoveTouch(1, new Vector2(0.345f, 0.456f), queueEventOnly: true);
         BeginTouch(2, new Vector2(0.456f, 0.567f), queueEventOnly: true);
-        runtime.currentTime = 0.333;
+        currentTime = 0.333;
         EndTouch(2, new Vector2(0.567f, 0.678f), queueEventOnly: true);
         InputSystem.Update();
 
@@ -516,8 +520,8 @@ internal class EnhancedTouchTests : CoreTestsFixture
             Is.EqualTo(new Vector2(0.123f, 0.234f)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Touch.activeTouches[1].startScreenPosition,
             Is.EqualTo(new Vector2(0.456f, 0.567f)).Using(Vector2EqualityComparer.Instance));
-        Assert.That(Touch.activeTouches[0].startTime, Is.EqualTo(0.111));
-        Assert.That(Touch.activeTouches[1].startTime, Is.EqualTo(0.222));
+        Assert.That(Touch.activeTouches[0].startTime, Is.EqualTo(0.111).Within(0.0001));
+        Assert.That(Touch.activeTouches[1].startTime, Is.EqualTo(0.222).Within(0.0001));
     }
 
     [Test]
@@ -526,6 +530,8 @@ internal class EnhancedTouchTests : CoreTestsFixture
     [TestCase(true)]
     public void EnhancedTouch_CanAccessHistoryOfTouch_WithEventMergingSetTo(bool mergeRedundantEvents)
     {
+        ResetTime();
+
         InputSystem.settings.disableRedundantEventsMerging = !mergeRedundantEvents;
 
         // Noise. This one shouldn't show up in the history.
@@ -534,9 +540,9 @@ internal class EnhancedTouchTests : CoreTestsFixture
         InputSystem.Update();
         InputSystem.Update(); // The end touch lingers for one frame.
 
-        runtime.currentTime = 0.876;
+        currentTime = 0.876;
         BeginTouch(1, new Vector2(0.123f, 0.234f), queueEventOnly: true);
-        runtime.currentTime = 0.987;
+        currentTime = 0.987;
         MoveTouch(1, new Vector2(0.234f, 0.345f), queueEventOnly: true);
         MoveTouch(1, new Vector2(0.345f, 0.456f), queueEventOnly: true);
         MoveTouch(1, new Vector2(0.456f, 0.567f), queueEventOnly: true);
@@ -553,15 +559,15 @@ internal class EnhancedTouchTests : CoreTestsFixture
         Assert.That(Touch.activeTouches[0].history, Has.All.Property("finger").SameAs(Touch.activeTouches[0].finger));
         var beganIndex = mergeRedundantEvents ? 1 : 2;
         Assert.That(Touch.activeTouches[0].history[beganIndex].phase, Is.EqualTo(TouchPhase.Began));
-        Assert.That(Touch.activeTouches[0].history[beganIndex].time, Is.EqualTo(0.876));
-        Assert.That(Touch.activeTouches[0].history[beganIndex].startTime, Is.EqualTo(0.876));
+        Assert.That(Touch.activeTouches[0].history[beganIndex].time, Is.EqualTo(0.876).Within(0.0001));
+        Assert.That(Touch.activeTouches[0].history[beganIndex].startTime, Is.EqualTo(0.876).Within(0.0001));
         Assert.That(Touch.activeTouches[0].history[beganIndex].startScreenPosition,
             Is.EqualTo(new Vector2(0.123f, 0.234f)).Using(Vector2EqualityComparer.Instance));
         for (int index = 0; index < (mergeRedundantEvents ? 1 : 2); ++index)
         {
             Assert.That(Touch.activeTouches[0].history[index].phase, Is.EqualTo(TouchPhase.Moved));
-            Assert.That(Touch.activeTouches[0].history[index].time, Is.EqualTo(0.987));
-            Assert.That(Touch.activeTouches[0].history[index].startTime, Is.EqualTo(0.876));
+            Assert.That(Touch.activeTouches[0].history[index].time, Is.EqualTo(0.987).Within(0.0001));
+            Assert.That(Touch.activeTouches[0].history[index].startTime, Is.EqualTo(0.876).Within(0.0001));
             Assert.That(Touch.activeTouches[0].history[index].startScreenPosition,
                 Is.EqualTo(new Vector2(0.123f, 0.234f)).Using(Vector2EqualityComparer.Instance));
         }

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -251,6 +251,8 @@ internal class UITests : CoreTestsFixture
     [TestCase("GenericDeviceWithPointingAbility", UIPointerType.MouseOrPen, PointerEventData.InputButton.Left, ExpectedResult = 1)]
     public IEnumerator UI_CanDriveUIFromPointer(string deviceLayout, UIPointerType pointerType, PointerEventData.InputButton clickButton)
     {
+        ResetTime();
+
         InputSystem.RegisterLayout(kTrackedDeviceWithButton);
         InputSystem.RegisterLayout(kGenericDeviceWithPointingAbility);
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,14 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Fixed
+
+#### Actions
+
+* Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
+
+## [Unreleased]
+
 ### Changed
 
 - The artificial `ctrl`, `shift`, and `alt` controls (which combine the left and right controls into one) on the keyboard can now be written to and no longer throw `NotSupportedException` when trying to do so ([case 1340793](https://issuetracker.unity3d.com/issues/on-screen-button-errors-on-mouse-down-slash-up-when-its-control-path-is-set-to-control-keyboard)).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1372,7 +1372,7 @@ namespace UnityEngine.InputSystem
                         var duration = interactionState.timerDuration;
                         var startTime = interactionState.timerStartTime;
                         var endTime = startTime + duration;
-                        var remainingTime = endTime - InputRuntime.s_Instance.currentTime;
+                        var remainingTime = endTime - InputState.currentTime;
                         if (remainingTime <= 0)
                             timerCompletion = 1;
                         else

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -2095,7 +2095,7 @@ namespace UnityEngine.InputSystem
                     throw new InvalidOperationException(
                         "Must either have an action (call WithAction()) to apply binding to or have a custom callback to apply the binding (call OnApplyBinding())");
 
-                m_StartTime = InputRuntime.s_Instance.currentTime;
+                m_StartTime = InputState.currentTime;
 
                 if (m_WaitSecondsAfterMatch > 0 || m_Timeout > 0)
                 {
@@ -2390,7 +2390,7 @@ namespace UnityEngine.InputSystem
                             m_Scores[candidateIndex] = score;
 
                             if (m_WaitSecondsAfterMatch > 0)
-                                m_LastMatchTime = InputRuntime.s_Instance.currentTime;
+                                m_LastMatchTime = InputState.currentTime;
                         }
                     }
                     else
@@ -2404,7 +2404,7 @@ namespace UnityEngine.InputSystem
                         haveChangedCandidates = true;
 
                         if (m_WaitSecondsAfterMatch > 0)
-                            m_LastMatchTime = InputRuntime.s_Instance.currentTime;
+                            m_LastMatchTime = InputState.currentTime;
                     }
                 }
 
@@ -2490,7 +2490,7 @@ namespace UnityEngine.InputSystem
                 // If we don't have a match yet but we have a timeout and have expired it,
                 // cancel the operation.
                 if (m_LastMatchTime < 0 && m_Timeout > 0 &&
-                    InputRuntime.s_Instance.currentTime - m_StartTime > m_Timeout)
+                    InputState.currentTime - m_StartTime > m_Timeout)
                 {
                     Cancel();
                     return;
@@ -2505,7 +2505,7 @@ namespace UnityEngine.InputSystem
                     return;
 
                 // Complete if timeout has expired.
-                if (InputRuntime.s_Instance.currentTime >= m_LastMatchTime + m_WaitSecondsAfterMatch)
+                if (InputState.currentTime >= m_LastMatchTime + m_WaitSecondsAfterMatch)
                     Complete();
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -489,7 +489,7 @@ namespace UnityEngine.InputSystem
             if (actionState->phase != InputActionPhase.Waiting && actionState->phase != InputActionPhase.Disabled)
             {
                 // Cancellation calls should receive current time.
-                actionState->time = InputRuntime.s_Instance.currentTime;
+                actionState->time = InputState.currentTime;
 
                 // If the action got triggered from an interaction, go and reset all interactions on the binding
                 // that got triggered.
@@ -900,7 +900,7 @@ namespace UnityEngine.InputSystem
             Profiler.BeginSample("InitialActionStateCheck");
 
             // Use current time as time of control state change.
-            var time = InputRuntime.s_Instance.currentTime;
+            var time = InputState.currentTime;
 
             ////REVIEW: should we store this data in a separate place rather than go through all bindingStates?
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -623,9 +623,7 @@ namespace UnityEngine.InputSystem
                 var totalSize = 0u;
                 var eventPtr = new InputEventPtr(events);
                 for (var i = 0; i < eventCount; ++i, eventPtr = eventPtr.Next())
-                {
-                    totalSize += eventPtr.sizeInBytes;
-                }
+                    totalSize = totalSize.AlignToMultipleOf(4) + eventPtr.sizeInBytes;
 
                 // Copy event data to buffer. Would be nice if we didn't have to do that
                 // but unfortunately we need a byte[] and can't just pass the 'events' IntPtr

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -529,10 +529,7 @@ namespace UnityEngine.InputSystem
 
             void SetUpAndQueueEvent(InputEventPtr eventPtr)
             {
-                ////REVIEW: should we by default take the time from the device here?
-                if (time >= 0)
-                    eventPtr.time = time;
-                eventPtr.time += timeOffset;
+                eventPtr.time = (time >= 0 ? time : InputState.currentTime) + timeOffset;
                 control.WriteValueIntoEvent(state, eventPtr);
                 InputSystem.QueueEvent(eventPtr);
             }
@@ -650,7 +647,7 @@ namespace UnityEngine.InputSystem
                 position = position,
                 delta = delta,
                 pressure = pressure,
-            }, (time >= 0 ? time : InputRuntime.s_Instance.currentTime) + timeOffset);
+            }, (time >= 0 ? time : InputState.currentTime) + timeOffset);
             if (!queueEventOnly)
                 InputSystem.Update();
         }
@@ -726,10 +723,10 @@ namespace UnityEngine.InputSystem
         /// <value>Current time used by the input system.</value>
         public double currentTime
         {
-            get => runtime.currentTime;
+            get => runtime.currentTime - runtime.currentTimeOffsetToRealtimeSinceStartup;
             set
             {
-                runtime.currentTime = value;
+                runtime.currentTime = value + runtime.currentTimeOffsetToRealtimeSinceStartup;
                 runtime.dontAdvanceTimeNextDynamicUpdate = true;
             }
         }


### PR DESCRIPTION
Fixes [1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1377009/)).

### Description

`InputAction.GetTimeoutCompletionPercentage` would jump to 100% in next input update. Turns out that several places in `InputActionState` were tapping the wrong timeline and just taking `IInputRuntime.currentTime` as is. This meant that they didn't apply `currentTimeOffsetToRealTimeSinceStartup`.

### Changes made

* Changed several places to go to `InputState.currentTime` instead. This is what all code, except those parts dealing directly with raw events, should be using.
* Since our tests didn't catch this, changed our `CoreTestFixture` to actually run all tests with both an existing `currentTimeOffsetToRealTimeSinceStartup` and an actual non-zero time. This immediately made `Actions_CanGetCompletionPercentageOfTimeoutOnInteraction` fail.

### Notes

The last change required patching up a number of existing tests. Some I changed to be okay with relative time but some that are relying on absolute time I added a `ResetTime()` method for so that they can start at absolute zero.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
