### PR TITLE
FIX: Exceptions when accessing actions during startup (case 1378614).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -33,6 +33,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
 - Fixed `InvalidCastException: Specified cast is not valid.` being thrown when clicking on menu separators in the control picker ([case 1388049](https://issuetracker.unity3d.com/issues/invalidcastexception-is-thrown-when-selecting-the-header-of-an-advanceddropdown)).
+- Fixed accessing `InputAction`s directly during `RuntimeInitializeOnLoad` not initializing the input system as a whole and leading to exceptions ([case 1378614](https://issuetracker.unity3d.com/issues/input-system-nullreferenceexception-error-is-thrown-when-using-input-actions-in-builds)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -117,6 +117,8 @@ namespace UnityEngine.InputSystem
         {
             Debug.Assert(map != null, "Received null map");
 
+            InputSystem.EnsureInitialized();
+
             var actionsInThisMap = map.m_Actions;
             var bindingsInThisMap = map.m_Bindings;
             var bindingCountInThisMap = bindingsInThisMap?.Length ?? 0;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3175,6 +3175,13 @@ namespace UnityEngine.InputSystem
             #endif
         }
 
+        // Initialization is triggered by accessing InputSystem. Some parts (like InputActions)
+        // do not rely on InputSystem and thus can be accessed without tapping InputSystem.
+        // This method will explicitly make sure we trigger initialization.
+        internal static void EnsureInitialized()
+        {
+        }
+
 #if UNITY_EDITOR
         internal static InputSystemObject s_SystemObject;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeTable.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/TypeTable.cs
@@ -65,6 +65,9 @@ namespace UnityEngine.InputSystem.Utilities
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("Name cannot be null or empty", nameof(name));
 
+            if (table == null)
+                throw new InvalidOperationException("Input System not yet initialized");
+
             var internedName = new InternedString(name);
             if (table.TryGetValue(internedName, out var type))
                 return type;


### PR DESCRIPTION
Fixes [1378614](https://issuetracker.unity3d.com/issues/input-system-nullreferenceexception-error-is-thrown-when-using-input-actions-in-builds) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1378614/)).

### Description

Another small startup problem. All automatic initialization of the input system is keyed to accessing `UnityEngine.InputSystem.InputSystem` and thus triggering its static ctor. However, when just going straight to `InputAction`s, there's no access to `InputSystem` happening. And thus you get exceptions.

### Changes made

The problem is implicitly fixed by #1494. However, I opted to make a further change by ensuring that `InputBindingResolver` taps `InputSystem` and triggers initialization, if necessary.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
