### PR TITLE
Fixed event merger ignoring timeslicing boundaries

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -63,6 +63,7 @@ however, it has to be formatted properly to pass verification tests.
   * Fix contributed by [Russell Quinn](https://github.com/russellquinn) in [#1483](https://github.com/Unity-Technologies/InputSystem/pull/1483).
 - Fixed `AxisComposite` not respecting processors applied to `positive` and `negative` bindings (case 1398942).
   * This was a regression introduced in [1.0.0-pre.6](#axiscomposite-min-max-value-fix).
+- Fixed mouse events not being timesliced when input system is switched to process input in fixed updates (case 1386738).
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3239,11 +3239,18 @@ namespace UnityEngine.InputSystem
                         //       new buffering scheme for input events working in the native runtime.
 
                         var nextEvent = m_InputEventStream.Peek();
-                        if (nextEvent != null && currentEventReadPtr->deviceId == nextEvent->deviceId)
+                        // If there is next event after current one.
+                        if ((nextEvent != null)
+                            // And if next event is for the same device.
+                            && (currentEventReadPtr->deviceId == nextEvent->deviceId)
+                            // And if next event is in the same timeslicing slot.
+                            && (timesliceEvents ? (nextEvent->internalTime < currentTime) : true)
+                        )
                         {
+                            // Then try to merge current event into next event.
                             if (((IEventMerger)device).MergeForward(currentEventReadPtr, nextEvent))
                             {
-                                // Event was merged into next event, skipping.
+                                // And if succeeded, skip current event, as it was merged into next event.
                                 m_InputEventStream.Advance(false);
                                 continue;
                             }


### PR DESCRIPTION
### Description

When input system is in fixed updates mode, event merger was merging forward with "next" event, even if it was outside of current timeslice slot. That lead to potentially only one of the fixed updates in the player loop receiving all events merged at a same time.

### Changes made

Added an extra clause to limit merging to current timeslicing slot.
