### PR TITLE
CHANGE: Behavior between button release threshold and zero (case 1393330).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -335,7 +335,7 @@ internal partial class CoreTests
 
             Set(gamepad.leftTrigger, 0.3f);
 
-            Assert.That(trace, Canceled(action, control: gamepad.leftTrigger, value: 0f));
+            Assert.That(trace, Started(action, control: gamepad.leftTrigger, value: 0.3f));
         }
     }
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,25 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+## Changed
+
+* `Button` type `InputAction`s now go to `started` when a button goes from a press to below the release threshold but not yet to 0 ([case ]
+  ```CSharp
+  // Before:
+  Set(Gamepad.current.rightTrigger, 0.7f); // Performed (pressed)
+  Set(Gamepad.current.rightTrigger, 0.2f); // Canceled (released)
+  Set(Gamepad.current.rightTrigger, 0.1f); // Started!!
+  Set(Gamepad.current.rightTrigger, 0f);   // Canceled
+
+  // Now:
+  Set(Gamepad.current.rightTrigger, 0.7f); // Performed (pressed)
+  Set(Gamepad.current.rightTrigger, 0.2f); // Started (released but not fully)
+  Set(Gamepad.current.rightTrigger, 0.1f); // <Nothing>
+  Set(Gamepad.current.rightTrigger, 0f);   // Canceled
+  ```
+  - This also applies to `PressInteraction` when set to `Press` behavior.
+  - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
+
 ### Fixed
 
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1567,9 +1567,19 @@ namespace UnityEngine.InputSystem
                     {
                         var actuation = ComputeMagnitude(ref trigger);
                         var pressPoint = controls[trigger.controlIndex] is ButtonControl button ? button.pressPointOrDefault : ButtonControl.s_GlobalDefaultButtonPressPoint;
-                        var threshold = pressPoint * ButtonControl.s_GlobalDefaultButtonReleaseThreshold;
-                        if (actuation <= threshold)
+                        if (Mathf.Approximately(0f, actuation))
+                        {
                             ChangePhaseOfAction(InputActionPhase.Canceled, ref trigger);
+                        }
+                        else
+                        {
+                            var threshold = pressPoint * ButtonControl.s_GlobalDefaultButtonReleaseThreshold;
+                            if (actuation <= threshold)
+                            {
+                                // Button released to below threshold but not fully released.
+                                ChangePhaseOfAction(InputActionPhase.Started, ref trigger);
+                            }
+                        }
                     }
                     else if (actionState->isPassThrough)
                     {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -72,7 +72,10 @@ namespace UnityEngine.InputSystem.Interactions
                         if (actuation <= releasePointOrDefault)
                         {
                             m_WaitingForRelease = false;
-                            context.Canceled();
+                            if (Mathf.Approximately(0f, actuation))
+                                context.Canceled();
+                            else
+                                context.Started();
                         }
                     }
                     else if (actuation >= pressPointOrDefault)
@@ -84,6 +87,10 @@ namespace UnityEngine.InputSystem.Interactions
                     else if (actuation > 0 && !context.isStarted)
                     {
                         context.Started();
+                    }
+                    else if (Mathf.Approximately(0f, actuation) && context.isStarted)
+                    {
+                        context.Canceled();
                     }
                     break;
 

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -838,27 +838,27 @@ namespace UnityEngine.InputSystem
                 if (value != null)
                 {
                     var val = eventPtr.ReadValueAsObject();
-                    if (value is float f)
+                    if (val is float f)
                     {
-                        if (!Mathf.Approximately(f, Convert.ToSingle(val)))
+                        if (!Mathf.Approximately(f, Convert.ToSingle(value)))
                             return false;
                     }
-                    else if (value is double d)
+                    else if (val is double d)
                     {
-                        if (!Mathf.Approximately((float)d, (float)Convert.ToDouble(val)))
+                        if (!Mathf.Approximately((float)d, (float)Convert.ToDouble(value)))
                             return false;
                     }
-                    else if (value is Vector2 v2)
+                    else if (val is Vector2 v2)
                     {
-                        if (!Vector2EqualityComparer.Instance.Equals(v2, val.As<Vector2>()))
+                        if (!Vector2EqualityComparer.Instance.Equals(v2, value.As<Vector2>()))
                             return false;
                     }
-                    else if (value is Vector3 v3)
+                    else if (val is Vector3 v3)
                     {
-                        if (!Vector3EqualityComparer.Instance.Equals(v3, val.As<Vector3>()))
+                        if (!Vector3EqualityComparer.Instance.Equals(v3, value.As<Vector3>()))
                             return false;
                     }
-                    else if (!value.Equals(val))
+                    else if (!val.Equals(value))
                         return false;
                 }
 


### PR DESCRIPTION
Addresses [1393330](https://issuetracker.unity3d.com/issues/input-system-reading-a-gamepad-trigger-as-a-button-produces-inaccurate-press-slash-release-states) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1393330/)).

### Description

When a button, after a press, is released below its release threshold, we invariably go to `canceled`. This leads to slightly strange behavior when the button is not yet fully released (common with gamepad triggers). So, a release to 0.3 would trigger `canceled` and a subsequent release to 0.2 would trigger `started` again.

### Changes made

A button that is released but not yet fully depressed now makes the action go back to `started`.

`canceled` will only be transitioned to on full release (`actuation==0`).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
