### PR TITLE
FIX: Processors are now always applied when reading the value of an action.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -29,7 +29,41 @@ using Is = UnityEngine.TestTools.Constraints.Is;
 // in terms of complexity.
 partial class CoreTests
 {
-    #if UNITY_EDITOR
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenBindingsAreResolved_BindingIndexPointsToFirstBindingInAction()
+    {
+        InputSystem.AddDevice<Gamepad>();
+
+        var map = new InputActionMap("map");
+        map.AddAction("action2", binding: "<Gamepad>/buttonNorth");
+        var action1 = map.AddAction("action1", binding: "<Gamepad>/leftStick/x", processors: "normalize(min=-1,max=1,zero=-1)");
+        action1.AddBinding("<Gamepad>/rightStick/x", processors: "normalize(min=0,max=1)");
+
+        map.Enable();
+
+        Assert.That(action1.ReadValue<float>(), Is.EqualTo(0.5f));
+    }
+
+    [Test]
+    [Category("Actions")]
+    public void Actions_WhenResetActionState_BindingIndexPointsToFirstBindingInAction()
+    {
+        InputSystem.AddDevice<Gamepad>();
+
+        var map = new InputActionMap("map");
+        map.AddAction("action2", binding: "<Gamepad>/buttonNorth");
+        var action1 = map.AddAction("action1", binding: "<Gamepad>/leftStick/x", processors: "normalize(min=-1,max=1,zero=-1)");
+        action1.AddBinding("<Gamepad>/rightStick/x", processors: "normalize(min=0,max=1)");
+
+        map.Enable();
+
+        action1.Reset();
+
+        Assert.That(action1.ReadValue<float>(), Is.EqualTo(0.5f));
+    }
+
+#if UNITY_EDITOR
     [Test]
     [Category("Actions")]
     public void Actions_DoNotGetTriggeredByEditorUpdates()

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -31,7 +31,7 @@ partial class CoreTests
 {
     [Test]
     [Category("Actions")]
-    public void Actions_WhenBindingsAreResolved_BindingIndexPointsToFirstBindingInAction()
+    public void Actions_ReadingValueRightAfterEnabling_AppliesProcessorsFromFirstBinding()
     {
         InputSystem.AddDevice<Gamepad>();
 
@@ -47,7 +47,7 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
-    public void Actions_WhenResetActionState_BindingIndexPointsToFirstBindingInAction()
+    public void Actions_ReadingValueRightAfterResetting_AppliesProcessorsFromFirstBinding()
     {
         InputSystem.AddDevice<Gamepad>();
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,7 @@ however, it has to be formatted properly to pass verification tests.
   ```
   - This also applies to `PressInteraction` when set to `Press` behavior.
   - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
+- Processors are now always applied when reading action values through `InputAction.ReadValue<>` or `CallbackContext.ReadValue<>`. Previously, if no bound control was actuated, ReadValue calls would return the default value for the action type but not run the value through the processors.([case 1293728](https://issuetracker.unity3d.com/product/unity/issues/guid/1293728/)).
 
 ### Fixed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -984,7 +984,7 @@ namespace UnityEngine.InputSystem
             if (state == null) return default(TValue);
 
             var actionStatePtr = &state.actionStates[m_ActionIndexInState];
-            return phase.IsInProgress()
+            return actionStatePtr->phase.IsInProgress()
                 ? state.ReadValue<TValue>(actionStatePtr->bindingIndex, actionStatePtr->controlIndex)
                 : state.ApplyProcessors(actionStatePtr->bindingIndex, default(TValue));
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -525,7 +525,7 @@ namespace UnityEngine.InputSystem
             // Wipe state.
             actionState->phase = toPhase;
             actionState->controlIndex = kInvalidIndex;
-            actionState->bindingIndex = 0;
+            actionState->bindingIndex = memory.actionBindingIndices[memory.actionBindingIndicesAndCounts[actionIndex]];
             actionState->interactionIndex = kInvalidIndex;
             actionState->startTime = 0;
             actionState->time = 0;
@@ -2359,7 +2359,6 @@ namespace UnityEngine.InputSystem
             where TValue : struct
         {
             Debug.Assert(bindingIndex >= 0 && bindingIndex < totalBindingCount, "Binding index is out of range");
-            Debug.Assert(controlIndex >= 0 && controlIndex < totalControlCount, "Control index is out of range");
 
             var value = default(TValue);
 
@@ -2405,18 +2404,27 @@ namespace UnityEngine.InputSystem
             }
             else
             {
-                var control = controls[controlIndex];
-                Debug.Assert(control != null, "Control is null");
+                if (controlIndex != kInvalidIndex)
+                {
+                    var control = controls[controlIndex];
+                    Debug.Assert(control != null, "Control is null");
 
-                controlOfType = control as InputControl<TValue>;
-                if (controlOfType == null)
-                    throw new InvalidOperationException(
-                        $"Cannot read value of type '{TypeHelpers.GetNiceTypeName(typeof(TValue))}' from control '{control.path}' bound to action '{GetActionOrNull(bindingIndex)}' (control is a '{control.GetType().Name}' with value type '{TypeHelpers.GetNiceTypeName(control.valueType)}')");
+                    controlOfType = control as InputControl<TValue>;
+                    if (controlOfType == null)
+                        throw new InvalidOperationException(
+                            $"Cannot read value of type '{TypeHelpers.GetNiceTypeName(typeof(TValue))}' from control '{control.path}' bound to action '{GetActionOrNull(bindingIndex)}' (control is a '{control.GetType().Name}' with value type '{TypeHelpers.GetNiceTypeName(control.valueType)}')");
 
-                value = controlOfType.ReadValue();
+                    value = controlOfType.ReadValue();
+                }
             }
 
             // Run value through processors, if any.
+            return ApplyProcessors(bindingIndex, value, controlOfType);
+        }
+
+        internal TValue ApplyProcessors<TValue>(int bindingIndex, TValue value, InputControl<TValue> controlOfType = null)
+            where TValue : struct
+        {
             var processorCount = bindingStates[bindingIndex].processorCount;
             if (processorCount > 0)
             {
@@ -2638,10 +2646,9 @@ namespace UnityEngine.InputSystem
         internal object ReadValueAsObject(int bindingIndex, int controlIndex, bool ignoreComposites = false)
         {
             Debug.Assert(bindingIndex >= 0 && bindingIndex < totalBindingCount, "Binding index is out of range");
-            Debug.Assert(controlIndex >= 0 && controlIndex < totalControlCount, "Control index is out of range");
 
             InputControl control = null;
-            object value;
+            object value = null;
 
             // If the binding that triggered the action is part of a composite, let
             // the composite determine the value we return.
@@ -2666,18 +2673,24 @@ namespace UnityEngine.InputSystem
             }
             else
             {
-                control = controls[controlIndex];
-                Debug.Assert(control != null, "Control is null");
-                value = control.ReadValueAsObject();
+                if (controlIndex != kInvalidIndex)
+                {
+                    control = controls[controlIndex];
+                    Debug.Assert(control != null, "Control is null");
+                    value = control.ReadValueAsObject();
+                }
             }
 
-            // Run value through processors, if any.
-            var processorCount = bindingStates[bindingIndex].processorCount;
-            if (processorCount > 0)
+            if (value != null)
             {
-                var processorStartIndex = bindingStates[bindingIndex].processorStartIndex;
-                for (var i = 0; i < processorCount; ++i)
-                    value = processors[processorStartIndex + i].ProcessAsObject(value, control);
+                // Run value through processors, if any.
+                var processorCount = bindingStates[bindingIndex].processorCount;
+                if (processorCount > 0)
+                {
+                    var processorStartIndex = bindingStates[bindingIndex].processorStartIndex;
+                    for (var i = 0; i < processorCount; ++i)
+                        value = processors[processorStartIndex + i].ProcessAsObject(value, control);
+                }
             }
 
             return value;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBindingResolver.cs
@@ -477,8 +477,11 @@ namespace UnityEngine.InputSystem
                     // Correlate action with its trigger state.
                     action.m_ActionIndexInState = actionIndex;
 
+                    Debug.Assert(runningIndexInBindingIndices < ushort.MaxValue, "Binding start index on action exceeds limit");
+                    newMemory.actionBindingIndicesAndCounts[actionIndex * 2] = (ushort)runningIndexInBindingIndices;
+
                     // Collect bindings for action.
-                    var bindingStartIndexForAction = runningIndexInBindingIndices;
+                    var firstBindingIndexForAction = -1;
                     var bindingCountForAction = 0;
                     var numPossibleConcurrentActuations = 0;
 
@@ -496,6 +499,9 @@ namespace UnityEngine.InputSystem
                         ++runningIndexInBindingIndices;
                         ++bindingCountForAction;
 
+                        if (firstBindingIndexForAction == -1)
+                            firstBindingIndexForAction = bindingIndex;
+
                         // Keep track of how many concurrent actuations we may be seeing on the action so that
                         // we know whether we need to enable conflict resolution or not.
                         if (bindingState->isComposite)
@@ -511,9 +517,11 @@ namespace UnityEngine.InputSystem
                             numPossibleConcurrentActuations += bindingState->controlCount;
                         }
                     }
-                    Debug.Assert(bindingStartIndexForAction < ushort.MaxValue, "Binding start index on action exceeds limit");
+
+                    if (firstBindingIndexForAction == -1)
+                        firstBindingIndexForAction = 0;
+
                     Debug.Assert(bindingCountForAction < ushort.MaxValue, "Binding count on action exceeds limit");
-                    newMemory.actionBindingIndicesAndCounts[actionIndex * 2] = (ushort)bindingStartIndexForAction;
                     newMemory.actionBindingIndicesAndCounts[actionIndex * 2 + 1] = (ushort)bindingCountForAction;
 
                     // See if we may need conflict resolution on this action. Never needed for pass-through actions.
@@ -534,6 +542,7 @@ namespace UnityEngine.InputSystem
                         isPassThrough = isPassThroughAction,
                         isButton = isButtonAction,
                         mayNeedConflictResolution = mayNeedConflictResolution,
+                        bindingIndex = firstBindingIndexForAction
                     };
                 }
 


### PR DESCRIPTION
Case [1293728](https://issuetracker.unity3d.com/product/unity/issues/guid/1293728/)([Fogbugz](https://fogbugz.unity3d.com/f/cases/1293728/))

### Description

The original bug report suggested that the dead zone processor was interacting with the normalize processor and causing it to malfunction. The actual issue was that calling InputAction.ReadValue() when no binding/control is actuated always returns default(T), where in this case the user had a normalize processor on a stick X axis binding that they wanted to return 0.5 at the default state, instead of 0.

### Changes made

During binding resolution, and when action state is reset, the binding index for each action is set to point to the first binding in that actions' list of bindings. Additionally, when calling InputAction.ReadValue<T>(), if the action is not currently in progress, the default value of T is run through the processors of the active binding.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.
