### PR TITLE
Fixing CloseWindow being called when clicking on separator items in dropdown window

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,10 +13,11 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
+- Fixed `InvalidCastException: Specified cast is not valid.` being thrown when clicking on menu separators in the control picker ([case 1388049](https://issuetracker.unity3d.com/issues/invalidcastexception-is-thrown-when-selecting-the-header-of-an-advanceddropdown)).
 
 #### Actions
 
-* Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
+- Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
 
 ## [1.3.0] - 2021-12-10
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownWindow.cs
@@ -463,12 +463,9 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         GoToChild();
                     }
-                    else
+                    else if (!selectedChild.IsSeparator())
                     {
-                        if (!selectedChild.IsSeparator() && selectionChanged != null)
-                        {
-                            selectionChanged(selectedChild);
-                        }
+                        selectionChanged?.Invoke(selectedChild);
                         if (closeOnSelection)
                         {
                             CloseWindow();


### PR DESCRIPTION
### Description

If you click on separator item in the control picker, we were closing the window and as part of that calling `ItemSelected` which was trying to cast to `InputControlDropdownItem` and failing (InputControlDropdownItem.cs line 123), stack around the bug:

```
InvalidCastException: Specified cast is not valid.
UnityEngine.InputSystem.Editor.InputControlPickerDropdown.ItemSelected (UnityEngine.InputSystem.Editor.AdvancedDropdownItem item) (at Library/PackageCache/com.unity.inputsystem@1.2.0/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs:123)
UnityEngine.InputSystem.Editor.AdvancedDropdown.<Show>b__13_0 (UnityEngine.InputSystem.Editor.AdvancedDropdownWindow w) (at Library/PackageCache/com.unity.inputsystem@1.2.0/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdown.cs:46)
UnityEngine.InputSystem.Editor.AdvancedDropdownWindow.CloseWindow () (at Library/PackageCache/com.unity.inputsystem@1.2.0/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownWindow.cs:387)
```

### Changes made

Not closing the window when selecting separators.
