### PR TITLE
Make some internal classes public.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,7 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ## Changed
 
-* `Button` type `InputAction`s now go to `started` when a button goes from a press to below the release threshold but not yet to 0 ([case ]
+- `Button` type `InputAction`s now go to `started` when a button goes from a press to below the release threshold but not yet to 0 ([case ]
   ```CSharp
   // Before:
   Set(Gamepad.current.rightTrigger, 0.7f); // Performed (pressed)
@@ -26,13 +26,12 @@ however, it has to be formatted properly to pass verification tests.
   Set(Gamepad.current.rightTrigger, 0.1f); // <Nothing>
   Set(Gamepad.current.rightTrigger, 0f);   // Canceled
   ```
-  - This also applies to `PressInteraction` when set to `Press` behavior.
-  - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
-* Made the following internal types public, these types can be useful when deconstructing raw events captured via InputEventTrace.
-  - UnityEngine.InputSystem.Android.LowLevel.AndroidAxis
-  - UnityEngine.InputSystem.Android.LowLevel.AndroidGameControllerState
-  - UnityEngine.InputSystem.Android.LowLevel.AndroidKeyCode
-
+  * This also applies to `PressInteraction` when set to `Press` behavior.
+  * In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
+- Made the following internal types public. These types can be useful when deconstructing raw events captured via `InputEventTrace`.
+  * `UnityEngine.InputSystem.Android.LowLevel.AndroidAxis`
+  * `UnityEngine.InputSystem.Android.LowLevel.AndroidGameControllerState`
+  * `UnityEngine.InputSystem.Android.LowLevel.AndroidKeyCode`
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -32,7 +32,6 @@ however, it has to be formatted properly to pass verification tests.
   - UnityEngine.InputSystem.Android.LowLevel.AndroidAxis
   - UnityEngine.InputSystem.Android.LowLevel.AndroidGameControllerState
   - UnityEngine.InputSystem.Android.LowLevel.AndroidKeyCode
-  - UnityEngine.InputSystem.DualShock.LowLevel.DualShock4HIDInputReport
 
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,12 @@ however, it has to be formatted properly to pass verification tests.
   ```
   - This also applies to `PressInteraction` when set to `Press` behavior.
   - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
+* Made the following internal types public, these types can be useful when deconstructing raw events captured via InputEventTrace.
+  - UnityEngine.InputSystem.Android.LowLevel.AndroidAxis
+  - UnityEngine.InputSystem.Android.LowLevel.AndroidGameControllerState
+  - UnityEngine.InputSystem.Android.LowLevel.AndroidKeyCode
+  - UnityEngine.InputSystem.DualShock.LowLevel.DualShock4HIDInputReport
+
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidAxis.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidAxis.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_ANDROID
+#if UNITY_EDITOR || UNITY_ANDROID || PACKAGE_DOCS_GENERATION
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidAxis.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidAxis.cs
@@ -7,50 +7,221 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Android.LowLevel
 {
+    /// <summary>
+    /// Enum used to identity the axis type in the Android motion input event. See <see cref="AndroidGameControllerState.axis"/>.
+    /// See https://developer.android.com/reference/android/view/MotionEvent#constants_1 for more details.
+    /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1027:MarkEnumsWithFlags", Justification = "False positive")]
-    internal enum AndroidAxis
+    public enum AndroidAxis
     {
+        /// <summary>
+        /// X axis of a motion event.
+        /// </summary>
         X = 0,
+
+        /// <summary>
+        /// Y axis of a motion event.
+        /// </summary>
         Y = 1,
+
+        /// <summary>
+        /// Pressure axis of a motion event.
+        /// </summary>
         Pressure = 2,
+
+        /// <summary>
+        /// Size axis of a motion event.
+        /// </summary>
         Size = 3,
+
+        /// <summary>
+        /// TouchMajor axis  of a motion event.
+        /// </summary>
         TouchMajor = 4,
+
+        /// <summary>
+        /// TouchMinor axis of a motion event.
+        /// </summary>
         TouchMinor = 5,
+
+        /// <summary>
+        /// ToolMajor axis of a motion event.
+        /// </summary>
         ToolMajor = 6,
+
+        /// <summary>
+        /// ToolMinor axis of a motion event.
+        /// </summary>
         ToolMinor = 7,
+
+        /// <summary>
+        /// Orientation axis of a motion event.
+        /// </summary>
         Orientation = 8,
+
+        /// <summary>
+        /// Vertical Scroll of a motion event.
+        /// </summary>
         Vscroll = 9,
+
+        /// <summary>
+        /// Horizontal Scroll axis of a motion event.
+        /// </summary>
         Hscroll = 10,
+
+        /// <summary>
+        /// Z axis of a motion event.
+        /// </summary>
         Z = 11,
+
+        /// <summary>
+        /// X Rotation axis of a motion event.
+        /// </summary>
         Rx = 12,
+
+        /// <summary>
+        /// Y Rotation axis of a motion event.
+        /// </summary>
         Ry = 13,
+
+        /// <summary>
+        /// Z Rotation axis of a motion event.
+        /// </summary>
         Rz = 14,
+
+        /// <summary>
+        /// Hat X axis of a motion event.
+        /// </summary>
         HatX = 15,
+
+        /// <summary>
+        /// Hat Y axis of a motion event.
+        /// </summary>
         HatY = 16,
+
+        /// <summary>
+        /// Left Trigger axis of a motion event.
+        /// </summary>
         Ltrigger = 17,
+
+        /// <summary>
+        /// Right Trigger axis of a motion event.
+        /// </summary>
         Rtrigger = 18,
+
+        /// <summary>
+        /// Throttle axis of a motion event.
+        /// </summary>
         Throttle = 19,
+
+        /// <summary>
+        /// Rudder axis of a motion event.
+        /// </summary>
         Rudder = 20,
+
+        /// <summary>
+        /// Wheel axis of a motion event.
+        /// </summary>
         Wheel = 21,
+
+        /// <summary>
+        /// Gas axis of a motion event.
+        /// </summary>
         Gas = 22,
+
+        /// <summary>
+        /// Break axis of a motion event.
+        /// </summary>
         Brake = 23,
+
+        /// <summary>
+        /// Distance axis of a motion event.
+        /// </summary>
         Distance = 24,
+
+        /// <summary>
+        /// Tilt axis of a motion event.
+        /// </summary>
         Tilt = 25,
+
+        /// <summary>
+        /// Generic 1 axis of a motion event.
+        /// </summary>
         Generic1 = 32,
+
+        /// <summary>
+        /// Generic 2 axis of a motion event.
+        /// </summary>
         Generic2 = 33,
+
+        /// <summary>
+        /// Generic 3 axis of a motion event.
+        /// </summary>
         Generic3 = 34,
+
+        /// <summary>
+        /// Generic 4 axis of a motion event.
+        /// </summary>
         Generic4 = 35,
+
+        /// <summary>
+        /// Generic 5 axis of a motion event.
+        /// </summary>
         Generic5 = 36,
+
+        /// <summary>
+        /// Generic 6 axis of a motion event.
+        /// </summary>
         Generic6 = 37,
+
+        /// <summary>
+        /// Generic 7 axis of a motion event.
+        /// </summary>
         Generic7 = 38,
+
+        /// <summary>
+        /// Generic 8 axis of a motion event.
+        /// </summary>
         Generic8 = 39,
+
+        /// <summary>
+        /// Generic 9 axis of a motion event.
+        /// </summary>
         Generic9 = 40,
+
+        /// <summary>
+        /// Generic 10 axis of a motion event.
+        /// </summary>
         Generic10 = 41,
+
+        /// <summary>
+        /// Generic 11 axis of a motion event.
+        /// </summary>
         Generic11 = 42,
+
+        /// <summary>
+        /// Generic 12 axis of a motion event.
+        /// </summary>
         Generic12 = 43,
+
+        /// <summary>
+        /// Generic 13 axis of a motion event.
+        /// </summary>
         Generic13 = 44,
+
+        /// <summary>
+        /// Generic 14 axis of a motion event.
+        /// </summary>
         Generic14 = 45,
+
+        /// <summary>
+        /// Generic 15 axis of a motion event.
+        /// </summary>
         Generic15 = 46,
+
+        /// <summary>
+        /// Generic 16 axis of a motion event.
+        /// </summary>
         Generic16 = 47,
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -10,16 +10,19 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Android.LowLevel
 {
+    /// <summary>
+    /// Default state layout for Android game controller.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    internal unsafe struct AndroidGameControllerState : IInputStateTypeInfo
+    public unsafe struct AndroidGameControllerState : IInputStateTypeInfo
     {
         public const int MaxAxes = 48;
         public const int MaxButtons = 220;
 
-        internal const string kVariantGamepad = "Gamepad";
-        internal const string kVariantJoystick = "Joystick";
-        internal const string kVariantDPadAxes = "DpadAxes";
-        internal const string kVariantDPadButtons = "DpadButtons";
+        public const string kVariantGamepad = "Gamepad";
+        public const string kVariantJoystick = "Joystick";
+        public const string kVariantDPadAxes = "DpadAxes";
+        public const string kVariantDPadButtons = "DpadButtons";
 
         internal const uint kAxisOffset = sizeof(uint) * (uint)((MaxButtons + 31) / 32);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -19,49 +19,52 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         public const int MaxAxes = 48;
         public const int MaxButtons = 220;
 
-        public const string kVariantGamepad = "Gamepad";
-        public const string kVariantJoystick = "Joystick";
-        public const string kVariantDPadAxes = "DpadAxes";
-        public const string kVariantDPadButtons = "DpadButtons";
+        public class Variants
+        {
+            public const string Gamepad = "Gamepad";
+            public const string Joystick = "Joystick";
+            public const string DPadAxes = "DpadAxes";
+            public const string DPadButtons = "DpadButtons";
+        }
 
         internal const uint kAxisOffset = sizeof(uint) * (uint)((MaxButtons + 31) / 32);
 
         public static FourCC kFormat = new FourCC('A', 'G', 'C', ' ');
 
-        [InputControl(name = "dpad", layout = "Dpad", bit = (uint)AndroidKeyCode.DpadUp, sizeInBits = 4, variants = kVariantDPadButtons)]
-        [InputControl(name = "dpad/up", bit = (uint)AndroidKeyCode.DpadUp, variants = kVariantDPadButtons)]
-        [InputControl(name = "dpad/down", bit = (uint)AndroidKeyCode.DpadDown, variants = kVariantDPadButtons)]
-        [InputControl(name = "dpad/left", bit = (uint)AndroidKeyCode.DpadLeft, variants = kVariantDPadButtons)]
-        [InputControl(name = "dpad/right", bit = (uint)AndroidKeyCode.DpadRight, variants = kVariantDPadButtons)]
-        [InputControl(name = "buttonSouth", bit = (uint)AndroidKeyCode.ButtonA, variants = kVariantGamepad)]
-        [InputControl(name = "buttonWest", bit = (uint)AndroidKeyCode.ButtonX, variants = kVariantGamepad)]
-        [InputControl(name = "buttonNorth", bit = (uint)AndroidKeyCode.ButtonY, variants = kVariantGamepad)]
-        [InputControl(name = "buttonEast", bit = (uint)AndroidKeyCode.ButtonB, variants = kVariantGamepad)]
-        [InputControl(name = "leftStickPress", bit = (uint)AndroidKeyCode.ButtonThumbl, variants = kVariantGamepad)]
-        [InputControl(name = "rightStickPress", bit = (uint)AndroidKeyCode.ButtonThumbr, variants = kVariantGamepad)]
-        [InputControl(name = "leftShoulder", bit = (uint)AndroidKeyCode.ButtonL1, variants = kVariantGamepad)]
-        [InputControl(name = "rightShoulder", bit = (uint)AndroidKeyCode.ButtonR1, variants = kVariantGamepad)]
-        [InputControl(name = "start", bit = (uint)AndroidKeyCode.ButtonStart, variants = kVariantGamepad)]
-        [InputControl(name = "select", bit = (uint)AndroidKeyCode.ButtonSelect, variants = kVariantGamepad)]
+        [InputControl(name = "dpad", layout = "Dpad", bit = (uint)AndroidKeyCode.DpadUp, sizeInBits = 4, variants = Variants.DPadButtons)]
+        [InputControl(name = "dpad/up", bit = (uint)AndroidKeyCode.DpadUp, variants = Variants.DPadButtons)]
+        [InputControl(name = "dpad/down", bit = (uint)AndroidKeyCode.DpadDown, variants = Variants.DPadButtons)]
+        [InputControl(name = "dpad/left", bit = (uint)AndroidKeyCode.DpadLeft, variants = Variants.DPadButtons)]
+        [InputControl(name = "dpad/right", bit = (uint)AndroidKeyCode.DpadRight, variants = Variants.DPadButtons)]
+        [InputControl(name = "buttonSouth", bit = (uint)AndroidKeyCode.ButtonA, variants = Variants.Gamepad)]
+        [InputControl(name = "buttonWest", bit = (uint)AndroidKeyCode.ButtonX, variants = Variants.Gamepad)]
+        [InputControl(name = "buttonNorth", bit = (uint)AndroidKeyCode.ButtonY, variants = Variants.Gamepad)]
+        [InputControl(name = "buttonEast", bit = (uint)AndroidKeyCode.ButtonB, variants = Variants.Gamepad)]
+        [InputControl(name = "leftStickPress", bit = (uint)AndroidKeyCode.ButtonThumbl, variants = Variants.Gamepad)]
+        [InputControl(name = "rightStickPress", bit = (uint)AndroidKeyCode.ButtonThumbr, variants = Variants.Gamepad)]
+        [InputControl(name = "leftShoulder", bit = (uint)AndroidKeyCode.ButtonL1, variants = Variants.Gamepad)]
+        [InputControl(name = "rightShoulder", bit = (uint)AndroidKeyCode.ButtonR1, variants = Variants.Gamepad)]
+        [InputControl(name = "start", bit = (uint)AndroidKeyCode.ButtonStart, variants = Variants.Gamepad)]
+        [InputControl(name = "select", bit = (uint)AndroidKeyCode.ButtonSelect, variants = Variants.Gamepad)]
         public fixed uint buttons[(MaxButtons + 31) / 32];
 
-        [InputControl(name = "dpad", layout = "Dpad", offset = (uint)AndroidAxis.HatX * sizeof(float) + kAxisOffset, format = "VEC2", sizeInBits = 64, variants = kVariantDPadAxes)]
-        [InputControl(name = "dpad/right", offset = 0, bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=0,clampMax=1", variants = kVariantDPadAxes)]
-        [InputControl(name = "dpad/left", offset = 0, bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=-1,clampMax=0,invert", variants = kVariantDPadAxes)]
-        [InputControl(name = "dpad/down", offset = ((uint)AndroidAxis.HatY - (uint)AndroidAxis.HatX) * sizeof(float), bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=0,clampMax=1", variants = kVariantDPadAxes)]
-        [InputControl(name = "dpad/up", offset = ((uint)AndroidAxis.HatY - (uint)AndroidAxis.HatX) * sizeof(float), bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=-1,clampMax=0,invert", variants = kVariantDPadAxes)]
-        [InputControl(name = "leftTrigger", offset = (uint)AndroidAxis.Brake * sizeof(float) + kAxisOffset, parameters = "clamp=1,clampMin=0,clampMax=1.0", variants = kVariantGamepad)]
-        [InputControl(name = "rightTrigger", offset = (uint)AndroidAxis.Gas * sizeof(float) + kAxisOffset, parameters = "clamp=1,clampMin=0,clampMax=1.0", variants = kVariantGamepad)]
-        [InputControl(name = "leftStick", variants = kVariantGamepad)]
-        [InputControl(name = "leftStick/y", variants = kVariantGamepad, parameters = "invert")]
-        [InputControl(name = "leftStick/up", variants = kVariantGamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]
-        [InputControl(name = "leftStick/down", variants = kVariantGamepad, parameters = "invert=false,clamp=1,clampMin=0,clampMax=1.0")]
+        [InputControl(name = "dpad", layout = "Dpad", offset = (uint)AndroidAxis.HatX * sizeof(float) + kAxisOffset, format = "VEC2", sizeInBits = 64, variants = Variants.DPadAxes)]
+        [InputControl(name = "dpad/right", offset = 0, bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=0,clampMax=1", variants = Variants.DPadAxes)]
+        [InputControl(name = "dpad/left", offset = 0, bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=-1,clampMax=0,invert", variants = Variants.DPadAxes)]
+        [InputControl(name = "dpad/down", offset = ((uint)AndroidAxis.HatY - (uint)AndroidAxis.HatX) * sizeof(float), bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=0,clampMax=1", variants = Variants.DPadAxes)]
+        [InputControl(name = "dpad/up", offset = ((uint)AndroidAxis.HatY - (uint)AndroidAxis.HatX) * sizeof(float), bit = 0, sizeInBits = 32, format = "FLT", parameters = "clamp=3,clampConstant=0,clampMin=-1,clampMax=0,invert", variants = Variants.DPadAxes)]
+        [InputControl(name = "leftTrigger", offset = (uint)AndroidAxis.Brake * sizeof(float) + kAxisOffset, parameters = "clamp=1,clampMin=0,clampMax=1.0", variants = Variants.Gamepad)]
+        [InputControl(name = "rightTrigger", offset = (uint)AndroidAxis.Gas * sizeof(float) + kAxisOffset, parameters = "clamp=1,clampMin=0,clampMax=1.0", variants = Variants.Gamepad)]
+        [InputControl(name = "leftStick", variants = Variants.Gamepad)]
+        [InputControl(name = "leftStick/y", variants = Variants.Gamepad, parameters = "invert")]
+        [InputControl(name = "leftStick/up", variants = Variants.Gamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]
+        [InputControl(name = "leftStick/down", variants = Variants.Gamepad, parameters = "invert=false,clamp=1,clampMin=0,clampMax=1.0")]
         ////FIXME: state for this control is not contiguous
-        [InputControl(name = "rightStick", offset = (uint)AndroidAxis.Z * sizeof(float) + kAxisOffset, sizeInBits = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z + 1) * sizeof(float) * 8, variants = kVariantGamepad)]
-        [InputControl(name = "rightStick/x", variants = kVariantGamepad)]
-        [InputControl(name = "rightStick/y", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert")]
-        [InputControl(name = "rightStick/up", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]
-        [InputControl(name = "rightStick/down", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = kVariantGamepad, parameters = "invert=false,clamp=1,clampMin=0,clampMax=1.0")]
+        [InputControl(name = "rightStick", offset = (uint)AndroidAxis.Z * sizeof(float) + kAxisOffset, sizeInBits = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z + 1) * sizeof(float) * 8, variants = Variants.Gamepad)]
+        [InputControl(name = "rightStick/x", variants = Variants.Gamepad)]
+        [InputControl(name = "rightStick/y", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = Variants.Gamepad, parameters = "invert")]
+        [InputControl(name = "rightStick/up", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = Variants.Gamepad, parameters = "invert,clamp=1,clampMin=-1.0,clampMax=0.0")]
+        [InputControl(name = "rightStick/down", offset = ((uint)AndroidAxis.Rz - (uint)AndroidAxis.Z) * sizeof(float), variants = Variants.Gamepad, parameters = "invert=false,clamp=1,clampMin=0,clampMax=1.0")]
         public fixed float axis[MaxAxes];
 
         public FourCC format
@@ -179,7 +182,7 @@ namespace UnityEngine.InputSystem.Android
     ///  It's obvious that this depends on the driver and not Android OS, thus we can only assume Samsung in this case doesn't properly support Dualshock in their drivers
     ///  While we can do custom mapping for Samsung, we can never now when will they try to update the driver for Dualshock or some other gamepad
     /// </remarks>
-    [InputControlLayout(stateType = typeof(AndroidGameControllerState), variants = AndroidGameControllerState.kVariantGamepad)]
+    [InputControlLayout(stateType = typeof(AndroidGameControllerState), variants = AndroidGameControllerState.Variants.Gamepad)]
     public class AndroidGamepad : Gamepad
     {
     }
@@ -188,7 +191,7 @@ namespace UnityEngine.InputSystem.Android
     /// Generic controller with Dpad axes
     /// </summary>
     [InputControlLayout(stateType = typeof(AndroidGameControllerState), hideInUI = true,
-        variants = AndroidGameControllerState.kVariantGamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.kVariantDPadAxes)]
+        variants = AndroidGameControllerState.Variants.Gamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.Variants.DPadAxes)]
     public class AndroidGamepadWithDpadAxes : AndroidGamepad
     {
     }
@@ -197,7 +200,7 @@ namespace UnityEngine.InputSystem.Android
     /// Generic controller with Dpad buttons
     /// </summary>
     [InputControlLayout(stateType = typeof(AndroidGameControllerState), hideInUI = true,
-        variants = AndroidGameControllerState.kVariantGamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.kVariantDPadButtons)]
+        variants = AndroidGameControllerState.Variants.Gamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.Variants.DPadButtons)]
     public class AndroidGamepadWithDpadButtons : AndroidGamepad
     {
     }
@@ -205,7 +208,7 @@ namespace UnityEngine.InputSystem.Android
     /// <summary>
     /// Joystick on Android.
     /// </summary>
-    [InputControlLayout(stateType = typeof(AndroidGameControllerState), variants = AndroidGameControllerState.kVariantJoystick)]
+    [InputControlLayout(stateType = typeof(AndroidGameControllerState), variants = AndroidGameControllerState.Variants.Joystick)]
     public class AndroidJoystick : Joystick
     {
     }
@@ -214,7 +217,7 @@ namespace UnityEngine.InputSystem.Android
     /// A PlayStation DualShock 4 controller connected to an Android device.
     /// </summary>
     [InputControlLayout(stateType = typeof(AndroidGameControllerState), displayName = "Android DualShock 4 Gamepad",
-        variants = AndroidGameControllerState.kVariantGamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.kVariantDPadAxes)]
+        variants = AndroidGameControllerState.Variants.Gamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.Variants.DPadAxes)]
     public class DualShock4GamepadAndroid : DualShockGamepad
     {
     }
@@ -223,7 +226,7 @@ namespace UnityEngine.InputSystem.Android
     /// A PlayStation DualShock 4 controller connected to an Android device.
     /// </summary>
     [InputControlLayout(stateType = typeof(AndroidGameControllerState), displayName = "Android Xbox One Controller",
-        variants = AndroidGameControllerState.kVariantGamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.kVariantDPadAxes)]
+        variants = AndroidGameControllerState.Variants.Gamepad + InputControlLayout.VariantSeparator + AndroidGameControllerState.Variants.DPadAxes)]
     public class XboxOneGamepadAndroid : XInput.XInputController
     {
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidKeyCode.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidKeyCode.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_ANDROID
+#if UNITY_EDITOR || UNITY_ANDROID || PACKAGE_DOCS_GENERATION
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidKeyCode.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidKeyCode.cs
@@ -7,7 +7,11 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Android.LowLevel
 {
-    internal enum AndroidKeyCode
+    /// <summary>
+    /// Enum used to identity the key in the Android key event. See <see cref="AndroidGameControllerState.buttons"/>.
+    /// See https://developer.android.com/reference/android/view/KeyEvent#constants_1 for more details.
+    /// </summary>
+    public enum AndroidKeyCode
     {
         Unknown = 0,
         SoftLeft = 1,

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidKeyCode.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidKeyCode.cs
@@ -13,225 +13,1104 @@ namespace UnityEngine.InputSystem.Android.LowLevel
     /// </summary>
     public enum AndroidKeyCode
     {
+        /// <summary>
+        /// Unknown key code.
+        /// </summary>
         Unknown = 0,
+
+        /// <summary>
+        /// Soft Left key. Usually situated below the display on phones and used as a multi-function feature key for selecting a software defined function shown on the bottom left of the display.
+        /// </summary>
         SoftLeft = 1,
+
+        /// <summary>
+        /// Soft Right key. Usually situated below the display on phones and used as a multi-function feature key for selecting a software defined function shown on the bottom right of the display.
+        /// </summary>
         SoftRight = 2,
+
+        /// <summary>
+        /// Home key. This key is handled by the framework and is never delivered to applications.
+        /// </summary>
         Home = 3,
+
+        /// <summary>
+        /// Back key.
+        /// </summary>
         Back = 4,
+
+        /// <summary>
+        /// Call key.
+        /// </summary>
         Call = 5,
+
+        /// <summary>
+        /// End Call key.
+        /// </summary>
         Endcall = 6,
+
+        /// <summary>
+        /// '0' key.
+        /// </summary>
         Alpha0 = 7,
+
+        /// <summary>
+        /// '1' key.
+        /// </summary>
         Alpha1 = 8,
+
+        /// <summary>
+        /// '2' key.
+        /// </summary>
         Alpha2 = 9,
+
+        /// <summary>
+        /// '3' key.
+        /// </summary>
         Alpha3 = 10,
+
+        /// <summary>
+        /// '4' key.
+        /// </summary>
         Alpha4 = 11,
+
+        /// <summary>
+        /// '5' key.
+        /// </summary>
         Alpha5 = 12,
+
+        /// <summary>
+        /// '6' key.
+        /// </summary>
         Alpha6 = 13,
+
+        /// <summary>
+        /// '7' key.
+        /// </summary>
         Alpha7 = 14,
+
+        /// <summary>
+        /// '8' key.
+        /// </summary>
         Alpha8 = 15,
+
+        /// <summary>
+        /// '9' key.
+        /// </summary>
         Alpha9 = 16,
+
+        /// <summary>
+        /// '*' key.
+        /// </summary>
         Star = 17,
+
+        /// <summary>
+        /// '#' key.
+        /// </summary>
         Pound = 18,
+
+        /// <summary>
+        /// Directional Pad Up key. May also be synthesized from trackball motions.
+        /// </summary>
         DpadUp = 19,
+
+        /// <summary>
+        /// Directional Pad Down key. May also be synthesized from trackball motions.
+        /// </summary>
         DpadDown = 20,
+
+        /// <summary>
+        /// Directional Pad Left key. May also be synthesized from trackball motions.
+        /// </summary>
         DpadLeft = 21,
+
+        /// <summary>
+        /// Directional Pad Right key. May also be synthesized from trackball motions.
+        /// </summary>
         DpadRight = 22,
+
+        /// <summary>
+        /// Directional Pad Center key. May also be synthesized from trackball motions.
+        /// </summary>
         DpadCenter = 23,
+
+        /// <summary>
+        /// Volume Up key. Adjusts the speaker volume up.
+        /// </summary>
         VolumeUp = 24,
+
+        /// <summary>
+        /// Volume Down key. Adjusts the speaker volume down.
+        /// </summary>
         VolumeDown = 25,
+
+        /// <summary>
+        /// Power key.
+        /// </summary>
         Power = 26,
+
+        /// <summary>
+        /// Camera key. Used to launch a camera application or take pictures.
+        /// </summary>
         Camera = 27,
+
+        /// <summary>
+        /// Clear key.
+        /// </summary>
         Clear = 28,
+
+        /// <summary>
+        /// 'A' key.
+        /// </summary>
         A = 29,
+
+        /// <summary>
+        /// 'B' key.
+        /// </summary>
         B = 30,
+
+        /// <summary>
+        /// 'C' key.
+        /// </summary>
         C = 31,
+
+        /// <summary>
+        /// 'D' key.
+        /// </summary>
         D = 32,
+
+        /// <summary>
+        /// 'E' key.
+        /// </summary>
         E = 33,
+
+        /// <summary>
+        /// 'F' key.
+        /// </summary>
         F = 34,
+
+        /// <summary>
+        /// 'G' key.
+        /// </summary>
         G = 35,
+
+        /// <summary>
+        /// 'H' key.
+        /// </summary>
         H = 36,
+
+        /// <summary>
+        /// 'I' key.
+        /// </summary>
         I = 37,
+
+        /// <summary>
+        /// 'J' key.
+        /// </summary>
         J = 38,
+
+        /// <summary>
+        /// 'K' key.
+        /// </summary>
         K = 39,
+
+        /// <summary>
+        /// 'L' key.
+        /// </summary>
         L = 40,
+
+        /// <summary>
+        /// 'M' key.
+        /// </summary>
         M = 41,
+
+        /// <summary>
+        /// 'N' key.
+        /// </summary>
         N = 42,
+
+        /// <summary>
+        /// 'O' key.
+        /// </summary>
         O = 43,
+
+        /// <summary>
+        /// 'P' key.
+        /// </summary>
         P = 44,
+
+        /// <summary>
+        /// 'Q' key.
+        /// </summary>
         Q = 45,
+
+        /// <summary>
+        /// 'R' key.
+        /// </summary>
         R = 46,
+
+        /// <summary>
+        /// 'S' key.
+        /// </summary>
         S = 47,
+
+        /// <summary>
+        /// 'T' key.
+        /// </summary>
         T = 48,
+
+        /// <summary>
+        /// 'U' key.
+        /// </summary>
         U = 49,
+
+        /// <summary>
+        /// 'V' key.
+        /// </summary>
         V = 50,
+
+        /// <summary>
+        /// 'W' key.
+        /// </summary>
         W = 51,
+
+        /// <summary>
+        /// 'X' key.
+        /// </summary>
         X = 52,
+
+        /// <summary>
+        /// 'Y' key.
+        /// </summary>
         Y = 53,
+
+        /// <summary>
+        /// 'Z' key.
+        /// </summary>
         Z = 54,
+
+        /// <summary>
+        /// ',' key.
+        /// </summary>
         Comma = 55,
+
+        /// <summary>
+        /// '.' key.
+        /// </summary>
         Period = 56,
+
+        /// <summary>
+        /// Left Alt modifier key.
+        /// </summary>
         AltLeft = 57,
+
+        /// <summary>
+        /// Right Alt modifier key.
+        /// </summary>
         AltRight = 58,
+
+        /// <summary>
+        /// Left Shift modifier key.
+        /// </summary>
         ShiftLeft = 59,
+
+        /// <summary>
+        /// Right Shift modifier key.
+        /// </summary>
         ShiftRight = 60,
+
+        /// <summary>
+        /// Tab key.
+        /// </summary>
         Tab = 61,
+
+        /// <summary>
+        /// Space key.
+        /// </summary>
         Space = 62,
+
+        /// <summary>
+        /// Symbol modifier key. Used to enter alternate symbols.
+        /// </summary>
         Sym = 63,
+
+        /// <summary>
+        /// Explorer special function key. Used to launch a browser application.
+        /// </summary>
         Explorer = 64,
+
+        /// <summary>
+        /// Envelope special function key. Used to launch a mail application.
+        /// </summary>
         Envelope = 65,
+
+        /// <summary>
+        /// Enter key.
+        /// </summary>
         Enter = 66,
+
+        /// <summary>
+        /// Backspace key. Deletes characters before the insertion point, unlike <see cref="AndroidKeyCode.ForwardDel"/>.
+        /// </summary>
         Del = 67,
+
+        /// <summary>
+        /// '`' (backtick) key.
+        /// </summary>
         Grave = 68,
+
+        /// <summary>
+        /// '-' key.
+        /// </summary>
         Minus = 69,
+
+        /// <summary>
+        /// '=' key.
+        /// </summary>
         Equals = 70,
+
+        /// <summary>
+        /// '[' key.
+        /// </summary>
         LeftBracket = 71,
+
+        /// <summary>
+        /// ']' key.
+        /// </summary>
         RightBracket = 72,
+
+        /// <summary>
+        /// '\' key.
+        /// </summary>
         Backslash = 73,
+
+        /// <summary>
+        /// ';' key.
+        /// </summary>
         Semicolon = 74,
+
+        /// <summary>
+        /// ''' (apostrophe) key.
+        /// </summary>
         Apostrophe = 75,
+
+        /// <summary>
+        /// '/' key.
+        /// </summary>
         Slash = 76,
+
+        /// <summary>
+        /// '@' key.
+        /// </summary>
         At = 77,
+
+        /// <summary>
+        /// Number modifier key. Used to enter numeric symbols. This key is not Num Lock; it is more like <see cref="AndroidKeyCode.AltLeft"/>.
+        /// </summary>
         Num = 78,
+
+        /// <summary>
+        /// Headset Hook key. Used to hang up calls and stop media.
+        /// </summary>
         Headsethook = 79,
-        Focus = 80, // *Camera* focus
+
+        /// <summary>
+        /// Camera Focus key. Used to focus the camera.
+        /// </summary>
+        Focus = 80,
+
+        /// <summary>
+        /// '+' key.
+        /// </summary> // *Camera* focus
         Plus = 81,
+
+        /// <summary>
+        /// Menu key.
+        /// </summary>
         Menu = 82,
+
+        /// <summary>
+        /// Notification key.
+        /// </summary>
         Notification = 83,
+
+        /// <summary>
+        /// Search key.
+        /// </summary>
         Search = 84,
+
+        /// <summary>
+        /// Play/Pause media key.
+        /// </summary>
         MediaPlayPause = 85,
+
+        /// <summary>
+        /// Stop media key.
+        /// </summary>
         MediaStop = 86,
+
+        /// <summary>
+        /// Play Next media key.
+        /// </summary>
         MediaNext = 87,
+
+        /// <summary>
+        /// Play Previous media key.
+        /// </summary>
         MediaPrevious = 88,
+
+        /// <summary>
+        /// Rewind media key.
+        /// </summary>
         MediaRewind = 89,
+
+        /// <summary>
+        /// Fast Forward media key.
+        /// </summary>
         MediaFastForward = 90,
+
+        /// <summary>
+        /// Mute key. Mutes the microphone, unlike <see cref="AndroidKeyCode.VolumeMute"/>.
+        /// </summary>
         Mute = 91,
+
+        /// <summary>
+        /// Page Up key.
+        /// </summary>
         PageUp = 92,
+
+        /// <summary>
+        /// Page Down key.
+        /// </summary>
         PageDown = 93,
+
+        /// <summary>
+        /// Picture Symbols modifier key. Used to switch symbol sets (Emoji, Kao-moji).
+        /// </summary>
         Pictsymbols = 94,
+
+        /// <summary>
+        /// Switch Charset modifier key. Used to switch character sets (Kanji, Katakana).
+        /// </summary>
         SwitchCharset = 95,
+
+        /// <summary>
+        /// A Button key. On a game controller, the A button should be either the button labeled A or the first button on the bottom row of controller buttons.
+        /// </summary>
         ButtonA = 96,
+
+        /// <summary>
+        /// B Button key. On a game controller, the B button should be either the button labeled B or the second button on the bottom row of controller buttons.
+        /// </summary>
         ButtonB = 97,
+
+        /// <summary>
+        /// C Button key. On a game controller, the C button should be either the button labeled C or the third button on the bottom row of controller buttons.
+        /// </summary>
         ButtonC = 98,
+
+        /// <summary>
+        /// X Button key. On a game controller, the X button should be either the button labeled X or the first button on the upper row of controller buttons.
+        /// </summary>
         ButtonX = 99,
+
+        /// <summary>
+        /// Y Button key. On a game controller, the Y button should be either the button labeled Y or the second button on the upper row of controller buttons.
+        /// </summary>
         ButtonY = 100,
+
+        /// <summary>
+        /// Z Button key. On a game controller, the Z button should be either the button labeled Z or the third button on the upper row of controller buttons.
+        /// </summary>
         ButtonZ = 101,
+
+        /// <summary>
+        /// L1 Button key. On a game controller, the L1 button should be either the button labeled L1 (or L) or the top left trigger button.
+        /// </summary>
         ButtonL1 = 102,
+
+        /// <summary>
+        /// R1 Button key. On a game controller, the R1 button should be either the button labeled R1 (or R) or the top right trigger button.
+        /// </summary>
         ButtonR1 = 103,
+
+        /// <summary>
+        /// L2 Button key. On a game controller, the L2 button should be either the button labeled L2 or the bottom left trigger button.
+        /// </summary>
         ButtonL2 = 104,
+
+        /// <summary>
+        /// R2 Button key. On a game controller, the R2 button should be either the button labeled R2 or the bottom right trigger button.
+        /// </summary>
         ButtonR2 = 105,
+
+        /// <summary>
+        /// Left Thumb Button key. On a game controller, the left thumb button indicates that the left (or only) joystick is pressed.
+        /// </summary>
         ButtonThumbl = 106,
+
+        /// <summary>
+        /// Right Thumb Button key. On a game controller, the right thumb button indicates that the right joystick is pressed.
+        /// </summary>
         ButtonThumbr = 107,
+
+        /// <summary>
+        /// Start Button key. On a game controller, the button labeled Start.
+        /// </summary>
         ButtonStart = 108,
+
+        /// <summary>
+        /// Select Button key. On a game controller, the button labeled Select.
+        /// </summary>
         ButtonSelect = 109,
+
+        /// <summary>
+        /// Mode Button key. On a game controller, the button labeled Mode.
+        /// </summary>
         ButtonMode = 110,
+
+        /// <summary>
+        /// Escape key.
+        /// </summary>
         Escape = 111,
+
+        /// <summary>
+        /// Forward Delete key. Deletes characters ahead of the insertion point, unlike <see cref="AndroidKeyCode.Del"/>.
+        /// </summary>
         ForwardDel = 112,
+
+        /// <summary>
+        /// Left Control modifier key.
+        /// </summary>
         CtrlLeft = 113,
+
+        /// <summary>
+        /// Right Control modifier key.
+        /// </summary>
         CtrlRight = 114,
+
+        /// <summary>
+        /// Caps Lock key.
+        /// </summary>
         CapsLock = 115,
+
+        /// <summary>
+        /// Scroll Lock key.
+        /// </summary>
         ScrollLock = 116,
+
+        /// <summary>
+        /// Left Meta modifier key.
+        /// </summary>
         MetaLeft = 117,
+
+        /// <summary>
+        /// Right Meta modifier key.
+        /// </summary>
         MetaRight = 118,
+
+        /// <summary>
+        /// Function modifier key.
+        /// </summary>
         Function = 119,
+
+        /// <summary>
+        /// System Request / Print Screen key.
+        /// </summary>
         Sysrq = 120,
+
+        /// <summary>
+        /// Break / Pause key.
+        /// </summary>
         Break = 121,
+
+        /// <summary>
+        /// Home Movement key. Used for scrolling or moving the cursor around to the start of a line or to the top of a list.
+        /// </summary>
         MoveHome = 122,
+
+        /// <summary>
+        /// End Movement key. Used for scrolling or moving the cursor around to the end of a line or to the bottom of a list.
+        /// </summary>
         MoveEnd = 123,
+
+        /// <summary>
+        /// Insert key. Toggles insert / overwrite edit mode.
+        /// </summary>
         Insert = 124,
+
+        /// <summary>
+        /// Forward key. Navigates forward in the history stack. Complement of <see cref="AndroidKeyCode.Back"/>.
+        /// </summary>
         Forward = 125,
+
+        /// <summary>
+        /// Play media key.
+        /// </summary>
         MediaPlay = 126,
+
+        /// <summary>
+        /// Play/Pause media key.
+        /// </summary>
         MediaPause = 127,
+
+        /// <summary>
+        /// Close media key. May be used to close a CD tray, for example.
+        /// </summary>
         MediaClose = 128,
+
+        /// <summary>
+        /// Eject media key. May be used to eject a CD tray, for example.
+        /// </summary>
         MediaEject = 129,
+
+        /// <summary>
+        /// Record media key.
+        /// </summary>
         MediaRecord = 130,
+
+        /// <summary>
+        /// F1 key.
+        /// </summary>
         F1 = 131,
+
+        /// <summary>
+        /// F2 key.
+        /// </summary>
         F2 = 132,
+
+        /// <summary>
+        /// F3 key.
+        /// </summary>
         F3 = 133,
+
+        /// <summary>
+        /// F4 key.
+        /// </summary>
         F4 = 134,
+
+        /// <summary>
+        /// F5 key.
+        /// </summary>
         F5 = 135,
+
+        /// <summary>
+        /// F6 key.
+        /// </summary>
         F6 = 136,
+
+        /// <summary>
+        /// F7 key.
+        /// </summary>
         F7 = 137,
+
+        /// <summary>
+        /// F8 key.
+        /// </summary>
         F8 = 138,
+
+        /// <summary>
+        /// F9 key.
+        /// </summary>
         F9 = 139,
+
+        /// <summary>
+        /// F10 key.
+        /// </summary>
         F10 = 140,
+
+        /// <summary>
+        /// F11 key.
+        /// </summary>
         F11 = 141,
+
+        /// <summary>
+        /// F12 key.
+        /// </summary>
         F12 = 142,
+
+        /// <summary>
+        /// Num Lock key. This is the Num Lock key; it is different from <see cref="AndroidKeyCode.Num"/>. This key alters the behavior of other keys on the numeric keypad.
+        /// </summary>
         NumLock = 143,
+
+        /// <summary>
+        /// Numeric keypad '0' key.
+        /// </summary>
         Numpad0 = 144,
+
+        /// <summary>
+        /// Numeric keypad '1' key.
+        /// </summary>
         Numpad1 = 145,
+
+        /// <summary>
+        /// Numeric keypad '2' key.
+        /// </summary>
         Numpad2 = 146,
+
+        /// <summary>
+        /// Numeric keypad '3' key.
+        /// </summary>
         Numpad3 = 147,
+
+        /// <summary>
+        /// Numeric keypad '4' key.
+        /// </summary>
         Numpad4 = 148,
+
+        /// <summary>
+        /// Numeric keypad '5' key.
+        /// </summary>
         Numpad5 = 149,
+
+        /// <summary>
+        /// 'Numeric keypad '6' key.
+        /// </summary>
         Numpad6 = 150,
+
+        /// <summary>
+        /// 'Numeric keypad '7' key.
+        /// </summary>
         Numpad7 = 151,
+
+        /// <summary>
+        /// Numeric keypad '8' key.
+        /// </summary>
         Numpad8 = 152,
+
+        /// <summary>
+        /// Numeric keypad '9' key.
+        /// </summary>
         Numpad9 = 153,
+
+        /// <summary>
+        /// Numeric keypad '/' key (for division).
+        /// </summary>
         NumpadDivide = 154,
+
+        /// <summary>
+        /// Numeric keypad '*' key (for multiplication).
+        /// </summary>
         NumpadMultiply = 155,
+
+        /// <summary>
+        /// Numeric keypad '-' key (for subtraction).
+        /// </summary>
         NumpadSubtract = 156,
+
+        /// <summary>
+        /// Numeric keypad '+' key (for addition).
+        /// </summary>
         NumpadAdd = 157,
+
+        /// <summary>
+        /// Numeric keypad '.' key (for decimals or digit grouping).
+        /// </summary>
         NumpadDot = 158,
+
+        /// <summary>
+        /// Numeric keypad ',' key (for decimals or digit grouping).
+        /// </summary>
         NumpadComma = 159,
+
+        /// <summary>
+        /// Numeric keypad Enter key.
+        /// </summary>
         NumpadEnter = 160,
+
+        /// <summary>
+        /// Numeric keypad '=' key.
+        /// </summary>
         NumpadEquals = 161,
+
+        /// <summary>
+        /// Numeric keypad '(' key.
+        /// </summary>
         NumpadLeftParen = 162,
+
+        /// <summary>
+        /// Numeric keypad ')' key.
+        /// </summary>
         NumpadRightParen = 163,
+
+        /// <summary>
+        /// Volume Mute key. Mutes the speaker, unlike <see cref="AndroidKeyCode.Mute"/>. This key should normally be implemented as a toggle such that the first press mutes the speaker and the second press restores the original volum
+        /// </summary>
         VolumeMute = 164,
+
+        /// <summary>
+        /// Info key. Common on TV remotes to show additional information related to what is currently being viewed.
+        /// </summary>
         Info = 165,
+
+        /// <summary>
+        /// Channel up key. On TV remotes, increments the television channel.
+        /// </summary>
         ChannelUp = 166,
+
+        /// <summary>
+        /// Channel down key. On TV remotes, increments the television channel.
+        /// </summary>
         ChannelDown = 167,
+
+        /// <summary>
+        /// Zoom in key.
+        /// </summary>
         ZoomIn = 168,
+
+        /// <summary>
+        /// Zoom out key.
+        /// </summary>
         ZoomOut = 169,
+
+        /// <summary>
+        /// TV key. On TV remotes, switches to viewing live TV.
+        /// </summary>
         Tv = 170,
+
+        /// <summary>
+        /// Window key. On TV remotes, toggles picture-in-picture mode or other windowing functions. On Android Wear devices, triggers a display offset.
+        /// </summary>
         Window = 171,
+
+        /// <summary>
+        /// Guide key. On TV remotes, shows a programming guide.
+        /// </summary>
         Guide = 172,
+
+        /// <summary>
+        /// DVR key. On some TV remotes, switches to a DVR mode for recorded shows.
+        /// </summary>
         Dvr = 173,
+
+        /// <summary>
+        /// Bookmark key. On some TV remotes, bookmarks content or web pages.
+        /// </summary>
         Bookmark = 174,
+
+        /// <summary>
+        /// Toggle captions key. Switches the mode for closed-captioning text, for example during television shows.
+        /// </summary>
         Captions = 175,
+
+        /// <summary>
+        /// Settings key. Starts the system settings activity.
+        /// </summary>
         Settings = 176,
+
+        /// <summary>
+        /// TV power key. On HDMI TV panel devices and Android TV devices that don't support HDMI, toggles the power state of the device. On HDMI source devices, toggles the power state of the HDMI-connected TV via HDMI-CEC and makes the source device follow this power state.
+        /// </summary>
         TvPower = 177,
+
+        /// <summary>
+        /// TV input key. On TV remotes, switches the input on a television screen.
+        /// </summary>
         TvInput = 178,
+
+        /// <summary>
+        /// Set-top-box power key. On TV remotes, toggles the power on an external Set-top-box.
+        /// </summary>
         StbPower = 179,
+
+        /// <summary>
+        /// Set-top-box input key. On TV remotes, switches the input mode on an external Set-top-box.
+        /// </summary>
         StbInput = 180,
+
+        /// <summary>
+        /// A/V Receiver power key. On TV remotes, toggles the power on an external A/V Receiver.
+        /// </summary>
         AvrPower = 181,
+
+        /// <summary>
+        /// A/V Receiver input key. On TV remotes, switches the input mode on an external A/V Receive
+        /// </summary>
         AvrInput = 182,
+
+        /// <summary>
+        /// Red "programmable" key. On TV remotes, acts as a contextual/programmable key.
+        /// </summary>
         ProgRed = 183,
+
+        /// <summary>
+        /// Green "programmable" key. On TV remotes, actsas a contextual/programmable key.
+        /// </summary>
         ProgGreen = 184,
+
+        /// <summary>
+        /// Yellow "programmable" key. On TV remotes, actsas a contextual/programmable key.
+        /// </summary>
         ProgYellow = 185,
+
+        /// <summary>
+        /// Blue "programmable" key. On TV remotes, actsas a contextual/programmable key.
+        /// </summary>
         ProgBlue = 186,
+
+        /// <summary>
+        /// App switch key. Should bring up the application switcher dialog.
+        /// </summary>
         AppSwitch = 187,
+
+        /// <summary>
+        /// Generic Game Pad Button #1.
+        /// </summary>
         Button1 = 188,
+
+        /// <summary>
+        /// Generic Game Pad Button #2.
+        /// </summary>
         Button2 = 189,
+
+        /// <summary>
+        /// Generic Game Pad Button #3.
+        /// </summary>
         Button3 = 190,
+
+        /// <summary>
+        /// Generic Game Pad Button #4.
+        /// </summary>
         Button4 = 191,
+
+        /// <summary>
+        /// Generic Game Pad Button #5.
+        /// </summary>
         Button5 = 192,
+
+        /// <summary>
+        /// Generic Game Pad Button #6.
+        /// </summary>
         Button6 = 193,
+
+        /// <summary>
+        /// Generic Game Pad Button #7.
+        /// </summary>
         Button7 = 194,
+
+        /// <summary>
+        /// Generic Game Pad Button #8.
+        /// </summary>
         Button8 = 195,
+
+        /// <summary>
+        /// Generic Game Pad Button #9.
+        /// </summary>
         Button9 = 196,
+
+        /// <summary>
+        /// Generic Game Pad Button #10.
+        /// </summary>
         Button10 = 197,
+
+        /// <summary>
+        /// Generic Game Pad Button #11.
+        /// </summary>
         Button11 = 198,
+
+        /// <summary>
+        /// Generic Game Pad Button #12.
+        /// </summary>
         Button12 = 199,
+
+        /// <summary>
+        /// Generic Game Pad Button #13.
+        /// </summary>
         Button13 = 200,
+
+        /// <summary>
+        /// Generic Game Pad Button #14.
+        /// </summary>
         Button14 = 201,
+
+        /// <summary>
+        /// Generic Game Pad Button #15.
+        /// </summary>
         Button15 = 202,
+
+        /// <summary>
+        /// Generic Game Pad Button #16.
+        /// </summary>
         Button16 = 203,
+
+        /// <summary>
+        /// Language Switch key. Toggles the current input language such as switching between English and Japanese on a QWERTY keyboard. On some devices, the same function may be performed by pressing Shift+Spacebar.
+        /// </summary>
         LanguageSwitch = 204,
+
+        /// <summary>
+        /// 'Manner Mode key. Toggles silent or vibrate mode on and off to make the device behave more politely in certain settings such as on a crowded train. On some devices, the key may only operate when long-pressed.
+        /// </summary>
         MannerMode = 205,
+
+        /// <summary>
+        /// 3D Mode key. Toggles the display between 2D and 3D mode.
+        /// </summary>
         Mode3D = 206,
+
+        /// <summary>
+        /// Contacts special function key. Used to launch an address book application.
+        /// </summary>
         Contacts = 207,
+
+        /// <summary>
+        /// Calendar special function key. Used to launch a calendar application.
+        /// </summary>
         Calendar = 208,
+
+        /// <summary>
+        /// Music special function key. Used to launch a music player application.
+        /// </summary>
         Music = 209,
+
+        /// <summary>
+        /// Calculator special function key. Used to launch a calculator application.
+        /// </summary>
         Calculator = 210,
+
+        /// <summary>
+        /// Japanese full-width / half-width key.
+        /// </summary>
         ZenkakuHankaku = 211,
+
+        /// <summary>
+        /// Japanese alphanumeric key.
+        /// </summary>
         Eisu = 212,
+
+        /// <summary>
+        /// Japanese non-conversion key.
+        /// </summary>
         Muhenkan = 213,
+
+        /// <summary>
+        /// Japanese conversion key.
+        /// </summary>
         Henkan = 214,
+
+        /// <summary>
+        /// Japanese katakana / hiragana key.
+        /// </summary>
         KatakanaHiragana = 215,
+
+        /// <summary>
+        /// Japanese Yen key.
+        /// </summary>
         Yen = 216,
+
+        /// <summary>
+        /// Japanese Ro key.
+        /// </summary>
         Ro = 217,
+
+        /// <summary>
+        /// Japanese kana key.
+        /// </summary>
         Kana = 218,
+
+        /// <summary>
+        /// Assist key. Launches the global assist activity. Not delivered to applications.
+        /// </summary>
         Assist = 219,
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -147,7 +147,7 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
     /// Structure of HID input reports for PS4 DualShock 4 controllers.
     /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 32)]
-    public struct DualShock4HIDInputReport : IInputStateTypeInfo
+    internal struct DualShock4HIDInputReport : IInputStateTypeInfo
     {
         [FieldOffset(0)] public byte reportId;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -147,7 +147,7 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
     /// Structure of HID input reports for PS4 DualShock 4 controllers.
     /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 32)]
-    internal struct DualShock4HIDInputReport : IInputStateTypeInfo
+    public struct DualShock4HIDInputReport : IInputStateTypeInfo
     {
         [FieldOffset(0)] public byte reportId;
 


### PR DESCRIPTION
### Description

Make some internal classes public. I need those classes when deconstructing raw events captured via InputEventTrace.
Currently I am forced to various hacks like call my assembly Unity.InputSystem.Tests to be able to access those

### Changes made

Made the following internal classes public:
- AndroidAxis
- AndroidGameControllerState
- AndroidKeyCode
- DualShock4HIDInputReport

### Notes

No additional notes

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [X] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
