### PR TITLE
FIX: Input from other devices not working when DualShock 4 controller is connected

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -3070,7 +3070,7 @@ partial class CoreTests
         // codedom interprets as an error. Check for that here and just load the assembly manually in that case
         if (cr.Errors.HasErrors)
         {
-            if(!Encoding.UTF8.GetBytes(cr.Errors[0].ErrorText).SequenceEqual(Encoding.UTF8.GetPreamble()))
+            if (!Encoding.UTF8.GetBytes(cr.Errors[0].ErrorText).SequenceEqual(Encoding.UTF8.GetPreamble()))
                 Assert.Fail($"Compilation failed: {cr.Errors}");
 
             foreach (var tempFile in cr.TempFiles)

--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -2667,4 +2667,27 @@ partial class CoreTests
         InputSystem.RemoveDeviceUsage(gamepad, CommonUsages.Vertical);
         Assert.That(gamepad.usages, Is.Empty);
     }
+
+    private struct TestNoisyDeviceWithNoExplicityNoisyControlsState : IInputStateTypeInfo
+    {
+        [InputControl(layout = "Button")]
+        public bool control;
+
+        public FourCC format => new FourCC('T', 'E', 'S', 'T');
+    }
+
+    [InputControlLayout(stateType = typeof(TestNoisyDeviceWithNoExplicityNoisyControlsState), isNoisy = true)]
+    private class TestNoisyDeviceWithNoExplicityNoisyControls : InputDevice
+    {
+    }
+
+    [Test]
+    [Category("Layouts")]
+    public void Layouts_CanMarkDeviceNoisy_WhenDeviceHasNoExplicitlyNoisyControls()
+    {
+        InputSystem.RegisterLayout<TestNoisyDeviceWithNoExplicityNoisyControls>("Test");
+        var device = InputDevice.Build<InputDevice>("Test");
+
+        Assert.That(device.noisy, Is.True);
+    }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -33,6 +33,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
 - Fixed `InvalidCastException: Specified cast is not valid.` being thrown when clicking on menu separators in the control picker ([case 1388049](https://issuetracker.unity3d.com/issues/invalidcastexception-is-thrown-when-selecting-the-header-of-an-advanceddropdown)).
+- Fixed DualShock 4 controller not allowing input from other devices due to noisy input from its unmapped sensors ([case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)).
 
 #### Actions
 
@@ -73,7 +74,6 @@ however, it has to be formatted properly to pass verification tests.
   * This had effects such as `InputAction.WasPressedThisFrame()` returning false expectedly.
 - Fixed broken code example for state structs in `Devices.md` documentation (fix contributed by [jeffreylanters](https://github.com/jeffreylanters)).
 - Fixed `TrackedDeviceRaycaster` not picking closest hit in scene (fix originally contributed by [alexboost222](https://github.com/alexboost222)).
-- Fixed DualShock 4 controller not allowing input from other devices due to noisy input from its unmapped sensors ([case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -73,6 +73,7 @@ however, it has to be formatted properly to pass verification tests.
   * This had effects such as `InputAction.WasPressedThisFrame()` returning false expectedly.
 - Fixed broken code example for state structs in `Devices.md` documentation (fix contributed by [jeffreylanters](https://github.com/jeffreylanters)).
 - Fixed `TrackedDeviceRaycaster` not picking closest hit in scene (fix originally contributed by [alexboost222](https://github.com/alexboost222)).
+- Fixed DualShock 4 controller not allowing input from other devices due to noisy input from its unmapped sensors ([case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -349,7 +349,10 @@ namespace UnityEngine.InputSystem
                     // Making a control noisy makes all its children noisy.
                     var list = children;
                     for (var i = 0; i < list.Count; ++i)
-                        list[i].noisy = true;
+                    {
+                        if (null != list[i])
+                            list[i].noisy = true;
+                    }
                 }
                 else
                     m_ControlFlags &= ~ControlFlags.IsNoisy;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -475,6 +475,11 @@ namespace UnityEngine.InputSystem.Layouts
             }
         }
 
+        /// <summary>
+        /// Mark the input device created from this layout as noisy, irrespective of whether or not any
+        /// of its controls have been marked as noisy.
+        /// </summary>
+        /// <seealso cref="InputControlLayoutAttribute.isNoisy"/>
         public bool isNoisy
         {
             get => (m_Flags & Flags.IsNoisy) != 0;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -475,6 +475,18 @@ namespace UnityEngine.InputSystem.Layouts
             }
         }
 
+        public bool isNoisy
+        {
+            get => (m_Flags & Flags.IsNoisy) != 0;
+            internal set
+            {
+                if (value)
+                    m_Flags |= Flags.IsNoisy;
+                else
+                    m_Flags &= ~Flags.IsNoisy;
+            }
+        }
+
         /// <summary>
         /// Override value for <see cref="InputDevice.canRunInBackground"/>. If this is set by the
         /// layout, it will prevent <see cref="QueryCanRunInBackground"/> from being issued. However, other
@@ -976,6 +988,7 @@ namespace UnityEngine.InputSystem.Layouts
                 m_Description = layoutAttribute?.description,
                 m_DisplayName = layoutAttribute?.displayName,
                 canRunInBackground = layoutAttribute?.canRunInBackgroundInternal,
+                isNoisy = layoutAttribute?.isNoisy ?? false
             };
 
             if (layoutAttribute?.commonUsages != null)
@@ -1023,6 +1036,7 @@ namespace UnityEngine.InputSystem.Layouts
             IsOverride = 1 << 2,
             CanRunInBackground = 1 << 3,
             CanRunInBackgroundIsSet = 1 << 4,
+            IsNoisy = 1 << 5
         }
 
         private InputControlLayout(string name, Type type)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayoutAttribute.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayoutAttribute.cs
@@ -55,6 +55,19 @@ namespace UnityEngine.InputSystem.Layouts
 
         public string variants { get; set; }
 
+        /// <summary>
+        /// Allows marking a device as noisy regardless of control layout.
+        /// </summary>
+        /// <remarks>
+        /// Controls can be individually marked as noisy using the <see cref="InputControlAttribute.noisy"/>
+        /// attribute, but this property can be used to mark a device as noisy even when no control has been
+        /// marked as such. This can be useful when a device state layout has only been partially implemented
+        /// i.e. some data in the state memory has not been mapped to a control, and the unimplemented controls
+        /// are noisy. Without doing this, the device will constantly be made current as the system has no way
+        /// to know that the event data contains only noise.
+        /// </remarks>
+        public bool isNoisy { get; set; }
+
         internal bool? canRunInBackgroundInternal;
 
         public bool canRunInBackground

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
@@ -193,6 +193,12 @@ namespace UnityEngine.InputSystem.Layouts
             control.m_Parent = parent;
             control.m_Device = m_Device;
 
+            // this has to be done down here instead of in the device block above because the state for the
+            // device needs to be set up before setting noisy or error out because the device's m_Device
+            // hasn't been set yet. Yes, a device's m_Device is itself.
+            if (control is InputDevice)
+                control.noisy = layout.isNoisy;
+
             // Create children and configure their settings from our
             // layout values.
             var haveChildrenUsingStateFromOtherControl = false;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
@@ -194,7 +194,7 @@ namespace UnityEngine.InputSystem.Layouts
             control.m_Device = m_Device;
 
             // this has to be done down here instead of in the device block above because the state for the
-            // device needs to be set up before setting noisy or error out because the device's m_Device
+            // device needs to be set up before setting noisy or it will throw because the device's m_Device
             // hasn't been set yet. Yes, a device's m_Device is itself.
             if (control is InputDevice)
                 control.noisy = layout.isNoisy;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
@@ -231,7 +231,7 @@ namespace UnityEngine.InputSystem.Editor
             writer.WriteLine();
 
             if (device.noisy)
-	            writer.WriteLine("builder.IsNoisy(true);");
+                writer.WriteLine("builder.IsNoisy(true);");
 
             writer.WriteLine("builder.Finish();");
             writer.EndBlock();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
@@ -148,6 +148,9 @@ namespace UnityEngine.InputSystem.Editor
             writer.WriteLine($"    .WithLayout(new InternedString(\"{device.layout}\"))");
             writer.WriteLine($"    .WithStateBlock(new InputStateBlock {{ format = new FourCC({(int)device.stateBlock.format}), sizeInBits = {device.stateBlock.sizeInBits} }});");
 
+            if (device.noisy)
+                writer.WriteLine("builder.IsNoisy(true);");
+
             // Add controls to device.
             writer.WriteLine();
             foreach (var layout in usedControlLayouts)
@@ -229,9 +232,6 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             writer.WriteLine();
-
-            if (device.noisy)
-                writer.WriteLine("builder.IsNoisy(true);");
 
             writer.WriteLine("builder.Finish();");
             writer.EndBlock();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
@@ -146,8 +146,6 @@ namespace UnityEngine.InputSystem.Editor
             writer.WriteLine($"    .WithDisplayName(\"{device.displayName}\")");
             writer.WriteLine($"    .WithChildren({device.m_ChildStartIndex}, {device.m_ChildCount})");
             writer.WriteLine($"    .WithLayout(new InternedString(\"{device.layout}\"))");
-            if (device.noisy)
-                writer.WriteLine("    .IsNoisy(true)");
             writer.WriteLine($"    .WithStateBlock(new InputStateBlock {{ format = new FourCC({(int)device.stateBlock.format}), sizeInBits = {device.stateBlock.sizeInBits} }});");
 
             // Add controls to device.
@@ -231,6 +229,10 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             writer.WriteLine();
+
+            if (device.noisy)
+	            writer.WriteLine("builder.IsNoisy(true);");
+
             writer.WriteLine("builder.Finish();");
             writer.EndBlock();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -669,7 +669,7 @@ namespace UnityEngine.InputSystem.DualShock
     /// <summary>
     /// PS4 DualShock controller that is interfaced to a HID backend.
     /// </summary>
-    [InputControlLayout(stateType = typeof(DualShock4HIDInputReport), hideInUI = true)]
+    [InputControlLayout(stateType = typeof(DualShock4HIDInputReport), hideInUI = true, isNoisy = true)]
     public class DualShock4GamepadHID : DualShockGamepad
     {
         public ButtonControl leftTriggerButton { get; protected set; }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
@@ -230,6 +230,7 @@ namespace UnityEngine.InputSystem.DualShock
                 , 29361167u, 29885456u, 33562641u, 37756946u
             });
 
+            builder.IsNoisy(true);
             builder.Finish();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/FastDualShock4GamepadHID.cs
@@ -32,6 +32,7 @@ namespace UnityEngine.InputSystem.DualShock
                 .WithChildren(0, 19)
                 .WithLayout(new InternedString("DualShock4GamepadHID"))
                 .WithStateBlock(new InputStateBlock { format = new FourCC(1212761120), sizeInBits = 80 });
+            builder.IsNoisy(true);
 
             var kStickLayout = new InternedString("Stick");
             var kDpadLayout = new InternedString("Dpad");
@@ -230,7 +231,6 @@ namespace UnityEngine.InputSystem.DualShock
                 , 29361167u, 29885456u, 33562641u, 37756946u
             });
 
-            builder.IsNoisy(true);
             builder.Finish();
         }
 


### PR DESCRIPTION
[case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)

### Description

The sensors on the DualShock 4 have not yet been mapped to controls and marked as noisy, so whenever those sensors send events, which is all the time, the system has no way to know that the events represent noisy data. This means the DualShock 4 constantly sets itself as the current device, even if the user is using a different device.

### Changes made

Added the ability to mark a device as noisy even if none of the device's controls are marked as noisy.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
