### PR TITLE
Adding support for some 3rdparty Nintendo gamepads

### DIFF
--- a/Assets/Tests/InputSystem/SwitchTests.cs
+++ b/Assets/Tests/InputSystem/SwitchTests.cs
@@ -80,6 +80,29 @@ internal class SwitchTests : CoreTestsFixture
         }.WithButton(button);
     }
 
+    [Test]
+    [Category("Devices")]
+    [TestCase(0x0f0d, 0x00c1)]
+    [TestCase(0x20d6, 0xa712)]
+    [TestCase(0x0e6f, 0x0185)]
+    public void Devices_SupportsSwitchLikeControllers(int vendorId, int productId)
+    {
+        var hidDescriptor = new HID.HIDDeviceDescriptor
+        {
+            vendorId = vendorId,
+            productId = productId,
+        };
+
+        var device = InputSystem.AddDevice(
+            new InputDeviceDescription
+            {
+                interfaceName = HID.kHIDInterface,
+                capabilities = hidDescriptor.ToJson()
+            });
+
+        Assert.That(device, Is.TypeOf<SwitchProControllerHID>());
+    }
+
 #endif
 }
 #endif

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -42,6 +42,10 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
 
+### Added
+
+- Added support for "Hori Co HORIPAD for Nintendo Switch", "PowerA NSW Fusion Wired FightPad", "PDP Wired Fight Pad Pro: Mario".
+
 ## [1.3.0] - 2021-12-10
 
 ### Changed

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -28,9 +28,9 @@ Support for the following Devices doesn't require specialized support of particu
 |------|-------|---|-----|---|-------|---|----|----|---|------|-----|
 |Xbox 360 (4)|Yes|Yes (3)|Yes|Yes|No|No|No|Yes|No|No|Sometimes (2)|
 |Xbox One|Yes (1)|Yes (3)|Yes (1)|Yes|Yes (1)|Yes (6)|Yes (6)|Yes|No|No|Sometimes (2)|
-|PS3/PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
+|PS3/PS4|Yes (5)|Yes (5)|Yes (5)|Yes (5)|Yes (5, 8)|Yes (5, 6)|Yes (5, 6)|No|Yes|No|Sometimes (2)|
 |PS5|Yes (10)|Yes (10)|No (10)|Yes (10)|Yes (10)|No (10)|No (10)|No|Yes|No|Sometimes (2)|
-|Switch|Yes (8)|Yes (8)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
+|Switch|Yes (9)|Yes (9)|Yes|Yes|No|No|No|No|No|Yes|Sometimes (2)|
 |MFi (such as SteelSeries)|No|No|No|No|No|Yes|Yes|No|No|No|No|
 
 >__Notes__:
@@ -43,7 +43,7 @@ On UWP only USB connection is supported, motor rumble and lightbar are not worki
 >6. Unity supports Made for iOS (Mfi) certified controllers on iOS. Xbox One and PS4 controllers are only supported on iOS 13 or higher.
 >7. Consoles are supported using separate packages. You need to install these packages in your Project to enable console support.
 >8. Unity officially supports PS4 controllers only on [Android 10 or higher](https://playstation.com/en-us/support/hardware/ps4-pair-dualshock-4-wireless-with-sony-xperia-and-android).
->9. Switch Joy-Cons are not currently supported on Windows and Mac.
+>9. Switch Joy-Cons are not currently supported on Windows and Mac. Some of official accessories are supported on Windows and Mac: "Hori Co HORIPAD for Nintendo Switch", "PowerA NSW Fusion Wired FightPad", "PDP Wired Fight Pad Pro: Mario".
 >10. PS5 DualSense is supported on Windows and macOS via USB HID, though setting motor rumble and lightbar color when connected over Bluetooth is currently not supported.
 On UWP only USB connection is supported, motor rumble and lightbar are not working correctly.
 On Android it's expected to be working from Android 12.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -37,8 +37,8 @@ namespace UnityEngine.InputSystem.DualShock
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x54C) // Sony Entertainment.
                     .WithCapability("productId", 0x9CC)); // Wireless controller.
-            InputSystem.RegisterLayout<DualShock4GamepadHID>(
-                matches: new InputDeviceMatcher()
+            InputSystem.RegisterLayoutMatcher<DualShock4GamepadHID>(
+                new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x54C) // Sony Entertainment.
                     .WithCapability("productId", 0x5C4)); // Wireless controller.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -21,6 +21,21 @@ namespace UnityEngine.InputSystem.Switch
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x57e) // Nintendo
                     .WithCapability("productId", 0x2009)); // Pro Controller.
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00c1)); // HORIPAD for Nintendo Switch
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6) // PowerA NSW Fusion Wired FightPad
+                    .WithCapability("productId", 0xa712));
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f) // PDP Wired Fight Pad Pro: Mario
+                    .WithCapability("productId", 0x0185));
         #endif
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -19,7 +19,7 @@ namespace UnityEngine.InputSystem.Switch
             InputSystem.RegisterLayout<SwitchProControllerHID>(
                 matches: new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x57e) // Nintendo
+                    .WithCapability("vendorId", 0x057e) // Nintendo
                     .WithCapability("productId", 0x2009)); // Pro Controller.
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()


### PR DESCRIPTION
### Description

Adding support for:
- HORIPAD for Nintendo Switch
- PowerA NSW Fusion Wired FightPad
- PDP Wired Fight Pad Pro: Mario

Tested manually on Windows and macOS.
