### PR TITLE
Add missing mapIndex init when creating a new TriggerState

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1791,6 +1791,7 @@ namespace UnityEngine.InputSystem
                                     controlIndex = interactionStates[index].triggerControlIndex,
                                     bindingIndex = trigger.bindingIndex,
                                     interactionIndex = index,
+                                    mapIndex = trigger.mapIndex,
                                     time = interactionStates[index].performedTime, // Time when the interaction performed.
                                     startTime = startTime,
                                 };


### PR DESCRIPTION
### Description

My project (Unity 2020.3.25f1 and InputSystem 1.2.0) was experiencing lots of out-of-bound errors and exceptions related to actions not being valid in a map. I investigated the Package code and saw `mapIndex` was always zero. I traced this back to `ChangePhaseOfInteraction` in `InputActionState.cs`. There are two different times that a `new TriggerState` is created. The second instance, is missing the initialization of `mapIndex = trigger.mapIndex`.

### Changes made

I added in `mapIndex = trigger.mapIndex` to give `mapIndex` a valid value. It fixed my crashes.

### Notes

I tested this by cloning the InputSystem repo, creating a new branch from the 1.2.0 release commit (to verify that my change was the fix, and that it hadn't been resolved since), changed the line, removed the official InputSystem package from my project and then added a Git Package in Package Manager, pointing to my clone and branch. It fixed the crashes.

I think it might be the solution to this post too: https://forum.unity.com/threads/map-index-on-trigger-does-not-correspond-to-map-index-of-trigger-state.1145087/

@Rene-Damm It looks like the original code was added in this commit: https://github.com/Unity-Technologies/InputSystem/commit/7e6490903117a600299099bf3235ec4b3a2548b4

**UPDATE: See my comment below for further investigation into what bug this actually fixes.**