### PR TITLE
NEW: Add DeltaControl type.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -953,7 +953,7 @@ partial class CoreTests
 
         Set(gamepad.leftStick, new Vector2(0.234f, 0.345f));
 
-        Assert.That(action.controls, Is.EquivalentTo(new[] {gamepad.leftStick, mouse.delta}));
+        Assert.That(action.controls, Is.EquivalentTo(new InputControl[] {gamepad.leftStick, mouse.delta}));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -2436,7 +2436,33 @@ partial class CoreTests
         var device = InputSystem.AddDevice(layoutName);
         var control = (DeltaControl)device[controlPath];
 
-        Set(control, new Vector2(123, 234));
+        if (device is Touchscreen) // No delta events on Touchscreens.
+        {
+            // Delta on Begin will always be (0,0).
+            BeginTouch(1, new Vector2(0, 0));
+            MoveTouch(1, new Vector2(123, 234));
+        }
+        else
+            Set(control, new Vector2(123, 234));
+
+        Assert.That(control.x.ReadValue(), Is.EqualTo(123).Within(0.0001));
+        Assert.That(control.left.ReadValue(), Is.EqualTo(0).Within(0.0001));
+        Assert.That(control.right.ReadValue(), Is.EqualTo(123).Within(0.0001));
+        Assert.That(control.y.ReadValue(), Is.EqualTo(234).Within(0.0001));
+        Assert.That(control.up.ReadValue(), Is.EqualTo(234).Within(0.0001));
+        Assert.That(control.down.ReadValue(), Is.EqualTo(0).Within(0.0001));
+
+        if (device is Touchscreen) // No delta events on Touchscreens.
+            MoveTouch(1, new Vector2(-123, -234), delta: new Vector2(-123, -234));
+        else
+            Set(control, new Vector2(-123, -234));
+
+        Assert.That(control.x.ReadValue(), Is.EqualTo(-123).Within(0.0001));
+        Assert.That(control.left.ReadValue(), Is.EqualTo(123).Within(0.0001));
+        Assert.That(control.right.ReadValue(), Is.EqualTo(0).Within(0.0001));
+        Assert.That(control.y.ReadValue(), Is.EqualTo(-234).Within(0.0001));
+        Assert.That(control.up.ReadValue(), Is.EqualTo(0).Within(0.0001));
+        Assert.That(control.down.ReadValue(), Is.EqualTo(234).Within(0.0001));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -2426,6 +2426,21 @@ partial class CoreTests
 
     [Test]
     [Category("Devices")]
+    [TestCase("Pointer", "delta")]
+    [TestCase("Pen", "delta")]
+    [TestCase("Touchscreen", "delta")]
+    [TestCase("Mouse", "delta")]
+    [TestCase("Mouse", "scroll")]
+    public void Devices_PointerDeltasHaveDirectionalChildControls(string layoutName, string controlPath)
+    {
+        var device = InputSystem.AddDevice(layoutName);
+        var control = (DeltaControl)device[controlPath];
+
+        Set(control, new Vector2(123, 234));
+    }
+
+    [Test]
+    [Category("Devices")]
     public void Devices_PointerDeltasDoNotAccumulateFromPreviousFrame()
     {
         var pointer = InputSystem.AddDevice<Pointer>();
@@ -2441,6 +2456,42 @@ partial class CoreTests
 
         Assert.That(pointer.delta.x.ReadValue(), Is.EqualTo(0.5).Within(0.0000001));
         Assert.That(pointer.delta.y.ReadValue(), Is.EqualTo(0.5).Within(0.0000001));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_PointerDeltasHaveNoNormalizationAppliedToMagnitudes()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+        var pen = InputSystem.AddDevice<Pen>();
+        var touch = InputSystem.AddDevice<Touchscreen>();
+
+        Assert.That(mouse.delta.m_MinValue.isEmpty);
+        Assert.That(pen.delta.m_MinValue.isEmpty);
+        Assert.That(touch.delta.m_MinValue.isEmpty);
+
+        Assert.That(mouse.delta.m_MaxValue.isEmpty);
+        Assert.That(pen.delta.m_MaxValue.isEmpty);
+        Assert.That(touch.delta.m_MaxValue.isEmpty);
+
+        Set(mouse.delta, new Vector2(123, 234), queueEventOnly: true);
+        Set(pen.delta, new Vector2(123, 234), queueEventOnly: true);
+        BeginTouch(1, Vector2.zero, queueEventOnly: true);
+        MoveTouch(1, new Vector2(123, 234), queueEventOnly: true);
+
+        InputSystem.Update();
+
+        Assert.That(mouse.delta.x.EvaluateMagnitude(), Is.EqualTo(123));
+        Assert.That(mouse.delta.y.EvaluateMagnitude(), Is.EqualTo(234));
+        Assert.That(pen.delta.x.EvaluateMagnitude(), Is.EqualTo(123));
+        Assert.That(pen.delta.y.EvaluateMagnitude(), Is.EqualTo(234));
+        Assert.That(touch.delta.x.EvaluateMagnitude(), Is.EqualTo(123));
+        Assert.That(touch.delta.y.EvaluateMagnitude(), Is.EqualTo(234));
+
+        // But also to the Vector2 controls as a whole.
+        Assert.That(mouse.delta.EvaluateMagnitude(), Is.EqualTo(new Vector2(123, 234).magnitude));
+        Assert.That(pen.delta.EvaluateMagnitude(), Is.EqualTo(new Vector2(123, 234).magnitude));
+        Assert.That(touch.delta.EvaluateMagnitude(), Is.EqualTo(new Vector2(123, 234).magnitude));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,9 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
-* `Button` type `InputAction`s now go to `started` when a button goes from a press to below the release threshold but not yet to 0 ([case ]
+- `Button` type `InputAction`s now go to `started` when a button goes from a press to below the release threshold but not yet to 0 ([case ]
   ```CSharp
   // Before:
   Set(Gamepad.current.rightTrigger, 0.7f); // Performed (pressed)
@@ -26,13 +26,13 @@ however, it has to be formatted properly to pass verification tests.
   Set(Gamepad.current.rightTrigger, 0.1f); // <Nothing>
   Set(Gamepad.current.rightTrigger, 0f);   // Canceled
   ```
-  - This also applies to `PressInteraction` when set to `Press` behavior.
-  - In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
+  * This also applies to `PressInteraction` when set to `Press` behavior.
+  * In effect, it means that a button will be in `started` or `performed` phase for as long as its value is not 0 and will only go to `canceled` once dropping to 0.
 
 ### Fixed
-* Fixed an issue where a layout-override registered via `InputSystem.RegisterLayoutOverride(...)` would cause the editor to malfunction or crash if the layout override had a name already used by an existing layout. (case 1377685).
-* Fixed an issue where attempting to replace an existing layout-override by using an existing layout-override name didn't work as expected and would instead aggregate overrides instead of replacing them when an override with the given name already exists.
 
+- Fixed an issue where a layout-override registered via `InputSystem.RegisterLayoutOverride(...)` would cause the editor to malfunction or crash if the layout override had a name already used by an existing layout. (case 1377685).
+- Fixed an issue where attempting to replace an existing layout-override by using an existing layout-override name didn't work as expected and would instead aggregate overrides instead of replacing them when an override with the given name already exists.
 - Fixed Switch Pro controller not working correctly in different scenarios ([case 1369091](https://issuetracker.unity3d.com/issues/nintendo-switch-pro-controller-output-garbage), [case 1190216](https://issuetracker.unity3d.com/issues/inputsystem-windows-switch-pro-controller-only-works-when-connected-via-bluetooth-but-not-via-usb), case 1314869).
 - Fixed `InvalidCastException: Specified cast is not valid.` being thrown when clicking on menu separators in the control picker ([case 1388049](https://issuetracker.unity3d.com/issues/invalidcastexception-is-thrown-when-selecting-the-header-of-an-advanceddropdown)).
 - Fixed DualShock 4 controller not allowing input from other devices due to noisy input from its unmapped sensors ([case 1365891](https://issuetracker.unity3d.com/issues/input-from-the-keyboard-is-not-working-when-the-dualshock-4-controller-is-connected)).
@@ -41,6 +41,11 @@ however, it has to be formatted properly to pass verification tests.
 #### Actions
 
 - Fixed `InputAction.GetTimeoutCompletionPercentage` jumping to 100% completion early ([case 1377009](https://issuetracker.unity3d.com/issues/gettimeoutcompletionpercentage-returns-1-after-0-dot-1s-when-hold-action-was-started-even-though-it-is-not-performed-yet)).
+
+### Added
+
+- Added a new `DeltaControl` control type that is now used for delta-style controls such as `Mouse.delta` and `Mouse.scroll`.
+  * Like `StickControl`, this control has individual `up`, `down`, `left`, and `right` controls (as well as `x` and `y` that it inherits from `Vector2Control`). This means it is now possible to directly bind to individual scroll directions (such as `<Mouse>/scroll/up`).
 
 ## [1.3.0] - 2021-12-10
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -51,7 +51,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int up = 0;
+        [InputControl(layout = "Axis")] public int up = 0;
 
         /// <summary>
         /// Binding for the button represents the down (that is, <c>(0,-1)</c>) direction of the vector.
@@ -61,7 +61,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int down = 0;
+        [InputControl(layout = "Axis")] public int down = 0;
 
         /// <summary>
         /// Binding for the button represents the left (that is, <c>(-1,0)</c>) direction of the vector.
@@ -71,7 +71,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int left = 0;
+        [InputControl(layout = "Axis")] public int left = 0;
 
         /// <summary>
         /// Binding for the button that represents the right (that is, <c>(1,0)</c>) direction of the vector.
@@ -79,7 +79,7 @@ namespace UnityEngine.InputSystem.Composites
         /// <remarks>
         /// This property is automatically assigned by the input system.
         /// </remarks>
-        [InputControl(layout = "Button")] public int right = 0;
+        [InputControl(layout = "Axis")] public int right = 0;
 
         [Obsolete("Use Mode.DigitalNormalized with 'mode' instead")]
         public bool normalize = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -43,7 +43,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int up;
+        [InputControl(layout = "Axis")] public int up;
 
         /// <summary>
         /// Binding for the button that represents the down (that is, <c>(0,-1,0)</c>) direction of the vector.
@@ -53,7 +53,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int down;
+        [InputControl(layout = "Axis")] public int down;
 
         /// <summary>
         /// Binding for the button that represents the left (that is, <c>(-1,0,0)</c>) direction of the vector.
@@ -63,7 +63,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int left;
+        [InputControl(layout = "Axis")] public int left;
 
         /// <summary>
         /// Binding for the button that represents the right (that is, <c>(1,0,0)</c>) direction of the vector.
@@ -73,7 +73,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int right;
+        [InputControl(layout = "Axis")] public int right;
 
         /// <summary>
         /// Binding for the button that represents the right (that is, <c>(0,0,1)</c>) direction of the vector.
@@ -83,7 +83,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int forward;
+        [InputControl(layout = "Axis")] public int forward;
 
         /// <summary>
         /// Binding for the button that represents the right (that is, <c>(0,0,-1)</c>) direction of the vector.
@@ -93,7 +93,7 @@ namespace UnityEngine.InputSystem.Composites
         /// </remarks>
         // ReSharper disable once MemberCanBePrivate.Global
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
-        [InputControl(layout = "Button")] public int backward;
+        [InputControl(layout = "Axis")] public int backward;
 
         /// <summary>
         /// How to synthesize a <c>Vector3</c> from the values read from <see cref="up"/>, <see cref="down"/>,

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DeltaControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DeltaControl.cs
@@ -1,0 +1,72 @@
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.Scripting;
+
+namespace UnityEngine.InputSystem.Controls
+{
+    /// <summary>
+    /// A control representing a two-dimensional motion vector that accumulates within a frame
+    /// and resets at the beginning of a frame.
+    /// </summary>
+    /// <remarks>
+    /// Delta controls are
+    /// </remarks>
+    /// <see cref="Pointer.delta"/>
+    /// <seealso cref="Mouse.scroll"/>
+    [Preserve]
+    public class DeltaControl : Vector2Control
+    {
+        /// <summary>
+        /// A synthetic axis representing the upper half of the Y axis value, i.e. the 0 to 1 range.
+        /// </summary>
+        /// <value>Control representing the control's upper half Y axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
+        [InputControl(useStateFrom = "y", parameters = "clamp=1,clampMin=0,clampMax=3.402823E+38", synthetic = true, displayName = "Up")]
+        [Preserve]
+        public AxisControl up { get; set; }
+
+        /// <summary>
+        /// A synthetic axis representing the lower half of the Y axis value, i.e. the -1 to 1 range (inverted).
+        /// </summary>
+        /// <value>Control representing the control's lower half Y axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
+        [InputControl(useStateFrom = "y", parameters = "clamp=1,clampMin=-3.402823E+38,clampMax=0,invert", synthetic = true, displayName = "Down")]
+        [Preserve]
+        public AxisControl down { get; set; }
+
+        /// <summary>
+        /// A synthetic axis representing the left half of the X axis value, i.e. the -1 to 1 range (inverted).
+        /// </summary>
+        /// <value>Control representing the control's left half X axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
+        [InputControl(useStateFrom = "x", parameters = "clamp=1,clampMin=-3.402823E+38,clampMax=0,invert", synthetic = true, displayName = "Left")]
+        [Preserve]
+        public AxisControl left { get; set; }
+
+        /// <summary>
+        /// A synthetic axis representing the right half of the X axis value, i.e. the 0 to 1 range.
+        /// </summary>
+        /// <value>Control representing the control's right half X axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
+        [InputControl(useStateFrom = "x", parameters = "clamp=1,clampMin=0,clampMax=3.402823E+38", synthetic = true, displayName = "Right")]
+        [Preserve]
+        public AxisControl right { get; set; }
+
+        protected override void FinishSetup()
+        {
+            base.FinishSetup();
+
+            up = GetChildControl<AxisControl>("up");
+            down = GetChildControl<AxisControl>("down");
+            left = GetChildControl<AxisControl>("left");
+            right = GetChildControl<AxisControl>("right");
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/DeltaControl.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/DeltaControl.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 339c9c6bc0554ad79681e127d417ef3d
+timeCreated: 1630420986

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/StickControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/StickControl.cs
@@ -62,11 +62,10 @@ namespace UnityEngine.InputSystem.Controls
         ////        from state correctly.
 
         /// <summary>
-        /// A synthetic button representing the upper half of the stick's Y axis.
+        /// A synthetic button representing the upper half of the stick's Y axis, i.e. the 0 to 1 range.
         /// </summary>
         /// <value>Control representing the stick's upper half Y axis.</value>
         /// <remarks>
-        ///
         /// The control is marked as <see cref="InputControl.synthetic"/>.
         /// </remarks>
         [InputControl(useStateFrom = "y", processors = "axisDeadzone", parameters = "clamp=2,clampMin=0,clampMax=1", synthetic = true, displayName = "Up")]
@@ -77,12 +76,33 @@ namespace UnityEngine.InputSystem.Controls
         [InputControl(name = "y", minValue = -1f, maxValue = 1f, layout = "Axis", processors = "axisDeadzone")]
         public ButtonControl up { get; set; }
 
+        /// <summary>
+        /// A synthetic button representing the lower half of the stick's Y axis, i.e. the -1 to 0 range (inverted).
+        /// </summary>
+        /// <value>Control representing the stick's lower half Y axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
         [InputControl(useStateFrom = "y", processors = "axisDeadzone", parameters = "clamp=2,clampMin=-1,clampMax=0,invert", synthetic = true, displayName = "Down")]
         public ButtonControl down { get; set; }
 
+        /// <summary>
+        /// A synthetic button representing the left half of the stick's X axis, i.e. the -1 to 0 range (inverted).
+        /// </summary>
+        /// <value>Control representing the stick's left half X axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
         [InputControl(useStateFrom = "x", processors = "axisDeadzone", parameters = "clamp=2,clampMin=-1,clampMax=0,invert", synthetic = true, displayName = "Left")]
         public ButtonControl left { get; set; }
 
+        /// <summary>
+        /// A synthetic button representing the right half of the stick's X axis, i.e. the 0 to 1 range.
+        /// </summary>
+        /// <value>Control representing the stick's right half X axis.</value>
+        /// <remarks>
+        /// The control is marked as <see cref="InputControl.synthetic"/>.
+        /// </remarks>
         [InputControl(useStateFrom = "x", processors = "axisDeadzone", parameters = "clamp=2,clampMin=0,clampMax=1", synthetic = true, displayName = "Right")]
         public ButtonControl right { get; set; }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
@@ -69,7 +69,7 @@ namespace UnityEngine.InputSystem.Controls
         /// controls. See <see cref="Pointer.delta"/> for details.
         /// </remarks>
         /// <seealso cref="TouchState.delta"/>
-        public Vector2Control delta { get; set; }
+        public DeltaControl delta { get; set; }
 
         /// <summary>
         /// Normalized pressure of the touch against the touch surface.
@@ -204,7 +204,7 @@ namespace UnityEngine.InputSystem.Controls
             press = GetChildControl<TouchPressControl>("press");
             touchId = GetChildControl<IntegerControl>("touchId");
             position = GetChildControl<Vector2Control>("position");
-            delta = GetChildControl<Vector2Control>("delta");
+            delta = GetChildControl<DeltaControl>("delta");
             pressure = GetChildControl<AxisControl>("pressure");
             radius = GetChildControl<Vector2Control>("radius");
             phase = GetChildControl<TouchPhaseControl>("phase");

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
@@ -15,9 +15,9 @@ namespace UnityEngine.InputSystem.Controls
     ///     Mouse.current.position.x.ReadValue(),
     ///     Mouse.current.position.y.ReadValue()));
     /// </code>
+    /// </example>
     ///
     /// Normalization is not implied. The X and Y coordinates can be in any range or units.
-    /// </example>
     /// </remarks>
     public class Vector2Control : InputControl<Vector2>
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -36,7 +36,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <value>Mouse movement.</value>
         /// <seealso cref="Pointer.delta"/>
-        [InputControl(usage = "Secondary2DMotion")]
+        [InputControl(usage = "Secondary2DMotion", layout = "Delta")]
         [FieldOffset(8)]
         public Vector2 delta;
 
@@ -46,7 +46,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <value>Scroll wheel delta.</value>
         /// <seealso cref="Mouse.scroll"/>
-        [InputControl(displayName = "Scroll")]
+        [InputControl(displayName = "Scroll", layout = "Delta")]
         [InputControl(name = "scroll/x", aliases = new[] { "horizontal" }, usage = "ScrollHorizontal", displayName = "Left/Right")]
         [InputControl(name = "scroll/y", aliases = new[] { "vertical" }, usage = "ScrollVertical", displayName = "Up/Down", shortDisplayName = "Wheel")]
         [FieldOffset(16)]
@@ -178,7 +178,7 @@ namespace UnityEngine.InputSystem
         /// <c>y</c> component to the vertical scroll wheel. Most mice do not have
         /// horizontal scroll wheels and will thus only see activity on <c>y</c>.
         /// </remarks>
-        public Vector2Control scroll { get; protected set; }
+        public DeltaControl scroll { get; protected set; }
 
         /// <summary>
         /// The left mouse button.
@@ -280,7 +280,7 @@ namespace UnityEngine.InputSystem
         /// <inheritdoc />
         protected override void FinishSetup()
         {
-            scroll = GetChildControl<Vector2Control>("scroll");
+            scroll = GetChildControl<DeltaControl>("scroll");
             leftButton = GetChildControl<ButtonControl>("leftButton");
             middleButton = GetChildControl<ButtonControl>("middleButton");
             rightButton = GetChildControl<ButtonControl>("rightButton");

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pen.cs
@@ -44,7 +44,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <value>Screen-space motion delta.</value>
         /// <seealso cref="Pointer.delta"/>
-        [InputControl(usage = "Secondary2DMotion")]
+        [InputControl(usage = "Secondary2DMotion", layout = "Delta")]
         [FieldOffset(8)]
         public Vector2 delta;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -48,7 +48,7 @@ namespace UnityEngine.InputSystem.LowLevel
         public Vector2 position;
 
         ////REVIEW: if we have Secondary2DMotion on this, seems like this should be normalized
-        [InputControl(layout = "Vector2", displayName = "Delta", usage = "Secondary2DMotion")]
+        [InputControl(layout = "Delta", displayName = "Delta", usage = "Secondary2DMotion")]
         public Vector2 delta;
 
         [InputControl(layout = "Analog", displayName = "Pressure", usage = "Pressure", defaultState = 1f)]
@@ -143,7 +143,7 @@ namespace UnityEngine.InputSystem
         /// not <c>(2,2)</c> even though that's the value received from the event.
         /// </remarks>
         /// <seealso cref="InputControlExtensions.AccumulateValueInEvent"/>
-        public Vector2Control delta { get; protected set; }
+        public DeltaControl delta { get; protected set; }
 
         ////REVIEW: move this down to only TouchScreen?
         /// <summary>
@@ -206,7 +206,7 @@ namespace UnityEngine.InputSystem
         protected override void FinishSetup()
         {
             position = GetChildControl<Vector2Control>("position");
-            delta = GetChildControl<Vector2Control>("delta");
+            delta = GetChildControl<DeltaControl>("delta");
             radius = GetChildControl<Vector2Control>("radius");
             pressure = GetChildControl<AxisControl>("pressure");
             press = GetChildControl<ButtonControl>("press");

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.cs
@@ -21,10 +21,10 @@ namespace UnityEngine.InputSystem
 {
     internal partial class FastMouse : UnityEngine.InputSystem.Mouse
     {
-        public const string metadata = "AutoWindowSpace;Vector2;Button;Axis;Digital;Integer;Mouse;Pointer";
+        public const string metadata = "AutoWindowSpace;Vector2;Delta;Button;Axis;Digital;Integer;Mouse;Pointer";
         public FastMouse()
         {
-            var builder = this.Setup(21, 10, 2)
+            var builder = this.Setup(29, 10, 2)
                 .WithName("Mouse")
                 .WithDisplayName("Mouse")
                 .WithChildren(0, 13)
@@ -32,6 +32,7 @@ namespace UnityEngine.InputSystem
                 .WithStateBlock(new InputStateBlock { format = new FourCC(1297044819), sizeInBits = 392 });
 
             var kVector2Layout = new InternedString("Vector2");
+            var kDeltaLayout = new InternedString("Delta");
             var kButtonLayout = new InternedString("Button");
             var kAxisLayout = new InternedString("Axis");
             var kDigitalLayout = new InternedString("Digital");
@@ -41,10 +42,10 @@ namespace UnityEngine.InputSystem
             var ctrlMouseposition = Initialize_ctrlMouseposition(kVector2Layout, this);
 
             // /Mouse/delta
-            var ctrlMousedelta = Initialize_ctrlMousedelta(kVector2Layout, this);
+            var ctrlMousedelta = Initialize_ctrlMousedelta(kDeltaLayout, this);
 
             // /Mouse/scroll
-            var ctrlMousescroll = Initialize_ctrlMousescroll(kVector2Layout, this);
+            var ctrlMousescroll = Initialize_ctrlMousescroll(kDeltaLayout, this);
 
             // /Mouse/press
             var ctrlMousepress = Initialize_ctrlMousepress(kButtonLayout, this);
@@ -82,11 +83,35 @@ namespace UnityEngine.InputSystem
             // /Mouse/position/y
             var ctrlMousepositiony = Initialize_ctrlMousepositiony(kAxisLayout, ctrlMouseposition);
 
+            // /Mouse/delta/up
+            var ctrlMousedeltaup = Initialize_ctrlMousedeltaup(kAxisLayout, ctrlMousedelta);
+
+            // /Mouse/delta/down
+            var ctrlMousedeltadown = Initialize_ctrlMousedeltadown(kAxisLayout, ctrlMousedelta);
+
+            // /Mouse/delta/left
+            var ctrlMousedeltaleft = Initialize_ctrlMousedeltaleft(kAxisLayout, ctrlMousedelta);
+
+            // /Mouse/delta/right
+            var ctrlMousedeltaright = Initialize_ctrlMousedeltaright(kAxisLayout, ctrlMousedelta);
+
             // /Mouse/delta/x
             var ctrlMousedeltax = Initialize_ctrlMousedeltax(kAxisLayout, ctrlMousedelta);
 
             // /Mouse/delta/y
             var ctrlMousedeltay = Initialize_ctrlMousedeltay(kAxisLayout, ctrlMousedelta);
+
+            // /Mouse/scroll/up
+            var ctrlMousescrollup = Initialize_ctrlMousescrollup(kAxisLayout, ctrlMousescroll);
+
+            // /Mouse/scroll/down
+            var ctrlMousescrolldown = Initialize_ctrlMousescrolldown(kAxisLayout, ctrlMousescroll);
+
+            // /Mouse/scroll/left
+            var ctrlMousescrollleft = Initialize_ctrlMousescrollleft(kAxisLayout, ctrlMousescroll);
+
+            // /Mouse/scroll/right
+            var ctrlMousescrollright = Initialize_ctrlMousescrollright(kAxisLayout, ctrlMousescroll);
 
             // /Mouse/scroll/x
             var ctrlMousescrollx = Initialize_ctrlMousescrollx(kAxisLayout, ctrlMousescroll);
@@ -131,8 +156,16 @@ namespace UnityEngine.InputSystem
             this.press = ctrlMousepress;
             ctrlMouseposition.x = ctrlMousepositionx;
             ctrlMouseposition.y = ctrlMousepositiony;
+            ctrlMousedelta.up = ctrlMousedeltaup;
+            ctrlMousedelta.down = ctrlMousedeltadown;
+            ctrlMousedelta.left = ctrlMousedeltaleft;
+            ctrlMousedelta.right = ctrlMousedeltaright;
             ctrlMousedelta.x = ctrlMousedeltax;
             ctrlMousedelta.y = ctrlMousedeltay;
+            ctrlMousescroll.up = ctrlMousescrollup;
+            ctrlMousescroll.down = ctrlMousescrolldown;
+            ctrlMousescroll.left = ctrlMousescrollleft;
+            ctrlMousescroll.right = ctrlMousescrollright;
             ctrlMousescroll.x = ctrlMousescrollx;
             ctrlMousescroll.y = ctrlMousescrolly;
             ctrlMouseradius.x = ctrlMouseradiusx;
@@ -141,8 +174,9 @@ namespace UnityEngine.InputSystem
             // State offset to control index map.
             builder.WithStateOffsetToControlIndexMap(new uint[]
             {
-                32781u, 16809998u, 33587215u, 50364432u, 67141649u, 83918866u, 100664323u, 100664324u, 101188613u, 101712902u
-                , 102237191u, 102761480u, 117456908u, 134250505u, 167804947u, 184582164u, 201327627u
+                32781u, 16809998u, 33587217u, 33587218u, 33587219u, 50364431u, 50364432u, 50364436u, 67141655u, 67141656u
+                , 67141657u, 83918869u, 83918870u, 83918874u, 100664323u, 100664324u, 101188613u, 101712902u, 102237191u, 102761480u
+                , 117456908u, 134250505u, 167804955u, 184582172u, 201327627u
             });
 
             builder.Finish();
@@ -174,16 +208,16 @@ namespace UnityEngine.InputSystem
             return ctrlMouseposition;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlMousedelta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlMousedelta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlMousedelta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlMousedelta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlMousedelta.Setup()
                 .At(this, 1)
                 .WithParent(parent)
-                .WithChildren(15, 2)
+                .WithChildren(15, 6)
                 .WithName("delta")
                 .WithDisplayName("Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithUsages(1, 1)
                 .WithStateBlock(new InputStateBlock
                 {
@@ -196,16 +230,16 @@ namespace UnityEngine.InputSystem
             return ctrlMousedelta;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlMousescroll(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlMousescroll(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlMousescroll = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlMousescroll = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlMousescroll.Setup()
                 .At(this, 2)
                 .WithParent(parent)
-                .WithChildren(17, 2)
+                .WithChildren(21, 6)
                 .WithName("scroll")
                 .WithDisplayName("Scroll")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -385,7 +419,7 @@ namespace UnityEngine.InputSystem
             ctrlMouseradius.Setup()
                 .At(this, 10)
                 .WithParent(parent)
-                .WithChildren(19, 2)
+                .WithChildren(27, 2)
                 .WithName("radius")
                 .WithDisplayName("Radius")
                 .WithLayout(kVector2Layout)
@@ -486,11 +520,99 @@ namespace UnityEngine.InputSystem
             return ctrlMousepositiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousedeltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousedeltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlMousedeltaup.Setup()
+                .At(this, 15)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Delta Up")
+                .WithShortDisplayName("Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 12,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousedeltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousedeltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousedeltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlMousedeltadown.Setup()
+                .At(this, 16)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Delta Down")
+                .WithShortDisplayName("Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 12,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousedeltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousedeltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousedeltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlMousedeltaleft.Setup()
+                .At(this, 17)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Delta Left")
+                .WithShortDisplayName("Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 8,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousedeltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousedeltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousedeltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlMousedeltaright.Setup()
+                .At(this, 18)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Delta Right")
+                .WithShortDisplayName("Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 8,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousedeltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousedeltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlMousedeltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousedeltax.Setup()
-                .At(this, 15)
+                .At(this, 19)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Delta X")
@@ -511,7 +633,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousedeltay.Setup()
-                .At(this, 16)
+                .At(this, 20)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Delta Y")
@@ -528,11 +650,99 @@ namespace UnityEngine.InputSystem
             return ctrlMousedeltay;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousescrollup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousescrollup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlMousescrollup.Setup()
+                .At(this, 21)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Scroll Up")
+                .WithShortDisplayName("Scroll Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 20,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousescrollup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousescrolldown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousescrolldown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlMousescrolldown.Setup()
+                .At(this, 22)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Scroll Down")
+                .WithShortDisplayName("Scroll Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 20,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousescrolldown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousescrollleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousescrollleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlMousescrollleft.Setup()
+                .At(this, 23)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Scroll Left")
+                .WithShortDisplayName("Scroll Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 16,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousescrollleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousescrollright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlMousescrollright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlMousescrollright.Setup()
+                .At(this, 24)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Scroll Right")
+                .WithShortDisplayName("Scroll Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 16,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlMousescrollright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlMousescrollx(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlMousescrollx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousescrollx.Setup()
-                .At(this, 17)
+                .At(this, 25)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Scroll Left/Right")
@@ -555,7 +765,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrolly = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousescrolly.Setup()
-                .At(this, 18)
+                .At(this, 26)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Scroll Up/Down")
@@ -578,7 +788,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMouseradiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMouseradiusx.Setup()
-                .At(this, 19)
+                .At(this, 27)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Radius X")
@@ -599,7 +809,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMouseradiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMouseradiusy.Setup()
-                .At(this, 20)
+                .At(this, 28)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Radius Y")

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastTouchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastTouchscreen.cs
@@ -21,10 +21,10 @@ namespace UnityEngine.InputSystem
 {
     internal partial class FastTouchscreen : UnityEngine.InputSystem.Touchscreen
     {
-        public const string metadata = "AutoWindowSpace;Touch;Vector2;Analog;TouchPress;Button;Axis;Integer;TouchPhase;Double;Touchscreen;Pointer";
+        public const string metadata = "AutoWindowSpace;Touch;Vector2;Delta;Analog;TouchPress;Button;Axis;Integer;TouchPhase;Double;Touchscreen;Pointer";
         public FastTouchscreen()
         {
-            var builder = this.Setup(242, 5, 0)
+            var builder = this.Setup(290, 5, 0)
                 .WithName("Touchscreen")
                 .WithDisplayName("Touchscreen")
                 .WithChildren(0, 16)
@@ -33,6 +33,7 @@ namespace UnityEngine.InputSystem
 
             var kTouchLayout = new InternedString("Touch");
             var kVector2Layout = new InternedString("Vector2");
+            var kDeltaLayout = new InternedString("Delta");
             var kAnalogLayout = new InternedString("Analog");
             var kTouchPressLayout = new InternedString("TouchPress");
             var kIntegerLayout = new InternedString("Integer");
@@ -48,7 +49,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreenposition = Initialize_ctrlTouchscreenposition(kVector2Layout, this);
 
             // /Touchscreen/delta
-            var ctrlTouchscreendelta = Initialize_ctrlTouchscreendelta(kVector2Layout, this);
+            var ctrlTouchscreendelta = Initialize_ctrlTouchscreendelta(kDeltaLayout, this);
 
             // /Touchscreen/pressure
             var ctrlTouchscreenpressure = Initialize_ctrlTouchscreenpressure(kAnalogLayout, this);
@@ -96,7 +97,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreenprimaryTouchposition = Initialize_ctrlTouchscreenprimaryTouchposition(kVector2Layout, ctrlTouchscreenprimaryTouch);
 
             // /Touchscreen/primaryTouch/delta
-            var ctrlTouchscreenprimaryTouchdelta = Initialize_ctrlTouchscreenprimaryTouchdelta(kVector2Layout, ctrlTouchscreenprimaryTouch);
+            var ctrlTouchscreenprimaryTouchdelta = Initialize_ctrlTouchscreenprimaryTouchdelta(kDeltaLayout, ctrlTouchscreenprimaryTouch);
 
             // /Touchscreen/primaryTouch/pressure
             var ctrlTouchscreenprimaryTouchpressure = Initialize_ctrlTouchscreenprimaryTouchpressure(kAxisLayout, ctrlTouchscreenprimaryTouch);
@@ -131,6 +132,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/primaryTouch/position/y
             var ctrlTouchscreenprimaryTouchpositiony = Initialize_ctrlTouchscreenprimaryTouchpositiony(kAxisLayout, ctrlTouchscreenprimaryTouchposition);
 
+            // /Touchscreen/primaryTouch/delta/up
+            var ctrlTouchscreenprimaryTouchdeltaup = Initialize_ctrlTouchscreenprimaryTouchdeltaup(kAxisLayout, ctrlTouchscreenprimaryTouchdelta);
+
+            // /Touchscreen/primaryTouch/delta/down
+            var ctrlTouchscreenprimaryTouchdeltadown = Initialize_ctrlTouchscreenprimaryTouchdeltadown(kAxisLayout, ctrlTouchscreenprimaryTouchdelta);
+
+            // /Touchscreen/primaryTouch/delta/left
+            var ctrlTouchscreenprimaryTouchdeltaleft = Initialize_ctrlTouchscreenprimaryTouchdeltaleft(kAxisLayout, ctrlTouchscreenprimaryTouchdelta);
+
+            // /Touchscreen/primaryTouch/delta/right
+            var ctrlTouchscreenprimaryTouchdeltaright = Initialize_ctrlTouchscreenprimaryTouchdeltaright(kAxisLayout, ctrlTouchscreenprimaryTouchdelta);
+
             // /Touchscreen/primaryTouch/delta/x
             var ctrlTouchscreenprimaryTouchdeltax = Initialize_ctrlTouchscreenprimaryTouchdeltax(kAxisLayout, ctrlTouchscreenprimaryTouchdelta);
 
@@ -155,6 +168,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/position/y
             var ctrlTouchscreenpositiony = Initialize_ctrlTouchscreenpositiony(kAxisLayout, ctrlTouchscreenposition);
 
+            // /Touchscreen/delta/up
+            var ctrlTouchscreendeltaup = Initialize_ctrlTouchscreendeltaup(kAxisLayout, ctrlTouchscreendelta);
+
+            // /Touchscreen/delta/down
+            var ctrlTouchscreendeltadown = Initialize_ctrlTouchscreendeltadown(kAxisLayout, ctrlTouchscreendelta);
+
+            // /Touchscreen/delta/left
+            var ctrlTouchscreendeltaleft = Initialize_ctrlTouchscreendeltaleft(kAxisLayout, ctrlTouchscreendelta);
+
+            // /Touchscreen/delta/right
+            var ctrlTouchscreendeltaright = Initialize_ctrlTouchscreendeltaright(kAxisLayout, ctrlTouchscreendelta);
+
             // /Touchscreen/delta/x
             var ctrlTouchscreendeltax = Initialize_ctrlTouchscreendeltax(kAxisLayout, ctrlTouchscreendelta);
 
@@ -174,7 +199,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch0position = Initialize_ctrlTouchscreentouch0position(kVector2Layout, ctrlTouchscreentouch0);
 
             // /Touchscreen/touch0/delta
-            var ctrlTouchscreentouch0delta = Initialize_ctrlTouchscreentouch0delta(kVector2Layout, ctrlTouchscreentouch0);
+            var ctrlTouchscreentouch0delta = Initialize_ctrlTouchscreentouch0delta(kDeltaLayout, ctrlTouchscreentouch0);
 
             // /Touchscreen/touch0/pressure
             var ctrlTouchscreentouch0pressure = Initialize_ctrlTouchscreentouch0pressure(kAxisLayout, ctrlTouchscreentouch0);
@@ -209,6 +234,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch0/position/y
             var ctrlTouchscreentouch0positiony = Initialize_ctrlTouchscreentouch0positiony(kAxisLayout, ctrlTouchscreentouch0position);
 
+            // /Touchscreen/touch0/delta/up
+            var ctrlTouchscreentouch0deltaup = Initialize_ctrlTouchscreentouch0deltaup(kAxisLayout, ctrlTouchscreentouch0delta);
+
+            // /Touchscreen/touch0/delta/down
+            var ctrlTouchscreentouch0deltadown = Initialize_ctrlTouchscreentouch0deltadown(kAxisLayout, ctrlTouchscreentouch0delta);
+
+            // /Touchscreen/touch0/delta/left
+            var ctrlTouchscreentouch0deltaleft = Initialize_ctrlTouchscreentouch0deltaleft(kAxisLayout, ctrlTouchscreentouch0delta);
+
+            // /Touchscreen/touch0/delta/right
+            var ctrlTouchscreentouch0deltaright = Initialize_ctrlTouchscreentouch0deltaright(kAxisLayout, ctrlTouchscreentouch0delta);
+
             // /Touchscreen/touch0/delta/x
             var ctrlTouchscreentouch0deltax = Initialize_ctrlTouchscreentouch0deltax(kAxisLayout, ctrlTouchscreentouch0delta);
 
@@ -234,7 +271,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch1position = Initialize_ctrlTouchscreentouch1position(kVector2Layout, ctrlTouchscreentouch1);
 
             // /Touchscreen/touch1/delta
-            var ctrlTouchscreentouch1delta = Initialize_ctrlTouchscreentouch1delta(kVector2Layout, ctrlTouchscreentouch1);
+            var ctrlTouchscreentouch1delta = Initialize_ctrlTouchscreentouch1delta(kDeltaLayout, ctrlTouchscreentouch1);
 
             // /Touchscreen/touch1/pressure
             var ctrlTouchscreentouch1pressure = Initialize_ctrlTouchscreentouch1pressure(kAxisLayout, ctrlTouchscreentouch1);
@@ -269,6 +306,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch1/position/y
             var ctrlTouchscreentouch1positiony = Initialize_ctrlTouchscreentouch1positiony(kAxisLayout, ctrlTouchscreentouch1position);
 
+            // /Touchscreen/touch1/delta/up
+            var ctrlTouchscreentouch1deltaup = Initialize_ctrlTouchscreentouch1deltaup(kAxisLayout, ctrlTouchscreentouch1delta);
+
+            // /Touchscreen/touch1/delta/down
+            var ctrlTouchscreentouch1deltadown = Initialize_ctrlTouchscreentouch1deltadown(kAxisLayout, ctrlTouchscreentouch1delta);
+
+            // /Touchscreen/touch1/delta/left
+            var ctrlTouchscreentouch1deltaleft = Initialize_ctrlTouchscreentouch1deltaleft(kAxisLayout, ctrlTouchscreentouch1delta);
+
+            // /Touchscreen/touch1/delta/right
+            var ctrlTouchscreentouch1deltaright = Initialize_ctrlTouchscreentouch1deltaright(kAxisLayout, ctrlTouchscreentouch1delta);
+
             // /Touchscreen/touch1/delta/x
             var ctrlTouchscreentouch1deltax = Initialize_ctrlTouchscreentouch1deltax(kAxisLayout, ctrlTouchscreentouch1delta);
 
@@ -294,7 +343,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch2position = Initialize_ctrlTouchscreentouch2position(kVector2Layout, ctrlTouchscreentouch2);
 
             // /Touchscreen/touch2/delta
-            var ctrlTouchscreentouch2delta = Initialize_ctrlTouchscreentouch2delta(kVector2Layout, ctrlTouchscreentouch2);
+            var ctrlTouchscreentouch2delta = Initialize_ctrlTouchscreentouch2delta(kDeltaLayout, ctrlTouchscreentouch2);
 
             // /Touchscreen/touch2/pressure
             var ctrlTouchscreentouch2pressure = Initialize_ctrlTouchscreentouch2pressure(kAxisLayout, ctrlTouchscreentouch2);
@@ -329,6 +378,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch2/position/y
             var ctrlTouchscreentouch2positiony = Initialize_ctrlTouchscreentouch2positiony(kAxisLayout, ctrlTouchscreentouch2position);
 
+            // /Touchscreen/touch2/delta/up
+            var ctrlTouchscreentouch2deltaup = Initialize_ctrlTouchscreentouch2deltaup(kAxisLayout, ctrlTouchscreentouch2delta);
+
+            // /Touchscreen/touch2/delta/down
+            var ctrlTouchscreentouch2deltadown = Initialize_ctrlTouchscreentouch2deltadown(kAxisLayout, ctrlTouchscreentouch2delta);
+
+            // /Touchscreen/touch2/delta/left
+            var ctrlTouchscreentouch2deltaleft = Initialize_ctrlTouchscreentouch2deltaleft(kAxisLayout, ctrlTouchscreentouch2delta);
+
+            // /Touchscreen/touch2/delta/right
+            var ctrlTouchscreentouch2deltaright = Initialize_ctrlTouchscreentouch2deltaright(kAxisLayout, ctrlTouchscreentouch2delta);
+
             // /Touchscreen/touch2/delta/x
             var ctrlTouchscreentouch2deltax = Initialize_ctrlTouchscreentouch2deltax(kAxisLayout, ctrlTouchscreentouch2delta);
 
@@ -354,7 +415,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch3position = Initialize_ctrlTouchscreentouch3position(kVector2Layout, ctrlTouchscreentouch3);
 
             // /Touchscreen/touch3/delta
-            var ctrlTouchscreentouch3delta = Initialize_ctrlTouchscreentouch3delta(kVector2Layout, ctrlTouchscreentouch3);
+            var ctrlTouchscreentouch3delta = Initialize_ctrlTouchscreentouch3delta(kDeltaLayout, ctrlTouchscreentouch3);
 
             // /Touchscreen/touch3/pressure
             var ctrlTouchscreentouch3pressure = Initialize_ctrlTouchscreentouch3pressure(kAxisLayout, ctrlTouchscreentouch3);
@@ -389,6 +450,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch3/position/y
             var ctrlTouchscreentouch3positiony = Initialize_ctrlTouchscreentouch3positiony(kAxisLayout, ctrlTouchscreentouch3position);
 
+            // /Touchscreen/touch3/delta/up
+            var ctrlTouchscreentouch3deltaup = Initialize_ctrlTouchscreentouch3deltaup(kAxisLayout, ctrlTouchscreentouch3delta);
+
+            // /Touchscreen/touch3/delta/down
+            var ctrlTouchscreentouch3deltadown = Initialize_ctrlTouchscreentouch3deltadown(kAxisLayout, ctrlTouchscreentouch3delta);
+
+            // /Touchscreen/touch3/delta/left
+            var ctrlTouchscreentouch3deltaleft = Initialize_ctrlTouchscreentouch3deltaleft(kAxisLayout, ctrlTouchscreentouch3delta);
+
+            // /Touchscreen/touch3/delta/right
+            var ctrlTouchscreentouch3deltaright = Initialize_ctrlTouchscreentouch3deltaright(kAxisLayout, ctrlTouchscreentouch3delta);
+
             // /Touchscreen/touch3/delta/x
             var ctrlTouchscreentouch3deltax = Initialize_ctrlTouchscreentouch3deltax(kAxisLayout, ctrlTouchscreentouch3delta);
 
@@ -414,7 +487,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch4position = Initialize_ctrlTouchscreentouch4position(kVector2Layout, ctrlTouchscreentouch4);
 
             // /Touchscreen/touch4/delta
-            var ctrlTouchscreentouch4delta = Initialize_ctrlTouchscreentouch4delta(kVector2Layout, ctrlTouchscreentouch4);
+            var ctrlTouchscreentouch4delta = Initialize_ctrlTouchscreentouch4delta(kDeltaLayout, ctrlTouchscreentouch4);
 
             // /Touchscreen/touch4/pressure
             var ctrlTouchscreentouch4pressure = Initialize_ctrlTouchscreentouch4pressure(kAxisLayout, ctrlTouchscreentouch4);
@@ -449,6 +522,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch4/position/y
             var ctrlTouchscreentouch4positiony = Initialize_ctrlTouchscreentouch4positiony(kAxisLayout, ctrlTouchscreentouch4position);
 
+            // /Touchscreen/touch4/delta/up
+            var ctrlTouchscreentouch4deltaup = Initialize_ctrlTouchscreentouch4deltaup(kAxisLayout, ctrlTouchscreentouch4delta);
+
+            // /Touchscreen/touch4/delta/down
+            var ctrlTouchscreentouch4deltadown = Initialize_ctrlTouchscreentouch4deltadown(kAxisLayout, ctrlTouchscreentouch4delta);
+
+            // /Touchscreen/touch4/delta/left
+            var ctrlTouchscreentouch4deltaleft = Initialize_ctrlTouchscreentouch4deltaleft(kAxisLayout, ctrlTouchscreentouch4delta);
+
+            // /Touchscreen/touch4/delta/right
+            var ctrlTouchscreentouch4deltaright = Initialize_ctrlTouchscreentouch4deltaright(kAxisLayout, ctrlTouchscreentouch4delta);
+
             // /Touchscreen/touch4/delta/x
             var ctrlTouchscreentouch4deltax = Initialize_ctrlTouchscreentouch4deltax(kAxisLayout, ctrlTouchscreentouch4delta);
 
@@ -474,7 +559,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch5position = Initialize_ctrlTouchscreentouch5position(kVector2Layout, ctrlTouchscreentouch5);
 
             // /Touchscreen/touch5/delta
-            var ctrlTouchscreentouch5delta = Initialize_ctrlTouchscreentouch5delta(kVector2Layout, ctrlTouchscreentouch5);
+            var ctrlTouchscreentouch5delta = Initialize_ctrlTouchscreentouch5delta(kDeltaLayout, ctrlTouchscreentouch5);
 
             // /Touchscreen/touch5/pressure
             var ctrlTouchscreentouch5pressure = Initialize_ctrlTouchscreentouch5pressure(kAxisLayout, ctrlTouchscreentouch5);
@@ -509,6 +594,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch5/position/y
             var ctrlTouchscreentouch5positiony = Initialize_ctrlTouchscreentouch5positiony(kAxisLayout, ctrlTouchscreentouch5position);
 
+            // /Touchscreen/touch5/delta/up
+            var ctrlTouchscreentouch5deltaup = Initialize_ctrlTouchscreentouch5deltaup(kAxisLayout, ctrlTouchscreentouch5delta);
+
+            // /Touchscreen/touch5/delta/down
+            var ctrlTouchscreentouch5deltadown = Initialize_ctrlTouchscreentouch5deltadown(kAxisLayout, ctrlTouchscreentouch5delta);
+
+            // /Touchscreen/touch5/delta/left
+            var ctrlTouchscreentouch5deltaleft = Initialize_ctrlTouchscreentouch5deltaleft(kAxisLayout, ctrlTouchscreentouch5delta);
+
+            // /Touchscreen/touch5/delta/right
+            var ctrlTouchscreentouch5deltaright = Initialize_ctrlTouchscreentouch5deltaright(kAxisLayout, ctrlTouchscreentouch5delta);
+
             // /Touchscreen/touch5/delta/x
             var ctrlTouchscreentouch5deltax = Initialize_ctrlTouchscreentouch5deltax(kAxisLayout, ctrlTouchscreentouch5delta);
 
@@ -534,7 +631,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch6position = Initialize_ctrlTouchscreentouch6position(kVector2Layout, ctrlTouchscreentouch6);
 
             // /Touchscreen/touch6/delta
-            var ctrlTouchscreentouch6delta = Initialize_ctrlTouchscreentouch6delta(kVector2Layout, ctrlTouchscreentouch6);
+            var ctrlTouchscreentouch6delta = Initialize_ctrlTouchscreentouch6delta(kDeltaLayout, ctrlTouchscreentouch6);
 
             // /Touchscreen/touch6/pressure
             var ctrlTouchscreentouch6pressure = Initialize_ctrlTouchscreentouch6pressure(kAxisLayout, ctrlTouchscreentouch6);
@@ -569,6 +666,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch6/position/y
             var ctrlTouchscreentouch6positiony = Initialize_ctrlTouchscreentouch6positiony(kAxisLayout, ctrlTouchscreentouch6position);
 
+            // /Touchscreen/touch6/delta/up
+            var ctrlTouchscreentouch6deltaup = Initialize_ctrlTouchscreentouch6deltaup(kAxisLayout, ctrlTouchscreentouch6delta);
+
+            // /Touchscreen/touch6/delta/down
+            var ctrlTouchscreentouch6deltadown = Initialize_ctrlTouchscreentouch6deltadown(kAxisLayout, ctrlTouchscreentouch6delta);
+
+            // /Touchscreen/touch6/delta/left
+            var ctrlTouchscreentouch6deltaleft = Initialize_ctrlTouchscreentouch6deltaleft(kAxisLayout, ctrlTouchscreentouch6delta);
+
+            // /Touchscreen/touch6/delta/right
+            var ctrlTouchscreentouch6deltaright = Initialize_ctrlTouchscreentouch6deltaright(kAxisLayout, ctrlTouchscreentouch6delta);
+
             // /Touchscreen/touch6/delta/x
             var ctrlTouchscreentouch6deltax = Initialize_ctrlTouchscreentouch6deltax(kAxisLayout, ctrlTouchscreentouch6delta);
 
@@ -594,7 +703,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch7position = Initialize_ctrlTouchscreentouch7position(kVector2Layout, ctrlTouchscreentouch7);
 
             // /Touchscreen/touch7/delta
-            var ctrlTouchscreentouch7delta = Initialize_ctrlTouchscreentouch7delta(kVector2Layout, ctrlTouchscreentouch7);
+            var ctrlTouchscreentouch7delta = Initialize_ctrlTouchscreentouch7delta(kDeltaLayout, ctrlTouchscreentouch7);
 
             // /Touchscreen/touch7/pressure
             var ctrlTouchscreentouch7pressure = Initialize_ctrlTouchscreentouch7pressure(kAxisLayout, ctrlTouchscreentouch7);
@@ -629,6 +738,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch7/position/y
             var ctrlTouchscreentouch7positiony = Initialize_ctrlTouchscreentouch7positiony(kAxisLayout, ctrlTouchscreentouch7position);
 
+            // /Touchscreen/touch7/delta/up
+            var ctrlTouchscreentouch7deltaup = Initialize_ctrlTouchscreentouch7deltaup(kAxisLayout, ctrlTouchscreentouch7delta);
+
+            // /Touchscreen/touch7/delta/down
+            var ctrlTouchscreentouch7deltadown = Initialize_ctrlTouchscreentouch7deltadown(kAxisLayout, ctrlTouchscreentouch7delta);
+
+            // /Touchscreen/touch7/delta/left
+            var ctrlTouchscreentouch7deltaleft = Initialize_ctrlTouchscreentouch7deltaleft(kAxisLayout, ctrlTouchscreentouch7delta);
+
+            // /Touchscreen/touch7/delta/right
+            var ctrlTouchscreentouch7deltaright = Initialize_ctrlTouchscreentouch7deltaright(kAxisLayout, ctrlTouchscreentouch7delta);
+
             // /Touchscreen/touch7/delta/x
             var ctrlTouchscreentouch7deltax = Initialize_ctrlTouchscreentouch7deltax(kAxisLayout, ctrlTouchscreentouch7delta);
 
@@ -654,7 +775,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch8position = Initialize_ctrlTouchscreentouch8position(kVector2Layout, ctrlTouchscreentouch8);
 
             // /Touchscreen/touch8/delta
-            var ctrlTouchscreentouch8delta = Initialize_ctrlTouchscreentouch8delta(kVector2Layout, ctrlTouchscreentouch8);
+            var ctrlTouchscreentouch8delta = Initialize_ctrlTouchscreentouch8delta(kDeltaLayout, ctrlTouchscreentouch8);
 
             // /Touchscreen/touch8/pressure
             var ctrlTouchscreentouch8pressure = Initialize_ctrlTouchscreentouch8pressure(kAxisLayout, ctrlTouchscreentouch8);
@@ -689,6 +810,18 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch8/position/y
             var ctrlTouchscreentouch8positiony = Initialize_ctrlTouchscreentouch8positiony(kAxisLayout, ctrlTouchscreentouch8position);
 
+            // /Touchscreen/touch8/delta/up
+            var ctrlTouchscreentouch8deltaup = Initialize_ctrlTouchscreentouch8deltaup(kAxisLayout, ctrlTouchscreentouch8delta);
+
+            // /Touchscreen/touch8/delta/down
+            var ctrlTouchscreentouch8deltadown = Initialize_ctrlTouchscreentouch8deltadown(kAxisLayout, ctrlTouchscreentouch8delta);
+
+            // /Touchscreen/touch8/delta/left
+            var ctrlTouchscreentouch8deltaleft = Initialize_ctrlTouchscreentouch8deltaleft(kAxisLayout, ctrlTouchscreentouch8delta);
+
+            // /Touchscreen/touch8/delta/right
+            var ctrlTouchscreentouch8deltaright = Initialize_ctrlTouchscreentouch8deltaright(kAxisLayout, ctrlTouchscreentouch8delta);
+
             // /Touchscreen/touch8/delta/x
             var ctrlTouchscreentouch8deltax = Initialize_ctrlTouchscreentouch8deltax(kAxisLayout, ctrlTouchscreentouch8delta);
 
@@ -714,7 +847,7 @@ namespace UnityEngine.InputSystem
             var ctrlTouchscreentouch9position = Initialize_ctrlTouchscreentouch9position(kVector2Layout, ctrlTouchscreentouch9);
 
             // /Touchscreen/touch9/delta
-            var ctrlTouchscreentouch9delta = Initialize_ctrlTouchscreentouch9delta(kVector2Layout, ctrlTouchscreentouch9);
+            var ctrlTouchscreentouch9delta = Initialize_ctrlTouchscreentouch9delta(kDeltaLayout, ctrlTouchscreentouch9);
 
             // /Touchscreen/touch9/pressure
             var ctrlTouchscreentouch9pressure = Initialize_ctrlTouchscreentouch9pressure(kAxisLayout, ctrlTouchscreentouch9);
@@ -748,6 +881,18 @@ namespace UnityEngine.InputSystem
 
             // /Touchscreen/touch9/position/y
             var ctrlTouchscreentouch9positiony = Initialize_ctrlTouchscreentouch9positiony(kAxisLayout, ctrlTouchscreentouch9position);
+
+            // /Touchscreen/touch9/delta/up
+            var ctrlTouchscreentouch9deltaup = Initialize_ctrlTouchscreentouch9deltaup(kAxisLayout, ctrlTouchscreentouch9delta);
+
+            // /Touchscreen/touch9/delta/down
+            var ctrlTouchscreentouch9deltadown = Initialize_ctrlTouchscreentouch9deltadown(kAxisLayout, ctrlTouchscreentouch9delta);
+
+            // /Touchscreen/touch9/delta/left
+            var ctrlTouchscreentouch9deltaleft = Initialize_ctrlTouchscreentouch9deltaleft(kAxisLayout, ctrlTouchscreentouch9delta);
+
+            // /Touchscreen/touch9/delta/right
+            var ctrlTouchscreentouch9deltaright = Initialize_ctrlTouchscreentouch9deltaright(kAxisLayout, ctrlTouchscreentouch9delta);
 
             // /Touchscreen/touch9/delta/x
             var ctrlTouchscreentouch9deltax = Initialize_ctrlTouchscreentouch9deltax(kAxisLayout, ctrlTouchscreentouch9delta);
@@ -806,6 +951,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouch.startPosition = ctrlTouchscreenprimaryTouchstartPosition;
             ctrlTouchscreenposition.x = ctrlTouchscreenpositionx;
             ctrlTouchscreenposition.y = ctrlTouchscreenpositiony;
+            ctrlTouchscreendelta.up = ctrlTouchscreendeltaup;
+            ctrlTouchscreendelta.down = ctrlTouchscreendeltadown;
+            ctrlTouchscreendelta.left = ctrlTouchscreendeltaleft;
+            ctrlTouchscreendelta.right = ctrlTouchscreendeltaright;
             ctrlTouchscreendelta.x = ctrlTouchscreendeltax;
             ctrlTouchscreendelta.y = ctrlTouchscreendeltay;
             ctrlTouchscreenradius.x = ctrlTouchscreenradiusx;
@@ -932,6 +1081,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch9.startPosition = ctrlTouchscreentouch9startPosition;
             ctrlTouchscreenprimaryTouchposition.x = ctrlTouchscreenprimaryTouchpositionx;
             ctrlTouchscreenprimaryTouchposition.y = ctrlTouchscreenprimaryTouchpositiony;
+            ctrlTouchscreenprimaryTouchdelta.up = ctrlTouchscreenprimaryTouchdeltaup;
+            ctrlTouchscreenprimaryTouchdelta.down = ctrlTouchscreenprimaryTouchdeltadown;
+            ctrlTouchscreenprimaryTouchdelta.left = ctrlTouchscreenprimaryTouchdeltaleft;
+            ctrlTouchscreenprimaryTouchdelta.right = ctrlTouchscreenprimaryTouchdeltaright;
             ctrlTouchscreenprimaryTouchdelta.x = ctrlTouchscreenprimaryTouchdeltax;
             ctrlTouchscreenprimaryTouchdelta.y = ctrlTouchscreenprimaryTouchdeltay;
             ctrlTouchscreenprimaryTouchradius.x = ctrlTouchscreenprimaryTouchradiusx;
@@ -940,6 +1093,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouchstartPosition.y = ctrlTouchscreenprimaryTouchstartPositiony;
             ctrlTouchscreentouch0position.x = ctrlTouchscreentouch0positionx;
             ctrlTouchscreentouch0position.y = ctrlTouchscreentouch0positiony;
+            ctrlTouchscreentouch0delta.up = ctrlTouchscreentouch0deltaup;
+            ctrlTouchscreentouch0delta.down = ctrlTouchscreentouch0deltadown;
+            ctrlTouchscreentouch0delta.left = ctrlTouchscreentouch0deltaleft;
+            ctrlTouchscreentouch0delta.right = ctrlTouchscreentouch0deltaright;
             ctrlTouchscreentouch0delta.x = ctrlTouchscreentouch0deltax;
             ctrlTouchscreentouch0delta.y = ctrlTouchscreentouch0deltay;
             ctrlTouchscreentouch0radius.x = ctrlTouchscreentouch0radiusx;
@@ -948,6 +1105,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch0startPosition.y = ctrlTouchscreentouch0startPositiony;
             ctrlTouchscreentouch1position.x = ctrlTouchscreentouch1positionx;
             ctrlTouchscreentouch1position.y = ctrlTouchscreentouch1positiony;
+            ctrlTouchscreentouch1delta.up = ctrlTouchscreentouch1deltaup;
+            ctrlTouchscreentouch1delta.down = ctrlTouchscreentouch1deltadown;
+            ctrlTouchscreentouch1delta.left = ctrlTouchscreentouch1deltaleft;
+            ctrlTouchscreentouch1delta.right = ctrlTouchscreentouch1deltaright;
             ctrlTouchscreentouch1delta.x = ctrlTouchscreentouch1deltax;
             ctrlTouchscreentouch1delta.y = ctrlTouchscreentouch1deltay;
             ctrlTouchscreentouch1radius.x = ctrlTouchscreentouch1radiusx;
@@ -956,6 +1117,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch1startPosition.y = ctrlTouchscreentouch1startPositiony;
             ctrlTouchscreentouch2position.x = ctrlTouchscreentouch2positionx;
             ctrlTouchscreentouch2position.y = ctrlTouchscreentouch2positiony;
+            ctrlTouchscreentouch2delta.up = ctrlTouchscreentouch2deltaup;
+            ctrlTouchscreentouch2delta.down = ctrlTouchscreentouch2deltadown;
+            ctrlTouchscreentouch2delta.left = ctrlTouchscreentouch2deltaleft;
+            ctrlTouchscreentouch2delta.right = ctrlTouchscreentouch2deltaright;
             ctrlTouchscreentouch2delta.x = ctrlTouchscreentouch2deltax;
             ctrlTouchscreentouch2delta.y = ctrlTouchscreentouch2deltay;
             ctrlTouchscreentouch2radius.x = ctrlTouchscreentouch2radiusx;
@@ -964,6 +1129,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch2startPosition.y = ctrlTouchscreentouch2startPositiony;
             ctrlTouchscreentouch3position.x = ctrlTouchscreentouch3positionx;
             ctrlTouchscreentouch3position.y = ctrlTouchscreentouch3positiony;
+            ctrlTouchscreentouch3delta.up = ctrlTouchscreentouch3deltaup;
+            ctrlTouchscreentouch3delta.down = ctrlTouchscreentouch3deltadown;
+            ctrlTouchscreentouch3delta.left = ctrlTouchscreentouch3deltaleft;
+            ctrlTouchscreentouch3delta.right = ctrlTouchscreentouch3deltaright;
             ctrlTouchscreentouch3delta.x = ctrlTouchscreentouch3deltax;
             ctrlTouchscreentouch3delta.y = ctrlTouchscreentouch3deltay;
             ctrlTouchscreentouch3radius.x = ctrlTouchscreentouch3radiusx;
@@ -972,6 +1141,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch3startPosition.y = ctrlTouchscreentouch3startPositiony;
             ctrlTouchscreentouch4position.x = ctrlTouchscreentouch4positionx;
             ctrlTouchscreentouch4position.y = ctrlTouchscreentouch4positiony;
+            ctrlTouchscreentouch4delta.up = ctrlTouchscreentouch4deltaup;
+            ctrlTouchscreentouch4delta.down = ctrlTouchscreentouch4deltadown;
+            ctrlTouchscreentouch4delta.left = ctrlTouchscreentouch4deltaleft;
+            ctrlTouchscreentouch4delta.right = ctrlTouchscreentouch4deltaright;
             ctrlTouchscreentouch4delta.x = ctrlTouchscreentouch4deltax;
             ctrlTouchscreentouch4delta.y = ctrlTouchscreentouch4deltay;
             ctrlTouchscreentouch4radius.x = ctrlTouchscreentouch4radiusx;
@@ -980,6 +1153,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch4startPosition.y = ctrlTouchscreentouch4startPositiony;
             ctrlTouchscreentouch5position.x = ctrlTouchscreentouch5positionx;
             ctrlTouchscreentouch5position.y = ctrlTouchscreentouch5positiony;
+            ctrlTouchscreentouch5delta.up = ctrlTouchscreentouch5deltaup;
+            ctrlTouchscreentouch5delta.down = ctrlTouchscreentouch5deltadown;
+            ctrlTouchscreentouch5delta.left = ctrlTouchscreentouch5deltaleft;
+            ctrlTouchscreentouch5delta.right = ctrlTouchscreentouch5deltaright;
             ctrlTouchscreentouch5delta.x = ctrlTouchscreentouch5deltax;
             ctrlTouchscreentouch5delta.y = ctrlTouchscreentouch5deltay;
             ctrlTouchscreentouch5radius.x = ctrlTouchscreentouch5radiusx;
@@ -988,6 +1165,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch5startPosition.y = ctrlTouchscreentouch5startPositiony;
             ctrlTouchscreentouch6position.x = ctrlTouchscreentouch6positionx;
             ctrlTouchscreentouch6position.y = ctrlTouchscreentouch6positiony;
+            ctrlTouchscreentouch6delta.up = ctrlTouchscreentouch6deltaup;
+            ctrlTouchscreentouch6delta.down = ctrlTouchscreentouch6deltadown;
+            ctrlTouchscreentouch6delta.left = ctrlTouchscreentouch6deltaleft;
+            ctrlTouchscreentouch6delta.right = ctrlTouchscreentouch6deltaright;
             ctrlTouchscreentouch6delta.x = ctrlTouchscreentouch6deltax;
             ctrlTouchscreentouch6delta.y = ctrlTouchscreentouch6deltay;
             ctrlTouchscreentouch6radius.x = ctrlTouchscreentouch6radiusx;
@@ -996,6 +1177,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch6startPosition.y = ctrlTouchscreentouch6startPositiony;
             ctrlTouchscreentouch7position.x = ctrlTouchscreentouch7positionx;
             ctrlTouchscreentouch7position.y = ctrlTouchscreentouch7positiony;
+            ctrlTouchscreentouch7delta.up = ctrlTouchscreentouch7deltaup;
+            ctrlTouchscreentouch7delta.down = ctrlTouchscreentouch7deltadown;
+            ctrlTouchscreentouch7delta.left = ctrlTouchscreentouch7deltaleft;
+            ctrlTouchscreentouch7delta.right = ctrlTouchscreentouch7deltaright;
             ctrlTouchscreentouch7delta.x = ctrlTouchscreentouch7deltax;
             ctrlTouchscreentouch7delta.y = ctrlTouchscreentouch7deltay;
             ctrlTouchscreentouch7radius.x = ctrlTouchscreentouch7radiusx;
@@ -1004,6 +1189,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch7startPosition.y = ctrlTouchscreentouch7startPositiony;
             ctrlTouchscreentouch8position.x = ctrlTouchscreentouch8positionx;
             ctrlTouchscreentouch8position.y = ctrlTouchscreentouch8positiony;
+            ctrlTouchscreentouch8delta.up = ctrlTouchscreentouch8deltaup;
+            ctrlTouchscreentouch8delta.down = ctrlTouchscreentouch8deltadown;
+            ctrlTouchscreentouch8delta.left = ctrlTouchscreentouch8deltaleft;
+            ctrlTouchscreentouch8delta.right = ctrlTouchscreentouch8deltaright;
             ctrlTouchscreentouch8delta.x = ctrlTouchscreentouch8deltax;
             ctrlTouchscreentouch8delta.y = ctrlTouchscreentouch8deltay;
             ctrlTouchscreentouch8radius.x = ctrlTouchscreentouch8radiusx;
@@ -1012,6 +1201,10 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch8startPosition.y = ctrlTouchscreentouch8startPositiony;
             ctrlTouchscreentouch9position.x = ctrlTouchscreentouch9positionx;
             ctrlTouchscreentouch9position.y = ctrlTouchscreentouch9positiony;
+            ctrlTouchscreentouch9delta.up = ctrlTouchscreentouch9deltaup;
+            ctrlTouchscreentouch9delta.down = ctrlTouchscreentouch9deltadown;
+            ctrlTouchscreentouch9delta.left = ctrlTouchscreentouch9deltaleft;
+            ctrlTouchscreentouch9delta.right = ctrlTouchscreentouch9deltaright;
             ctrlTouchscreentouch9delta.x = ctrlTouchscreentouch9deltax;
             ctrlTouchscreentouch9delta.y = ctrlTouchscreentouch9deltay;
             ctrlTouchscreentouch9radius.x = ctrlTouchscreentouch9radiusx;
@@ -1022,25 +1215,30 @@ namespace UnityEngine.InputSystem
             // State offset to control index map.
             builder.WithStateOffsetToControlIndexMap(new uint[]
             {
-                32784u, 16810012u, 16810020u, 33587229u, 33587237u, 50364446u, 50364454u, 67141663u, 67141671u, 83918851u
-                , 83918867u, 100696096u, 100696104u, 117473313u, 117473321u, 134225925u, 134225941u, 134225942u, 138420247u, 146801688u
-                , 148898841u, 167837722u, 201359394u, 218136611u, 234913834u, 251691062u, 268468279u, 285245496u, 302022713u, 318799917u
-                , 335577146u, 352354363u, 369106991u, 369106992u, 373301297u, 381682738u, 383779891u, 402718772u, 436240444u, 453017661u
-                , 469794878u, 486572106u, 503349323u, 520126540u, 536903757u, 553680961u, 570458190u, 587235407u, 603988035u, 603988036u
-                , 608182341u, 616563782u, 618660935u, 637599816u, 671121488u, 687898705u, 704675922u, 721453150u, 738230367u, 755007584u
-                , 771784801u, 788562005u, 805339234u, 822116451u, 838869079u, 838869080u, 843063385u, 851444826u, 853541979u, 872480860u
-                , 906002532u, 922779749u, 939556966u, 956334194u, 973111411u, 989888628u, 1006665845u, 1023443049u, 1040220278u, 1056997495u
-                , 1073750123u, 1073750124u, 1077944429u, 1086325870u, 1088423023u, 1107361904u, 1140883576u, 1157660793u, 1174438010u, 1191215238u
-                , 1207992455u, 1224769672u, 1241546889u, 1258324093u, 1275101322u, 1291878539u, 1308631167u, 1308631168u, 1312825473u, 1321206914u
-                , 1323304067u, 1342242948u, 1375764620u, 1392541837u, 1409319054u, 1426096282u, 1442873499u, 1459650716u, 1476427933u, 1493205137u
-                , 1509982366u, 1526759583u, 1543512211u, 1543512212u, 1547706517u, 1556087958u, 1558185111u, 1577123992u, 1610645664u, 1627422881u
-                , 1644200098u, 1660977326u, 1677754543u, 1694531760u, 1711308977u, 1728086181u, 1744863410u, 1761640627u, 1778393255u, 1778393256u
-                , 1782587561u, 1790969002u, 1793066155u, 1812005036u, 1845526708u, 1862303925u, 1879081142u, 1895858370u, 1912635587u, 1929412804u
-                , 1946190021u, 1962967225u, 1979744454u, 1996521671u, 2013274299u, 2013274300u, 2017468605u, 2025850046u, 2027947199u, 2046886080u
-                , 2080407752u, 2097184969u, 2113962186u, 2130739414u, 2147516631u, 2164293848u, 2181071065u, 2197848269u, 2214625498u, 2231402715u
-                , 2248155343u, 2248155344u, 2252349649u, 2260731090u, 2262828243u, 2281767124u, 2315288796u, 2332066013u, 2348843230u, 2365620458u
-                , 2382397675u, 2399174892u, 2415952109u, 2432729313u, 2449506542u, 2466283759u, 2483036387u, 2483036388u, 2487230693u, 2495612134u
-                , 2497709287u, 2516648168u, 2550169840u, 2566947057u
+                32784u, 16810012u, 16810024u, 33587229u, 33587241u, 50364448u, 50364449u, 50364450u, 50364460u, 50364461u
+                , 50364462u, 67141662u, 67141663u, 67141667u, 67141674u, 67141675u, 67141679u, 83918851u, 83918867u, 100696100u
+                , 100696112u, 117473317u, 117473329u, 134225925u, 134225941u, 134225942u, 138420247u, 146801688u, 148898841u, 167837722u
+                , 201359398u, 218136615u, 234913842u, 251691070u, 268468287u, 285245506u, 285245507u, 285245508u, 302022720u, 302022721u
+                , 302022725u, 318799925u, 335577158u, 352354375u, 369106999u, 369107000u, 373301305u, 381682746u, 383779899u, 402718780u
+                , 436240456u, 453017673u, 469794890u, 486572118u, 503349335u, 520126554u, 520126555u, 520126556u, 536903768u, 536903769u
+                , 536903773u, 553680973u, 570458206u, 587235423u, 603988047u, 603988048u, 608182353u, 616563794u, 618660947u, 637599828u
+                , 671121504u, 687898721u, 704675938u, 721453166u, 738230383u, 755007602u, 755007603u, 755007604u, 771784816u, 771784817u
+                , 771784821u, 788562021u, 805339254u, 822116471u, 838869095u, 838869096u, 843063401u, 851444842u, 853541995u, 872480876u
+                , 906002552u, 922779769u, 939556986u, 956334214u, 973111431u, 989888650u, 989888651u, 989888652u, 1006665864u, 1006665865u
+                , 1006665869u, 1023443069u, 1040220302u, 1056997519u, 1073750143u, 1073750144u, 1077944449u, 1086325890u, 1088423043u, 1107361924u
+                , 1140883600u, 1157660817u, 1174438034u, 1191215262u, 1207992479u, 1224769698u, 1224769699u, 1224769700u, 1241546912u, 1241546913u
+                , 1241546917u, 1258324117u, 1275101350u, 1291878567u, 1308631191u, 1308631192u, 1312825497u, 1321206938u, 1323304091u, 1342242972u
+                , 1375764648u, 1392541865u, 1409319082u, 1426096310u, 1442873527u, 1459650746u, 1459650747u, 1459650748u, 1476427960u, 1476427961u
+                , 1476427965u, 1493205165u, 1509982398u, 1526759615u, 1543512239u, 1543512240u, 1547706545u, 1556087986u, 1558185139u, 1577124020u
+                , 1610645696u, 1627422913u, 1644200130u, 1660977358u, 1677754575u, 1694531794u, 1694531795u, 1694531796u, 1711309008u, 1711309009u
+                , 1711309013u, 1728086213u, 1744863446u, 1761640663u, 1778393287u, 1778393288u, 1782587593u, 1790969034u, 1793066187u, 1812005068u
+                , 1845526744u, 1862303961u, 1879081178u, 1895858406u, 1912635623u, 1929412842u, 1929412843u, 1929412844u, 1946190056u, 1946190057u
+                , 1946190061u, 1962967261u, 1979744494u, 1996521711u, 2013274335u, 2013274336u, 2017468641u, 2025850082u, 2027947235u, 2046886116u
+                , 2080407792u, 2097185009u, 2113962226u, 2130739454u, 2147516671u, 2164293890u, 2164293891u, 2164293892u, 2181071104u, 2181071105u
+                , 2181071109u, 2197848309u, 2214625542u, 2231402759u, 2248155383u, 2248155384u, 2252349689u, 2260731130u, 2262828283u, 2281767164u
+                , 2315288840u, 2332066057u, 2348843274u, 2365620502u, 2382397719u, 2399174938u, 2399174939u, 2399174940u, 2415952152u, 2415952153u
+                , 2415952157u, 2432729357u, 2449506590u, 2466283807u, 2483036431u, 2483036432u, 2487230737u, 2495612178u, 2497709331u, 2516648212u
+                , 2550169888u, 2566947105u
             });
 
             builder.Finish();
@@ -1074,7 +1272,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenposition.Setup()
                 .At(this, 1)
                 .WithParent(parent)
-                .WithChildren(36, 2)
+                .WithChildren(40, 2)
                 .WithName("position")
                 .WithDisplayName("Position")
                 .WithLayout(kVector2Layout)
@@ -1094,16 +1292,16 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreenposition;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreendelta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreendelta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreendelta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreendelta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreendelta.Setup()
                 .At(this, 2)
                 .WithParent(parent)
-                .WithChildren(38, 2)
+                .WithChildren(42, 6)
                 .WithName("delta")
                 .WithDisplayName("Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithUsages(2, 1)
                 .WithStateBlock(new InputStateBlock
                 {
@@ -1144,7 +1342,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenradius.Setup()
                 .At(this, 4)
                 .WithParent(parent)
-                .WithChildren(40, 2)
+                .WithChildren(48, 2)
                 .WithName("radius")
                 .WithDisplayName("Radius")
                 .WithLayout(kVector2Layout)
@@ -1189,7 +1387,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch0.Setup()
                 .At(this, 6)
                 .WithParent(parent)
-                .WithChildren(42, 12)
+                .WithChildren(50, 12)
                 .WithName("touch0")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1210,7 +1408,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch1.Setup()
                 .At(this, 7)
                 .WithParent(parent)
-                .WithChildren(62, 12)
+                .WithChildren(74, 12)
                 .WithName("touch1")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1231,7 +1429,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch2.Setup()
                 .At(this, 8)
                 .WithParent(parent)
-                .WithChildren(82, 12)
+                .WithChildren(98, 12)
                 .WithName("touch2")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1252,7 +1450,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch3.Setup()
                 .At(this, 9)
                 .WithParent(parent)
-                .WithChildren(102, 12)
+                .WithChildren(122, 12)
                 .WithName("touch3")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1273,7 +1471,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch4.Setup()
                 .At(this, 10)
                 .WithParent(parent)
-                .WithChildren(122, 12)
+                .WithChildren(146, 12)
                 .WithName("touch4")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1294,7 +1492,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch5.Setup()
                 .At(this, 11)
                 .WithParent(parent)
-                .WithChildren(142, 12)
+                .WithChildren(170, 12)
                 .WithName("touch5")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1315,7 +1513,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch6.Setup()
                 .At(this, 12)
                 .WithParent(parent)
-                .WithChildren(162, 12)
+                .WithChildren(194, 12)
                 .WithName("touch6")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1336,7 +1534,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch7.Setup()
                 .At(this, 13)
                 .WithParent(parent)
-                .WithChildren(182, 12)
+                .WithChildren(218, 12)
                 .WithName("touch7")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1357,7 +1555,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch8.Setup()
                 .At(this, 14)
                 .WithParent(parent)
-                .WithChildren(202, 12)
+                .WithChildren(242, 12)
                 .WithName("touch8")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1378,7 +1576,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch9.Setup()
                 .At(this, 15)
                 .WithParent(parent)
-                .WithChildren(222, 12)
+                .WithChildren(266, 12)
                 .WithName("touch9")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1439,17 +1637,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreenprimaryTouchposition;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreenprimaryTouchdelta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreenprimaryTouchdelta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreenprimaryTouchdelta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreenprimaryTouchdelta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreenprimaryTouchdelta.Setup()
                 .At(this, 18)
                 .WithParent(parent)
-                .WithChildren(30, 2)
+                .WithChildren(30, 6)
                 .WithName("delta")
                 .WithDisplayName("Primary Touch Delta")
                 .WithShortDisplayName("Primary Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -1488,7 +1686,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouchradius.Setup()
                 .At(this, 20)
                 .WithParent(parent)
-                .WithChildren(32, 2)
+                .WithChildren(36, 2)
                 .WithName("radius")
                 .WithDisplayName("Primary Touch Radius")
                 .WithShortDisplayName("Primary Touch Radius")
@@ -1646,7 +1844,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouchstartPosition.Setup()
                 .At(this, 27)
                 .WithParent(parent)
-                .WithChildren(34, 2)
+                .WithChildren(38, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Primary Touch Start Position")
                 .WithShortDisplayName("Primary Touch Start Position")
@@ -1707,11 +1905,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreenprimaryTouchpositiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreenprimaryTouchdeltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreenprimaryTouchdeltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreenprimaryTouchdeltaup.Setup()
+                .At(this, 30)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Primary Touch Primary Touch Delta Up")
+                .WithShortDisplayName("Primary Touch Primary Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 16,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreenprimaryTouchdeltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreenprimaryTouchdeltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreenprimaryTouchdeltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreenprimaryTouchdeltadown.Setup()
+                .At(this, 31)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Primary Touch Primary Touch Delta Down")
+                .WithShortDisplayName("Primary Touch Primary Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 16,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreenprimaryTouchdeltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreenprimaryTouchdeltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreenprimaryTouchdeltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreenprimaryTouchdeltaleft.Setup()
+                .At(this, 32)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Primary Touch Primary Touch Delta Left")
+                .WithShortDisplayName("Primary Touch Primary Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 12,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreenprimaryTouchdeltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreenprimaryTouchdeltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreenprimaryTouchdeltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreenprimaryTouchdeltaright.Setup()
+                .At(this, 33)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Primary Touch Primary Touch Delta Right")
+                .WithShortDisplayName("Primary Touch Primary Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 12,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreenprimaryTouchdeltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreenprimaryTouchdeltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreenprimaryTouchdeltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchdeltax.Setup()
-                .At(this, 30)
+                .At(this, 34)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Delta X")
@@ -1732,7 +2018,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchdeltay.Setup()
-                .At(this, 31)
+                .At(this, 35)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Delta Y")
@@ -1753,7 +2039,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchradiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchradiusx.Setup()
-                .At(this, 32)
+                .At(this, 36)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Radius X")
@@ -1774,7 +2060,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchradiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchradiusy.Setup()
-                .At(this, 33)
+                .At(this, 37)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Radius Y")
@@ -1795,7 +2081,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchstartPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchstartPositionx.Setup()
-                .At(this, 34)
+                .At(this, 38)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Start Position X")
@@ -1816,7 +2102,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchstartPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchstartPositiony.Setup()
-                .At(this, 35)
+                .At(this, 39)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Start Position Y")
@@ -1837,7 +2123,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenpositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenpositionx.Setup()
-                .At(this, 36)
+                .At(this, 40)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Position X")
@@ -1859,7 +2145,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenpositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenpositiony.Setup()
-                .At(this, 37)
+                .At(this, 41)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Position Y")
@@ -1877,11 +2163,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreenpositiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreendeltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreendeltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreendeltaup.Setup()
+                .At(this, 42)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Delta Up")
+                .WithShortDisplayName("Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 16,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreendeltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreendeltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreendeltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreendeltadown.Setup()
+                .At(this, 43)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Delta Down")
+                .WithShortDisplayName("Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 16,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreendeltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreendeltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreendeltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreendeltaleft.Setup()
+                .At(this, 44)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Delta Left")
+                .WithShortDisplayName("Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 12,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreendeltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreendeltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreendeltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreendeltaright.Setup()
+                .At(this, 45)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Delta Right")
+                .WithShortDisplayName("Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 12,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreendeltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreendeltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreendeltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreendeltax.Setup()
-                .At(this, 38)
+                .At(this, 46)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Delta X")
@@ -1902,7 +2276,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreendeltay.Setup()
-                .At(this, 39)
+                .At(this, 47)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Delta Y")
@@ -1923,7 +2297,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenradiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenradiusx.Setup()
-                .At(this, 40)
+                .At(this, 48)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Radius X")
@@ -1944,7 +2318,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenradiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenradiusy.Setup()
-                .At(this, 41)
+                .At(this, 49)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Radius Y")
@@ -1965,7 +2339,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch0touchId.Setup()
-                .At(this, 42)
+                .At(this, 50)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -1988,9 +2362,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch0position.Setup()
-                .At(this, 43)
+                .At(this, 51)
                 .WithParent(parent)
-                .WithChildren(54, 2)
+                .WithChildren(62, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -2007,17 +2381,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch0position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch0delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch0delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch0delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch0delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch0delta.Setup()
-                .At(this, 44)
+                .At(this, 52)
                 .WithParent(parent)
-                .WithChildren(56, 2)
+                .WithChildren(64, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -2033,7 +2407,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0pressure.Setup()
-                .At(this, 45)
+                .At(this, 53)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -2054,9 +2428,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch0radius.Setup()
-                .At(this, 46)
+                .At(this, 54)
                 .WithParent(parent)
-                .WithChildren(58, 2)
+                .WithChildren(70, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -2076,7 +2450,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch0phase.Setup()
-                .At(this, 47)
+                .At(this, 55)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -2098,7 +2472,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch0press.Setup()
-                .At(this, 48)
+                .At(this, 56)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -2121,7 +2495,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch0tapCount.Setup()
-                .At(this, 49)
+                .At(this, 57)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -2142,7 +2516,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch0indirectTouch.Setup()
-                .At(this, 50)
+                .At(this, 58)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -2166,7 +2540,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch0tap.Setup()
-                .At(this, 51)
+                .At(this, 59)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -2189,7 +2563,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch0startTime.Setup()
-                .At(this, 52)
+                .At(this, 60)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -2211,9 +2585,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch0startPosition.Setup()
-                .At(this, 53)
+                .At(this, 61)
                 .WithParent(parent)
-                .WithChildren(60, 2)
+                .WithChildren(72, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -2234,7 +2608,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0positionx.Setup()
-                .At(this, 54)
+                .At(this, 62)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -2256,7 +2630,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0positiony.Setup()
-                .At(this, 55)
+                .At(this, 63)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -2274,11 +2648,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch0positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch0deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch0deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch0deltaup.Setup()
+                .At(this, 64)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 72,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch0deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch0deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch0deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch0deltadown.Setup()
+                .At(this, 65)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 72,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch0deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch0deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch0deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch0deltaleft.Setup()
+                .At(this, 66)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 68,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch0deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch0deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch0deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch0deltaright.Setup()
+                .At(this, 67)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 68,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch0deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch0deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch0deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0deltax.Setup()
-                .At(this, 56)
+                .At(this, 68)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -2299,7 +2761,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0deltay.Setup()
-                .At(this, 57)
+                .At(this, 69)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -2320,7 +2782,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0radiusx.Setup()
-                .At(this, 58)
+                .At(this, 70)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -2341,7 +2803,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0radiusy.Setup()
-                .At(this, 59)
+                .At(this, 71)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -2362,7 +2824,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0startPositionx.Setup()
-                .At(this, 60)
+                .At(this, 72)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -2383,7 +2845,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0startPositiony.Setup()
-                .At(this, 61)
+                .At(this, 73)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -2404,7 +2866,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch1touchId.Setup()
-                .At(this, 62)
+                .At(this, 74)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -2427,9 +2889,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch1position.Setup()
-                .At(this, 63)
+                .At(this, 75)
                 .WithParent(parent)
-                .WithChildren(74, 2)
+                .WithChildren(86, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -2446,17 +2908,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch1position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch1delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch1delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch1delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch1delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch1delta.Setup()
-                .At(this, 64)
+                .At(this, 76)
                 .WithParent(parent)
-                .WithChildren(76, 2)
+                .WithChildren(88, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -2472,7 +2934,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1pressure.Setup()
-                .At(this, 65)
+                .At(this, 77)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -2493,9 +2955,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch1radius.Setup()
-                .At(this, 66)
+                .At(this, 78)
                 .WithParent(parent)
-                .WithChildren(78, 2)
+                .WithChildren(94, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -2515,7 +2977,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch1phase.Setup()
-                .At(this, 67)
+                .At(this, 79)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -2537,7 +2999,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch1press.Setup()
-                .At(this, 68)
+                .At(this, 80)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -2560,7 +3022,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch1tapCount.Setup()
-                .At(this, 69)
+                .At(this, 81)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -2581,7 +3043,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch1indirectTouch.Setup()
-                .At(this, 70)
+                .At(this, 82)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -2605,7 +3067,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch1tap.Setup()
-                .At(this, 71)
+                .At(this, 83)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -2628,7 +3090,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch1startTime.Setup()
-                .At(this, 72)
+                .At(this, 84)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -2650,9 +3112,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch1startPosition.Setup()
-                .At(this, 73)
+                .At(this, 85)
                 .WithParent(parent)
-                .WithChildren(80, 2)
+                .WithChildren(96, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -2673,7 +3135,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1positionx.Setup()
-                .At(this, 74)
+                .At(this, 86)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -2695,7 +3157,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1positiony.Setup()
-                .At(this, 75)
+                .At(this, 87)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -2713,11 +3175,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch1positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch1deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch1deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch1deltaup.Setup()
+                .At(this, 88)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 128,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch1deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch1deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch1deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch1deltadown.Setup()
+                .At(this, 89)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 128,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch1deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch1deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch1deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch1deltaleft.Setup()
+                .At(this, 90)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 124,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch1deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch1deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch1deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch1deltaright.Setup()
+                .At(this, 91)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 124,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch1deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch1deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch1deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1deltax.Setup()
-                .At(this, 76)
+                .At(this, 92)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -2738,7 +3288,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1deltay.Setup()
-                .At(this, 77)
+                .At(this, 93)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -2759,7 +3309,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1radiusx.Setup()
-                .At(this, 78)
+                .At(this, 94)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -2780,7 +3330,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1radiusy.Setup()
-                .At(this, 79)
+                .At(this, 95)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -2801,7 +3351,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1startPositionx.Setup()
-                .At(this, 80)
+                .At(this, 96)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -2822,7 +3372,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1startPositiony.Setup()
-                .At(this, 81)
+                .At(this, 97)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -2843,7 +3393,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch2touchId.Setup()
-                .At(this, 82)
+                .At(this, 98)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -2866,9 +3416,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch2position.Setup()
-                .At(this, 83)
+                .At(this, 99)
                 .WithParent(parent)
-                .WithChildren(94, 2)
+                .WithChildren(110, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -2885,17 +3435,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch2position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch2delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch2delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch2delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch2delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch2delta.Setup()
-                .At(this, 84)
+                .At(this, 100)
                 .WithParent(parent)
-                .WithChildren(96, 2)
+                .WithChildren(112, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -2911,7 +3461,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2pressure.Setup()
-                .At(this, 85)
+                .At(this, 101)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -2932,9 +3482,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch2radius.Setup()
-                .At(this, 86)
+                .At(this, 102)
                 .WithParent(parent)
-                .WithChildren(98, 2)
+                .WithChildren(118, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -2954,7 +3504,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch2phase.Setup()
-                .At(this, 87)
+                .At(this, 103)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -2976,7 +3526,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch2press.Setup()
-                .At(this, 88)
+                .At(this, 104)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -2999,7 +3549,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch2tapCount.Setup()
-                .At(this, 89)
+                .At(this, 105)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -3020,7 +3570,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch2indirectTouch.Setup()
-                .At(this, 90)
+                .At(this, 106)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -3044,7 +3594,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch2tap.Setup()
-                .At(this, 91)
+                .At(this, 107)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -3067,7 +3617,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch2startTime.Setup()
-                .At(this, 92)
+                .At(this, 108)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -3089,9 +3639,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch2startPosition.Setup()
-                .At(this, 93)
+                .At(this, 109)
                 .WithParent(parent)
-                .WithChildren(100, 2)
+                .WithChildren(120, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -3112,7 +3662,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2positionx.Setup()
-                .At(this, 94)
+                .At(this, 110)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -3134,7 +3684,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2positiony.Setup()
-                .At(this, 95)
+                .At(this, 111)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -3152,11 +3702,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch2positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch2deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch2deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch2deltaup.Setup()
+                .At(this, 112)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 184,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch2deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch2deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch2deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch2deltadown.Setup()
+                .At(this, 113)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 184,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch2deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch2deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch2deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch2deltaleft.Setup()
+                .At(this, 114)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 180,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch2deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch2deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch2deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch2deltaright.Setup()
+                .At(this, 115)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 180,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch2deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch2deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch2deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2deltax.Setup()
-                .At(this, 96)
+                .At(this, 116)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -3177,7 +3815,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2deltay.Setup()
-                .At(this, 97)
+                .At(this, 117)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -3198,7 +3836,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2radiusx.Setup()
-                .At(this, 98)
+                .At(this, 118)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -3219,7 +3857,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2radiusy.Setup()
-                .At(this, 99)
+                .At(this, 119)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -3240,7 +3878,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2startPositionx.Setup()
-                .At(this, 100)
+                .At(this, 120)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -3261,7 +3899,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2startPositiony.Setup()
-                .At(this, 101)
+                .At(this, 121)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -3282,7 +3920,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch3touchId.Setup()
-                .At(this, 102)
+                .At(this, 122)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -3305,9 +3943,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch3position.Setup()
-                .At(this, 103)
+                .At(this, 123)
                 .WithParent(parent)
-                .WithChildren(114, 2)
+                .WithChildren(134, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -3324,17 +3962,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch3position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch3delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch3delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch3delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch3delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch3delta.Setup()
-                .At(this, 104)
+                .At(this, 124)
                 .WithParent(parent)
-                .WithChildren(116, 2)
+                .WithChildren(136, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -3350,7 +3988,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3pressure.Setup()
-                .At(this, 105)
+                .At(this, 125)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -3371,9 +4009,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch3radius.Setup()
-                .At(this, 106)
+                .At(this, 126)
                 .WithParent(parent)
-                .WithChildren(118, 2)
+                .WithChildren(142, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -3393,7 +4031,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch3phase.Setup()
-                .At(this, 107)
+                .At(this, 127)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -3415,7 +4053,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch3press.Setup()
-                .At(this, 108)
+                .At(this, 128)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -3438,7 +4076,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch3tapCount.Setup()
-                .At(this, 109)
+                .At(this, 129)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -3459,7 +4097,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch3indirectTouch.Setup()
-                .At(this, 110)
+                .At(this, 130)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -3483,7 +4121,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch3tap.Setup()
-                .At(this, 111)
+                .At(this, 131)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -3506,7 +4144,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch3startTime.Setup()
-                .At(this, 112)
+                .At(this, 132)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -3528,9 +4166,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch3startPosition.Setup()
-                .At(this, 113)
+                .At(this, 133)
                 .WithParent(parent)
-                .WithChildren(120, 2)
+                .WithChildren(144, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -3551,7 +4189,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3positionx.Setup()
-                .At(this, 114)
+                .At(this, 134)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -3573,7 +4211,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3positiony.Setup()
-                .At(this, 115)
+                .At(this, 135)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -3591,11 +4229,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch3positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch3deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch3deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch3deltaup.Setup()
+                .At(this, 136)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 240,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch3deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch3deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch3deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch3deltadown.Setup()
+                .At(this, 137)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 240,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch3deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch3deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch3deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch3deltaleft.Setup()
+                .At(this, 138)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 236,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch3deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch3deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch3deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch3deltaright.Setup()
+                .At(this, 139)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 236,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch3deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch3deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch3deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3deltax.Setup()
-                .At(this, 116)
+                .At(this, 140)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -3616,7 +4342,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3deltay.Setup()
-                .At(this, 117)
+                .At(this, 141)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -3637,7 +4363,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3radiusx.Setup()
-                .At(this, 118)
+                .At(this, 142)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -3658,7 +4384,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3radiusy.Setup()
-                .At(this, 119)
+                .At(this, 143)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -3679,7 +4405,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3startPositionx.Setup()
-                .At(this, 120)
+                .At(this, 144)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -3700,7 +4426,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3startPositiony.Setup()
-                .At(this, 121)
+                .At(this, 145)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -3721,7 +4447,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch4touchId.Setup()
-                .At(this, 122)
+                .At(this, 146)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -3744,9 +4470,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch4position.Setup()
-                .At(this, 123)
+                .At(this, 147)
                 .WithParent(parent)
-                .WithChildren(134, 2)
+                .WithChildren(158, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -3763,17 +4489,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch4position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch4delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch4delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch4delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch4delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch4delta.Setup()
-                .At(this, 124)
+                .At(this, 148)
                 .WithParent(parent)
-                .WithChildren(136, 2)
+                .WithChildren(160, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -3789,7 +4515,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4pressure.Setup()
-                .At(this, 125)
+                .At(this, 149)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -3810,9 +4536,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch4radius.Setup()
-                .At(this, 126)
+                .At(this, 150)
                 .WithParent(parent)
-                .WithChildren(138, 2)
+                .WithChildren(166, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -3832,7 +4558,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch4phase.Setup()
-                .At(this, 127)
+                .At(this, 151)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -3854,7 +4580,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch4press.Setup()
-                .At(this, 128)
+                .At(this, 152)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -3877,7 +4603,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch4tapCount.Setup()
-                .At(this, 129)
+                .At(this, 153)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -3898,7 +4624,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch4indirectTouch.Setup()
-                .At(this, 130)
+                .At(this, 154)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -3922,7 +4648,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch4tap.Setup()
-                .At(this, 131)
+                .At(this, 155)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -3945,7 +4671,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch4startTime.Setup()
-                .At(this, 132)
+                .At(this, 156)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -3967,9 +4693,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch4startPosition.Setup()
-                .At(this, 133)
+                .At(this, 157)
                 .WithParent(parent)
-                .WithChildren(140, 2)
+                .WithChildren(168, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -3990,7 +4716,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4positionx.Setup()
-                .At(this, 134)
+                .At(this, 158)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -4012,7 +4738,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4positiony.Setup()
-                .At(this, 135)
+                .At(this, 159)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -4030,11 +4756,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch4positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch4deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch4deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch4deltaup.Setup()
+                .At(this, 160)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 296,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch4deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch4deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch4deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch4deltadown.Setup()
+                .At(this, 161)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 296,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch4deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch4deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch4deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch4deltaleft.Setup()
+                .At(this, 162)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 292,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch4deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch4deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch4deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch4deltaright.Setup()
+                .At(this, 163)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 292,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch4deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch4deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch4deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4deltax.Setup()
-                .At(this, 136)
+                .At(this, 164)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -4055,7 +4869,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4deltay.Setup()
-                .At(this, 137)
+                .At(this, 165)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -4076,7 +4890,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4radiusx.Setup()
-                .At(this, 138)
+                .At(this, 166)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -4097,7 +4911,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4radiusy.Setup()
-                .At(this, 139)
+                .At(this, 167)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -4118,7 +4932,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4startPositionx.Setup()
-                .At(this, 140)
+                .At(this, 168)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -4139,7 +4953,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4startPositiony.Setup()
-                .At(this, 141)
+                .At(this, 169)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -4160,7 +4974,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch5touchId.Setup()
-                .At(this, 142)
+                .At(this, 170)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -4183,9 +4997,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch5position.Setup()
-                .At(this, 143)
+                .At(this, 171)
                 .WithParent(parent)
-                .WithChildren(154, 2)
+                .WithChildren(182, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -4202,17 +5016,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch5position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch5delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch5delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch5delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch5delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch5delta.Setup()
-                .At(this, 144)
+                .At(this, 172)
                 .WithParent(parent)
-                .WithChildren(156, 2)
+                .WithChildren(184, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -4228,7 +5042,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5pressure.Setup()
-                .At(this, 145)
+                .At(this, 173)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -4249,9 +5063,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch5radius.Setup()
-                .At(this, 146)
+                .At(this, 174)
                 .WithParent(parent)
-                .WithChildren(158, 2)
+                .WithChildren(190, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -4271,7 +5085,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch5phase.Setup()
-                .At(this, 147)
+                .At(this, 175)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -4293,7 +5107,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch5press.Setup()
-                .At(this, 148)
+                .At(this, 176)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -4316,7 +5130,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch5tapCount.Setup()
-                .At(this, 149)
+                .At(this, 177)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -4337,7 +5151,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch5indirectTouch.Setup()
-                .At(this, 150)
+                .At(this, 178)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -4361,7 +5175,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch5tap.Setup()
-                .At(this, 151)
+                .At(this, 179)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -4384,7 +5198,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch5startTime.Setup()
-                .At(this, 152)
+                .At(this, 180)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -4406,9 +5220,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch5startPosition.Setup()
-                .At(this, 153)
+                .At(this, 181)
                 .WithParent(parent)
-                .WithChildren(160, 2)
+                .WithChildren(192, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -4429,7 +5243,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5positionx.Setup()
-                .At(this, 154)
+                .At(this, 182)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -4451,7 +5265,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5positiony.Setup()
-                .At(this, 155)
+                .At(this, 183)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -4469,11 +5283,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch5positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch5deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch5deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch5deltaup.Setup()
+                .At(this, 184)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 352,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch5deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch5deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch5deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch5deltadown.Setup()
+                .At(this, 185)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 352,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch5deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch5deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch5deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch5deltaleft.Setup()
+                .At(this, 186)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 348,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch5deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch5deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch5deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch5deltaright.Setup()
+                .At(this, 187)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 348,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch5deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch5deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch5deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5deltax.Setup()
-                .At(this, 156)
+                .At(this, 188)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -4494,7 +5396,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5deltay.Setup()
-                .At(this, 157)
+                .At(this, 189)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -4515,7 +5417,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5radiusx.Setup()
-                .At(this, 158)
+                .At(this, 190)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -4536,7 +5438,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5radiusy.Setup()
-                .At(this, 159)
+                .At(this, 191)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -4557,7 +5459,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5startPositionx.Setup()
-                .At(this, 160)
+                .At(this, 192)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -4578,7 +5480,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5startPositiony.Setup()
-                .At(this, 161)
+                .At(this, 193)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -4599,7 +5501,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch6touchId.Setup()
-                .At(this, 162)
+                .At(this, 194)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -4622,9 +5524,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch6position.Setup()
-                .At(this, 163)
+                .At(this, 195)
                 .WithParent(parent)
-                .WithChildren(174, 2)
+                .WithChildren(206, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -4641,17 +5543,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch6position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch6delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch6delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch6delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch6delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch6delta.Setup()
-                .At(this, 164)
+                .At(this, 196)
                 .WithParent(parent)
-                .WithChildren(176, 2)
+                .WithChildren(208, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -4667,7 +5569,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6pressure.Setup()
-                .At(this, 165)
+                .At(this, 197)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -4688,9 +5590,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch6radius.Setup()
-                .At(this, 166)
+                .At(this, 198)
                 .WithParent(parent)
-                .WithChildren(178, 2)
+                .WithChildren(214, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -4710,7 +5612,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch6phase.Setup()
-                .At(this, 167)
+                .At(this, 199)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -4732,7 +5634,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch6press.Setup()
-                .At(this, 168)
+                .At(this, 200)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -4755,7 +5657,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch6tapCount.Setup()
-                .At(this, 169)
+                .At(this, 201)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -4776,7 +5678,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch6indirectTouch.Setup()
-                .At(this, 170)
+                .At(this, 202)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -4800,7 +5702,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch6tap.Setup()
-                .At(this, 171)
+                .At(this, 203)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -4823,7 +5725,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch6startTime.Setup()
-                .At(this, 172)
+                .At(this, 204)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -4845,9 +5747,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch6startPosition.Setup()
-                .At(this, 173)
+                .At(this, 205)
                 .WithParent(parent)
-                .WithChildren(180, 2)
+                .WithChildren(216, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -4868,7 +5770,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6positionx.Setup()
-                .At(this, 174)
+                .At(this, 206)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -4890,7 +5792,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6positiony.Setup()
-                .At(this, 175)
+                .At(this, 207)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -4908,11 +5810,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch6positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch6deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch6deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch6deltaup.Setup()
+                .At(this, 208)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 408,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch6deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch6deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch6deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch6deltadown.Setup()
+                .At(this, 209)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 408,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch6deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch6deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch6deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch6deltaleft.Setup()
+                .At(this, 210)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 404,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch6deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch6deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch6deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch6deltaright.Setup()
+                .At(this, 211)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 404,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch6deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch6deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch6deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6deltax.Setup()
-                .At(this, 176)
+                .At(this, 212)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -4933,7 +5923,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6deltay.Setup()
-                .At(this, 177)
+                .At(this, 213)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -4954,7 +5944,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6radiusx.Setup()
-                .At(this, 178)
+                .At(this, 214)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -4975,7 +5965,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6radiusy.Setup()
-                .At(this, 179)
+                .At(this, 215)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -4996,7 +5986,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6startPositionx.Setup()
-                .At(this, 180)
+                .At(this, 216)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -5017,7 +6007,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6startPositiony.Setup()
-                .At(this, 181)
+                .At(this, 217)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -5038,7 +6028,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch7touchId.Setup()
-                .At(this, 182)
+                .At(this, 218)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -5061,9 +6051,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch7position.Setup()
-                .At(this, 183)
+                .At(this, 219)
                 .WithParent(parent)
-                .WithChildren(194, 2)
+                .WithChildren(230, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -5080,17 +6070,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch7position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch7delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch7delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch7delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch7delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch7delta.Setup()
-                .At(this, 184)
+                .At(this, 220)
                 .WithParent(parent)
-                .WithChildren(196, 2)
+                .WithChildren(232, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -5106,7 +6096,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7pressure.Setup()
-                .At(this, 185)
+                .At(this, 221)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -5127,9 +6117,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch7radius.Setup()
-                .At(this, 186)
+                .At(this, 222)
                 .WithParent(parent)
-                .WithChildren(198, 2)
+                .WithChildren(238, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -5149,7 +6139,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch7phase.Setup()
-                .At(this, 187)
+                .At(this, 223)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -5171,7 +6161,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch7press.Setup()
-                .At(this, 188)
+                .At(this, 224)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -5194,7 +6184,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch7tapCount.Setup()
-                .At(this, 189)
+                .At(this, 225)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -5215,7 +6205,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch7indirectTouch.Setup()
-                .At(this, 190)
+                .At(this, 226)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -5239,7 +6229,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch7tap.Setup()
-                .At(this, 191)
+                .At(this, 227)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -5262,7 +6252,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch7startTime.Setup()
-                .At(this, 192)
+                .At(this, 228)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -5284,9 +6274,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch7startPosition.Setup()
-                .At(this, 193)
+                .At(this, 229)
                 .WithParent(parent)
-                .WithChildren(200, 2)
+                .WithChildren(240, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -5307,7 +6297,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7positionx.Setup()
-                .At(this, 194)
+                .At(this, 230)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -5329,7 +6319,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7positiony.Setup()
-                .At(this, 195)
+                .At(this, 231)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -5347,11 +6337,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch7positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch7deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch7deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch7deltaup.Setup()
+                .At(this, 232)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 464,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch7deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch7deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch7deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch7deltadown.Setup()
+                .At(this, 233)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 464,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch7deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch7deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch7deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch7deltaleft.Setup()
+                .At(this, 234)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 460,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch7deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch7deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch7deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch7deltaright.Setup()
+                .At(this, 235)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 460,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch7deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch7deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch7deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7deltax.Setup()
-                .At(this, 196)
+                .At(this, 236)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -5372,7 +6450,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7deltay.Setup()
-                .At(this, 197)
+                .At(this, 237)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -5393,7 +6471,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7radiusx.Setup()
-                .At(this, 198)
+                .At(this, 238)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -5414,7 +6492,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7radiusy.Setup()
-                .At(this, 199)
+                .At(this, 239)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -5435,7 +6513,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7startPositionx.Setup()
-                .At(this, 200)
+                .At(this, 240)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -5456,7 +6534,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7startPositiony.Setup()
-                .At(this, 201)
+                .At(this, 241)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -5477,7 +6555,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch8touchId.Setup()
-                .At(this, 202)
+                .At(this, 242)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -5500,9 +6578,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch8position.Setup()
-                .At(this, 203)
+                .At(this, 243)
                 .WithParent(parent)
-                .WithChildren(214, 2)
+                .WithChildren(254, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -5519,17 +6597,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch8position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch8delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch8delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch8delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch8delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch8delta.Setup()
-                .At(this, 204)
+                .At(this, 244)
                 .WithParent(parent)
-                .WithChildren(216, 2)
+                .WithChildren(256, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -5545,7 +6623,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8pressure.Setup()
-                .At(this, 205)
+                .At(this, 245)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -5566,9 +6644,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch8radius.Setup()
-                .At(this, 206)
+                .At(this, 246)
                 .WithParent(parent)
-                .WithChildren(218, 2)
+                .WithChildren(262, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -5588,7 +6666,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch8phase.Setup()
-                .At(this, 207)
+                .At(this, 247)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -5610,7 +6688,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch8press.Setup()
-                .At(this, 208)
+                .At(this, 248)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -5633,7 +6711,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch8tapCount.Setup()
-                .At(this, 209)
+                .At(this, 249)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -5654,7 +6732,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch8indirectTouch.Setup()
-                .At(this, 210)
+                .At(this, 250)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -5678,7 +6756,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch8tap.Setup()
-                .At(this, 211)
+                .At(this, 251)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -5701,7 +6779,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch8startTime.Setup()
-                .At(this, 212)
+                .At(this, 252)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -5723,9 +6801,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch8startPosition.Setup()
-                .At(this, 213)
+                .At(this, 253)
                 .WithParent(parent)
-                .WithChildren(220, 2)
+                .WithChildren(264, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -5746,7 +6824,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8positionx.Setup()
-                .At(this, 214)
+                .At(this, 254)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -5768,7 +6846,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8positiony.Setup()
-                .At(this, 215)
+                .At(this, 255)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -5786,11 +6864,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch8positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch8deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch8deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch8deltaup.Setup()
+                .At(this, 256)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 520,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch8deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch8deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch8deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch8deltadown.Setup()
+                .At(this, 257)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 520,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch8deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch8deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch8deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch8deltaleft.Setup()
+                .At(this, 258)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 516,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch8deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch8deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch8deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch8deltaright.Setup()
+                .At(this, 259)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 516,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch8deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch8deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch8deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8deltax.Setup()
-                .At(this, 216)
+                .At(this, 260)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -5811,7 +6977,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8deltay.Setup()
-                .At(this, 217)
+                .At(this, 261)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -5832,7 +6998,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8radiusx.Setup()
-                .At(this, 218)
+                .At(this, 262)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -5853,7 +7019,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8radiusy.Setup()
-                .At(this, 219)
+                .At(this, 263)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -5874,7 +7040,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8startPositionx.Setup()
-                .At(this, 220)
+                .At(this, 264)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -5895,7 +7061,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8startPositiony.Setup()
-                .At(this, 221)
+                .At(this, 265)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -5916,7 +7082,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch9touchId.Setup()
-                .At(this, 222)
+                .At(this, 266)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -5939,9 +7105,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch9position.Setup()
-                .At(this, 223)
+                .At(this, 267)
                 .WithParent(parent)
-                .WithChildren(234, 2)
+                .WithChildren(278, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -5958,17 +7124,17 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch9position;
         }
 
-        private UnityEngine.InputSystem.Controls.Vector2Control Initialize_ctrlTouchscreentouch9delta(InternedString kVector2Layout, InputControl parent)
+        private UnityEngine.InputSystem.Controls.DeltaControl Initialize_ctrlTouchscreentouch9delta(InternedString kDeltaLayout, InputControl parent)
         {
-            var ctrlTouchscreentouch9delta = new UnityEngine.InputSystem.Controls.Vector2Control();
+            var ctrlTouchscreentouch9delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch9delta.Setup()
-                .At(this, 224)
+                .At(this, 268)
                 .WithParent(parent)
-                .WithChildren(236, 2)
+                .WithChildren(280, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
-                .WithLayout(kVector2Layout)
+                .WithLayout(kDeltaLayout)
                 .WithStateBlock(new InputStateBlock
                 {
                     format = new FourCC(1447379762),
@@ -5984,7 +7150,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9pressure.Setup()
-                .At(this, 225)
+                .At(this, 269)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -6005,9 +7171,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch9radius.Setup()
-                .At(this, 226)
+                .At(this, 270)
                 .WithParent(parent)
-                .WithChildren(238, 2)
+                .WithChildren(286, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -6027,7 +7193,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch9phase.Setup()
-                .At(this, 227)
+                .At(this, 271)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -6049,7 +7215,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch9press.Setup()
-                .At(this, 228)
+                .At(this, 272)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -6072,7 +7238,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch9tapCount.Setup()
-                .At(this, 229)
+                .At(this, 273)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -6093,7 +7259,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch9indirectTouch.Setup()
-                .At(this, 230)
+                .At(this, 274)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -6117,7 +7283,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch9tap.Setup()
-                .At(this, 231)
+                .At(this, 275)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -6140,7 +7306,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch9startTime.Setup()
-                .At(this, 232)
+                .At(this, 276)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -6162,9 +7328,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch9startPosition.Setup()
-                .At(this, 233)
+                .At(this, 277)
                 .WithParent(parent)
-                .WithChildren(240, 2)
+                .WithChildren(288, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -6185,7 +7351,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9positionx.Setup()
-                .At(this, 234)
+                .At(this, 278)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -6207,7 +7373,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9positiony.Setup()
-                .At(this, 235)
+                .At(this, 279)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -6225,11 +7391,99 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch9positiony;
         }
 
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch9deltaup(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch9deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch9deltaup.Setup()
+                .At(this, 280)
+                .WithParent(parent)
+                .WithName("up")
+                .WithDisplayName("Touch Touch Delta Up")
+                .WithShortDisplayName("Touch Touch Delta Up")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 576,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch9deltaup;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch9deltadown(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch9deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch9deltadown.Setup()
+                .At(this, 281)
+                .WithParent(parent)
+                .WithName("down")
+                .WithDisplayName("Touch Touch Delta Down")
+                .WithShortDisplayName("Touch Touch Delta Down")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 576,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch9deltadown;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch9deltaleft(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch9deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
+            ctrlTouchscreentouch9deltaleft.Setup()
+                .At(this, 282)
+                .WithParent(parent)
+                .WithName("left")
+                .WithDisplayName("Touch Touch Delta Left")
+                .WithShortDisplayName("Touch Touch Delta Left")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 572,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch9deltaleft;
+        }
+
+        private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch9deltaright(InternedString kAxisLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch9deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
+            ctrlTouchscreentouch9deltaright.Setup()
+                .At(this, 283)
+                .WithParent(parent)
+                .WithName("right")
+                .WithDisplayName("Touch Touch Delta Right")
+                .WithShortDisplayName("Touch Touch Delta Right")
+                .WithLayout(kAxisLayout)
+                .IsSynthetic(true)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1179407392),
+                    byteOffset = 572,
+                    bitOffset = 0,
+                    sizeInBits = 32
+                })
+                .Finish();
+            return ctrlTouchscreentouch9deltaright;
+        }
+
         private UnityEngine.InputSystem.Controls.AxisControl Initialize_ctrlTouchscreentouch9deltax(InternedString kAxisLayout, InputControl parent)
         {
             var ctrlTouchscreentouch9deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9deltax.Setup()
-                .At(this, 236)
+                .At(this, 284)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -6250,7 +7504,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9deltay.Setup()
-                .At(this, 237)
+                .At(this, 285)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -6271,7 +7525,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9radiusx.Setup()
-                .At(this, 238)
+                .At(this, 286)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -6292,7 +7546,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9radiusy.Setup()
-                .At(this, 239)
+                .At(this, 287)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -6313,7 +7567,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9startPositionx.Setup()
-                .At(this, 240)
+                .At(this, 288)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -6334,7 +7588,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9startPositiony.Setup()
-                .At(this, 241)
+                .At(this, 289)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -109,7 +109,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         /// <value>Screen-space movement delta.</value>
         /// <seealso cref="TouchControl.delta"/>
-        [InputControl(displayName = "Delta")]
+        [InputControl(displayName = "Delta", layout = "Delta")]
         [FieldOffset(12)]
         public Vector2 delta;
 
@@ -368,7 +368,7 @@ namespace UnityEngine.InputSystem.LowLevel
         //       them by assigning them invalid offsets (thus having automatic state
         //       layout put them at the end of our fixed state).
         [InputControl(name = "position", useStateFrom = "primaryTouch/position")]
-        [InputControl(name = "delta", useStateFrom = "primaryTouch/delta")]
+        [InputControl(name = "delta", useStateFrom = "primaryTouch/delta", layout = "Delta")]
         [InputControl(name = "pressure", useStateFrom = "primaryTouch/pressure")]
         [InputControl(name = "radius", useStateFrom = "primaryTouch/radius")]
         [InputControl(name = "press", useStateFrom = "primaryTouch/phase", layout = "TouchPress", synthetic = true, usages = new string[0])]

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1832,6 +1832,8 @@ namespace UnityEngine.InputSystem
             m_PollingFrequency = 60;
 
             // Register layouts.
+            // NOTE: Base layouts must be registered before their derived layouts
+            //       for the detection of base layouts to work.
             RegisterControlLayout("Axis", typeof(AxisControl)); // Controls.
             RegisterControlLayout("Button", typeof(ButtonControl));
             RegisterControlLayout("DiscreteButton", typeof(DiscreteButtonControl));
@@ -1842,6 +1844,7 @@ namespace UnityEngine.InputSystem
             RegisterControlLayout("Double", typeof(DoubleControl));
             RegisterControlLayout("Vector2", typeof(Vector2Control));
             RegisterControlLayout("Vector3", typeof(Vector3Control));
+            RegisterControlLayout("Delta", typeof(DeltaControl));
             RegisterControlLayout("Quaternion", typeof(QuaternionControl));
             RegisterControlLayout("Stick", typeof(StickControl));
             RegisterControlLayout("Dpad", typeof(DpadControl));


### PR DESCRIPTION
### Description

On current `develop`, it is not possible to bind to scrolling up or scrolling down. One has to bind to `scroll/y` as a whole and then apply processors to get to the desired values.

### Changes made

This PR adds a new `DeltaControl` type that is used for delta and scroll controls on pointers. It is based on `Vector2Control` and is similar to `StickControl` (except that it doesn't prescribe a [-1..1] range).

### Notes

I've also loosened the control type constraints on some composites to make it possible to bind to the newly added scroll directions. The composites are constrained to `Button`s when in fact they allow any `Axis` as well.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
