### PR TITLE
Fixed bug where 'Keyboard/escape' would match 'Keyboard/e', and the k…

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -1404,22 +1404,21 @@ namespace UnityEngine.InputSystem
                 var pathElementLength = pathElement.length;
                 var elementLength = element.Length;
 
-                // `element` is expected to not include escape sequence. `pathElement` may.
-                // So if `element` is longer than `pathElement`, the two can't be a match.
-                if (elementLength > pathElementLength)
-                    return false;
-
-                for (var i = 0; i < pathElementLength && i < elementLength; ++i)
+                for (int i = 0, j = 0;;i++, j++)
                 {
+                    var pathElementDone = i == pathElementLength;
+                    var elementDone     = j == elementLength;
+
+                    if (pathElementDone || elementDone)
+                        return pathElementDone == elementDone;
+
                     var ch = pathElement[i];
                     if (ch == '\\' && i + 1 < pathElementLength)
                         ch = pathElement[++i];
 
-                    if (char.ToLowerInvariant(ch) != char.ToLowerInvariant(element[i]))
+                    if (char.ToLowerInvariant(ch) != char.ToLowerInvariant(element[j]))
                         return false;
                 }
-
-                return true;
             }
         }
 


### PR DESCRIPTION
Fixed bug where 'Keyboard/escape' would match 'Keyboard/e', and the key 'e' would therefore not be mappable.

### Problem

When using RebindingOperation().WithCancelingThrough("\<Keyboard\>/escape"), the operation will be treated as cancelled, if the user presses the e button.

### Changes made

The custom string comparison was written so that only the shortest string length was used during comparison. And while the index of the compared character would happily skip ahead if any "escaped characters", no index was tracking the string that supposedly didn't have that same escaped character.

So previously  'abc\n'  would match 'abc*n', (and the fourth character isn't compared) but now instead 'abc\n' will match 'abcn', because the escaping character i taken out of the equation.

More importantly   'AB' will no longer match 'A', and vice versa.
