### PR TITLE
Nimbus+ mac HID support

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/OSXTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OSXTests.cs
@@ -9,7 +9,7 @@ using UnityEngine.InputSystem.OSX;
 using UnityEngine.InputSystem.OSX.LowLevel;
 using UnityEngine.TestTools.Utils;
 
-internal class OSXTests
+internal class OSXTests : CoreTestsFixture
 {
     [Test]
     [Category("Devices")]

--- a/Assets/Tests/InputSystem/Plugins/OSXTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OSXTests.cs
@@ -1,0 +1,187 @@
+#if UNITY_EDITOR || UNITY_OSX
+
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.HID;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.OSX;
+using UnityEngine.InputSystem.OSX.LowLevel;
+using UnityEngine.TestTools.Utils;
+
+internal class OSXTests
+{
+    [Test]
+    [Category("Devices")]
+    [TestCase(0xd, 0x0)] // OSX dummy VID/PID
+    public void Devices_SupportsNimbusPlusAsHID_WithProductNameAndPIDAndVID(int vendorId, int productId)
+    {
+        var device = InputSystem.AddDevice(new InputDeviceDescription
+        {
+            interfaceName = "HID",
+            product = "Nimbus+",
+            capabilities = new HID.HIDDeviceDescriptor
+            {
+                vendorId = vendorId,
+                productId = productId,
+            }.ToJson()
+        });
+
+        Assert.That(device, Is.AssignableTo<NimbusGamepadHid>());
+        Assert.That(device.displayName, Is.EqualTo("Nimbus+"));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_DoNotSupportNimbusPlusAsHID_WithProductName()
+    {
+        Assert.Throws<System.ArgumentException>(() => InputSystem.AddDevice(new InputDeviceDescription
+        {
+            product = "Nimbus+",
+            interfaceName = "HID",
+        }));
+    }
+
+    [Test]
+    [Category("Devices")]
+    [TestCase(0xd, 0x0)] // OSX dummy VID/PID
+    public void Devices_DoNotSupportNimbusPlusAsHID_WithOnlyPidAndVid(int vendorId, int productId)
+    {
+        Assert.Throws<System.ArgumentException>(() => InputSystem.AddDevice(new InputDeviceDescription
+        {
+            interfaceName = "HID",
+            capabilities = new HID.HIDDeviceDescriptor
+            {
+                vendorId = vendorId,
+                productId = productId,
+            }.ToJson()
+        }));
+    }
+
+    [Test]
+    [Category("Devices")]
+    [TestCase(true)]
+    [TestCase(false)]
+    public void Devices_SupportsNimbusPlusAsHID(bool precompiled)
+    {
+        if (!precompiled)
+            InputControlLayout.s_Layouts.precompiledLayouts.Clear();
+
+        var gamepad = InputSystem.AddDevice<NimbusGamepadHid>();
+
+        // Variance 1
+        InputSystem.QueueStateEvent(gamepad, new NimbusPlusHIDInputReport() {});
+        InputSystem.Update();
+
+        var comparer = new Vector2EqualityComparer(0.04f);
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(Vector2.zero).Using(comparer));
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(Vector2.zero).Using(comparer));
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.False);
+        Assert.That(gamepad.rightTrigger.isPressed, Is.False);
+
+        Assert.That(gamepad.dpad.up.isPressed, Is.False);
+        Assert.That(gamepad.dpad.right.isPressed, Is.False);
+        Assert.That(gamepad.dpad.left.isPressed, Is.False);
+        Assert.That(gamepad.dpad.down.isPressed, Is.False);
+
+        Assert.That(gamepad.buttonSouth.isPressed, Is.False);
+        Assert.That(gamepad.buttonNorth.isPressed, Is.False);
+        Assert.That(gamepad.buttonWest.isPressed, Is.False);
+        Assert.That(gamepad.buttonEast.isPressed, Is.False);
+
+        Assert.That(gamepad.leftShoulder.isPressed, Is.False);
+        Assert.That(gamepad.rightShoulder.isPressed, Is.False);
+        Assert.That(gamepad.leftStickButton.isPressed, Is.False);
+        Assert.That(gamepad.rightStickButton.isPressed, Is.False);
+
+        Assert.That(gamepad.homeButton.isPressed, Is.False);
+
+        Assert.That(gamepad.startButton.isPressed, Is.False);
+        Assert.That(gamepad.selectButton.isPressed, Is.False);
+
+        Assert.That(gamepad.homeButton.isPressed, Is.False);
+
+        // Variance 2
+        InputSystem.QueueStateEvent(gamepad, new NimbusPlusHIDInputReport()
+        {
+            leftStickX = 127,
+            leftStickY = 0,
+            rightStickX = 0,
+            rightStickY = -64,
+            leftTrigger = 10,
+            rightTrigger = 180,
+            buttons1 = (1 << 4) | (1 << 7) | (1 << 3) | (1 << 2),
+            buttons2 = (1 << 0) | (1 << 3) | (1 << 4) | (1 << 5)
+        });
+        InputSystem.Update();
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(new Vector2(1.0f, 0.0f)).Using(comparer));
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(new Vector2(0.0f, -0.5f)).Using(comparer));
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.False);
+        Assert.That(gamepad.rightTrigger.isPressed, Is.True);
+
+        Assert.That(gamepad.dpad.up.isPressed, Is.False);
+        Assert.That(gamepad.dpad.right.isPressed, Is.False);
+        Assert.That(gamepad.dpad.left.isPressed, Is.True);
+        Assert.That(gamepad.dpad.down.isPressed, Is.True);
+
+        Assert.That(gamepad.buttonSouth.isPressed, Is.True);
+        Assert.That(gamepad.buttonNorth.isPressed, Is.True);
+        Assert.That(gamepad.buttonWest.isPressed, Is.False);
+        Assert.That(gamepad.buttonEast.isPressed, Is.False);
+
+        Assert.That(gamepad.leftShoulder.isPressed, Is.True);
+        Assert.That(gamepad.rightShoulder.isPressed, Is.False);
+        Assert.That(gamepad.leftStickButton.isPressed, Is.False);
+        Assert.That(gamepad.rightStickButton.isPressed, Is.True);
+
+        Assert.That(gamepad.startButton.isPressed, Is.False);
+        Assert.That(gamepad.selectButton.isPressed, Is.True);
+
+        Assert.That(gamepad.homeButton.isPressed, Is.True);
+
+        // Variance 3
+        InputSystem.QueueStateEvent(gamepad, new NimbusPlusHIDInputReport()
+        {
+            leftStickX = 0,
+            leftStickY = 127,
+            rightStickX = -64,
+            rightStickY = 0,
+            leftTrigger = 130,
+            rightTrigger = 5,
+            buttons1 = (1 << 6) | (1 << 0) | (1 << 1),
+            buttons2 = (1 << 1) | (1 << 2) | (1 << 6)
+        });
+        InputSystem.Update();
+
+        Assert.That(gamepad.leftStick.ReadValue(), Is.EqualTo(new Vector2(0.0f, 1.0f)).Using(comparer));
+        Assert.That(gamepad.rightStick.ReadValue(), Is.EqualTo(new Vector2(-0.5f, 0.0f)).Using(comparer));
+
+        Assert.That(gamepad.leftTrigger.isPressed, Is.True);
+        Assert.That(gamepad.rightTrigger.isPressed, Is.False);
+
+        Assert.That(gamepad.dpad.up.isPressed, Is.True);
+        Assert.That(gamepad.dpad.right.isPressed, Is.True);
+        Assert.That(gamepad.dpad.left.isPressed, Is.False);
+        Assert.That(gamepad.dpad.down.isPressed, Is.False);
+
+        Assert.That(gamepad.buttonSouth.isPressed, Is.False);
+        Assert.That(gamepad.buttonNorth.isPressed, Is.False);
+        Assert.That(gamepad.buttonWest.isPressed, Is.True);
+        Assert.That(gamepad.buttonEast.isPressed, Is.False);
+
+        Assert.That(gamepad.leftShoulder.isPressed, Is.False);
+        Assert.That(gamepad.rightShoulder.isPressed, Is.True);
+        Assert.That(gamepad.leftStickButton.isPressed, Is.True);
+        Assert.That(gamepad.rightStickButton.isPressed, Is.False);
+
+        Assert.That(gamepad.startButton.isPressed, Is.True);
+        Assert.That(gamepad.selectButton.isPressed, Is.False);
+
+        Assert.That(gamepad.homeButton.isPressed, Is.False);
+    }
+}
+
+#endif // UNITY_EDITOR || UNITY_OSX

--- a/Assets/Tests/InputSystem/Plugins/OSXTests.cs.meta
+++ b/Assets/Tests/InputSystem/Plugins/OSXTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f46b7472a2db344aa58124a452fabed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -40,6 +40,9 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
 
+### Added
+- Added support for SteelSeries Nimbus+ gamepad on Mac via HID and explicit layout (Addition contributed by [Mollyjameson](https://github.com/MollyJameson)).
+
 ## [1.3.0] - 2021-12-10
 
 ### Changed

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -43,7 +43,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
 
 ### Added
-- Added support for SteelSeries Nimbus+ gamepad on Mac via HID and explicit layout (Addition contributed by [Mollyjameson](https://github.com/MollyJameson)).
+- Added support for SteelSeries Nimbus+ gamepad on Mac (Addition contributed by [Mollyjameson](https://github.com/MollyJameson)).
 
 ## [1.3.0] - 2021-12-10
 

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -31,7 +31,7 @@ Support for the following Devices doesn't require specialized support of particu
 |PS3/PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
 |PS5|Yes (10)|Yes (10)|No (10)|Yes (10)|Yes (10)|No (10)|No (10)|No|Yes|No|Sometimes (2)|
 |Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
-|MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
+|MFi (such as SteelSeries)|No|Sometimes (11)|No|No|No|Yes|Yes|No|No|No|No|
 
 >__Notes__:
 >1. The trigger motors on the Xbox One controller are only supported on UWP and Xbox.
@@ -45,6 +45,7 @@ On UWP only USB connection is supported, motor rumble and lightbar are not worki
 >8. Unity officially supports PS4 controllers only on [Android 10 or higher](https://playstation.com/en-us/support/hardware/ps4-pair-dualshock-4-wireless-with-sony-xperia-and-android).
 >9. Switch Joy-Cons are not currently supported on Windows and Mac.
 >10. PS5 DualSense is supported on Windows and macOS via USB HID, though setting motor rumble and lightbar color when connected over Bluetooth is currently not supported.
+>11. SteelSeries Nimbus+ supported via HID on macOS.
 On UWP only USB connection is supported, motor rumble and lightbar are not working correctly.
 On Android it's expected to be working from Android 12.
 On iOS/tvOS it's currently recognized as a generic gamepad and most controls do work.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3429,6 +3429,10 @@ namespace UnityEngine.InputSystem
             iOS.iOSSupport.Initialize();
             #endif
 
+            #if UNITY_EDITOR || UNITY_STANDALONE_OSX
+            OSX.OSXSupport.Initialize();
+            #endif
+
             #if UNITY_EDITOR || UNITY_WEBGL
             WebGL.WebGLSupport.Initialize();
             #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea65eddf43398654fa32b724723c71a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
@@ -1,0 +1,76 @@
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX
+using System.Runtime.InteropServices;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
+using UnityEngine.InputSystem.OSX.LowLevel;
+
+namespace UnityEngine.InputSystem.OSX.LowLevel
+{
+    /// <summary>
+    /// Structure of HID input reports for SteelSeries Nimbus+ controllers.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = 8)]
+    internal struct NimbusControllerHIDInputState : IInputStateTypeInfo
+    {
+        [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "SBYT", parameters = "")]
+        [InputControl(name = "leftStick/left", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [InputControl(name = "leftStick/right", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "leftStick/y", offset = 1, format = "SBYT", parameters = "")]
+        [InputControl(name = "leftStick/up", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "leftStick/down", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [FieldOffset(0)] public sbyte leftStickX;
+        [FieldOffset(1)] public sbyte leftStickY;
+
+        [InputControl(name = "rightStick", layout = "Stick", format = "VC2B")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "SBYT")]
+        [InputControl(name = "rightStick/left", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [InputControl(name = "rightStick/right", offset = 0, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "rightStick/y", offset = 1, format = "SBYT")]
+        [InputControl(name = "rightStick/up", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=0,clampMax=1")]
+        [InputControl(name = "rightStick/down", offset = 1, format = "SBYT", parameters = "clamp=1,clampMin=-1,clampMax=0,invert")]
+        [FieldOffset(2)] public sbyte rightStickX;
+        [FieldOffset(3)] public sbyte rightStickY;
+
+        [InputControl(name = "leftTrigger", format = "BYTE")]
+        [FieldOffset(4)] public byte leftTrigger;
+        [InputControl(name = "rightTrigger", format = "BYTE")]
+        [FieldOffset(5)] public byte rightTrigger;
+
+        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4)]
+        [InputControl(name = "dpad/up", format = "BIT", bit = 0)]
+        [InputControl(name = "dpad/right", format = "BIT", bit = 1)]
+        [InputControl(name = "dpad/down", format = "BIT", bit = 2)]
+        [InputControl(name = "dpad/left", format = "BIT", bit = 3)]
+        [InputControl(name = "buttonSouth", displayName = "A", bit = 4)]
+        [InputControl(name = "buttonEast", displayName = "B", bit = 5)]
+        [InputControl(name = "buttonWest", displayName = "X", bit = 6)]
+        [InputControl(name = "buttonNorth", displayName = "Y", bit = 7)]
+        [FieldOffset(6)] public byte buttons1;
+        [InputControl(name = "leftShoulder", bit = 0)]
+        [InputControl(name = "rightShoulder", bit = 1)]
+        [InputControl(name = "leftStickPress", bit = 2)]
+        [InputControl(name = "rightStickPress", bit = 3)]
+        [InputControl(name = "menuButton", layout = "Button", bit = 4)]
+        [InputControl(name = "select", bit = 5)]
+        [InputControl(name = "start", bit = 6)]
+        [FieldOffset(7)] public byte buttons2;
+
+        public FourCC format => new FourCC('H', 'I', 'D');
+    }
+}
+
+namespace UnityEngine.InputSystem.OSX
+{
+    /// <summary>
+    /// Steel Series Nimbus+ uses iOSGameController MFI when on iOS but
+    /// is just a standard HID on osx.
+    /// </summary>
+    [InputControlLayout(stateType = typeof(NimbusControllerHIDInputState), displayName = "nimbus+ Gamepad")]
+    [Scripting.Preserve]
+    public class NimbusGameController : Gamepad
+    {
+    }
+}
+#endif // UNITY_EDITOR || UNITY_STANDALONE_OSX

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
@@ -9,7 +9,8 @@ using UnityEngine.InputSystem.Controls;
 namespace UnityEngine.InputSystem.OSX.LowLevel
 {
     /// <summary>
-    /// Structure of HID input reports for SteelSeries Nimbus+ controllers.
+    /// Structure of HID input reports for SteelSeries Nimbus+ controllers supported
+    /// via HID on OSX.
     /// </summary>
     [StructLayout(LayoutKind.Explicit, Size = 8)]
     internal struct NimbusPlusHIDInputReport : IInputStateTypeInfo
@@ -79,7 +80,8 @@ namespace UnityEngine.InputSystem.OSX
     /// <summary>
     /// Steel Series Nimbus+ uses iOSGameController MFI when on iOS but
     /// is just a standard HID on OSX. Note that the gamepad is made available
-    /// with incorrect VID/PID by OSX. Instead of
+    /// with incorrect VID/PID by OSX instead of the true VID/PID registred with
+    /// USB.org for this device.
     /// </summary>
     [InputControlLayout(stateType = typeof(NimbusPlusHIDInputReport), displayName = "Nimbus+ Gamepad")]
     [Scripting.Preserve]
@@ -91,7 +93,6 @@ namespace UnityEngine.InputSystem.OSX
         /// <remarks>
         /// Note that this button is also picked up by OS.
         /// </remarks>
-        /// <value>Same as <see cref="Gamepad.selectButton"/>.</value>
         [InputControl(name = "homeButton", displayName = "Home", shortDisplayName = "Home")]
         public ButtonControl homeButton { get; protected set; }
 
@@ -99,6 +100,7 @@ namespace UnityEngine.InputSystem.OSX
         protected override void FinishSetup()
         {
             homeButton = GetChildControl<ButtonControl>("homeButton");
+            Debug.Assert(homeButton != null);
 
             base.FinishSetup();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_STANDALONE_OSX
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX || PACKAGE_DOCS_GENERATION
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXGameController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9817b64a59aab947a96a4cf6247d018
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
@@ -4,6 +4,9 @@ using UnityEngine.InputSystem.OSX.LowLevel;
 
 namespace UnityEngine.InputSystem.OSX
 {
+    /// <summary>
+    /// A small helper class to aid in initializing and registering HID device layout builders.
+    /// </summary>
 #if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
     public
 #else
@@ -11,6 +14,9 @@ namespace UnityEngine.InputSystem.OSX
 #endif
     static class OSXSupport
     {
+        /// <summary>
+        /// Registers HID device layouts for OSX.
+        /// </summary>
         public static void Initialize()
         {
             // Note that OSX reports manufacturer "Unknown" and a bogus VID/PID according

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
@@ -1,0 +1,21 @@
+#if UNITY_EDITOR || UNITY_STANDALONE_OSX
+using UnityEngine.InputSystem.Layouts;
+
+namespace UnityEngine.InputSystem.OSX
+{
+#if UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
+    public
+#else
+    internal
+#endif
+    static class OSXSupport
+    {
+        public static void Initialize()
+        {
+            InputSystem.RegisterLayout<NimbusGameController>(
+                matches: new InputDeviceMatcher()
+                    .WithProduct("Nimbus+"));
+        }
+    }
+}
+#endif // UNITY_EDITOR || UNITY_STANDALONE_OSX

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR || UNITY_STANDALONE_OSX
 using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.OSX.LowLevel;
 
 namespace UnityEngine.InputSystem.OSX
 {
@@ -12,9 +13,12 @@ namespace UnityEngine.InputSystem.OSX
     {
         public static void Initialize()
         {
-            InputSystem.RegisterLayout<NimbusGameController>(
+            // Note that OSX reports manufacturer "Unknown"
+            InputSystem.RegisterLayout<NimbusGamepadHid>(
                 matches: new InputDeviceMatcher()
-                    .WithProduct("Nimbus+"));
+                    .WithProduct("Nimbus+", supportRegex: false)
+                    .WithCapability("vendorId", NimbusPlusHIDInputReport.OSXVendorId)
+                    .WithCapability("productId", NimbusPlusHIDInputReport.OSXProductId));
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs
@@ -13,7 +13,8 @@ namespace UnityEngine.InputSystem.OSX
     {
         public static void Initialize()
         {
-            // Note that OSX reports manufacturer "Unknown"
+            // Note that OSX reports manufacturer "Unknown" and a bogus VID/PID according
+            // to matcher below.
             InputSystem.RegisterLayout<NimbusGamepadHid>(
                 matches: new InputDeviceMatcher()
                     .WithProduct("Nimbus+", supportRegex: false)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OSX/OSXSupport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec5b5d14e5b51f44abf18ab8f288cdb5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

Adds support for SteelSeries Nimbus+ gamepad on OSX where the device is surfaced as a HID device. (Contribution by [MollyJameson](https://github.com/MollyJameson)).
It should be noted that this device is enumerated with bogus Vendor and Product ID.

### Changes made

Original contribution:
- Gamepad layout mapping. See https://github.com/Unity-Technologies/InputSystem/pull/1318/files

Additional changes added to the original contribution:
- Renamed "menuButton" to "homeButton" since this button is referenced as "Home Button" in the device manual: https://steelseries.com/gaming-controllers/nimbus-plus 
- Added unit tests.
- Added more string matching against OSX VID/PID provided via HID and regexp turned off.

### Notes

Note that this doesn't add support for SteelSeries Nimbus.
Note that the device is not picked up by e.g. Windows when using the provided vendor and product name. The original contribution could be picked up on other OS when using proper product and vecor ID. 

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
