### PR TITLE
FIX: D-pad inputs sometimes getting skipped over (case 1389858).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -2321,6 +2321,34 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
     }
 
+    // https://fogbugz.unity3d.com/f/cases/1389858/
+    [Test]
+    [Category("Actions")]
+    public void Actions_WithMultipleBoundControls_ValueChangesOfEqualMagnitudeAreNotIgnored()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction();
+        action.AddBinding("<Gamepad>/leftStick");
+        action.AddBinding("<Gamepad>/dpad");
+
+        action.Enable();
+
+        using (var trace = new InputActionTrace(action))
+        {
+            Set(gamepad.dpad, Vector2.left);
+
+            Assert.That(trace, Started(action, value: Vector2.left, control: gamepad.dpad)
+                .AndThen(Performed(action, value: Vector2.left, control: gamepad.dpad)));
+
+            trace.Clear();
+
+            Set(gamepad.dpad, Vector2.right);
+
+            Assert.That(trace, Performed(action, value: Vector2.right, control: gamepad.dpad));
+        }
+    }
+
     // There can be situations where two different controls are driven from the same state. Most prominently, this is
     // the case with the Pointer.button control that subclasses usually rewrite to whatever their primary button is.
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -197,6 +197,7 @@ partial class CoreTests
         action3.AddBinding("<Gamepad>/buttonSouth");
         action4.AddBinding("<Gamepad>/buttonSouth"); // Should not be removed; different action.
 
+        ////REVIEW: This setup here doesn't seem to make any sense; there's probably no need to support something like this.
         action5.AddBinding("<Gamepad>/buttonSouth", interactions: "press(behavior=0)");
         action5.AddBinding("<Gamepad>/buttonSouth", interactions: "press(behavior=1)");
         action5.AddBinding("<Gamepad>/buttonSouth", processors: "invert");
@@ -8834,6 +8835,7 @@ partial class CoreTests
                     .AndThen(Started(pressAction, touchscreen.press, 1, time: 0.3))
                     .AndThen(Performed(pressAction, touchscreen.press, 1, time: 0.3))
                     .AndThen(Performed(positionAction, touchscreen.position, new Vector2(10, 20), time: 0.4))
+                    .AndThen(Performed(pressAction, touchscreen.press, 1, time: 0.4)) // Because `press` is tied to `phase` which changes state twice (but not value).
                     .AndThen(Started(deltaAction, touchscreen.delta, new Vector2(9, 18), time: 0.4))
                     .AndThen(Performed(deltaAction, touchscreen.delta, new Vector2(9, 18), time: 0.4))
                     .AndThen(Canceled(pressAction, touchscreen.press, 0, time: 0.5))

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -37,6 +37,7 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
+- Fixed d-pad inputs sometimes being ignored on actions that were binding to multiple controls ([case 1389858](https://unity.slack.com/archives/G01RVV1SPU4/p1642501574002300)).
 
 ## [1.3.0] - 2021-12-10
 

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -21,7 +21,7 @@
 * [Details](#details)
   * [Binding resolution](#binding-resolution)
     * [Choosing which Devices to use](#choosing-which-devices-to-use)
-  * [Disambiguation](#disambiguation)
+  * [Conflict resolution](#conflict-resolution)
   * [Initial state check](#initial-state-check)
 
 An [`InputBinding`](../api/UnityEngine.InputSystem.InputBinding.html) represents a connection between an [Action](Actions.md) and one or more [Controls](Controls.md) identified by a [Control path](Controls.md#control-paths). An Action can have an arbitrary number of Bindings pointed at it. Multiple Bindings can reference the same Control.
@@ -680,15 +680,40 @@ You can override this behavior by restricting [`InputActionAssets`](../api/Unity
     actionMap.devices = new[] { Gamepad.all[0] };
 ```
 
-### Disambiguation
+### Conflict Resolution
 
-If multiple Controls are bound to an Action, the Input System monitors input from each bound Control to feed the Action. The Input System must also define which of the bound controls to use for the value of the action. For example, if you have a Binding to `<Gamepad>/leftStick`, and you have multiple connected gamepads, the Input System must determine which gamepad's stick provides the input value for the Action.
+If multiple Controls are bound to an Action, conflicting inputs may arise. For example, if an Action is bound to both the left and the right trigger on a gamepad, then if the player presses *both* triggers at the same time, then which of the triggers needs to be released for the Action to be considered stopped?
 
-This Control is the "driving" Control; the Control which is driving the Action. Unity decides which Control is currently driving the Action in a process called disambiguation.
+To resolve this, the Input System uses a "rule of maximum actuation". Simply put, at any point, the Control with the highest level of [actuation](Controls.md#control-actuation) is chosen to "drive" the action and thus determine its value.
 
-During the disambiguation process, the Input System looks at the value of each Control bound to an Action. If the [magnitude](Controls.md#control-actuation) of the input from any Control is higher then the magnitude of the Control currently driving the Action, then the Control with the higher magnitude becomes the new Control driving the Action. In the above example of `<Gamepad>/leftStick` binding to multiple gamepads, the Control driving the Action is the left stick which is actuated the furthest of all the gamepads. You can query which Control is currently driving the Action by checking the [`InputAction.CallbackContext.control`](../api/UnityEngine.InputSystem.InputAction.CallbackContext.html#UnityEngine_InputSystem_InputAction_CallbackContext_control) property in an [Action callback](Actions.md#action-callbacks).
+In the scenario with the two triggers, releasing one of the triggers would not cause the Action to stop as the other trigger is still held. Only once both triggers are fully released will the Action be stopped.
 
-If you don't want your Action to perform disambiguation, you can set your Action type to [Pass-Through](Actions.md#pass-through). Pass-Through Actions skip disambiguation, and changes to any bound Control trigger them. The value of a Pass-Through Action is the value of whichever bound Control changed most recently.
+This rule can lead to outcomes that may not appear intuitive at first. Consider the following sequence of events:
+
+1. Left  trigger is fully pressed (value=1).
+2. Right trigger is partially pressed (value=0.6).
+3. Left trigger is released.
+4. Right trigger is released.
+
+Applying the "rule of maximum actuation", this leads to the following sequence of changes on the Action:
+
+1. Action is `started` and then `performed`. Value is 1, Control is left trigger.
+2. Nothing happens. The right trigger is not actuated enough for it to override the input on the left trigger.
+3. Action is `performed`. Value is 0.6, Control is right trigger. This is because now the left trigger has fallen below the level of the right trigger and thus the latter is chosen to now "drive" the action.
+4. Action is `canceled` as no more active inputs are feeding into the Action.
+
+Note that when a Control is part of a Composite, the "rule of maximum actuation" is applied to the Composite as a whole, not to the individual Controls bound as part of it. So, a WASD keyboard binding, for example, has a single value of actuation corresponding to the magnitude of the resulting vector.
+
+#### Disabling Conflict Resolution
+
+Conflict resolution is always applied to [Button](Actions.md#button) and [Value](Actions.md#value) type Actions. However, it can be undesirable in situations when an Action is simply used to gather any and all inputs from bound Controls. For example, the following Action would monitor the A button of all available gamepads:
+
+```CSharp
+var action = new InputAction(type: InputActionType.PassThrough, binding: "<Gamepad>/buttonSouth");
+action.Enable();
+```
+
+By using the [Pass-Through](Actions.md#pass-through) Action type, conflict resolution is bypassed and thus, pressing the A button on one gamepad will not result in a press on a different gamepad being ignored.
 
 ### Initial state check
 

--- a/Packages/com.unity.inputsystem/Documentation~/Actions.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Actions.md
@@ -445,7 +445,7 @@ Each Action can be one of three different [Action types](../api/UnityEngine.Inpu
 
 This is the default Action type. Use this for any inputs which should track continuous changes to the state of a Control.
 
- [`Value`](../api/UnityEngine.InputSystem.InputActionType.html#UnityEngine_InputSystem_InputActionType_Value) type actions continuously monitor all the Controls which are bound to the Action, and then choose the one which is the most actuated to be the Control driving the Action, and report the values from that Control in callbacks, triggered whenever the value changes. If a different bound Control actuated more, then that Control becomes the Control driving the Action, and the Action starts reporting values from that Control. This process is called [disambiguation](ActionBindings.md#disambiguation). This is useful if you want to allow different Controls to control an Action in the game, but only take input from one Control at the same time.
+ [`Value`](../api/UnityEngine.InputSystem.InputActionType.html#UnityEngine_InputSystem_InputActionType_Value) type actions continuously monitor all the Controls which are bound to the Action, and then choose the one which is the most actuated to be the Control driving the Action, and report the values from that Control in callbacks, triggered whenever the value changes. If a different bound Control actuated more, then that Control becomes the Control driving the Action, and the Action starts reporting values from that Control. This process is called [conflict resolution](ActionBindings.md#conflict-resolution). This is useful if you want to allow different Controls to control an Action in the game, but only take input from one Control at the same time.
 
 When the Action initially enables, it performs an [initial state check](ActionBindings.md#initial-state-check) of all bound Controls. If any of them is actuated, the Action then triggers a callback with the current value.
 
@@ -455,7 +455,7 @@ This is very similar to [`Value`](../api/UnityEngine.InputSystem.InputActionType
 
 #### Pass-Through
 
- [`Pass-Through`](../api/UnityEngine.InputSystem.InputActionType.html#UnityEngine_InputSystem_InputActionType_PassThrough) Actions bypass the [disambiguation](ActionBindings.md#disambiguation) process described above for `Value` Actions and don't use the concept of a specific Control driving the Action. Instead, any change to any bound Control triggers a callback with that Control's value. This is useful if you want to process all input from a set of Controls.
+ [`Pass-Through`](../api/UnityEngine.InputSystem.InputActionType.html#UnityEngine_InputSystem_InputActionType_PassThrough) Actions bypass the [conflict resolution](ActionBindings.md#conflict-resolution) process described above for `Value` Actions and don't use the concept of a specific Control driving the Action. Instead, any change to any bound Control triggers a callback with that Control's value. This is useful if you want to process all input from a set of Controls.
 
 ### Debugging Actions
 

--- a/Packages/com.unity.inputsystem/Documentation~/Controls.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Controls.md
@@ -204,7 +204,7 @@ if (Gamepad.current.leftStick.EvaluateMagnitude() > 0.25f)
 There are two mechanisms that most notably make use of Control actuation:
 
 - [Interactive rebinding](ActionBindings.md#interactive-rebinding) (`InputActionRebindingExceptions.RebindOperation`) uses it to select between multiple suitable Controls to find the one that is actuated the most.
-- [Disambiguation](ActionBindings.md#disambiguation) between multiple Controls that are bound to the same action uses it to decide which Control gets to drive the action.
+- [Conflict resolution](ActionBindings.md#conflict-resolution) between multiple Controls that are bound to the same action uses it to decide which Control gets to drive the action.
 
 ## Noisy Controls
 

--- a/Packages/com.unity.inputsystem/Documentation~/Interactions.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Interactions.md
@@ -67,7 +67,7 @@ fireAction.canceled +=
 
 ### Multiple Controls on an Action
 
-If you have multiple Controls bound to a Binding or an Action which has an Interaction, then the Input System first applies the [Control disambiguation](ActionBindings.md#disambiguation) logic to get a single value for the Action, which it then feeds to the Interaction logic. Any of the bound Controls can perform the Interaction.
+If you have multiple Controls bound to a Binding or an Action which has an Interaction, then the Input System first applies the [conflict resolution](ActionBindings.md#conflict-resolution) logic to get a single value for the Action, which it then feeds to the Interaction logic. Any of the bound Controls can perform the Interaction.
 
 ### Multiple Interactions on a Binding
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1588,10 +1588,6 @@ namespace UnityEngine.InputSystem
                         ChangePhaseOfAction(InputActionPhase.Performed, ref trigger,
                             phaseAfterPerformedOrCanceled: InputActionPhase.Performed);
                     }
-                    else
-                    {
-                        Debug.Assert(false, "Value type actions should not be left in performed state");
-                    }
                     break;
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DpadControl.cs
@@ -99,7 +99,15 @@ namespace UnityEngine.InputSystem.Controls
 
         public override unsafe void WriteValueIntoState(Vector2 value, void* statePtr)
         {
-            throw new NotImplementedException();
+            var upIsPressed = up.IsValueConsideredPressed(value.y);
+            var downIsPressed = down.IsValueConsideredPressed(value.y * -1f);
+            var leftIsPressed = left.IsValueConsideredPressed(value.x * -1f);
+            var rightIsPressed = right.IsValueConsideredPressed(value.x);
+
+            up.WriteValueIntoState(upIsPressed && !downIsPressed ? value.y : 0f, statePtr);
+            down.WriteValueIntoState(downIsPressed && !upIsPressed ? value.y * -1f : 0f, statePtr);
+            left.WriteValueIntoState(leftIsPressed && !rightIsPressed ? value.x * -1f : 0f, statePtr);
+            right.WriteValueIntoState(rightIsPressed && !leftIsPressed ? value.x : 0f, statePtr);
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -414,7 +414,7 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 case kFormatBit:
                     if (sizeInBits == 1)
-                        MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value >= 0.5f);
+                        MemoryHelpers.WriteSingleBit(valuePtr, bitOffset, value >= 0.5f);////REVIEW: Shouldn't this be the global button press point?
                     else
                         MemoryHelpers.WriteNormalizedUIntAsMultipleBits(valuePtr, bitOffset, sizeInBits, value);
                     break;


### PR DESCRIPTION
Fixes [1389858](https://issuetracker.unity3d.com/issues/onmove-debugs-different-value-than-input-debugger-when-quickly-pressing-two-different-d-pad-buttons-in-a-row) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1389858/)).

### Description

When binding an action to multiple controls, one of which was a D-Pad, inputs would sometimes get skipped over.

We perform a check on whether the new magnitude is *increasing* over what we already have. But this we should only do on controls *other* than the one already driving the action. Instead, we'd do

1. Dpad(-1,0) [left] -> magnitude(1) -> don't skip
2. Dpad(1,0) [right] -> magnitude(1) == magnitude(1) -> skip (... facepalm... )

### Changes made

Removed stupid.

### Notes

Also refactored some minor bits in the `IsConflictingInput` method. Also made some checks of "is this the same control?" 'more correct'.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
