### PR TITLE
adding newly supported 3rd party Nintendo gamepads

### DIFF
--- a/Assets/Tests/InputSystem/SwitchTests.cs
+++ b/Assets/Tests/InputSystem/SwitchTests.cs
@@ -93,15 +93,15 @@ internal class SwitchTests : CoreTestsFixture
     [TestCase(0x0e6f, 0x0187)]
     [TestCase(0x20d6, 0xa712)]
     [TestCase(0x20d6, 0xa716)]
-    
+
     //these currently break Mac editor and standalone
     #if !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
-        [TestCase(0x0e6f, 0x0184)]
-        [TestCase(0x0e6f, 0x0188)]
-        [TestCase(0x20d6, 0xa714)]
-        [TestCase(0x20d6, 0xa715)]
+    [TestCase(0x0e6f, 0x0184)]
+    [TestCase(0x0e6f, 0x0188)]
+    [TestCase(0x20d6, 0xa714)]
+    [TestCase(0x20d6, 0xa715)]
     #endif
-    
+
     public void Devices_SupportsSwitchLikeControllers(int vendorId, int productId)
     {
         var hidDescriptor = new HID.HIDDeviceDescriptor

--- a/Assets/Tests/InputSystem/SwitchTests.cs
+++ b/Assets/Tests/InputSystem/SwitchTests.cs
@@ -82,9 +82,26 @@ internal class SwitchTests : CoreTestsFixture
 
     [Test]
     [Category("Devices")]
+    [TestCase(0x0f0d, 0x0092)]
+    [TestCase(0x0f0d, 0x00aa)]
     [TestCase(0x0f0d, 0x00c1)]
-    [TestCase(0x20d6, 0xa712)]
+    [TestCase(0x0f0d, 0x00dc)]
+    [TestCase(0x0f0d, 0x00f6)]
+    [TestCase(0x0e6f, 0x0180)]
     [TestCase(0x0e6f, 0x0185)]
+    [TestCase(0x0e6f, 0x0186)]
+    [TestCase(0x0e6f, 0x0187)]
+    [TestCase(0x20d6, 0xa712)]
+    [TestCase(0x20d6, 0xa716)]
+    
+    //these currently break Mac editor and standalone
+    #if !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
+        [TestCase(0x0e6f, 0x0184)]
+        [TestCase(0x0e6f, 0x0188)]
+        [TestCase(0x20d6, 0xa714)]
+        [TestCase(0x20d6, 0xa715)]
+    #endif
+    
     public void Devices_SupportsSwitchLikeControllers(int vendorId, int productId)
     {
         var hidDescriptor = new HID.HIDDeviceDescriptor

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -66,7 +66,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 
-- Added support for "Hori Co HORIPAD for Nintendo Switch", "PowerA NSW Fusion Wired FightPad", "PDP Wired Fight Pad Pro: Mario".
+- Added support for "Hori Co HORIPAD for Nintendo Switch", "HORI Pokken Tournament DX Pro Pad", "HORI Wireless Switch Pad", "HORI Real Arcade Pro V Hayabusa in Switch Mode", "PowerA NSW Fusion Wired FightPad", "PowerA NSW Fusion Pro Controller (USB only)", "PDP Wired Fight Pad Pro: Mario", "PDP Faceoff Wired Pro Controller for Nintendo Switch", "PDP Afterglow Wireless Switch Controller", "PDP Rockcandy Wired Controller".
 - Added a new `DeltaControl` control type that is now used for delta-style controls such as `Mouse.delta` and `Mouse.scroll`.
   * Like `StickControl`, this control has individual `up`, `down`, `left`, and `right` controls (as well as `x` and `y` that it inherits from `Vector2Control`). This means it is now possible to directly bind to individual scroll directions (such as `<Mouse>/scroll/up`).
 

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -43,7 +43,7 @@ On UWP only USB connection is supported, motor rumble and lightbar are not worki
 >6. Unity supports Made for iOS (Mfi) certified controllers on iOS. Xbox One and PS4 controllers are only supported on iOS 13 or higher.
 >7. Consoles are supported using separate packages. You need to install these packages in your Project to enable console support.
 >8. Unity officially supports PS4 controllers only on [Android 10 or higher](https://playstation.com/en-us/support/hardware/ps4-pair-dualshock-4-wireless-with-sony-xperia-and-android).
->9. Switch Joy-Cons are not currently supported on Windows and Mac. Some of official accessories are supported on Windows and Mac: "Hori Co HORIPAD for Nintendo Switch", "PowerA NSW Fusion Wired FightPad", "PDP Wired Fight Pad Pro: Mario".
+>9. Switch Joy-Cons are not currently supported on Windows and Mac. Some of official accessories are supported on Windows and Mac: "Hori Co HORIPAD for Nintendo Switch", "HORI Pokken Tournament DX Pro Pad", "HORI Wireless Switch Pad", "HORI Real Arcade Pro V Hayabusa in Switch Mode", "PowerA NSW Fusion Wired FightPad", "PowerA NSW Fusion Pro Controller (USB only)", "PDP Wired Fight Pad Pro: Mario", "PDP Faceoff Wired Pro Controller for Nintendo Switch", "PDP Afterglow Wireless Switch Controller", "PDP Rockcandy Wired Controller".
 >10. PS5 DualSense is supported on Windows and macOS via USB HID, though setting motor rumble and lightbar color when connected over Bluetooth is currently not supported.
 On UWP only USB connection is supported, motor rumble and lightbar are not working correctly.
 On Android it's expected to be working from Android 12.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -29,44 +29,34 @@ namespace UnityEngine.InputSystem.Switch
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x20d6) // PowerA 
-                    .WithCapability("productId", 0xa712)); // NSW Fusion Wired FightPad
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x0092)); // Pokken Tournament DX Pro Pad
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00f6)); // HORI Wireless Switch Pad
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00dc)); // Fighting Commander
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00aa)); // Real Arcade Pro
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
                     .WithCapability("productId", 0x0185)); // Wired Fight Pad Pro
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
-                    .WithCapability("productId", 0x0092)); // Pokken Tournament DX Pro Pad
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
-                    .WithCapability("productId", 0x00f6)); // HORI Wireless Switch Pad		
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
                     .WithCapability("productId", 0x0180)); // Faceoff Wired Pro Controller for Nintendo Switch	
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0e6f) // PDP
-                    .WithCapability("productId", 0x0188)); // Afterglow Deluxe+ Audio Wired Controller				
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
-                    .WithCapability("productId", 0x00dc)); // Fighting Commander						
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0e6f) // PDP
-                    .WithCapability("productId", 0x0184)); // Faceoff Premiere Wired Pro Controller for Nintendo Switch								
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
@@ -80,22 +70,36 @@ namespace UnityEngine.InputSystem.Switch
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x20d6) // PowerA
-                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller					
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller	
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x20d6) // PowerA
-                    .WithCapability("productId", 0xa715)); // Fusion Wireless Arcade Stick	
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x20d6) // PowerA
-                    .WithCapability("productId", 0xa714)); // NSW Spectra Wired Controller	
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
-                    .WithCapability("productId", 0x00aa)); // Real Arcade Pro
+                    .WithCapability("vendorId", 0x20d6) // PowerA 
+                    .WithCapability("productId", 0xa712)); // NSW Fusion Wired FightPad
+			
+            // gamepads below currently break Mac Editor and Standalone
+            #if !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
+                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                    new InputDeviceMatcher()
+                        .WithInterface("HID")
+                        .WithCapability("vendorId", 0x0e6f) // PDP
+                        .WithCapability("productId", 0x0184)); // Faceoff Premiere Wired Pro Controller for Nintendo Switch
+                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                    new InputDeviceMatcher()
+                        .WithInterface("HID")
+                        .WithCapability("vendorId", 0x0e6f) // PDP
+                        .WithCapability("productId", 0x0188)); // Afterglow Deluxe+ Audio Wired Controller
+                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                    new InputDeviceMatcher()
+                        .WithInterface("HID")
+                        .WithCapability("vendorId", 0x20d6) // PowerA
+                        .WithCapability("productId", 0xa714)); // NSW Spectra Wired Controller
+                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                    new InputDeviceMatcher()
+                        .WithInterface("HID")
+                        .WithCapability("vendorId", 0x20d6) // PowerA
+                        .WithCapability("productId", 0xa715)); // Fusion Wireless Arcade Stick	
+            #endif
         #endif
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -36,6 +36,11 @@ namespace UnityEngine.InputSystem.Switch
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP Wired Fight Pad Pro: Mario
                     .WithCapability("productId", 0x0185));
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x0092)); // Pokken Tournament DX Pro Pad
         #endif
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -85,7 +85,17 @@ namespace UnityEngine.InputSystem.Switch
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x20d6) // PowerA
-                    .WithCapability("productId", 0xa715)); // Fusion Wireless Arcade Stick							
+                    .WithCapability("productId", 0xa715)); // Fusion Wireless Arcade Stick	
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6) // PowerA
+                    .WithCapability("productId", 0xa714)); // NSW Spectra Wired Controller	
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00aa)); // Real Arcade Pro
         #endif
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -29,18 +29,63 @@ namespace UnityEngine.InputSystem.Switch
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x20d6) // PowerA NSW Fusion Wired FightPad
-                    .WithCapability("productId", 0xa712));
+                    .WithCapability("vendorId", 0x20d6) // PowerA 
+                    .WithCapability("productId", 0xa712)); // NSW Fusion Wired FightPad
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0e6f) // PDP Wired Fight Pad Pro: Mario
-                    .WithCapability("productId", 0x0185));
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0185)); // Wired Fight Pad Pro
 			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
                     .WithCapability("productId", 0x0092)); // Pokken Tournament DX Pro Pad
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00f6)); // HORI Wireless Switch Pad		
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0180)); // Faceoff Wired Pro Controller for Nintendo Switch	
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0188)); // Afterglow Deluxe+ Audio Wired Controller				
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00dc)); // Fighting Commander						
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0184)); // Faceoff Premiere Wired Pro Controller for Nintendo Switch								
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0187)); // Rock Candy Wired Controller for Nintendo Switch										
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0186)); //  Afterglow Wireless Switch Controller - "Nintento Wireless Gamepad"
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6) // PowerA
+                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller					
+			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6) // PowerA
+                    .WithCapability("productId", 0xa715)); // Fusion Wireless Arcade Stick							
         #endif
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -25,32 +25,27 @@ namespace UnityEngine.InputSystem.Switch
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0f0d) // Hori Co., Ltd
-                    .WithCapability("productId", 0x00c1)); // HORIPAD for Nintendo Switch
-            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
                     .WithCapability("productId", 0x0092)); // Pokken Tournament DX Pro Pad
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
-                    .WithCapability("productId", 0x00f6)); // HORI Wireless Switch Pad
-            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
-                    .WithCapability("productId", 0x00dc)); // Fighting Commander
-            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                new InputDeviceMatcher()
-                    .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0f0d ) // Hori Co., Ltd
+                    .WithCapability("vendorId", 0x0f0d) // Hori Co., Ltd
                     .WithCapability("productId", 0x00aa)); // Real Arcade Pro
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x0e6f) // PDP
-                    .WithCapability("productId", 0x0185)); // Wired Fight Pad Pro
+                    .WithCapability("vendorId", 0x0f0d) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00c1)); // HORIPAD for Nintendo Switch
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00dc)); // Fighting Commander
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0f0d) // Hori Co., Ltd
+                    .WithCapability("productId", 0x00f6)); // HORI Wireless Switch Pad
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
@@ -60,23 +55,28 @@ namespace UnityEngine.InputSystem.Switch
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
-                    .WithCapability("productId", 0x0187)); // Rock Candy Wired Controller for Nintendo Switch										
+                    .WithCapability("productId", 0x0185)); // Wired Fight Pad Pro										
 			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
                     .WithCapability("productId", 0x0186)); //  Afterglow Wireless Switch Controller - "Nintento Wireless Gamepad"
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x20d6) // PowerA
-                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller	
+                    .WithCapability("vendorId", 0x0e6f) // PDP
+                    .WithCapability("productId", 0x0187)); // Rock Candy Wired Controller for Nintendo Switch
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x20d6) // PowerA 
                     .WithCapability("productId", 0xa712)); // NSW Fusion Wired FightPad
-			
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6) // PowerA
+                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller	
+            
             // gamepads below currently break Mac Editor and Standalone
             #if !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
                 InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchSupportHID.cs
@@ -50,13 +50,13 @@ namespace UnityEngine.InputSystem.Switch
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
-                    .WithCapability("productId", 0x0180)); // Faceoff Wired Pro Controller for Nintendo Switch	
+                    .WithCapability("productId", 0x0180)); // Faceoff Wired Pro Controller for Nintendo Switch
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
-                    .WithCapability("productId", 0x0185)); // Wired Fight Pad Pro										
-			InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                    .WithCapability("productId", 0x0185)); // Wired Fight Pad Pro
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x0e6f) // PDP
@@ -69,36 +69,36 @@ namespace UnityEngine.InputSystem.Switch
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithCapability("vendorId", 0x20d6) // PowerA 
+                    .WithCapability("vendorId", 0x20d6) // PowerA
                     .WithCapability("productId", 0xa712)); // NSW Fusion Wired FightPad
             InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x20d6) // PowerA
-                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller	
-            
+                    .WithCapability("productId", 0xa716)); // NSW Fusion Pro Controller
+
             // gamepads below currently break Mac Editor and Standalone
             #if !(UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX)
-                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                    new InputDeviceMatcher()
-                        .WithInterface("HID")
-                        .WithCapability("vendorId", 0x0e6f) // PDP
-                        .WithCapability("productId", 0x0184)); // Faceoff Premiere Wired Pro Controller for Nintendo Switch
-                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                    new InputDeviceMatcher()
-                        .WithInterface("HID")
-                        .WithCapability("vendorId", 0x0e6f) // PDP
-                        .WithCapability("productId", 0x0188)); // Afterglow Deluxe+ Audio Wired Controller
-                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                    new InputDeviceMatcher()
-                        .WithInterface("HID")
-                        .WithCapability("vendorId", 0x20d6) // PowerA
-                        .WithCapability("productId", 0xa714)); // NSW Spectra Wired Controller
-                InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
-                    new InputDeviceMatcher()
-                        .WithInterface("HID")
-                        .WithCapability("vendorId", 0x20d6) // PowerA
-                        .WithCapability("productId", 0xa715)); // Fusion Wireless Arcade Stick	
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f)     // PDP
+                    .WithCapability("productId", 0x0184));     // Faceoff Premiere Wired Pro Controller for Nintendo Switch
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x0e6f)     // PDP
+                    .WithCapability("productId", 0x0188));     // Afterglow Deluxe+ Audio Wired Controller
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6)     // PowerA
+                    .WithCapability("productId", 0xa714));     // NSW Spectra Wired Controller
+            InputSystem.RegisterLayoutMatcher<SwitchProControllerHID>(
+                new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x20d6)     // PowerA
+                    .WithCapability("productId", 0xa715));     // Fusion Wireless Arcade Stick
             #endif
         #endif
         }


### PR DESCRIPTION
### Description

Adding the fully working 3rd party Nintendo Switch Pro controllers after testing.

### Changes made

Added tested devices to explicitly map to the SwitchProController layout.
Added them to tests too.


### Checklist

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
