### PR TITLE
Fix Path Combine Exception on illegal File name

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/GUIHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/GUIHelpers.cs
@@ -45,6 +45,8 @@ namespace UnityEngine.InputSystem.Editor
             var skinPrefix = EditorGUIUtility.isProSkin ? "d_" : "";
             var scale = Mathf.Clamp((int)EditorGUIUtility.pixelsPerPoint, 0, 4);
             var scalePostFix = scale > 1 ? $"@{scale}x" : "";
+            if (name.IndexOfAny(Path.GetInvalidFileNameChars())>-1) 
+                name = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
             var path = Path.Combine(kIconPath, skinPrefix + name + scalePostFix + ".png");
             return AssetDatabase.LoadAssetAtPath<Texture2D>(path);
         }


### PR DESCRIPTION
Some custom HID sticks have unusual characters in the device name.
Fix Exception in Path.Combine by replacing these characters.

### Changes made

Replace invalid characters by underscore in GUIHelpers.cs
