### PR TITLE
Ignoring error if more than max amount of touches present

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -5490,10 +5490,12 @@ partial class CoreTests
 
         InputSystem.onEvent += (InputEventPtr eventPtr, InputDevice device) =>
         {
-            eventPtr.HasButtonPress();
+            Assert.That(() => eventPtr.HasButtonPress(), Throws.Nothing);
         };
 
-        for (var i = 0; i < TouchscreenState.MaxTouches + 5; ++i)
-            BeginTouch(i, new Vector2(i * 1.0f, i * 2.0f), time: 0);
+        Assert.That(() => {
+            for (var i = 0; i < TouchscreenState.MaxTouches + 5; ++i)
+                BeginTouch(i, new Vector2(i * 1.0f, i * 2.0f), time: 0);
+        }, Throws.Nothing);
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -5480,4 +5480,20 @@ partial class CoreTests
         Assert.That(device.value1.ReadValue(), Is.EqualTo(expectedValue1));
         Assert.That(device.value2.ReadValue(), Is.EqualTo(expectedValue2));
     }
+
+    // https://fogbugz.unity3d.com/f/cases/1395648/
+    [Test]
+    [Category("Devices")]
+    public unsafe void Devices_DoesntErrorOutOnMaxTouchCount()
+    {
+        var touch = InputSystem.AddDevice<Touchscreen>();
+
+        InputSystem.onEvent += (InputEventPtr eventPtr, InputDevice device) =>
+        {
+            eventPtr.HasButtonPress();
+        };
+
+        for (var i = 0; i < TouchscreenState.MaxTouches + 5; ++i)
+            BeginTouch(i, new Vector2(i * 1.0f, i * 2.0f), time: 0);
+    }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -40,6 +40,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `InputControlPath.Matches` incorrectly reporting matches when only a prefix was matching.
   * This would, for example, cause `Keyboard.eKey` to be matched by `<Keyboard>/escape`.
   * Fix contributed by [Fredrik Ludvigsen](https://github.com/steinbitglis) in [#1485](https://github.com/Unity-Technologies/InputSystem/pull/1485).
+- Fixed "STAT event with state format TOUC cannot be used with device 'Touchscreen:/Touchscreen'" when more than max supported amount of fingers, currently 10, are present on the screen at a same time (case 1395648).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1511,8 +1511,18 @@ namespace UnityEngine.InputSystem
                             m_NoiseMask += stateOffset;
                     }
                     else
-                        throw new InvalidOperationException(
-                            $"{eventType} event with state format {stateFormat} cannot be used with device '{m_Device}'");
+                    {
+                        // https://fogbugz.unity3d.com/f/cases/1395648/
+                        if (m_Device is Touchscreen && m_EventPtr.IsA<StateEvent>() &&
+                            StateEvent.FromUnchecked(m_EventPtr)->stateFormat == TouchState.Format)
+                        {
+                            // if GetStateOffsetForEvent(null, ...) return false on touchscreen it means that
+                            // we don't have a free slot for incoming touch, so ignore it for now
+                        }
+                        else
+                            throw new InvalidOperationException(
+                                $"{eventType} event with state format {stateFormat} cannot be used with device '{m_Device}'");
+                    }
                 }
 
                 // NOTE: We *could* run a CheckDefault() or even CheckCurrent() over the entire event here to rule


### PR DESCRIPTION
### Description

- If `HasButtonPress` is called on incoming events.
- And more than 10 touches are present.
- Then `GetStateOffsetForEvent(null, ...)` returns false for touchscreen, because it can't find a free slot for incoming touch.
- That leads to `InputEventControlEnumerator.Reset()` throws an exception.

### Changes made

Ignoring the exception for specific case of touch events to touchscreen.
