### PR TITLE
CHANGE: Adding or removing device no longer temp-disables actions (case 1379932).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -3232,6 +3232,7 @@ partial class CoreTests
 
     public class ModificationCases : IEnumerable
     {
+        [Preserve]
         public ModificationCases() {}
 
         public IEnumerator GetEnumerator()

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -650,12 +651,9 @@ partial class CoreTests
         actionThatShouldNotTrigger.started += ctx => Assert.Fail("Action should not start");
         actionThatShouldNotTrigger.performed += ctx => Assert.Fail("Action should not be performed");
 
-        using (var trace1 = new InputActionTrace())
-        using (var trace2 = new InputActionTrace())
+        using (var trace1 = new InputActionTrace(actionWithoutInteraction))
+        using (var trace2 = new InputActionTrace(actionWithHold))
         {
-            trace1.SubscribeTo(actionWithoutInteraction);
-            trace2.SubscribeTo(actionWithHold);
-
             actionWithoutInteraction.Enable();
             actionWithHold.Enable();
             actionThatShouldNotTrigger.Enable();
@@ -666,39 +664,10 @@ partial class CoreTests
             InputSystem.QueueDeltaStateEvent(gamepad.leftStick, new Vector2(0.345f, 0.456f));
             InputSystem.Update();
 
-            var actions1 = trace1.ToArray();
-            var actions2 = trace2.ToArray();
-
-            Assert.That(actions1, Has.Length.EqualTo(3));
-            Assert.That(actions2, Has.Length.EqualTo(1));
-
-            Assert.That(actions1[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions1[0].action, Is.SameAs(actionWithoutInteraction));
-            Assert.That(actions1[0].interaction, Is.Null);
-            Assert.That(actions1[0].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions1[0].ReadValue<Vector2>(),
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions1[1].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions1[1].action, Is.SameAs(actionWithoutInteraction));
-            Assert.That(actions1[1].interaction, Is.Null);
-            Assert.That(actions1[1].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions1[1].ReadValue<Vector2>(),
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)))
-                    .Using(Vector2EqualityComparer.Instance));
-            Assert.That(actions1[2].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions1[2].action, Is.SameAs(actionWithoutInteraction));
-            Assert.That(actions1[2].interaction, Is.Null);
-            Assert.That(actions1[2].control, Is.SameAs(gamepad.leftStick));
-            Assert.That(actions1[2].ReadValue<Vector2>(),
-                Is.EqualTo(new StickDeadzoneProcessor().Process(new Vector2(0.345f, 0.456f)))
-                    .Using(Vector2EqualityComparer.Instance));
-
-            Assert.That(actions2[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions2[0].action, Is.SameAs(actionWithHold));
-            Assert.That(actions2[0].interaction, Is.TypeOf<HoldInteraction>());
-            Assert.That(actions2[0].control, Is.SameAs(gamepad.buttonSouth));
-            Assert.That(actions2[0].ReadValue<float>(), Is.EqualTo(1).Within(0.00001));
+            Assert.That(trace1, Started(actionWithoutInteraction, control: gamepad.leftStick, value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)))
+                .AndThen(Performed(actionWithoutInteraction, control: gamepad.leftStick, value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f))))
+                .AndThen(Performed(actionWithoutInteraction, control: gamepad.leftStick, value: new StickDeadzoneProcessor().Process(new Vector2(0.345f, 0.456f)))));
+            Assert.That(trace2, Started<HoldInteraction>(actionWithHold, control: gamepad.buttonSouth, value: 1f));
         }
     }
 
@@ -3244,14 +3213,335 @@ partial class CoreTests
                 .Property("path").EqualTo("<Keyboard>/rightArrow"));
     }
 
-    // Case 1218544
+    public enum Modification
+    {
+        AddBinding,
+        RemoveBinding,
+        ModifyBinding,
+        ApplyBindingOverride,
+        AddAction,
+        RemoveAction,
+        AddMap,
+        RemoveMap,
+        ChangeBindingMask,
+        AddDevice,
+        RemoveDevice,
+        AddDeviceGlobally,
+        RemoveDeviceGlobally,
+    }
+
+    public class ModificationCases : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            bool ModificationAppliesToSingletonAction(Modification modification)
+            {
+                switch (modification)
+                {
+                    case Modification.AddBinding:
+                    case Modification.RemoveBinding:
+                    case Modification.ModifyBinding:
+                    case Modification.ApplyBindingOverride:
+                    case Modification.AddDeviceGlobally:
+                    case Modification.RemoveDeviceGlobally:
+                        return true;
+                }
+                return false;
+            }
+
+            bool ModificationAppliesToSingleActionMap(Modification modification)
+            {
+                switch (modification)
+                {
+                    case Modification.AddMap:
+                    case Modification.RemoveMap:
+                        return false;
+                }
+                return true;
+            }
+
+            // NOTE: This executes *outside* of our test fixture during test discovery.
+
+            // Creates a matrix of all permutations of Modifications combined with assets, maps, and singleton actions.
+            foreach (var func in new Func<IInputActionCollection2>[] { () => new DefaultInputActions().asset, CreateMap, CreateSingletonAction })
+            {
+                foreach (var value in Enum.GetValues(typeof(Modification)))
+                {
+                    var actions = func();
+                    if (actions is InputActionMap map)
+                    {
+                        if (map.m_SingletonAction != null)
+                        {
+                            if (!ModificationAppliesToSingletonAction((Modification)value))
+                                continue;
+                        }
+                        else if (!ModificationAppliesToSingleActionMap((Modification)value))
+                        {
+                            continue;
+                        }
+                    }
+
+                    yield return new object[] { value, func() };
+                }
+            }
+        }
+
+        private InputActionMap CreateMap()
+        {
+            var map = new InputActionMap("SingleActionMap");
+            var action1 = map.AddAction("action1");
+            var action2 = map.AddAction("action2");
+            var action3 = map.AddAction("action3");
+            action1.AddBinding("<Keyboard>/space", groups: "Keyboard");
+            action1.AddBinding("<Gamepad>/buttonNorth", groups: "Gamepad");
+            action2.AddBinding("<Gamepad>/buttonSouth", groups: "Gamepad");
+            action3.AddBinding("<Mouse>/leftButton", groups: "Mouse");
+            action3.AddBinding("<Gamepad>/rightTrigger", groups: "Gamepad");
+            return map;
+        }
+
+        private InputActionMap CreateSingletonAction()
+        {
+            var action = new InputAction("SingletonAction");
+            action.AddBinding("<Gamepad>/buttonSouth", groups: "Gamepad");
+            action.AddBinding("<Keyboard>/space", groups: "Keyboard");
+            return action.GetOrCreateActionMap();
+        }
+    }
+
     [Test]
     [Category("Actions")]
-    public void Actions_CanAddBindingsToActions_AfterActionHasBeenEnabled()
+    [TestCaseSource(typeof(ModificationCases))]
+    public void Actions_CanHandleModification(Modification modification, IInputActionCollection2 actions)
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        if (modification == Modification.AddDevice || modification == Modification.RemoveDevice)
+            actions.devices = new[] { gamepad };
+        else if (modification == Modification.ChangeBindingMask)
+            actions.bindingMask = InputBinding.MaskByGroup("Gamepad");
+
+        List<InputControl> listOfControlsBeforeModification = null;
+        InputAction enabledAction = null;
+
+        bool NeedsFullResolve()
+        {
+            switch (modification)
+            {
+                case Modification.AddDevice:
+                case Modification.RemoveDevice:
+                case Modification.AddDeviceGlobally:
+                case Modification.RemoveDeviceGlobally:
+                    return false;
+            }
+            return true;
+        }
+
+        bool NeedsActionsToBeDisabled()
+        {
+            switch (modification)
+            {
+                case Modification.AddAction:
+                case Modification.RemoveAction:
+                case Modification.AddMap:
+                case Modification.RemoveMap:
+                    return true;
+            }
+            return false;
+        }
+
+        void ApplyAndVerifyModification()
+        {
+            switch (modification)
+            {
+                case Modification.AddBinding:
+                {
+                    var action = actions.Last(a => a.controls.Contains(gamepad.buttonSouth));
+                    action.AddBinding("<Gamepad>/buttonNorth");
+                    Assert.That(action.controls, Has.Exactly(1).SameAs(gamepad.buttonSouth));
+                    Assert.That(action.controls, Has.Exactly(1).SameAs(gamepad.buttonNorth));
+                    Assert.That(actions.SelectMany(a => a.controls).Distinct(),
+                        Is.EquivalentTo(listOfControlsBeforeModification.Append(gamepad.buttonNorth).Distinct()));
+                    break;
+                }
+
+                case Modification.RemoveBinding:
+                {
+                    var action = actions.First(a => a.controls.Contains(gamepad.buttonSouth));
+                    action.ChangeBinding(0).Erase();
+                    Assert.That(action.controls, Has.Exactly(0).SameAs(gamepad.buttonSouth));
+                    break;
+                }
+
+                case Modification.ModifyBinding:
+                {
+                    var action = actions.First(a => a.controls.Contains(gamepad.buttonSouth));
+                    action.ChangeBinding(0).WithPath("<Gamepad>/buttonNorth");
+                    Assert.That(action.controls, Does.Contain(gamepad.buttonNorth));
+                    break;
+                }
+
+                case Modification.ApplyBindingOverride:
+                {
+                    var action = actions.Last(a => a.controls.Contains(gamepad.buttonSouth));
+                    action.ApplyBindingOverride("<Gamepad>/buttonNorth");
+                    Assert.That(action.controls, Does.Contain(gamepad.buttonNorth));
+                    break;
+                }
+
+                case Modification.AddAction:
+                {
+                    foreach (var map in actions.Select(a => a.actionMap).Distinct())
+                        map.AddAction("NewAction", binding: "<Gamepad>/leftTrigger");
+                    Assert.That(actions.FindAction("NewAction"), Is.Not.Null);
+                    Assert.That(actions.FindAction("NewAction").enabled, Is.False);
+                    Assert.That(actions.FindAction("NewAction").controls, Is.EqualTo(new[] { gamepad.leftTrigger }));
+                    break;
+                }
+
+                case Modification.RemoveAction:
+                {
+                    var action = actions.First(a => a.controls.Contains(gamepad.buttonSouth));
+                    action.RemoveAction();
+                    Assert.That(actions.FindAction(action.name), Is.Not.SameAs(action));
+                    break;
+                }
+
+                case Modification.AddMap:
+                {
+                    var map = new InputActionMap("NewMap");
+                    var action = map.AddAction("NewAction", binding: "<Gamepad>/buttonEast");
+                    ((InputActionAsset)actions).AddActionMap(map);
+                    Assert.That(action.controls, Is.EqualTo(new[] { gamepad.buttonEast }));
+                    Assert.That(actions.SelectMany(a => a.controls).Distinct(),
+                        Is.EquivalentTo(listOfControlsBeforeModification.Append(gamepad.buttonEast).Distinct()));
+                    break;
+                }
+
+                case Modification.RemoveMap:
+                {
+                    var asset = (InputActionAsset)actions;
+                    var map = asset.actionMaps[0];
+                    asset.RemoveActionMap(map);
+                    Assert.That(actions.SelectMany(a => a.controls), Is.Not.Empty);
+                    break;
+                }
+
+                case Modification.ChangeBindingMask:
+                {
+                    actions.bindingMask = InputBinding.MaskByGroup("Nothing");
+                    Assert.That(actions.SelectMany(a => a.controls), Is.Empty);
+                    break;
+                }
+
+                case Modification.AddDevice:
+                {
+                    var addedDevice = InputSystem.AddDevice<Gamepad>();
+                    actions.devices = new[] { gamepad, addedDevice };
+                    Assert.That(actions.SelectMany(a => a.controls), Is.SupersetOf(listOfControlsBeforeModification));
+                    Assert.That(actions.SelectMany(a => a.controls).Select(c => c.device), Does.Contain(addedDevice));
+                    break;
+                }
+
+                case Modification.RemoveDevice:
+                {
+                    InputSystem.RemoveDevice(gamepad);
+                    Assert.That(actions.devices, Is.Not.Null);
+                    Assert.That(actions.devices, Is.Empty);
+                    Assert.That(actions.SelectMany(a => a.controls), Is.Empty);
+                    Assert.That(actions.Where(a => a.enabled), Is.EquivalentTo(new[] { enabledAction }));
+                    break;
+                }
+
+                case Modification.AddDeviceGlobally:
+                {
+                    var addedDevice = InputSystem.AddDevice<Gamepad>();
+                    Assert.That(actions.Where(a => a.controls.Any(c => c.device == addedDevice)), Is.Not.Empty,
+                        "Expected at least one action to bind to a control on the newly added device");
+                    break;
+                }
+
+                case Modification.RemoveDeviceGlobally:
+                {
+                    InputSystem.RemoveDevice(gamepad);
+                    Assert.That(actions.Where(a => a.controls.Any(c => c.device == gamepad)), Is.Empty,
+                        "Expected that none of the actions binds to a control on the removed device anymore");
+                    Assert.That(actions.Where(a => a.enabled), Is.EquivalentTo(new[] { enabledAction }));
+                    break;
+                }
+            }
+        }
+
+        var changes = new List<InputActionChange>();
+        InputSystem.onActionChange += (_, change) => changes.Add(change);
+
+        // Initial resolve.
+        Assert.That(actions.Where(x => x.controls.Contains(gamepad.buttonSouth)), Is.Not.Empty,
+            "Expecting at least one action bound to the A button");
+        Assert.That(changes, Is.EqualTo(new[] { InputActionChange.BoundControlsChanged }));
+        listOfControlsBeforeModification = actions.SelectMany(a => a.controls).Distinct().ToList();
+
+        // Put one action into enabled and in-progress state.
+        var aButtonAction = actions.First(x => x.controls.Contains(gamepad.buttonSouth));
+        aButtonAction.Enable();
+        Press(gamepad.buttonSouth);
+        Assert.That(aButtonAction.IsInProgress(), Is.True);
+        Assert.That(aButtonAction.activeControl, Is.SameAs(gamepad.buttonSouth));
+
+        // If actions need to be disabled for the modification to be valid,
+        // make sure we throw if we attempt the modification now.
+        if (NeedsActionsToBeDisabled())
+        {
+            Assert.That(() => ApplyAndVerifyModification(), Throws.InvalidOperationException);
+            aButtonAction.Disable();
+        }
+        else
+        {
+            enabledAction = aButtonAction;
+        }
+
+        changes.Clear();
+
+        // Apply.
+        ApplyAndVerifyModification();
+
+        // If we have removed the gamepad, the action will have been cancelled (but NOT disabled!) by virtue of
+        // losing its active control.
+        if (modification == Modification.RemoveDevice || modification == Modification.RemoveDeviceGlobally)
+        {
+            Assert.That(changes, Is.EqualTo(new[] { InputActionChange.ActionCanceled, InputActionChange.BoundControlsAboutToChange, InputActionChange.BoundControlsChanged }));
+            Assert.That(aButtonAction.phase.IsInProgress(), Is.False);
+            Assert.That(aButtonAction.activeControl, Is.Null);
+            Assert.That(aButtonAction.ReadValue<float>(), Is.EqualTo(0f));
+        }
+        // If the modification doesn't need a full resolve, the action
+        // should have kept going uninterrupted.
+        else if (!NeedsFullResolve())
+        {
+            Assert.That(changes, Is.EqualTo(new[] { InputActionChange.BoundControlsAboutToChange, InputActionChange.BoundControlsChanged }));
+            Assert.That(aButtonAction.phase.IsInProgress(), Is.True);
+            Assert.That(aButtonAction.activeControl, Is.SameAs(gamepad.buttonSouth));
+            Assert.That(aButtonAction.ReadValue<float>(), Is.EqualTo(1f));
+        }
+        else if (!NeedsActionsToBeDisabled())
+        {
+            // Action should have been automatically disabled and re-enabled.
+            Assert.That(changes,
+                Is.EqualTo(new[]
+                {
+                    InputActionChange.ActionCanceled, InputActionChange.ActionDisabled, InputActionChange.BoundControlsAboutToChange,
+                    InputActionChange.BoundControlsChanged, InputActionChange.ActionEnabled
+                }));
+        }
+    }
+
+    // https://fogbugz.unity3d.com/f/cases/1218544
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanAddBindingsToActions_AfterActionHasAlreadyResolvedControls()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
         var action = new InputAction(name: "test", binding: "<Gamepad>/leftStick");
-        action.Enable();
 
         Assert.That(action.controls, Is.EquivalentTo(new[] { gamepad.leftStick }));
         Assert.That(action.bindings, Has.Count.EqualTo(1));
@@ -3720,6 +4010,44 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_WhenDeviceIsAdded_OngoingActionsAreUnaffected()
+    {
+        var gamepad1 = InputSystem.AddDevice<Gamepad>();
+
+        var buttonAction = new InputAction(type: InputActionType.Button, binding: "<Gamepad>/buttonSouth");
+        var valueAction = new InputAction(type: InputActionType.Value, binding: "<Gamepad>/leftTrigger");
+
+        buttonAction.Enable();
+        valueAction.Enable();
+
+        Press(gamepad1.buttonSouth);
+        Set(gamepad1.leftTrigger, 0.5f);
+
+        Assert.That(buttonAction.IsPressed, Is.True);
+        Assert.That(valueAction.ReadValue<float>(), Is.EqualTo(0.5f));
+
+        using (var trace = new InputActionTrace())
+        {
+            trace.SubscribeToAll();
+
+            var gamepad2 = InputSystem.AddDevice<Gamepad>();
+
+            Assert.That(trace, Is.Empty);
+
+            // Make sure we execute initial state checks.
+            InputSystem.Update();
+
+            Assert.That(trace, Is.Empty);
+
+            Set(gamepad2.leftTrigger, 1f);
+
+            Assert.That(valueAction.ReadValue<float>(), Is.EqualTo(1f));
+            Assert.That(valueAction.activeControl, Is.SameAs(gamepad2.leftTrigger));
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_WhenDeviceIsRemoved_BoundControlsAreUpdated()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -3733,24 +4061,6 @@ partial class CoreTests
         InputSystem.RemoveDevice(gamepad);
 
         Assert.That(action.controls, Has.Count.Zero);
-    }
-
-    [Test]
-    [Category("Actions")]
-    public void Actions_WhenDeviceIsRemoved_OngoingActionsAreCancelled()
-    {
-        var gamepad = InputSystem.AddDevice<Gamepad>();
-
-        var action = new InputAction(binding: "<Gamepad>/leftTrigger");
-        action.Enable();
-
-        Set(gamepad.leftTrigger, 0.75f);
-
-        Assert.That(action.inProgress, Is.True);
-
-        InputSystem.RemoveDevice(gamepad);
-
-        Assert.That(action.inProgress, Is.False);
     }
 
     [Test]
@@ -3872,7 +4182,7 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
-    public void Actions_ControlsUpdateWhenDeviceUsagesChange()
+    public void Actions_ControlsUpdate_WhenDeviceUsagesChange()
     {
         var device1 = InputSystem.AddDevice<Mouse>();
         var device2 = InputSystem.AddDevice<Mouse>();
@@ -3896,7 +4206,7 @@ partial class CoreTests
     // layout which in turn affects bindings to keys by "display name" (i.e. text character).
     [Test]
     [Category("Actions")]
-    public void Actions_ControlsUpdateWhenDeviceConfigurationChanges()
+    public void Actions_ControlsUpdate_WhenDeviceConfigurationChanges()
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();
 
@@ -3914,7 +4224,7 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
-    public void Actions_ControlsUpdateWhenDeviceConfigurationChanges_AndControlIsNotFound()
+    public void Actions_ControlsUpdate_WhenDeviceConfigurationChanges_AndControlIsNotFound()
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();
 
@@ -3961,14 +4271,10 @@ partial class CoreTests
         InputSystem.AddDevice<Gamepad>();
 
         Assert.That(received,
-            Is.EquivalentTo(new object[]
+            Is.EqualTo(new object[]
             {
-                // When the action map re-resolves it will temporarily disable the action
-                // which we see surface through the notifications.
-                enabledAction, InputActionChange.ActionDisabled,
                 enabledAction, InputActionChange.BoundControlsAboutToChange,
-                enabledAction, InputActionChange.BoundControlsChanged,
-                enabledAction, InputActionChange.ActionEnabled,
+                enabledAction, InputActionChange.BoundControlsChanged
             }));
 
         received.Clear();
@@ -3978,7 +4284,7 @@ partial class CoreTests
         _ = controlsQueriedAction.controls;
 
         Assert.That(received,
-            Is.EquivalentTo(new object[]
+            Is.EqualTo(new object[]
             {
                 controlsQueriedAction, InputActionChange.BoundControlsChanged
             }));
@@ -3988,7 +4294,7 @@ partial class CoreTests
         InputSystem.AddDevice<Keyboard>();
 
         Assert.That(received,
-            Is.EquivalentTo(new object[]
+            Is.EqualTo(new object[]
             {
                 controlsQueriedAction, InputActionChange.BoundControlsAboutToChange,
                 controlsQueriedAction, InputActionChange.BoundControlsChanged
@@ -4014,14 +4320,10 @@ partial class CoreTests
         InputSystem.AddDevice<Gamepad>();
 
         Assert.That(received,
-            Is.EquivalentTo(new object[]
+            Is.EqualTo(new object[]
             {
-                // When the action map re-resolves it will temporarily disable the action
-                // which we see surface through the notifications.
-                actionMap, InputActionChange.ActionMapDisabled,
                 actionMap, InputActionChange.BoundControlsAboutToChange,
                 actionMap, InputActionChange.BoundControlsChanged,
-                actionMap, InputActionChange.ActionMapEnabled,
             }));
     }
 
@@ -4046,17 +4348,167 @@ partial class CoreTests
 
         InputSystem.AddDevice<Gamepad>();
 
-        // For some reason, actionMap and asset are considered equivalent so we do the element
-        // checks individually here.
-        Assert.That(received, Has.Count.EqualTo(8));
-        Assert.That(received[0], Is.SameAs(actionMap));
-        Assert.That(received[1], Is.EqualTo(InputActionChange.ActionMapDisabled));
-        Assert.That(received[2], Is.SameAs(asset));
-        Assert.That(received[3], Is.EqualTo(InputActionChange.BoundControlsAboutToChange));
-        Assert.That(received[4], Is.SameAs(asset));
-        Assert.That(received[5], Is.EqualTo(InputActionChange.BoundControlsChanged));
-        Assert.That(received[6], Is.SameAs(actionMap));
-        Assert.That(received[7], Is.EqualTo(InputActionChange.ActionMapEnabled));
+        Assert.That(received, Is.EqualTo(new object[]
+        {
+            asset, InputActionChange.BoundControlsAboutToChange,
+            asset, InputActionChange.BoundControlsChanged,
+        }));
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenControlsUpdate_TimeoutsAreCarriedOver()
+    {
+        currentTime = 0;
+        var gamepad1 = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction(binding: "<Gamepad>/buttonSouth", interactions: "hold(duration=3)");
+        action.Enable();
+
+        currentTime = 1;
+        Press(gamepad1.buttonSouth);
+
+        Assert.That(action.WasPerformedThisFrame(), Is.False);
+        Assert.That(action.IsInProgress(), Is.True);
+        Assert.That(action.activeControl, Is.SameAs(gamepad1.buttonSouth));
+        Assert.That(action.GetTimeoutCompletionPercentage(), Is.EqualTo(0).Within(0.0001));
+
+        currentTime = 2;
+        InputSystem.Update();
+
+        Assert.That(action.GetTimeoutCompletionPercentage(), Is.EqualTo(1 / 3f).Within(0.0001));
+
+        var gamepad2 = InputSystem.AddDevice<Gamepad>();
+
+        Assert.That(action.WasPerformedThisFrame(), Is.False);
+        Assert.That(action.IsInProgress(), Is.True);
+        Assert.That(action.activeControl, Is.SameAs(gamepad1.buttonSouth));
+        Assert.That(action.GetTimeoutCompletionPercentage(), Is.EqualTo(1 / 3f).Within(0.0001));
+
+        currentTime = 5;
+        InputSystem.Update();
+
+        Assert.That(action.WasPerformedThisFrame(), Is.True);
+        Assert.That(action.IsInProgress(), Is.True);
+        Assert.That(action.activeControl, Is.SameAs(gamepad1.buttonSouth));
+        Assert.That(action.GetTimeoutCompletionPercentage(), Is.EqualTo(1f).Within(0.0001));
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenControlsUpdate_InProgressActionsKeepGoing()
+    {
+        currentTime = 0;
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action1 = new InputAction(binding: "<Gamepad>/leftStick");
+        var action2 = new InputAction(binding: "<Gamepad>/buttonSouth", interactions: "hold(duration=3)");
+        var action3 = new InputAction(binding: "<Gamepad>/buttonNorth");
+
+        action1.Enable();
+        action2.Enable();
+        action3.Enable();
+
+        Set(gamepad.leftStick, new Vector2(0.6f, 0.6f));
+        currentTime = 1;
+        Press(gamepad.buttonSouth);
+
+        Assert.That(action1.IsInProgress(), Is.True);
+        Assert.That(action2.IsInProgress(), Is.True);
+        Assert.That(action3.IsInProgress(), Is.False);
+        Assert.That(action1.activeControl, Is.SameAs(gamepad.leftStick));
+        Assert.That(action2.activeControl, Is.SameAs(gamepad.buttonSouth));
+        Assert.That(action3.activeControl, Is.Null);
+        Assert.That(action2.GetTimeoutCompletionPercentage(), Is.EqualTo(0f));
+
+        currentTime = 2;
+        var gamepad2 = InputSystem.AddDevice<Gamepad>();
+        InputSystem.Update();
+
+        Assert.That(action1.IsInProgress(), Is.True);
+        Assert.That(action2.IsInProgress(), Is.True);
+        Assert.That(action3.IsInProgress(), Is.False);
+        Assert.That(action1.activeControl, Is.SameAs(gamepad.leftStick));
+        Assert.That(action2.activeControl, Is.SameAs(gamepad.buttonSouth));
+        Assert.That(action3.activeControl, Is.Null);
+        Assert.That(action2.GetTimeoutCompletionPercentage(), Is.EqualTo(1 / 3f).Within(0.001));
+
+        InputSystem.RemoveDevice(gamepad2);
+        currentTime = 3;
+        Set(gamepad.leftStick, new Vector2(0.7f, 0.7f));
+
+        Assert.That(action1.IsInProgress(), Is.True);
+        Assert.That(action2.IsInProgress(), Is.True);
+        Assert.That(action3.IsInProgress(), Is.False);
+        Assert.That(action1.activeControl, Is.SameAs(gamepad.leftStick));
+        Assert.That(action2.activeControl, Is.SameAs(gamepad.buttonSouth));
+        Assert.That(action3.activeControl, Is.Null);
+        Assert.That(action2.GetTimeoutCompletionPercentage(), Is.EqualTo(2 * (1 / 3f)).Within(0.001));
+
+        currentTime = 5;
+        InputSystem.Update();
+
+        Assert.That(action1.IsInProgress(), Is.True);
+        Assert.That(action2.IsInProgress(), Is.True);
+        Assert.That(action3.IsInProgress(), Is.False);
+        Assert.That(action1.activeControl, Is.SameAs(gamepad.leftStick));
+        Assert.That(action2.activeControl, Is.SameAs(gamepad.buttonSouth));
+        Assert.That(action3.activeControl, Is.Null);
+        Assert.That(action2.GetTimeoutCompletionPercentage(), Is.EqualTo(1f));
+        Assert.That(action2.WasPerformedThisFrame(), Is.True);
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenInProgress_AddingAndRemovingUnusedDevice_DoesNotAffectActionInProgress()
+    {
+        InputSystem.settings.defaultDeadzoneMax = 1f;
+        InputSystem.settings.defaultDeadzoneMin = 0f;
+
+        var usedGamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction(binding: "<Gamepad>/leftStick");
+        action.Enable();
+
+        Set(usedGamepad.leftStick, new Vector2(0.6f, 0.6f));
+
+        Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
+        Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(0.6f, 0.6f)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(action.activeControl, Is.SameAs(usedGamepad.leftStick));
+
+        using (var trace = new InputActionTrace(action))
+        {
+            // Adding an unused gamepad should re-resolve but should not
+            // alter the progression state of the action.
+            var unusedGamepad = InputSystem.AddDevice<Gamepad>();
+            InputSystem.Update();
+
+            Assert.That(action.controls, Is.EquivalentTo(new[] { usedGamepad.leftStick, unusedGamepad.leftStick }));
+            Assert.That(trace, Is.Empty);
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(0.6f, 0.6f)).Using(Vector2EqualityComparer.Instance));
+            Assert.That(action.activeControl, Is.SameAs(usedGamepad.leftStick));
+
+            InputSystem.RemoveDevice(unusedGamepad);
+            InputSystem.Update();
+
+            Assert.That(action.controls, Is.EquivalentTo(new[] { usedGamepad.leftStick }));
+            Assert.That(trace, Is.Empty);
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(new Vector2(0.6f, 0.6f)).Using(Vector2EqualityComparer.Instance));
+            Assert.That(action.activeControl, Is.SameAs(usedGamepad.leftStick));
+
+            // Finally, add an unused device but then remove the actively used one.
+            InputSystem.AddDevice(unusedGamepad);
+            InputSystem.RemoveDevice(usedGamepad);
+            InputSystem.Update();
+
+            Assert.That(action.controls, Is.EquivalentTo(new[] { unusedGamepad.leftStick }));
+            Assert.That(trace, Canceled(action, control: usedGamepad.leftStick, value: Vector2.zero));
+            Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
+            Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
+            Assert.That(action.activeControl, Is.Null);
+        }
     }
 
     [Test]
@@ -6640,22 +7092,15 @@ partial class CoreTests
             InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.345f});
             InputSystem.Update();
 
-            var actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(2));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(-0.345).Within(0.00001));
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[1].ReadValue<float>(), Is.EqualTo(-0.345).Within(0.00001));
+            Assert.That(trace, Started(action, value: -0.345f)
+                .AndThen(Performed(action, value: -0.345f)));
 
             trace.Clear();
 
             InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.345f, rightTrigger = 0.543f});
             InputSystem.Update();
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.00001));
+            Assert.That(trace, Canceled(action, value: 0f));
 
             trace.Clear();
 
@@ -6666,15 +7111,9 @@ partial class CoreTests
             InputSystem.Update();
 
             // We get a started and performed when switching to the right trigger and then another performed
-            // when we right trigger changes value.
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(3));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(0.543f).Within(0.00001));
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[1].ReadValue<float>(), Is.EqualTo(0.543f).Within(0.00001));
-            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[2].ReadValue<float>(), Is.EqualTo(0.234f).Within(0.00001));
+            // when the right trigger changes value.
+            Assert.That(trace,
+                Started(action, value: 0.543f).AndThen(Performed(action, value: 0.543f)).AndThen(Performed(action, value: 0.234f)));
 
             trace.Clear();
 
@@ -6684,16 +7123,9 @@ partial class CoreTests
             InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.567f, rightTrigger = 0.765f});
             InputSystem.Update();
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(4));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(0).Within(0.00001));
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[1].ReadValue<float>(), Is.EqualTo(-0.123f).Within(0.00001));
-            Assert.That(actions[2].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[2].ReadValue<float>(), Is.EqualTo(-0.123).Within(0.00001));
-            Assert.That(actions[3].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[3].ReadValue<float>(), Is.EqualTo(-0.567).Within(0.00001));
+            Assert.That(trace,
+                Canceled(action, value: 0f).AndThen(Started(action, value: -0.123f)).AndThen(Performed(action, value: -0.123f))
+                    .AndThen(Performed(action, value: -0.567f)));
         }
     }
 
@@ -9074,9 +9506,7 @@ partial class CoreTests
 
         // adding an action now should fail with a descriptive exception
         Assert.That(() => map1.AddAction("action4"),
-            Throws.InvalidOperationException.With.Message.Contains("action4")
-                .And.With.Message.Contains("map1")
-                .And.With.Message.Contains("map2"));
+            Throws.InvalidOperationException);
         Assert.That(map1.actions, Has.Count.EqualTo(2));
     }
 

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -3232,6 +3232,8 @@ partial class CoreTests
 
     public class ModificationCases : IEnumerable
     {
+        public ModificationCases() {}
+
         public IEnumerator GetEnumerator()
         {
             bool ModificationAppliesToSingletonAction(Modification modification)

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -3213,6 +3213,7 @@ partial class CoreTests
                 .Property("path").EqualTo("<Keyboard>/rightArrow"));
     }
 
+    [Serializable]
     public enum Modification
     {
         AddBinding,
@@ -3284,7 +3285,7 @@ partial class CoreTests
                         }
                     }
 
-                    yield return new object[] { value, func() };
+                    yield return new TestCaseData(value, actions);
                 }
             }
         }

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -174,7 +174,7 @@ internal partial class CoreTests
 
     [Test]
     [Category("Actions")]
-    public void Action_WithMultipleInteractions_DoesNotThrowWhenUsingMultipleMaps()
+    public void Actions_WithMultipleInteractions_DoNotThrowWhenUsingMultipleMaps()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,8 +26,6 @@ however, it has to be formatted properly to pass verification tests.
   Set(Gamepad.current.rightTrigger, 0.1f); // <Nothing>
   Set(Gamepad.current.rightTrigger, 0f);   // Canceled
   ```
-  - This also applies to `PressInteraction` when set to `Press` behavior.
-  - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
   * This also applies to `PressInteraction` when set to `Press` behavior.
   * In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
 - Made the following internal types public. These types can be useful when deconstructing raw events captured via `InputEventTrace`.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,10 @@ however, it has to be formatted properly to pass verification tests.
   ```
   - This also applies to `PressInteraction` when set to `Press` behavior.
   - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
+* Adding or removing a device no longer leads to affected actions being temporarily disabled ([case 1379932](https://issuetracker.unity3d.com/issues/inputactionreferences-reading-resets-when-inputactionmap-has-an-action-for-the-other-hand-and-that-hand-starts-slash-stops-tracking)).
+  - If, for example, an action was bound to `<Gamepad>/buttonSouth` and was enabled, adding a second `Gamepad` would lead to the action being temporarily disabled, then updated, and finally re-enabled.
+  - This was especially noticeable if the action was currently in progress as it would get cancelled and then subsequently resumed.
+  - Now, an in-progress action will get cancelled if the device of its active control is removed. If its active control is not affected, however, the action will keep going regardless of whether controls are added or removed from its `InputAction.controls` list.
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -20,6 +20,7 @@
 * [Control schemes](#control-schemes)
 * [Details](#details)
   * [Binding resolution](#binding-resolution)
+    * [Binding resolution while Actions are enabled](#binding-resolution-while-actions-are-enabled)
     * [Choosing which Devices to use](#choosing-which-devices-to-use)
   * [Disambiguation](#disambiguation)
   * [Initial state check](#initial-state-check)
@@ -664,6 +665,18 @@ Note that a single [Binding path](Controls.md#control-paths) can match multiple 
 If there are multiple Bindings on the same Action that all reference the same Control(s), the Control will effectively feed into the Action multiple times. This is to allow, for example, a single Control to produce different input on the same Action by virtue of being bound in a different fashion (composites, processors, interactions, etc). However, regardless of how many times a Control is bound on any given action, it will only be mentioned once in the Action's [array of `controls`](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_controls).
 
 To query the Controls that an Action resolves to, you can use [`InputAction.controls`](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_controls). You can also run this query if the Action is disabled.
+
+To be notified when binding resolution happens, you can listen to [`InputSystem.onActionChange`](../api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_onActionChange) which triggers [`InputActionChange.BoundControlsAboutToChange`](../api/UnityEngine.InputSystem.InputActionChange.html#UnityEngine_InputSystem_InputActionChange_BoundControlsAboutToChange) before modifying Control lists and triggers [`InputActionChange.BoundControlsChanged`](../api/UnityEngine.InputSystem.InputActionChange.html#UnityEngine_InputSystem_InputActionChange_BoundControlsChanged) after having updated them.
+
+#### Binding resolution while Actions are enabled
+
+In certain situations, the [Controls](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_controls) bound to an Action have to be updated more than once. For example, if a new [Device](Devices.md) becomes usable with an Action, the Action may now pick up input from additional controls. Also, if Bindings are added, removed, or modified, Control lists will need to be updated.
+
+This updating of Controls usually happens transparently in the background. However, when an Action is [enabled](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_enabled) and especially when it is [in progress](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_IsInProgress_), there may be a noticeable effect on the Action.
+
+Adding or removing a device &ndash; either [globally](../api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_devices) or to/from the [device list](../api/UnityEngine.InputSystem.InputActionAsset.html#UnityEngine_InputSystem_InputActionAsset_devices) of an Action &ndash; will remain transparent __except__ if an Action is in progress and it is the device of its [active Control](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_activeControl) that is being removed. In this case, the Action will automatically be [cancelled](../api/UnityEngine.InputSystem.InputAction.html#UnityEngine_InputSystem_InputAction_canceled).
+
+Modifying the [binding mask](../api/UnityEngine.InputSystem.InputActionAsset.html#UnityEngine_InputSystem_InputActionAsset_bindingMask) or modifying any of the Bindings (such as through [rebinding](#interactive-rebinding) or by adding or removing bindings) will, however, lead to all enabled Actions being temporarily disabled and then re-enabled and resumed.
 
 #### Choosing which Devices to use
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/IInputActionCollection.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/IInputActionCollection.cs
@@ -18,6 +18,9 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <remarks>
         /// If this is not null, only bindings that match the mask will be used.
+        ///
+        /// Modifying this property while any of the actions in the collection are enabled will
+        /// lead to the actions getting disabled temporarily and then re-enabled.
         /// </remarks>
         InputBinding? bindingMask { get; set; }
 
@@ -31,6 +34,13 @@ namespace UnityEngine.InputSystem
         /// only one gamepad is listed here, then a "&lt;Gamepad&gt;/leftStick" binding will
         /// only bind to the gamepad in the list and not to the one that is only available
         /// globally.
+        ///
+        /// Modifying this property after bindings in the collection have already been resolved,
+        /// will lead to <see cref="InputAction.controls"/> getting refreshed. If any of the actions
+        /// in the collection are currently in progress (see <see cref="InputAction.phase"/>),
+        /// the actions will remain unaffected and in progress except if the controls currently
+        /// driving them (see <see cref="InputAction.activeControl"/>) are no longer part of any
+        /// of the selected devices. In that case, the action is <see cref="InputAction.canceled"/>.
         /// </remarks>
         ReadOnlyArray<InputDevice>? devices { get; set; }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
@@ -187,7 +187,7 @@ namespace UnityEngine.InputSystem
 
                 m_BindingMask = value;
 
-                ReResolveIfNecessary();
+                ReResolveIfNecessary(fullResolve: true);
             }
         }
 
@@ -240,7 +240,7 @@ namespace UnityEngine.InputSystem
             set
             {
                 if (m_Devices.Set(value))
-                    ReResolveIfNecessary();
+                    ReResolveIfNecessary(fullResolve: false);
             }
         }
 
@@ -866,7 +866,23 @@ namespace UnityEngine.InputSystem
 #endif
         }
 
-        private void ReResolveIfNecessary()
+        internal void OnWantToChangeSetup()
+        {
+            if (m_ActionMaps.LengthSafe() > 0)
+                m_ActionMaps[0].OnWantToChangeSetup();
+        }
+
+        internal void OnSetupChanged()
+        {
+            MarkAsDirty();
+
+            if (m_ActionMaps.LengthSafe() > 0)
+                m_ActionMaps[0].OnSetupChanged();
+            else
+                m_SharedStateForAllMaps = null;
+        }
+
+        private void ReResolveIfNecessary(bool fullResolve)
         {
             if (m_SharedStateForAllMaps == null)
                 return;
@@ -874,7 +890,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(m_ActionMaps != null && m_ActionMaps.Length > 0);
             // State is share between all action maps in the asset. Resolving bindings for the
             // first map will resolve them for all maps.
-            m_ActionMaps[0].LazyResolveBindings();
+            m_ActionMaps[0].LazyResolveBindings(fullResolve);
         }
 
         private void OnDestroy()

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1147,10 +1147,6 @@ namespace UnityEngine.InputSystem
             LazyResolveBindings(fullResolve: true);
         }
 
-        internal void OnDeviceAddedOrRemoved()
-        {
-        }
-
         ////TODO: re-use allocations such that only grow the arrays and hit zero GC allocs when we already have enough memory
         internal void ClearCachedActionData(bool onlyControls = false)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Unity.Collections;
 using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: given we have the global ActionPerformed callback, do we really need the per-map callback?
@@ -215,7 +216,7 @@ namespace UnityEngine.InputSystem
                     return;
 
                 m_BindingMask = value;
-                LazyResolveBindings();
+                LazyResolveBindings(fullResolve: true);
             }
         }
 
@@ -266,7 +267,7 @@ namespace UnityEngine.InputSystem
             set
             {
                 if (m_Devices.Set(value))
-                    LazyResolveBindings();
+                    LazyResolveBindings(fullResolve: false);
             }
         }
 
@@ -703,9 +704,6 @@ namespace UnityEngine.InputSystem
 
         [NonSerialized] private InputControl[] m_ControlsForEachAction;
 
-        [NonSerialized] private bool m_ControlsForEachActionInitialized;
-        [NonSerialized] private bool m_BindingsForEachActionInitialized;
-
         /// <summary>
         /// Number of actions currently enabled in the map.
         /// </summary>
@@ -728,14 +726,71 @@ namespace UnityEngine.InputSystem
         /// Initialized when map (or any action in it) is first enabled.
         /// </remarks>
         [NonSerialized] internal InputActionState m_State;
-        [NonSerialized] private bool m_NeedToResolveBindings;
         [NonSerialized] internal InputBinding? m_BindingMask;
+        [NonSerialized] private Flags m_Flags;
 
         [NonSerialized] internal DeviceArray m_Devices;
 
         [NonSerialized] internal CallbackArray<Action<InputAction.CallbackContext>> m_ActionCallbacks;
 
         [NonSerialized] internal Dictionary<string, int> m_ActionIndexByNameOrId;
+
+        private bool needToResolveBindings
+        {
+            get => (m_Flags & Flags.NeedToResolveBindings) != 0;
+            set
+            {
+                if (value)
+                    m_Flags |= Flags.NeedToResolveBindings;
+                else
+                    m_Flags &= ~Flags.NeedToResolveBindings;
+            }
+        }
+
+        private bool bindingResolutionNeedsFullReResolve
+        {
+            get => (m_Flags & Flags.BindingResolutionNeedsFullReResolve) != 0;
+            set
+            {
+                if (value)
+                    m_Flags |= Flags.BindingResolutionNeedsFullReResolve;
+                else
+                    m_Flags &= ~Flags.BindingResolutionNeedsFullReResolve;
+            }
+        }
+
+        private bool controlsForEachActionInitialized
+        {
+            get => (m_Flags & Flags.ControlsForEachActionInitialized) != 0;
+            set
+            {
+                if (value)
+                    m_Flags |= Flags.ControlsForEachActionInitialized;
+                else
+                    m_Flags &= ~Flags.ControlsForEachActionInitialized;
+            }
+        }
+
+        private bool bindingsForEachActionInitialized
+        {
+            get => (m_Flags & Flags.BindingsForEachActionInitialized) != 0;
+            set
+            {
+                if (value)
+                    m_Flags |= Flags.BindingsForEachActionInitialized;
+                else
+                    m_Flags &= ~Flags.BindingsForEachActionInitialized;
+            }
+        }
+
+        [Flags]
+        private enum Flags
+        {
+            NeedToResolveBindings = 1 << 0,
+            BindingResolutionNeedsFullReResolve = 1 << 1,
+            ControlsForEachActionInitialized = 1 << 2,
+            BindingsForEachActionInitialized = 1 << 3,
+        }
 
         internal static int s_DeferBindingResolution;
 
@@ -820,7 +875,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(!action.isSingletonAction || m_SingletonAction == action, "Action is not a singleton action");
 
             // See if we need to refresh.
-            if (!m_BindingsForEachActionInitialized)
+            if (!bindingsForEachActionInitialized)
                 SetUpPerActionControlAndBindingArrays();
 
             return new ReadOnlyArray<InputBinding>(m_BindingsForEachAction, action.m_BindingsStartIndex,
@@ -836,7 +891,7 @@ namespace UnityEngine.InputSystem
             Debug.Assert(action.m_ActionMap == this);
             Debug.Assert(!action.isSingletonAction || m_SingletonAction == action);
 
-            if (!m_ControlsForEachActionInitialized)
+            if (!controlsForEachActionInitialized)
                 SetUpPerActionControlAndBindingArrays();
 
             return new ReadOnlyArray<InputControl>(m_ControlsForEachAction, action.m_ControlStartIndex,
@@ -862,8 +917,8 @@ namespace UnityEngine.InputSystem
             {
                 m_ControlsForEachAction = null;
                 m_BindingsForEachAction = null;
-                m_ControlsForEachActionInitialized = true;
-                m_BindingsForEachActionInitialized = true;
+                controlsForEachActionInitialized = true;
+                bindingsForEachActionInitialized = true;
                 return;
             }
 
@@ -1050,18 +1105,64 @@ namespace UnityEngine.InputSystem
                 }
             }
 
-            m_ControlsForEachActionInitialized = true;
-            m_BindingsForEachActionInitialized = true;
+            controlsForEachActionInitialized = true;
+            bindingsForEachActionInitialized = true;
+        }
+
+        internal void OnWantToChangeSetup()
+        {
+            if (asset != null)
+            {
+                foreach (var assetMap in asset.actionMaps)
+                    if (assetMap.enabled)
+                        throw new InvalidOperationException(
+                            $"Cannot add, remove, or change elements of InputActionAsset {asset} while one or more of its actions are enabled");
+            }
+            else if (enabled)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot add, remove, or change elements of InputActionMap {this} while one or more of its actions are enabled");
+            }
+        }
+
+        internal void OnSetupChanged()
+        {
+            if (m_Asset != null)
+            {
+                m_Asset.MarkAsDirty();
+                foreach (var map in m_Asset.actionMaps)
+                    map.m_State = default;
+            }
+            else
+            {
+                m_State = default;
+            }
+            ClearCachedActionData();
+            LazyResolveBindings(fullResolve: true);
+        }
+
+        internal void OnBindingModified()
+        {
+            ClearCachedActionData();
+            LazyResolveBindings(fullResolve: true);
+        }
+
+        internal void OnDeviceAddedOrRemoved()
+        {
         }
 
         ////TODO: re-use allocations such that only grow the arrays and hit zero GC allocs when we already have enough memory
-        internal void ClearCachedActionData()
+        internal void ClearCachedActionData(bool onlyControls = false)
         {
-            m_BindingsForEachActionInitialized = default;
-            m_ControlsForEachActionInitialized = default;
-            m_BindingsForEachAction = default;
+            if (!onlyControls)
+            {
+                bindingsForEachActionInitialized = false;
+                m_BindingsForEachAction = default;
+                m_ActionIndexByNameOrId = default;
+            }
+
+            controlsForEachActionInitialized = false;
             m_ControlsForEachAction = default;
-            m_ActionIndexByNameOrId = default;
         }
 
         internal void GenerateId()
@@ -1073,11 +1174,11 @@ namespace UnityEngine.InputSystem
         /// Resolve bindings right away if we have to. Otherwise defer it to when we next need
         /// the bindings.
         /// </summary>
-        internal bool LazyResolveBindings()
+        internal bool LazyResolveBindings(bool fullResolve)
         {
             // Clear cached controls for actions. Don't need to necessarily clear m_BindingsForEachAction.
             m_ControlsForEachAction = null;
-            m_ControlsForEachActionInitialized = false;
+            controlsForEachActionInitialized = false;
 
             // If we haven't had to resolve bindings yet, we can wait until when we
             // actually have to.
@@ -1089,11 +1190,11 @@ namespace UnityEngine.InputSystem
             // rebinding UIs), so now we just always re-resolve anything that ever had an InputActionState
             // created. Unfortunately, this can lead to some unnecessary re-resolving.
 
+            needToResolveBindings = true;
+            bindingResolutionNeedsFullReResolve = fullResolve;
+
             if (s_DeferBindingResolution > 0)
-            {
-                m_NeedToResolveBindings = true;
                 return false;
-            }
 
             // Have to do it straight away.
             ResolveBindings();
@@ -1107,17 +1208,55 @@ namespace UnityEngine.InputSystem
             //       We only resolve if a map is used that needs resolution to happen. Note that
             //       this will still resolve bindings for *all* maps in the asset.
 
-            if (m_State == null || m_NeedToResolveBindings)
+            if (m_State == null || needToResolveBindings)
             {
                 if (m_State != null && m_State.isProcessingControlStateChange)
                 {
-                    Debug.Assert(s_DeferBindingResolution > 0);
+                    Debug.Assert(s_DeferBindingResolution > 0, "While processing control state changes, binding resolution should be suppressed");
                     return;
                 }
 
                 ResolveBindings();
             }
         }
+
+        // We have three different starting scenarios for binding resolution:
+        //
+        // (1) From scratch.
+        //     There is no InputActionState and we resolve everything from a completely fresh start. This happens when
+        //     we either have not resolved bindings at all yet or when something touches the action setup (e.g. adds
+        //     or removes an action or binding) and we thus throw away the existing InputActionState.
+        //     NOTE:
+        //      * Actions can be in enabled state.
+        //      * No action can be in an in-progress state (since binding resolution is needed for actions to
+        //        be processed, no action processing can have happened yet)
+        //
+        // (2) From an existing InputActionState when a device has been added or removed.
+        //     There is an InputActionState and the action setup (maps, actions, bindings, binding masks) has not changed. However,
+        //     the set of devices usable with the action has changed (either the per-asset/map device list or the global
+        //     list, if we're using it).
+        //     NOTE:
+        //      * Actions can be in enabled state.
+        //      * Actions *can* be in an in-progress state.
+        //        IF the control currently driving the action is on a device that is no longer usable with the action, the
+        //        action is CANCELLED. OTHERWISE, the action will be left as is and keep being in progress from its active control.
+        //      * A device CONFIGURATION change will NOT go down this path (e.g. changing the Keyboard layout). This is because
+        //        any binding path involving display names may now resolve to different controls -- which may impact currently
+        //        active controls of in-progress actions.
+        //      * A change in the USAGES of a device will NOT go down this path either. This is for the same reason -- i.e. an
+        //        active control may no longer match the binding path it matched before. If, for example, we switch the left-hand
+        //        and right-hand roles of two controllers, will will go down path (3) and not (2).
+        //
+        // (3) From an existing InputActionState on any other change not covered before.
+        //     There is an InputActionState and the action setup (maps, actions, bindings, binding masks) may have changed. Also,
+        //     any change may have happened in the set of usable devices and targeted controls. This includes binding overrides
+        //     having been applied.
+        //     NOTE:
+        //      * Action can be in enabled state.
+        //      * Actions *can* be in an in-progress state.
+        //        Any such action will be CANCELLED as part of the re-resolution process.
+        //
+        // Both (1) and (3) are considered a "full resolve". (2) is not.
 
         /// <summary>
         /// Resolve all bindings to their controls and also add any action interactions
@@ -1133,13 +1272,12 @@ namespace UnityEngine.InputSystem
         ///
         /// Bindings can be re-resolved while actions are enabled. This happens changing device or binding
         /// masks on action maps or assets (<see cref="devices"/>, <see cref="bindingMask"/>, <see cref="InputAction.bindingMask"/>,
-        /// <see cref="InputActionAsset.devices"/>, <see cref="InputActionAsset.bindingMask"/>). When this happens,
-        /// we temporarily disable and then reenable actions. Note that this is visible to observers.
+        /// <see cref="InputActionAsset.devices"/>, <see cref="InputActionAsset.bindingMask"/>). Doing so will
+        /// not affect the enable state of actions and, as much as possible, will try to take current
+        /// action states across.
         /// </remarks>
         internal void ResolveBindings()
         {
-            m_ControlsForEachActionInitialized = false;
-
             // Make sure that if we trigger callbacks as part of disabling and re-enabling actions,
             // we don't trigger a re-resolve while we're already resolving bindings.
             using (InputActionRebindingExtensions.DeferBindingResolution())
@@ -1147,7 +1285,7 @@ namespace UnityEngine.InputSystem
                 // In case we have actions that are currently enabled, we temporarily retain the
                 // UnmanagedMemory of our InputActionState so that we can sync action states after
                 // we have re-resolved bindings.
-                var tempMemory = new InputActionState.UnmanagedMemory();
+                var oldMemory = new InputActionState.UnmanagedMemory();
                 try
                 {
                     OneOrMore<InputActionMap, ReadOnlyArray<InputActionMap>> actionMaps;
@@ -1157,6 +1295,7 @@ namespace UnityEngine.InputSystem
 
                     // If we're part of an asset, we share state and thus binding resolution with
                     // all maps in the asset.
+                    var needFullResolve = m_State == null;
                     if (m_Asset != null)
                     {
                         actionMaps = m_Asset.actionMaps;
@@ -1165,8 +1304,13 @@ namespace UnityEngine.InputSystem
                         // If there's a binding mask set on the asset, apply it.
                         resolver.bindingMask = m_Asset.m_BindingMask;
 
-                        for (var i = 0; i < actionMaps.Count; ++i)
-                            actionMaps[i].m_NeedToResolveBindings = false;
+                        foreach (var map in actionMaps)
+                        {
+                            needFullResolve |= map.bindingResolutionNeedsFullReResolve;
+                            map.needToResolveBindings = false;
+                            map.bindingResolutionNeedsFullReResolve = false;
+                            map.controlsForEachActionInitialized = false;
+                        }
                     }
                     else
                     {
@@ -1174,7 +1318,10 @@ namespace UnityEngine.InputSystem
                         // Gets its own private state.
 
                         actionMaps = this;
-                        m_NeedToResolveBindings = false;
+                        needFullResolve |= bindingResolutionNeedsFullReResolve;
+                        needToResolveBindings = false;
+                        bindingResolutionNeedsFullReResolve = false;
+                        controlsForEachActionInitialized = false;
                     }
 
                     // If we already have a state, re-use the arrays we have already allocated.
@@ -1182,95 +1329,49 @@ namespace UnityEngine.InputSystem
                     //       case where we didn't have to grow the arrays, we should end up with zero GC allocations
                     //       here.
                     var hasEnabledActions = false;
+                    InputControlList<InputControl> activeControls = default;
                     if (m_State != null)
                     {
                         // Grab a clone of the current memory. We clone because disabling all the actions
                         // in the map will alter the memory state and we want the state before we start
                         // touching it.
-                        //
-                        // Technically, ATM we only need the phase values in the action states but duplicating
-                        // the unmanaged memory is cheap and avoids having to add yet more complication to the
-                        // code paths here.
-                        tempMemory = m_State.memory.Clone();
+                        oldMemory = m_State.memory.Clone();
 
-                        // If the state has enabled actions, temporarily disable them.
-                        hasEnabledActions = m_State.HasEnabledActions();
-                        for (var i = 0; i < actionMaps.Count; ++i)
-                        {
-                            var map = actionMaps[i];
-
-                            if (hasEnabledActions)
-                                m_State.DisableAllActions(map);
-
-                            // Let listeners know we are about to modify bindings. Do this *after* we disabled the
-                            // actions so that cancellations happen first.
-                            if (map.m_SingletonAction != null)
-                                InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsAboutToChange, map.m_SingletonAction);
-                            else if (m_Asset == null)
-                                InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsAboutToChange, map);
-                        }
-                        if (m_Asset != null)
-                            InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsAboutToChange, m_Asset);
+                        m_State.PrepareForBindingReResolution(needFullResolve, ref activeControls, ref hasEnabledActions);
 
                         // Reuse the arrays we have so that we can avoid managed memory allocations, if possible.
-                        resolver.StartWithArraysFrom(m_State);
+                        resolver.StartWithPreviousResolve(m_State, isFullResolve: needFullResolve);
 
                         // Throw away old memory.
                         m_State.memory.Dispose();
                     }
 
                     // Resolve all maps in the asset.
-                    for (var i = 0; i < actionMaps.Count; ++i)
-                        resolver.AddActionMap(actionMaps[i]);
+                    foreach (var map in actionMaps)
+                        resolver.AddActionMap(map);
 
                     // Install state.
                     if (m_State == null)
                     {
-                        if (m_Asset != null)
-                        {
-                            var state = new InputActionState();
-                            for (var i = 0; i < actionMaps.Count; ++i)
-                                actionMaps[i].m_State = state;
-                            m_Asset.m_SharedStateForAllMaps = state;
-                        }
-                        else
-                        {
-                            m_State = new InputActionState();
-                        }
+                        m_State = new InputActionState();
                         m_State.Initialize(resolver);
                     }
                     else
                     {
                         m_State.ClaimDataFrom(resolver);
                     }
-
-                    // Wipe caches.
-                    for (var i = 0; i < actionMaps.Count; ++i)
-                    {
-                        var map = actionMaps[i];
-
-                        ////TODO: determine whether we really need to wipe this; keep them if nothing has changed
-                        map.m_ControlsForEachAction = null;
-                        map.m_ControlsForEachActionInitialized = false;
-
-                        if (map.m_SingletonAction != null)
-                            InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged, map.m_SingletonAction);
-                        else if (m_Asset == null)
-                            InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged, map);
-                    }
                     if (m_Asset != null)
-                        InputActionState.NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged, m_Asset);
+                    {
+                        foreach (var map in actionMaps)
+                            map.m_State = m_State;
+                        m_Asset.m_SharedStateForAllMaps = m_State;
+                    }
 
-                    // Fire InputBindingComposite.FinishSetup() calls.
-                    m_State.FinishBindingCompositeSetups();
-
-                    // Re-enable actions.
-                    if (hasEnabledActions)
-                        m_State.RestoreActionStates(tempMemory);
+                    m_State.FinishBindingResolution(hasEnabledActions, oldMemory, activeControls, isFullResolve: needFullResolve);
                 }
                 finally
                 {
-                    tempMemory.Dispose();
+                    oldMemory.Dispose();
                 }
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -591,9 +591,19 @@ namespace UnityEngine.InputSystem
             if (action == null)
                 throw new ArgumentNullException(nameof(action));
 
+            var enabled = action.enabled;
+            if (enabled)
+                action.Disable();
+
             bindingOverride.action = action.name;
             var actionMap = action.GetOrCreateActionMap();
             ApplyBindingOverride(actionMap, bindingOverride);
+
+            if (enabled)
+            {
+                action.Enable();
+                action.RequestInitialStateCheckOnEnabledAction();
+            }
         }
 
         /// <summary>
@@ -705,10 +715,7 @@ namespace UnityEngine.InputSystem
             }
 
             if (matchCount > 0)
-            {
-                actionMap.ClearCachedActionData();
-                actionMap.LazyResolveBindings();
-            }
+                actionMap.OnBindingModified();
 
             return matchCount;
         }
@@ -740,8 +747,7 @@ namespace UnityEngine.InputSystem
             actionMap.m_Bindings[bindingIndex].overrideInteractions = bindingOverride.overrideInteractions;
             actionMap.m_Bindings[bindingIndex].overrideProcessors = bindingOverride.overrideProcessors;
 
-            actionMap.ClearCachedActionData();
-            actionMap.LazyResolveBindings();
+            actionMap.OnBindingModified();
         }
 
         /// <summary>
@@ -835,8 +841,7 @@ namespace UnityEngine.InputSystem
                         binding.RemoveOverrides();
                     }
 
-                    actionMap.ClearCachedActionData();
-                    actionMap.LazyResolveBindings();
+                    actionMap.OnBindingModified();
                 }
             }
         }
@@ -874,8 +879,7 @@ namespace UnityEngine.InputSystem
                 bindings[i].overrideProcessors = null;
             }
 
-            actionMap.ClearCachedActionData();
-            actionMap.LazyResolveBindings();
+            actionMap.OnBindingModified();
         }
 
         ////REVIEW: are the IEnumerable variations worth having?

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -51,7 +51,8 @@ namespace UnityEngine.InputSystem
         /// <param name="map">A named action map.</param>
         /// <exception cref="ArgumentNullException"><paramref name="map"/> or <paramref name="asset"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="map"/> has no name or asset already contains a
-        /// map with the same name.</exception>
+        /// map with the same name -or- <paramref name="map"/> is currently enabled -or- <paramref name="map"/> is part of
+        /// an <see cref="InputActionAsset"/> that has <see cref="InputActionMap"/>s that are enabled.</exception>
         /// <seealso cref="InputActionAsset.actionMaps"/>
         public static void AddActionMap(this InputActionAsset asset, InputActionMap map)
         {
@@ -69,9 +70,12 @@ namespace UnityEngine.InputSystem
                 throw new InvalidOperationException(
                     $"An action map called '{map.name}' already exists in the asset");
 
+            map.OnWantToChangeSetup();
+            asset.OnWantToChangeSetup();
+
             ArrayHelpers.Append(ref asset.m_ActionMaps, map);
-            asset.MarkAsDirty();
             map.m_Asset = asset;
+            asset.OnSetupChanged();
         }
 
         /// <summary>
@@ -82,7 +86,8 @@ namespace UnityEngine.InputSystem
         /// does nothing.</param>
         /// <exception cref="ArgumentNullException"><paramref name="asset"/> or <paramref name="map"/> is <c>null</c>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="map"/> is currently enabled (see <see
-        /// cref="InputActionMap.enabled"/>).</exception>
+        /// cref="InputActionMap.enabled"/>) or is part of an <see cref="InputActionAsset"/> that has <see cref="InputActionMap"/>s
+        /// that are currently enabled.</exception>
         /// <seealso cref="RemoveActionMap(InputActionAsset,string)"/>
         /// <seealso cref="InputActionAsset.actionMaps"/>
         public static void RemoveActionMap(this InputActionAsset asset, InputActionMap map)
@@ -91,16 +96,17 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentNullException(nameof(asset));
             if (map == null)
                 throw new ArgumentNullException(nameof(map));
-            if (map.enabled)
-                throw new InvalidOperationException("Cannot remove an action map from the asset while it is enabled");
+
+            map.OnWantToChangeSetup();
+            asset.OnWantToChangeSetup();
 
             // Ignore if not part of this asset.
             if (map.m_Asset != asset)
                 return;
 
             ArrayHelpers.Erase(ref asset.m_ActionMaps, map);
-            asset.MarkAsDirty();
             map.m_Asset = null;
+            asset.OnSetupChanged();
         }
 
         /// <summary>
@@ -151,8 +157,8 @@ namespace UnityEngine.InputSystem
         /// <exception cref="ArgumentNullException"><paramref name="map"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException"><paramref name="name"/> is <c>null</c> or empty.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="map"/> is enabled (see <see cref="InputActionMap.enabled"/>)
+        /// or is part of an <see cref="InputActionAsset"/> that has <see cref="InputActionMap"/>s that are <see cref="InputActionMap.enabled"/>
         /// -or- <paramref name="map"/> already contains an action called <paramref name="name"/> (case-insensitive).</exception>
-        /// <exception cref="InvalidOperationException"><paramref name="map"/> parent InputActionAsset has one or more maps enabled (see <see cref="InputActionAsset.enabled"/>).</exception>
         public static InputAction AddAction(this InputActionMap map, string name, InputActionType type = default, string binding = null,
             string interactions = null, string processors = null, string groups = null, string expectedControlLayout = null)
         {
@@ -160,14 +166,7 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentNullException(nameof(map));
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("Action must have name", nameof(name));
-            if (map.enabled)
-                throw new InvalidOperationException(
-                    $"Cannot add action '{name}' to map '{map}' while it the map is enabled");
-            if (map.asset != null)
-                foreach (var assetMap in map.asset.actionMaps)
-                    if (assetMap.enabled)
-                        throw new InvalidOperationException(
-                            $"Cannot add action '{name}' to map '{map}' while any of the maps in the parent input asset are enabled, found '{assetMap}' currently enabled.");
+            map.OnWantToChangeSetup();
             if (map.FindAction(name) != null)
                 throw new InvalidOperationException(
                     $"Cannot add action with duplicate name '{name}' to set '{map.name}'");
@@ -184,6 +183,7 @@ namespace UnityEngine.InputSystem
             // Add binding, if supplied.
             if (!string.IsNullOrEmpty(binding))
             {
+                // Will trigger OnSetupChanged.
                 action.AddBinding(binding, interactions: interactions, processors: processors, groups: groups);
             }
             else
@@ -196,13 +196,9 @@ namespace UnityEngine.InputSystem
                 // If no binding has been supplied but there are interactions and processors, they go on the action itself.
                 action.m_Interactions = interactions;
                 action.m_Processors = processors;
+
+                map.OnSetupChanged();
             }
-
-            if (map.asset != null)
-                map.asset.MarkAsDirty();
-
-            map.ClearCachedActionData();
-            map.LazyResolveBindings();
 
             return action;
         }
@@ -212,9 +208,10 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <param name="action">An input action that is part of an <see cref="InputActionMap"/>.</param>
         /// <exception cref="ArgumentNullException"><paramref name="action"/> is <c>null</c>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="action"/> is part of an <see cref="InputActionMap"/>
-        /// that has at least one enabled action -or- <paramref name="action"/> is a standalone action
+        /// <exception cref="ArgumentException"><paramref name="action"/> is a standalone action
         /// that is not part of an <see cref="InputActionMap"/> and thus cannot be removed from anything.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="action"/> is part of an <see cref="InputActionMap"/>
+        /// or <see cref="InputActionAsset"/> that has at least one enabled action.</exception>
         /// <remarks>
         /// After removal, the action's <see cref="InputAction.actionMap"/> will be set to <c>null</c>
         /// and the action will effectively become a standalone action that is not associated with
@@ -231,27 +228,23 @@ namespace UnityEngine.InputSystem
             if (actionMap == null)
                 throw new ArgumentException(
                     $"Action '{action}' does not belong to an action map; nowhere to remove from", nameof(action));
-            if (actionMap.enabled)
-                throw new ArgumentException($"Cannot remove action '{action}' while its action map is enabled");
+            actionMap.OnWantToChangeSetup();
 
             var bindingsForAction = action.bindings.ToArray();
 
-            var index = ArrayHelpers.IndexOfReference(actionMap.m_Actions, action);
+            var index = actionMap.m_Actions.IndexOfReference(action);
             Debug.Assert(index != -1, "Could not find action in map");
             ArrayHelpers.EraseAt(ref actionMap.m_Actions, index);
 
             action.m_ActionMap = null;
             action.m_SingletonActionBindings = bindingsForAction;
 
-            if (actionMap.asset != null)
-                actionMap.asset.MarkAsDirty();
-
-            actionMap.ClearCachedActionData();
-
             // Remove bindings to action from map.
             var newActionMapBindingCount = actionMap.m_Bindings.Length - bindingsForAction.Length;
             if (newActionMapBindingCount == 0)
+            {
                 actionMap.m_Bindings = null;
+            }
             else
             {
                 var newActionMapBindings = new InputBinding[newActionMapBindingCount];
@@ -265,6 +258,8 @@ namespace UnityEngine.InputSystem
                 }
                 actionMap.m_Bindings = newActionMapBindings;
             }
+
+            actionMap.OnSetupChanged();
         }
 
         /// <summary>
@@ -514,17 +509,15 @@ namespace UnityEngine.InputSystem
             if (map.asset != null)
                 map.asset.MarkAsDirty();
 
-            // Invalidate per-action binding sets so that this gets refreshed if
-            // anyone queries it.
-            map.ClearCachedActionData();
-
-            // Make sure bindings get re-resolved.
-            map.LazyResolveBindings();
-
             // If we're looking at a singleton action, make sure m_Bindings is up to date just
             // in case the action gets serialized.
             if (map.m_SingletonAction != null)
                 map.m_SingletonAction.m_SingletonActionBindings = map.m_Bindings;
+
+            // NOTE: We treat this as a mere binding modification, even though we have added something.
+            //       InputAction.RestoreActionStatesAfterReResolvingBindings() can deal with bindings
+            //       having been removed or added.
+            map.OnBindingModified();
 
             return bindingIndex;
         }
@@ -1067,8 +1060,7 @@ namespace UnityEngine.InputSystem
                 if (!valid)
                     throw new InvalidOperationException("Accessor is not valid");
                 m_ActionMap.m_Bindings[m_BindingIndexInMap].name = name;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
                 return this;
             }
 
@@ -1084,8 +1076,7 @@ namespace UnityEngine.InputSystem
                 if (!valid)
                     throw new InvalidOperationException("Accessor is not valid");
                 m_ActionMap.m_Bindings[m_BindingIndexInMap].path = path;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
                 return this;
             }
 
@@ -1123,8 +1114,7 @@ namespace UnityEngine.InputSystem
 
                 // Set groups on binding.
                 m_ActionMap.m_Bindings[m_BindingIndexInMap].groups = groups;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
 
                 return this;
             }
@@ -1156,8 +1146,7 @@ namespace UnityEngine.InputSystem
 
                 // Set interactions on binding.
                 m_ActionMap.m_Bindings[m_BindingIndexInMap].interactions = interactions;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
 
                 return this;
             }
@@ -1202,8 +1191,7 @@ namespace UnityEngine.InputSystem
 
                 // Set processors on binding.
                 m_ActionMap.m_Bindings[m_BindingIndexInMap].processors = processors;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
 
                 return this;
             }
@@ -1230,8 +1218,7 @@ namespace UnityEngine.InputSystem
                     throw new ArgumentException(
                         $"Cannot change the action a binding triggers on singleton action '{action}'", nameof(action));
                 m_ActionMap.m_Bindings[m_BindingIndexInMap].action = action.name;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
                 return this;
             }
 
@@ -1251,12 +1238,12 @@ namespace UnityEngine.InputSystem
                     throw new InvalidOperationException("Accessor is not valid");
 
                 m_ActionMap.m_Bindings[m_BindingIndexInMap] = binding;
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
 
                 // If it's a singleton action, we force the binding to stay with the action.
                 if (m_ActionMap.m_SingletonAction != null)
                     m_ActionMap.m_Bindings[m_BindingIndexInMap].action = m_ActionMap.m_SingletonAction.name;
+
+                m_ActionMap.OnBindingModified();
 
                 return this;
             }
@@ -1473,8 +1460,7 @@ namespace UnityEngine.InputSystem
                         ArrayHelpers.EraseAt(ref m_ActionMap.m_Bindings, m_BindingIndexInMap);
                 }
 
-                m_ActionMap.ClearCachedActionData();
-                m_ActionMap.LazyResolveBindings();
+                m_ActionMap.OnBindingModified();
 
                 // We have switched to a different binding array. For singleton actions, we need to
                 // sync up the reference that the action itself has.

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -130,7 +130,7 @@ namespace UnityEngine.InputSystem
             AddToGlobalList();
         }
 
-        internal void ClaimDataFrom(InputBindingResolver resolver)
+        public void ClaimDataFrom(InputBindingResolver resolver)
         {
             totalProcessorCount = resolver.totalProcessorCount;
 
@@ -308,7 +308,7 @@ namespace UnityEngine.InputSystem
             return false;
         }
 
-        public void FinishBindingCompositeSetups()
+        private void FinishBindingCompositeSetups()
         {
             for (var i = 0; i < totalBindingCount; ++i)
             {
@@ -320,6 +320,107 @@ namespace UnityEngine.InputSystem
                 var context = new InputBindingCompositeContext { m_State = this, m_BindingIndex = i };
                 composite.CallFinishSetup(ref context);
             }
+        }
+
+        internal void PrepareForBindingReResolution(bool needFullResolve,
+            ref InputControlList<InputControl> activeControls, ref bool hasEnabledActions)
+        {
+            // Let listeners know we're about to modify bindings.
+            var needToCloneActiveControls = false;
+            for (var i = 0; i < totalMapCount; ++i)
+            {
+                var map = maps[i];
+
+                if (map.enabled)
+                {
+                    hasEnabledActions = true;
+
+                    if (needFullResolve)
+                    {
+                        // For a full-resolve, we temporarily disable all actions and then re-enable
+                        // all that were enabled after bindings have been resolved (plus we also flip on
+                        // initial state checks for those actions to make sure they react right away
+                        // to whatever state controls are in).
+                        DisableAllActions(map);
+                    }
+                    else
+                    {
+                        // Cancel any action that is driven from a control we will lose when we re-resolve.
+                        // For any other on-going action, save active controls.
+                        foreach (var action in map.actions)
+                        {
+                            if (!action.phase.IsInProgress())
+                                continue;
+
+                            // Skip action's that are in progress but whose active control is not affected
+                            // by the changes that lead to re-resolution.
+                            if (action.ActiveControlIsValid(action.activeControl))
+                            {
+                                // As part of re-resolving, we're losing m_State.controls. So, while we retain
+                                // the current execution state of the method including the index of the currently
+                                // active control, we lose the actual references to the control.
+                                // Thus, we retain an explicit list of active controls into which we *only* copy
+                                // those few controls that are currently active. Also, this list is kept in unmanaged
+                                // memory so we don't add an additional GC allocation here.
+                                if (needToCloneActiveControls == false)
+                                {
+                                    activeControls = new InputControlList<InputControl>(Allocator.Temp);
+                                    activeControls.Resize(totalControlCount);
+                                    needToCloneActiveControls = true;
+                                }
+
+                                ref var actionState = ref actionStates[action.m_ActionIndexInState];
+                                var activeControlIndex = actionState.controlIndex;
+                                activeControls[activeControlIndex] = controls[activeControlIndex];
+
+                                // Also save active controls for other ongoing interactions.
+                                var bindingState = bindingStates[actionState.bindingIndex];
+                                for (var n = 0; n < bindingState.interactionCount; ++n)
+                                {
+                                    var interactionIndex = bindingState.interactionStartIndex + n;
+                                    if (!interactionStates[interactionIndex].phase.IsInProgress())
+                                        continue;
+
+                                    activeControlIndex = interactionStates[interactionIndex]
+                                        .triggerControlIndex;
+                                    if (action.ActiveControlIsValid(controls[activeControlIndex]))
+                                        activeControls[activeControlIndex] = controls[activeControlIndex];
+                                    else
+                                        ResetInteractionState(interactionIndex);
+                                }
+                            }
+                            else
+                            {
+                                ResetActionState(action.m_ActionIndexInState);
+                            }
+                        }
+
+                        // NOTE: Removing state monitors here also means we're terminating any pending
+                        //       timeouts. However, we have information in the action state about how much
+                        //       is time is remaining on each of them so we can resume them later.
+
+                        DisableControls(map);
+                    }
+                }
+
+                map.ClearCachedActionData(onlyControls: !needFullResolve);
+            }
+
+            NotifyListenersOfActionChange(InputActionChange.BoundControlsAboutToChange);
+        }
+
+        public void FinishBindingResolution(bool hasEnabledActions, UnmanagedMemory oldMemory, InputControlList<InputControl> activeControls, bool isFullResolve)
+        {
+            // Fire InputBindingComposite.FinishSetup() calls.
+            FinishBindingCompositeSetups();
+
+            // Sync action states between the old and the new state. This also ensures
+            // that any action that was already in progress just keeps going -- except
+            // if we actually lost the control that was driving it.
+            if (hasEnabledActions)
+                RestoreActionStatesAfterReResolvingBindings(oldMemory, activeControls, isFullResolve);
+            else
+                NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged);
         }
 
         /// <summary>
@@ -335,76 +436,232 @@ namespace UnityEngine.InputSystem
         /// reenable all the actions and controls that were enabled before and then let the next update
         /// take it from there.
         /// </remarks>
-        public void RestoreActionStates(UnmanagedMemory oldState)
+        private void RestoreActionStatesAfterReResolvingBindings(UnmanagedMemory oldState, InputControlList<InputControl> activeControls, bool isFullResolve)
         {
             Debug.Assert(oldState.isAllocated, "Old state contains no memory");
 
-            // This method cannot deal with actions and/or maps having been removed.
-            // It DOES cope with bindings have been added and/or removed, though!
+            // No maps and/or actions must have been added, replaced, or removed.
+            //
+            // IF
+            //  isFullResolve==true:
+            //     - No bindings must have been added, replaced, or removed or touched in any other way.
+            //     - The only thing that is allowed to have changed is the list of controls used by the actions.
+            //     - Binding masks must not have changed.
+            //
+            //  isFullResolve==false:
+            //     - Bindings may have been added, replaced, modified, and/or removed.
+            //     - Also, the list of controls may have changed.
+            //     - Binding masks may have changed.
+            //
+            // This means that when we compare UnmanagedMemory from before and after:
+            //  - Map indices are identical.
+            //  - Action indices are identical.
+            //  - Binding indices may have changed arbitrarily.
+            //  - Control indices may have changed arbitrarily (controls[] before and after need not relate at all).
+            //  - Processor indices may have changed arbitrarily.
+            //  - Interaction indices may have changed arbitrarily.
+            //
+            // HOWEVER, if isFullResolve==false, then ONLY control indices may have changed. All other
+            // indices must have remained unchanged.
             Debug.Assert(oldState.actionCount == memory.actionCount, "Action count in old and new state must be the same");
             Debug.Assert(oldState.mapCount == memory.mapCount, "Map count in old and new state must be the same");
-
-            // Go through the state map by map and in each map, binding by binding. Enable
-            // all bound controls for which the respective action isn't disabled.
-            for (var i = 0; i < memory.bindingCount; ++i)
+            if (!isFullResolve)
             {
-                var bindingState = &memory.bindingStates[i];
-                if (bindingState->isPartOfComposite)
+                Debug.Assert(oldState.bindingCount == memory.bindingCount, "Binding count in old and new state must be the same");
+                Debug.Assert(oldState.interactionCount == memory.interactionCount, "Interaction count in old and new state must be the same");
+                Debug.Assert(oldState.compositeCount == memory.compositeCount, "Composite count in old and new state must be the same");
+            }
+
+            // Restore action states.
+            for (var actionIndex = 0; actionIndex < totalActionCount; ++actionIndex)
+            {
+                ref var oldActionState = ref oldState.actionStates[actionIndex];
+                ref var newActionState = ref actionStates[actionIndex];
+
+                newActionState.lastCanceledInUpdate = oldActionState.lastCanceledInUpdate;
+                newActionState.lastPerformedInUpdate = oldActionState.lastPerformedInUpdate;
+                newActionState.pressedInUpdate = oldActionState.pressedInUpdate;
+                newActionState.releasedInUpdate = oldActionState.releasedInUpdate;
+                newActionState.startTime = oldActionState.startTime;
+
+                if (oldActionState.phase != InputActionPhase.Disabled)
+                {
+                    // In this step, we only put enabled actions into Waiting phase.
+                    // When isFullResolve==false, we will restore the actual phase from
+                    // before when we look at bindings further down in the code.
+                    newActionState.phase = InputActionPhase.Waiting;
+
+                    // In a full resolve, we actually disable any action we find enabled.
+                    // So count any action we reenable here.
+                    if (isFullResolve)
+                        ++maps[newActionState.mapIndex].m_EnabledActionsCount;
+                }
+            }
+
+            // Restore binding (and interaction) states.
+            for (var bindingIndex = 0; bindingIndex < totalBindingCount; ++bindingIndex)
+            {
+                ref var newBindingState = ref memory.bindingStates[bindingIndex];
+                if (newBindingState.isPartOfComposite)
                 {
                     // Bindings that are part of composites get enabled through the composite itself.
                     continue;
                 }
 
-                var actionIndex = bindingState->actionIndex;
+                var actionIndex = newBindingState.actionIndex;
                 if (actionIndex == kInvalidIndex)
                 {
                     // Binding is not targeting an action.
                     continue;
                 }
 
-                // Skip any binding for which the action was disabled.
-                // NOTE: We check the OLD STATE here. The phase in the new state will change immediately
-                //       on the first binding to an action but there may be multiple bindings leading to the
-                //       same action.
-                if (oldState.actionStates[actionIndex].phase == InputActionPhase.Disabled)
+                // Skip if action is disabled.
+                ref var newActionState = ref actionStates[actionIndex];
+                if (newActionState.isDisabled)
                     continue;
 
-                // Mark the action as enabled, if not already done.
-                var actionState = &memory.actionStates[actionIndex];
-                if (actionState->phase == InputActionPhase.Disabled)
-                {
-                    actionState->phase = InputActionPhase.Waiting;
-
-                    // Keep track of actions we enable in each map.
-                    var mapIndex = actionState->mapIndex;
-                    var map = maps[mapIndex];
-                    ++map.m_EnabledActionsCount;
-                }
+                // For all bindings to actions that are enabled, we flip on initial state checks to make sure
+                // we're checking the action's current state against the most up-to-date actuation state of controls.
+                // NOTE: We're only restore execution state for currently active controls. So, if there were multiple
+                //       concurrent actuations on an action that was in progress, we let initial state checks restore
+                //       relevant state.
+                newBindingState.initialStateCheckPending = true;
 
                 // Enable all controls on the binding.
-                EnableControls(actionState->mapIndex, bindingState->controlStartIndex,
-                    bindingState->controlCount);
+                EnableControls(newBindingState.mapIndex, newBindingState.controlStartIndex,
+                    newBindingState.controlCount);
+
+                // For the remainder of what we do, we need binding indices to be stable.
+                if (isFullResolve)
+                    continue;
+
+                ref var oldBindingState = ref memory.bindingStates[bindingIndex];
+                newBindingState.triggerEventIdForComposite = oldBindingState.triggerEventIdForComposite;
+
+                // If we only re-resolved controls and the action was in progress from the binding we're currently
+                // looking at and we still have the control that was driving the action, we can simply keep the
+                // action going from its previous state. However, control indices may have shifted (devices may have been added
+                // or removed) so we need to be careful to update those. Other indices (bindings, actions, maps, etc.)
+                // are guaranteed to still match.
+                ref var oldActionState = ref oldState.actionStates[actionIndex];
+                if (bindingIndex == oldActionState.bindingIndex && oldActionState.phase.IsInProgress() &&
+                    activeControls.Count > 0 && activeControls[oldActionState.controlIndex] != null)
+                {
+                    var control = activeControls[oldActionState.controlIndex];
+
+                    // Find the new control index. Binding index is guaranteed to be the same,
+                    // so we can simply look on the binding for where the control is now.
+                    var newControlIndex = FindControlIndexOnBinding(bindingIndex, control);
+
+                    Debug.Assert(newControlIndex != kInvalidIndex, "Could not find active control after binding resolution");
+                    if (newControlIndex != kInvalidIndex)
+                    {
+                        newActionState.phase = oldActionState.phase;
+                        newActionState.controlIndex = newControlIndex;
+                        newActionState.magnitude = oldActionState.magnitude;
+                        newActionState.interactionIndex = oldActionState.interactionIndex;
+
+                        memory.controlMagnitudes[newControlIndex] = oldActionState.magnitude;
+                    }
+
+                    // Also bring over interaction states.
+                    Debug.Assert(newBindingState.interactionCount == oldBindingState.interactionCount,
+                        "Interaction count on binding must not have changed when doing a control-only resolve");
+                    for (var n = 0; n < newBindingState.interactionCount; ++n)
+                    {
+                        ref var oldInteractionState = ref oldState.interactionStates[oldBindingState.interactionStartIndex + n];
+                        if (!oldInteractionState.phase.IsInProgress())
+                            continue;
+
+                        control = activeControls[oldInteractionState.triggerControlIndex];
+                        if (control == null)
+                            continue;
+
+                        newControlIndex = FindControlIndexOnBinding(bindingIndex, control);
+                        Debug.Assert(newControlIndex != kInvalidIndex, "Could not find active control on interaction after binding resolution");
+
+                        ref var newInteractionState = ref interactionStates[newBindingState.interactionStartIndex + n];
+                        newInteractionState.phase = oldInteractionState.phase;
+                        newInteractionState.performedTime = oldInteractionState.performedTime;
+                        newInteractionState.startTime = oldInteractionState.startTime;
+                        newInteractionState.triggerControlIndex = newControlIndex;
+
+                        // If there was a running timeout on the interaction, resume it now.
+                        if (oldInteractionState.isTimerRunning)
+                        {
+                            var trigger = new TriggerState
+                            {
+                                mapIndex = newBindingState.mapIndex,
+                                controlIndex = newControlIndex,
+                                bindingIndex = bindingIndex,
+                                time = oldInteractionState.timerStartTime,
+                                interactionIndex = newBindingState.interactionStartIndex + n
+                            };
+                            StartTimeout(oldInteractionState.timerDuration, ref trigger);
+
+                            newInteractionState.totalTimeoutCompletionDone = oldInteractionState.totalTimeoutCompletionDone;
+                            newInteractionState.totalTimeoutCompletionTimeRemaining = oldInteractionState.totalTimeoutCompletionTimeRemaining;
+                        }
+                    }
+                }
             }
 
             // Make sure we get an initial state check.
             HookOnBeforeUpdate();
 
-            // Fire notifications.
-            if (s_GlobalState.onActionChange.length > 0)
+            // Let listeners know we have changed controls.
+            NotifyListenersOfActionChange(InputActionChange.BoundControlsChanged);
+
+            // For a full resolve, we will have temporarily disabled actions and reenabled them now.
+            // Let listeners now.
+            if (isFullResolve && s_GlobalState.onActionChange.length > 0)
             {
                 for (var i = 0; i < totalMapCount; ++i)
                 {
                     var map = maps[i];
                     if (map.m_SingletonAction == null && map.m_EnabledActionsCount == map.m_Actions.LengthSafe())
+                    {
                         NotifyListenersOfActionChange(InputActionChange.ActionMapEnabled, map);
+                    }
                     else
                     {
                         var actions = map.actions;
-                        for (var n = 0; n < actions.Count; ++n)
-                            NotifyListenersOfActionChange(InputActionChange.ActionEnabled, actions[n]);
+                        foreach (var action in actions)
+                            if (action.enabled)
+                                NotifyListenersOfActionChange(InputActionChange.ActionEnabled, action);
                     }
                 }
             }
+        }
+
+        // Return true if the action that bindingIndex is bound to is currently driven from the given control
+        // -OR- if any of the interactions on the binding are currently driven from the control.
+        private bool IsActiveControl(int bindingIndex, int controlIndex)
+        {
+            ref var bindingState = ref bindingStates[bindingIndex];
+            var actionIndex = bindingState.actionIndex;
+            if (actionIndex == kInvalidIndex)
+                return false;
+            if (actionStates[actionIndex].controlIndex == controlIndex)
+                return true;
+            for (var i = 0; i < bindingState.interactionCount; ++i)
+                if (interactionStates[bindingStates->interactionStartIndex + i].triggerControlIndex == controlIndex)
+                    return true;
+            return false;
+        }
+
+        private int FindControlIndexOnBinding(int bindingIndex, InputControl control)
+        {
+            var controlStartIndex = bindingStates[bindingIndex].controlStartIndex;
+            var controlCount = bindingStates[bindingIndex].controlCount;
+
+            for (var n = 0; n < controlCount; ++n)
+            {
+                if (control == controls[controlStartIndex + n])
+                    return controlStartIndex + n;
+            }
+
+            return kInvalidIndex;
         }
 
         private void ResetActionStatesDrivenBy(InputDevice device)
@@ -685,11 +942,16 @@ namespace UnityEngine.InputSystem
             Debug.Assert(mapIndex >= 0 && mapIndex < totalMapCount, "Map index out of range in DisableAllActions");
             var actionStartIndex = mapIndices[mapIndex].actionStartIndex;
             var actionCount = mapIndices[mapIndex].actionCount;
+            var allActionsEnabled = map.m_EnabledActionsCount == actionCount;
             for (var i = 0; i < actionCount; ++i)
             {
                 var actionIndex = actionStartIndex + i;
                 if (actionStates[actionIndex].phase != InputActionPhase.Disabled)
+                {
                     ResetActionState(actionIndex, toPhase: InputActionPhase.Disabled);
+                    if (!allActionsEnabled)
+                        NotifyListenersOfActionChange(InputActionChange.ActionDisabled, map.m_Actions[i]);
+                }
             }
             map.m_EnabledActionsCount = 0;
 
@@ -697,11 +959,11 @@ namespace UnityEngine.InputSystem
             // action, we notify on the action, not the hidden map.
             if (map.m_SingletonAction != null)
                 NotifyListenersOfActionChange(InputActionChange.ActionDisabled, map.m_SingletonAction);
-            else
+            else if (allActionsEnabled)
                 NotifyListenersOfActionChange(InputActionChange.ActionMapDisabled, map);
         }
 
-        private void DisableControls(InputActionMap map)
+        public void DisableControls(InputActionMap map)
         {
             Debug.Assert(map != null, "Map must not be null");
             Debug.Assert(map.m_Actions != null, "Map must have actions");
@@ -810,6 +1072,7 @@ namespace UnityEngine.InputSystem
             for (var i = 0; i < numControls; ++i)
             {
                 var controlIndex = controlStartIndex + i;
+                ////TODO: This can be done much more efficiently by at least going byte by byte in the mask instead of just bit by bit
                 if (!IsControlEnabled(controlIndex))
                     continue;
 
@@ -821,6 +1084,19 @@ namespace UnityEngine.InputSystem
                 manager.RemoveStateChangeMonitor(controls[controlIndex], this, mapControlAndBindingIndex);
 
                 SetControlEnabled(controlIndex, false);
+            }
+        }
+
+        public void SetInitialStateCheckPending(int actionIndex, bool value = true)
+        {
+            var mapIndex = actionStates[actionIndex].mapIndex;
+            var bindingStartIndex = mapIndices[mapIndex].bindingStartIndex;
+            var bindingCount = mapIndices[mapIndex].bindingCount;
+            for (var i = 0; i < bindingCount; ++i)
+            {
+                ref var bindingState = ref bindingStates[bindingStartIndex + i];
+                if (bindingState.actionIndex == actionIndex && !bindingState.isPartOfComposite)
+                    bindingState.initialStateCheckPending = value;
             }
         }
 
@@ -909,22 +1185,26 @@ namespace UnityEngine.InputSystem
             // that the control just got actuated.
             for (var bindingIndex = 0; bindingIndex < totalBindingCount; ++bindingIndex)
             {
-                var bindingStatePtr = &bindingStates[bindingIndex];
-                if (!bindingStatePtr->initialStateCheckPending)
+                ref var bindingState = ref bindingStates[bindingIndex];
+                if (!bindingState.initialStateCheckPending)
                     continue;
 
-                Debug.Assert(!bindingStatePtr->isPartOfComposite, "Initial state check flag must be set on composite, not on its parts");
-                bindingStatePtr->initialStateCheckPending = false;
+                Debug.Assert(!bindingState.isPartOfComposite, "Initial state check flag must be set on composite, not on its parts");
+                bindingState.initialStateCheckPending = false;
 
-                var mapIndex = bindingStatePtr->mapIndex;
-                var controlStartIndex = bindingStatePtr->controlStartIndex;
-                var controlCount = bindingStatePtr->controlCount;
+                var mapIndex = bindingState.mapIndex;
+                var controlStartIndex = bindingState.controlStartIndex;
+                var controlCount = bindingState.controlCount;
 
-                var isComposite = bindingStatePtr->isComposite;
+                var isComposite = bindingState.isComposite;
                 for (var n = 0; n < controlCount; ++n)
                 {
                     var controlIndex = controlStartIndex + n;
                     var control = controls[controlIndex];
+
+                    // Leave any control alone that is already driving an interaction and/or action.
+                    if (IsActiveControl(bindingIndex, controlIndex))
+                        continue;
 
                     if (!control.CheckStateIsAtDefault())
                     {
@@ -1401,7 +1681,7 @@ namespace UnityEngine.InputSystem
                         //       a 1 second "Hold" when the user shifts to a different control, then this code here
                         //       will *cancel* the current "Hold" and restart from scratch.
                         if (actionState->interactionIndex != kInvalidIndex)
-                            ResetInteractionState(trigger.mapIndex, actionState->bindingIndex, actionState->interactionIndex);
+                            ResetInteractionState(actionState->interactionIndex);
 
                         // If there's an interaction in progress on the new binding, let
                         // it drive the action.
@@ -1851,7 +2131,7 @@ namespace UnityEngine.InputSystem
                         {
                             var index = interactionStartIndex + i;
                             if (index != trigger.interactionIndex)
-                                ResetInteractionState(trigger.mapIndex, trigger.bindingIndex, index);
+                                ResetInteractionState(index);
                         }
                     }
                 }
@@ -1874,7 +2154,7 @@ namespace UnityEngine.InputSystem
             }
             else if (newPhase == InputActionPhase.Performed || newPhase == InputActionPhase.Canceled)
             {
-                ResetInteractionState(trigger.mapIndex, trigger.bindingIndex, trigger.interactionIndex);
+                ResetInteractionState(trigger.interactionIndex);
             }
         }
 
@@ -2197,13 +2477,12 @@ namespace UnityEngine.InputSystem
                 actionStates[actionIndex].interactionIndex = kInvalidIndex;
             }
 
-            ResetInteractionState(mapIndex, bindingIndex, interactionIndex);
+            ResetInteractionState(interactionIndex);
         }
 
-        private void ResetInteractionState(int mapIndex, int bindingIndex, int interactionIndex)
+        private void ResetInteractionState(int interactionIndex)
         {
             Debug.Assert(interactionIndex >= 0 && interactionIndex < totalInteractionCount, "Interaction index out of range");
-            Debug.Assert(bindingIndex >= 0 && bindingIndex < totalBindingCount, "Binding index out of range");
 
             // Clean up internal state that the interaction may keep.
             interactions[interactionIndex].Reset();
@@ -2219,6 +2498,7 @@ namespace UnityEngine.InputSystem
                 // We never set interactions to disabled. This way we don't have to go through them
                 // when we disable/enable actions.
                 phase = InputActionPhase.Waiting,
+                triggerControlIndex = kInvalidIndex
             };
         }
 
@@ -2718,13 +2998,22 @@ namespace UnityEngine.InputSystem
 
             public int triggerControlIndex
             {
-                get => m_TriggerControlIndex;
+                get
+                {
+                    if (m_TriggerControlIndex == ushort.MaxValue)
+                        return kInvalidIndex;
+                    return m_TriggerControlIndex;
+                }
                 set
                 {
-                    Debug.Assert(value >= 0 && value <= ushort.MaxValue, "Trigger control index is out of range");
-                    if (value < 0 || value > ushort.MaxValue)
-                        throw new NotSupportedException("Cannot have more than ushort.MaxValue controls in a single InputActionState");
-                    m_TriggerControlIndex = (ushort)value;
+                    if (value == kInvalidIndex)
+                        m_TriggerControlIndex = ushort.MaxValue;
+                    else
+                    {
+                        if (value < 0 || value >= ushort.MaxValue)
+                            throw new NotSupportedException("More than ushort.MaxValue-1 controls in a single InputActionState");
+                        m_TriggerControlIndex = (ushort)value;
+                    }
                 }
             }
 
@@ -3780,6 +4069,27 @@ namespace UnityEngine.InputSystem
             s_GlobalState.globalList.length = head;
         }
 
+        internal void NotifyListenersOfActionChange(InputActionChange change)
+        {
+            for (var i = 0; i < totalMapCount; ++i)
+            {
+                var map = maps[i];
+                if (map.m_SingletonAction != null)
+                {
+                    NotifyListenersOfActionChange(change, map.m_SingletonAction);
+                }
+                else if (map.m_Asset == null)
+                {
+                    NotifyListenersOfActionChange(change, map);
+                }
+                else
+                {
+                    NotifyListenersOfActionChange(change, map.m_Asset);
+                    return;
+                }
+            }
+        }
+
         internal static void NotifyListenersOfActionChange(InputActionChange change, object actionOrMapOrAsset)
         {
             Debug.Assert(actionOrMapOrAsset != null, "Should have action or action map or asset object to notify about");
@@ -3891,11 +4201,13 @@ namespace UnityEngine.InputSystem
                 var state = (InputActionState)handle.Target;
 
                 // If this state is not affected by the change, skip.
+                var needsFullResolve = true;
                 switch (change)
                 {
                     case InputDeviceChange.Added:
                         if (!state.CanUseDevice(device))
                             continue;
+                        needsFullResolve = false;
                         break;
 
                     case InputDeviceChange.Removed:
@@ -3911,6 +4223,7 @@ namespace UnityEngine.InputSystem
                             map.asset?.m_Devices.Remove(device);
                         }
 
+                        needsFullResolve = false;
                         break;
 
                     // NOTE: ConfigurationChanges can affect display names of controls which may make a device usable that
@@ -3919,6 +4232,7 @@ namespace UnityEngine.InputSystem
                     case InputDeviceChange.UsageChanged:
                         if (!state.IsUsingDevice(device) && !state.CanUseDevice(device))
                             continue;
+                        // Full resolve necessary!
                         break;
 
                     // On reset, cancel all actions currently in progress from the device that got reset.
@@ -3934,12 +4248,14 @@ namespace UnityEngine.InputSystem
 
                 // Trigger a lazy-resolve on all action maps in the state.
                 for (var n = 0; n < state.totalMapCount; ++n)
-                    if (state.maps[n].LazyResolveBindings())
+                {
+                    if (state.maps[n].LazyResolveBindings(fullResolve: needsFullResolve))
                     {
                         // Map has chosen to resolve right away. This will resolve bindings for *all*
                         // maps in the state, so we're done here.
                         break;
                     }
+                }
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -54,7 +54,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         public InputBinding? bindingMask;
 
-        private List<NameAndParameters> m_Parameters;
+        private bool m_IsControlOnlyResolve;
 
         /// <summary>
         /// Release native memory held by the resolver.
@@ -68,14 +68,17 @@ namespace UnityEngine.InputSystem
         /// Steal the already allocated arrays from the given state.
         /// </summary>
         /// <param name="state">Action map state that was previously created.</param>
-        /// <remarks>
-        /// This is useful to avoid allocating new arrays from scratch when re-resolving bindings.
-        /// </remarks>
-        public void StartWithArraysFrom(InputActionState state)
+        /// <param name="isFullResolve">If false, the only thing that is allowed to change in the re-resolution
+        /// is the list of controls. In other words, devices may have been added or removed but otherwise the configuration
+        /// is exactly the same as in the last resolve. If true, anything may have changed and the resolver will only reuse
+        /// allocations but not contents.</param>
+        public void StartWithPreviousResolve(InputActionState state, bool isFullResolve)
         {
             Debug.Assert(state != null, "Received null state");
             Debug.Assert(!state.isProcessingControlStateChange,
                 "Cannot re-resolve bindings for an InputActionState that is currently executing an action callback; binding resolution must be deferred to until after the callback has completed");
+
+            m_IsControlOnlyResolve = !isFullResolve;
 
             maps = state.maps;
             interactions = state.interactions;
@@ -84,15 +87,18 @@ namespace UnityEngine.InputSystem
             controls = state.controls;
 
             // Clear the arrays so that we don't leave references around.
-            if (maps != null)
-                Array.Clear(maps, 0, state.totalMapCount);
-            if (interactions != null)
-                Array.Clear(interactions, 0, state.totalInteractionCount);
-            if (processors != null)
-                Array.Clear(processors, 0, state.totalProcessorCount);
-            if (composites != null)
-                Array.Clear(composites, 0, state.totalCompositeCount);
-            if (controls != null)
+            if (isFullResolve)
+            {
+                if (maps != null)
+                    Array.Clear(maps, 0, state.totalMapCount);
+                if (interactions != null)
+                    Array.Clear(interactions, 0, state.totalInteractionCount);
+                if (processors != null)
+                    Array.Clear(processors, 0, state.totalProcessorCount);
+                if (composites != null)
+                    Array.Clear(composites, 0, state.totalCompositeCount);
+            }
+            if (controls != null) // Always clear this one as every resolve will change it.
                 Array.Clear(controls, 0, state.totalControlCount);
 
             // Null out the arrays on the state so that there is no strange bugs with
@@ -280,30 +286,27 @@ namespace UnityEngine.InputSystem
                                 // Search globally.
                                 numControls = InputSystem.FindControls(path, ref resolvedControls);
                             }
-
-                            // Disable binding if it doesn't resolve to any controls.
-                            // NOTE: This also happens to bindings that got all their resolved controls removed because other bindings from the same
-                            //       action already grabbed them.
-                            if (numControls == 0)
-                                bindingIsDisabled = true;
                         }
 
                         // If the binding isn't disabled, resolve its controls, processors, and interactions.
                         if (!bindingIsDisabled)
                         {
+                            // NOTE: When isFullResolve==false, it is *imperative* that we do count processor and interaction
+                            //       counts here come out exactly the same as in the previous full resolve.
+
                             // Instantiate processors.
                             var processorString = unresolvedBinding.effectiveProcessors;
                             if (!string.IsNullOrEmpty(processorString))
                             {
                                 // Add processors from binding.
-                                firstProcessorIndex = ResolveProcessors(processorString);
+                                firstProcessorIndex = InstantiateWithParameters(InputProcessor.s_Processors, processorString, ref processors, ref totalProcessorCount);
                                 if (firstProcessorIndex != InputActionState.kInvalidIndex)
                                     numProcessors = totalProcessorCount - firstProcessorIndex;
                             }
                             if (!string.IsNullOrEmpty(action.m_Processors))
                             {
                                 // Add processors from action.
-                                var index = ResolveProcessors(action.m_Processors);
+                                var index = InstantiateWithParameters(InputProcessor.s_Processors, action.m_Processors, ref processors, ref totalProcessorCount);
                                 if (index != InputActionState.kInvalidIndex)
                                 {
                                     if (firstProcessorIndex == InputActionState.kInvalidIndex)
@@ -317,14 +320,14 @@ namespace UnityEngine.InputSystem
                             if (!string.IsNullOrEmpty(interactionString))
                             {
                                 // Add interactions from binding.
-                                firstInteractionIndex = ResolveInteractions(interactionString);
+                                firstInteractionIndex = InstantiateWithParameters(InputInteraction.s_Interactions, interactionString, ref interactions, ref totalInteractionCount);
                                 if (firstInteractionIndex != InputActionState.kInvalidIndex)
                                     numInteractions = totalInteractionCount - firstInteractionIndex;
                             }
                             if (!string.IsNullOrEmpty(action.m_Interactions))
                             {
                                 // Add interactions from action.
-                                var index = ResolveInteractions(action.m_Interactions);
+                                var index = InstantiateWithParameters(InputInteraction.s_Interactions, action.m_Interactions, ref interactions, ref totalInteractionCount);
                                 if (index != InputActionState.kInvalidIndex)
                                 {
                                     if (firstInteractionIndex == InputActionState.kInvalidIndex)
@@ -333,8 +336,7 @@ namespace UnityEngine.InputSystem
                                 }
                             }
 
-                            // If it's the start of a composite chain, create the composite. Otherwise, go and
-                            // resolve controls for the binding.
+                            // If it's the start of a composite chain, create the composite.
                             if (isComposite)
                             {
                                 // The composite binding entry itself does not resolve to any controls.
@@ -465,7 +467,11 @@ namespace UnityEngine.InputSystem
 
                 // Initialize initial interaction states.
                 for (var i = memory.interactionCount; i < newMemory.interactionCount; ++i)
-                    newMemory.interactionStates[i].phase = InputActionPhase.Waiting;
+                {
+                    ref var interactionState = ref newMemory.interactionStates[i];
+                    interactionState.phase = InputActionPhase.Waiting;
+                    interactionState.triggerControlIndex = InputActionState.kInvalidIndex;
+                }
 
                 // Initialize action data.
                 var runningIndexInBindingIndices = memory.bindingCount;
@@ -576,65 +582,42 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        private int ResolveInteractions(string interactionString)
+        private List<NameAndParameters> m_Parameters; // We retain this to reuse the allocation.
+        private int InstantiateWithParameters<TType>(TypeTable registrations, string namesAndParameters, ref TType[] array, ref int count)
         {
-            ////REVIEW: We're piggybacking off the processor parsing here as the two syntaxes are identical. Might consider
-            ////        moving the logic to a shared place.
-            ////        Alternatively, may split the paths. May help in getting rid of unnecessary allocations.
-
-            if (!NameAndParameters.ParseMultiple(interactionString, ref m_Parameters))
+            if (!NameAndParameters.ParseMultiple(namesAndParameters, ref m_Parameters))
                 return InputActionState.kInvalidIndex;
 
-            var firstInteractionIndex = totalInteractionCount;
+            var firstIndex = count;
             for (var i = 0; i < m_Parameters.Count; ++i)
             {
-                // Look up interaction.
-                var type = InputInteraction.s_Interactions.LookupTypeRegistration(m_Parameters[i].name);
+                // Look up type.
+                var type = registrations.LookupTypeRegistration(m_Parameters[i].name);
                 if (type == null)
                     throw new InvalidOperationException(
-                        $"No interaction with name '{m_Parameters[i].name}' (mentioned in '{interactionString}') has been registered");
+                        $"No {typeof(TType).Name} with name '{m_Parameters[i].name}' (mentioned in '{namesAndParameters}') has been registered");
 
-                // Instantiate it.
-                if (!(Activator.CreateInstance(type) is IInputInteraction interaction))
-                    throw new InvalidOperationException($"Interaction '{m_Parameters[i].name}' (mentioned in '{interactionString}') is not an IInputInteraction");
+                if (!m_IsControlOnlyResolve)
+                {
+                    // Instantiate it.
+                    if (!(Activator.CreateInstance(type) is TType instance))
+                        throw new InvalidOperationException(
+                            $"Type '{type.Name}' registered '{m_Parameters[i].name}' (mentioned in '{namesAndParameters}') is not an {typeof(TType).Name}");
 
-                // Pass parameters to it.
-                NamedValue.ApplyAllToObject(interaction, m_Parameters[i].parameters);
+                    // Pass parameters to it.
+                    NamedValue.ApplyAllToObject(instance, m_Parameters[i].parameters);
 
-                // Add to list.
-                ArrayHelpers.AppendWithCapacity(ref interactions, ref totalInteractionCount, interaction);
+                    // Add to list.
+                    ArrayHelpers.AppendWithCapacity(ref array, ref count, instance);
+                }
+                else
+                {
+                    Debug.Assert(type.IsInstanceOfType(array[count]), "Type of instance in array does not match expected type");
+                    ++count;
+                }
             }
 
-            return firstInteractionIndex;
-        }
-
-        private int ResolveProcessors(string processorString)
-        {
-            if (!NameAndParameters.ParseMultiple(processorString, ref m_Parameters))
-                return InputActionState.kInvalidIndex;
-
-            var firstProcessorIndex = totalProcessorCount;
-            for (var i = 0; i < m_Parameters.Count; ++i)
-            {
-                // Look up processor.
-                var type = InputProcessor.s_Processors.LookupTypeRegistration(m_Parameters[i].name);
-                if (type == null)
-                    throw new InvalidOperationException(
-                        $"No processor with name '{m_Parameters[i].name}' (mentioned in '{processorString}') has been registered");
-
-                // Instantiate it.
-                if (!(Activator.CreateInstance(type) is InputProcessor processor))
-                    throw new InvalidOperationException(
-                        $"Type '{type.Name}' registered as processor called '{m_Parameters[i].name}' (mentioned in '{processorString}') is not an InputProcessor");
-
-                // Pass parameters to it.
-                NamedValue.ApplyAllToObject(processor, m_Parameters[i].parameters);
-
-                // Add to list.
-                ArrayHelpers.AppendWithCapacity(ref processors, ref totalProcessorCount, processor);
-            }
-
-            return firstProcessorIndex;
+            return firstIndex;
         }
 
         private static InputBindingComposite InstantiateBindingComposite(string nameAndParameters)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -586,6 +586,7 @@ namespace UnityEngine.InputSystem
                         $"Could not create remote device '{data.description}' with layout '{data.layout}' locally (exception: {exception})");
                     return;
                 }
+                ////FIXME: Setting this here like so means none of this is visible during onDeviceChange
                 device.m_Description = data.description;
                 device.m_DeviceFlags |= InputDevice.DeviceFlags.Remote;
                 foreach (var usage in data.usages)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.cs
@@ -665,7 +665,7 @@ namespace UnityEngine.InputSystem
                     ""path"": ""*/{Submit}"",
                     ""interactions"": """",
                     ""processors"": """",
-                    ""groups"": """",
+                    ""groups"": ""Keyboard&Mouse;Gamepad;Touch;Joystick;XR"",
                     ""action"": ""Submit"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false
@@ -676,7 +676,7 @@ namespace UnityEngine.InputSystem
                     ""path"": ""*/{Cancel}"",
                     ""interactions"": """",
                     ""processors"": """",
-                    ""groups"": """",
+                    ""groups"": ""Keyboard&Mouse;Gamepad;Touch;Joystick;XR"",
                     ""action"": ""Cancel"",
                     ""isComposite"": false,
                     ""isPartOfComposite"": false

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions
@@ -622,7 +622,7 @@
                     "path": "*/{Submit}",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR",
                     "action": "Submit",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -633,7 +633,7 @@
                     "path": "*/{Cancel}",
                     "interactions": "",
                     "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR",
                     "action": "Cancel",
                     "isComposite": false,
                     "isPartOfComposite": false

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/OneOrMore.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/OneOrMore.cs
@@ -72,9 +72,9 @@ namespace UnityEngine.InputSystem.Utilities
 
             public bool MoveNext()
             {
+                ++m_Index;
                 if (m_Index >= m_List.Count)
                     return false;
-                ++m_Index;
                 return true;
             }
 


### PR DESCRIPTION
Fixes [1379932](https://issuetracker.unity3d.com/issues/inputactionreferences-reading-resets-when-inputactionmap-has-an-action-for-the-other-hand-and-that-hand-starts-slash-stops-tracking) ([FogBugz](https://fogbugz.unity3d.com/f/cases/1379932/)).

### Description

In current `develop`, we handle two cases that lead to bindings needing to be resolved more than once.

1. The controls targeted by the bindings have changed.
2. Actions and/or maps have been added or removed.

For case 2, we require actions to be disabled.

However, case 1 we allow to happen while actions may be enabled (and possibly even in progress). The sequence it triggers is:

1. We disable all the actions in the map or asset.
2. We resolve all bindings from scratch.
3. We re-enable all actions that we disabled and turn on "initial state checks" for them.
4. In the next input update, we check all the controls bound to the actions we re-enabled and thus trigger actions according to current control states.

The big downside of this is that if you simply add or remove a device, the actions that are affected by that will get interrupted.

For XR this is especially bad as we remove a controller when we lose tracking and re-add when we regain tracking. So if you press a button on the left hand controller and then the right hand controller comes online, there's a flicker of activity on the left hand button.

### Changes made

Introduce a third codepath that is specific to adding and removing devices. This codepath will only touch an action if its active control is disappearing. For example, if you press a button and then the controller's batteries die, the action gets cancelled. But if you simply add or remove devices without affecting any active controls, the change is transparent.

Due to how `InputActionState` packs all its state into arrays, this isn't a trivial change. Also, I went in and more rigorously channeled the different cases down the respective codepaths. And added more test coverage for that.

### Notes

Sorry for the huge PR :/

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
