### PR TITLE
FIX: InputControlPath.Matches() incorrectly matching prefixes.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1243,7 +1243,7 @@ partial class CoreTests
         Assert.That(InputControlPath.MatchesPrefix("<Keyboard>", gamepad.leftStick), Is.False);
         Assert.That(InputControlPath.MatchesPrefix("<Gamepad>/rightStick", gamepad.leftStick), Is.False);
     }
-    
+
     [Test]
     [Category("Controls")]
     public void Controls_MatchingPath_DoesNotMatchPrefixOnly()

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1243,6 +1243,18 @@ partial class CoreTests
         Assert.That(InputControlPath.MatchesPrefix("<Keyboard>", gamepad.leftStick), Is.False);
         Assert.That(InputControlPath.MatchesPrefix("<Gamepad>/rightStick", gamepad.leftStick), Is.False);
     }
+    
+    [Test]
+    [Category("Controls")]
+    public void Controls_MatchingPath_DoesNotMatchPrefixOnly()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        Assert.That(InputControlPath.Matches("<Keyboard>/e", keyboard.eKey), Is.True);
+        Assert.That(InputControlPath.Matches("<Keyboard>/escape", keyboard.eKey), Is.False);
+        Assert.That(InputControlPath.Matches("<Keyboard>/e", keyboard.escapeKey), Is.False);
+        Assert.That(InputControlPath.Matches("<Keyboard>/escape", keyboard.escapeKey), Is.True);
+    }
 
     [Test]
     [Category("Controls")]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,9 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
+- Fixed `InputControlPath.Matches` incorrectly reporting matches when only a prefix was matching.
+  * This would, for example, cause `Keyboard.eKey` to be matched by `<Keyboard>/escape`.
+  * Fix contributed by [Fredrik Ludvigsen](https://github.com/steinbitglis) in [#1485](https://github.com/Unity-Technologies/InputSystem/pull/1485).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -1404,22 +1404,21 @@ namespace UnityEngine.InputSystem
                 var pathElementLength = pathElement.length;
                 var elementLength = element.Length;
 
-                // `element` is expected to not include escape sequence. `pathElement` may.
-                // So if `element` is longer than `pathElement`, the two can't be a match.
-                if (elementLength > pathElementLength)
-                    return false;
-
-                for (var i = 0; i < pathElementLength && i < elementLength; ++i)
+                for (int i = 0, j = 0;;i++, j++)
                 {
+                    var pathElementDone = i == pathElementLength;
+                    var elementDone     = j == elementLength;
+
+                    if (pathElementDone || elementDone)
+                        return pathElementDone == elementDone;
+
                     var ch = pathElement[i];
                     if (ch == '\\' && i + 1 < pathElementLength)
                         ch = pathElement[++i];
 
-                    if (char.ToLowerInvariant(ch) != char.ToLowerInvariant(element[i]))
+                    if (char.ToLowerInvariant(ch) != char.ToLowerInvariant(element[j]))
                         return false;
                 }
-
-                return true;
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -1404,7 +1404,7 @@ namespace UnityEngine.InputSystem
                 var pathElementLength = pathElement.length;
                 var elementLength = element.Length;
 
-                for (int i = 0, j = 0;;i++, j++)
+                for (int i = 0, j = 0;; i++, j++)
                 {
                     var pathElementDone = i == pathElementLength;
                     var elementDone     = j == elementLength;


### PR DESCRIPTION
Fix contributed by @steinbitglis in #1485.

### Description

`<Keyboard>/escape` would match `"/Keyboard/e"` despite it only being a prefix.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
