### PR TITLE
adds tracking flags to the tracked pose driver.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Deprecated `InputSettings.filterNoiseOnCurrent`. Now noise filtering is always enabled. Device only will become `.current` if any non-noise control have changed state.
 - A device reset (such as when focus is lost) on `Touchscreen` will now result in all ongoing touches getting cancelled instead of all touches being simply reset to default state.
 - Calling `InputTestFixture.Press`, `InputTestFixture.Set`, etc. from within a `[UnityTest]` will no longer immediately process input. Instead, input will be processed like it normally would as part of the Unity player loop.
+- Added `TrackingStateFlags` to the tracked pose driver packaged with the input system. Assigning this to an IntegerControl which provides TrackingState information will now correctly only apply those elements that actually recieved reliable data. If a TrackingStateFlags is not provided, it is assumed both position and rotation are valid.
 
 ### Fixed
 


### PR DESCRIPTION
### Description

Adds optional tracking state flags to the Tracked Pose Driver.
When no action reference / inline action to the tracking state flags (int) is used, the Tracked Pose Driver operates as per current.
When an action is provided, we check the flags and only apply the position/rotation components that were actually indicated as correct by the tracking state flags.

This will resolve snap to zero issues when using the TPD

### Changes made

Change the trackedposedriver.cs file to allow additional Tracking State Flag actions.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
