### PR TITLE
FIX: AxisComposite ignoring processors (case 1398942).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -6573,14 +6573,8 @@ partial class CoreTests
             InputSystem.QueueStateEvent(gamepad, new GamepadState {leftTrigger = 0.345f});
             InputSystem.Update();
 
-            var actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(2));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Started));
-            Assert.That(actions[0].control, Is.EqualTo(gamepad.leftTrigger));
-            Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(-0.345).Within(0.00001));
-            Assert.That(actions[1].phase, Is.EqualTo(InputActionPhase.Performed));
-            Assert.That(actions[1].control, Is.EqualTo(gamepad.leftTrigger));
-            Assert.That(actions[1].ReadValue<float>(), Is.EqualTo(-0.345).Within(0.00001));
+            Assert.That(trace, Started(action, control: gamepad.leftTrigger, value: -0.345f)
+                .AndThen(Performed(action, control: gamepad.leftTrigger, value: -0.345f)));
 
             trace.Clear();
 
@@ -6588,14 +6582,10 @@ partial class CoreTests
             InputSystem.QueueStateEvent(gamepad, new GamepadState {rightTrigger = 0.456f});
             InputSystem.Update();
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Performed));
             // Bit of an odd case. leftTrigger and rightTrigger have both changed state here so
             // in a way, it's up to the system which one to pick. Might be useful if it was deliberately
             // picking the control with the highest magnitude but not sure it's worth the effort.
-            Assert.That(actions[0].control, Is.EqualTo(gamepad.leftTrigger));
-            Assert.That(actions[0].ReadValue<float>(), Is.EqualTo(0.456).Within(0.00001));
+            Assert.That(trace, Performed(action, control: gamepad.leftTrigger, value: 0.456f));
 
             trace.Clear();
 
@@ -6603,11 +6593,7 @@ partial class CoreTests
             InputSystem.QueueStateEvent(gamepad, new GamepadState());
             InputSystem.Update();
 
-            actions = trace.ToArray();
-            Assert.That(actions, Has.Length.EqualTo(1));
-            Assert.That(actions[0].phase, Is.EqualTo(InputActionPhase.Canceled));
-            Assert.That(actions[0].control, Is.EqualTo(gamepad.rightTrigger));
-            Assert.That(actions[0].ReadValue<float>(), Is.Zero.Within(0.00001));
+            Assert.That(trace, Canceled(action, control: gamepad.rightTrigger, value: 0f));
         }
     }
 
@@ -6735,6 +6721,28 @@ partial class CoreTests
         Set(gamepad.rightTrigger, 1f);
 
         Assert.That(action.ReadValue<float>(), Is.EqualTo(2).Within(0.00001));
+    }
+
+    // https://fogbugz.unity3d.com/f/cases/1398942/
+    [Test]
+    [Category("Actions")]
+    public void Actions_CanCreateAxisComposite_AndApplyProcessorsToPartBindings()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        var action = new InputAction();
+        action.AddCompositeBinding("1DAxis(minValue=0,maxValue=10)")
+            .With("Positive", "<Mouse>/scroll/y", processors: "clamp(min=0,max=1)")
+            .With("Negative", "<Mouse>/scroll/y", processors: "invert,clamp(min=0,max=1)");
+        action.Enable();
+
+        Set(mouse.scroll.y, 2f);
+
+        Assert.That(action.ReadValue<float>(), Is.EqualTo(10));
+
+        Set(mouse.scroll.y, -2f);
+
+        Assert.That(action.ReadValue<float>(), Is.EqualTo(0));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -30,9 +30,9 @@ however, it has to be formatted properly to pass verification tests.
   - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
 
 ### Fixed
+
 * Fixed an issue where a layout-override registered via `InputSystem.RegisterLayoutOverride(...)` would cause the editor to malfunction or crash if the layout override had a name already used by an existing layout. (case 1377685).
 * Fixed an issue where attempting to replace an existing layout-override by using an existing layout-override name didn't work as expected and would instead aggregate overrides instead of replacing them when an override with the given name already exists.
-
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
 - Fixed `InvalidCastException: Specified cast is not valid.` being thrown when clicking on menu separators in the control picker ([case 1388049](https://issuetracker.unity3d.com/issues/invalidcastexception-is-thrown-when-selecting-the-header-of-an-advanceddropdown)).
 - Fixed DualShock 4 controller not allowing input from other devices due to noisy input from its unmapped sensors ([case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)).
@@ -41,6 +41,8 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
+- Fixed `AxisComposite` not respecting processors applied to `positive` and `negative` bindings (case 1398942).
+  * This was a regression introduced in [1.0.0-pre.6](#axiscomposite-min-max-value-fix).
 
 ## [1.3.0] - 2021-12-10
 
@@ -199,7 +201,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `MultiTapInteraction` not respecting `InputSettings.multiTapDelayTime` ([case 1292754](https://issuetracker.unity3d.com/issues/multitapdelaytime-does-not-influence-maxtapspacing-in-input-action-assets)).
 - Fixed changing values in `Input System Package` project settings not affecting default values displayed in `.inputactions` editor window ([case 1292754](https://issuetracker.unity3d.com/issues/multitapdelaytime-does-not-influence-maxtapspacing-in-input-action-assets)).
 - Fixed rebinding a part of a composite with `RebindingOperation.WithTargetBinding` not also changing the type of control being looked for ([case 1272563](https://issuetracker.unity3d.com/issues/input-system-performinteractiverebinding-method-doesnt-detect-button-input-when-rebinding-part-of-a-2d-vector-composite)).
-- Fixed `AxisComposite` not respecting `minValue` and `maxValue` properties ([case 1335838](https://issuetracker.unity3d.com/issues/inputsystem-1d-axis-composite-binding-will-return-a-incorrect-value-if-minvalue-and-maxvalue-is-not-1-and-1)).
+- <a name="axiscomposite-min-max-value-fix"></a> Fixed `AxisComposite` not respecting `minValue` and `maxValue` properties ([case 1335838](https://issuetracker.unity3d.com/issues/inputsystem-1d-axis-composite-binding-will-return-a-incorrect-value-if-minvalue-and-maxvalue-is-not-1-and-1)).
 - Fixed `ArgumentOutOfRangeException` caused by `IsPointerOverGameObject` ([case 1337354](https://issuetracker.unity3d.com/issues/mobile-argumentoutofrangeexception-is-thrown-when-calling-ispointerovergameobject)).
 - `PlayerInput` no longer logs an error message when it is set to `Invoke UnityEvents` and can't find  an action in the given `.inputactions` asset ([case 1259577](https://issuetracker.unity3d.com/issues/an-error-is-thrown-when-deleting-an-input-action-and-entering-play-mode)).
 - Fixed `HoldInteraction` getting stuck when hold and release happens in same event ([case 1346786](https://issuetracker.unity3d.com/issues/input-system-the-canceled-event-is-not-fired-when-clicking-a-button-for-a-precise-amount-of-time)).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -36,9 +36,10 @@ namespace UnityEngine.InputSystem.Composites
     /// acceleration control(s), and setting <see cref="whichSideWins"/> to <see cref="WhichSideWins.Negative"/>,
     /// if the break button is pressed, it will always cause the acceleration button to be ignored.
     ///
-    /// The values returned are the actual actuation values of the buttons, unaltered for <see cref="positive"/>
-    /// and inverted for <see cref="negative"/>. This means that if the buttons are actual axes (e.g.
-    /// the triggers on gamepads), then the values correspond to how much the axis is actuated.
+    /// The actual <em>absolute</em> values of <see cref="negative"/> and <see cref="positive"/> are used
+    /// to scale <see cref="minValue"/> and <see cref="maxValue"/> respectively. So if, for example, <see cref="positive"/>
+    /// is bound to <see cref="Gamepad.rightTrigger"/> and the trigger is at a value of 0.5, then the resulting
+    /// value is <c>maxValue * 0.5</c> (the actual formula is <c>midPoint + (maxValue - midPoint) * positive</c>).
     /// </remarks>
     [DisplayStringFormat("{negative}/{positive}")]
     [DisplayName("Positive/Negative Binding")]
@@ -132,10 +133,11 @@ namespace UnityEngine.InputSystem.Composites
         /// <inheritdoc />
         public override float ReadValue(ref InputBindingCompositeContext context)
         {
-            var negativeValue = context.ReadValue<float>(negative);
-            var positiveValue = context.ReadValue<float>(positive);
-            var negativeIsActuated = Mathf.Abs(negativeValue) > Mathf.Epsilon;
-            var positiveIsActuated = Mathf.Abs(positiveValue) > Mathf.Epsilon;
+            var negativeValue = Mathf.Abs(context.ReadValue<float>(negative));
+            var positiveValue = Mathf.Abs(context.ReadValue<float>(positive));
+
+            var negativeIsActuated = negativeValue > Mathf.Epsilon;
+            var positiveIsActuated = positiveValue > Mathf.Epsilon;
 
             if (negativeIsActuated == positiveIsActuated)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -6,13 +6,10 @@ using UnityEngine.InputSystem.Utilities;
 namespace UnityEngine.InputSystem.Composites
 {
     /// <summary>
-    /// A single axis value computed from a "negative" and a "positive" button.
+    /// A single axis value computed from one axis that pulls in the <see cref="negative"/> direction (<see cref="minValue"/>) and one
+    /// axis that pulls in the <see cref="positive"/> direction (<see cref="maxValue"/>).
     /// </summary>
     /// <remarks>
-    /// This composite allows to arrange any arbitrary two buttons from a device in an
-    /// axis configuration such that one button pushes in one direction and the other
-    /// pushes in the opposite direction.
-    ///
     /// The limits of the axis are determined by <see cref="minValue"/> and <see cref="maxValue"/>.
     /// By default, they are set to <c>[-1..1]</c>. The values can be set as parameters.
     ///
@@ -25,7 +22,7 @@ namespace UnityEngine.InputSystem.Composites
     /// </code>
     /// </example>
     ///
-    /// If both buttons are pressed at the same time, the behavior depends on <see cref="whichSideWins"/>.
+    /// If both axes are actuated at the same time, the behavior depends on <see cref="whichSideWins"/>.
     /// By default, neither side will win (<see cref="WhichSideWins.Neither"/>) and the result
     /// will be 0 (or, more precisely, the midpoint between <see cref="minValue"/> and <see cref="maxValue"/>).
     /// This can be customized to make the positive side win (<see cref="WhichSideWins.Positive"/>)


### PR DESCRIPTION
Fixes [1398942](https://fogbugz.unity3d.com/f/cases/resolve/1398942/) (internally filed ticket).

### Description

A [previous change](https://github.com/Unity-Technologies/InputSystem/commit/38bdeec083d518f7abdaf4b83a2e083b137036cf#) of mine switched `AxisComposite` to read its `positive` and `negative` inputs as magnitudes. This, in effect, causes it to ignore processors as currently, our processors only deal in values but not in magnitudes.

### Changes made

Switched `AxisComposite` back to using `ReadValue<float>()`.

Also removed the (already incorrect) button semantics/constraints on `positive` and `negative` inputs -- which are now simply `Axis` (i.e. `float`) inputs that scale `minValue` and `maxValue`. We were already not checking for button press thresholds and treating the input as a value instead.

### Notes

The underlying problem here with processors not effecting magnitudes should be sorted out in v2.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
