### PR TITLE
FIX: Add missing tooltips on PlayerInputManagerEditor

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/XInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XInputTests.cs
@@ -141,6 +141,8 @@ internal class XInputTests : CoreTestsFixture
         AssertButtonPress(gamepad, new XInputControllerOSXState().WithButton(XInputControllerOSXState.Button.Select), gamepad.selectButton);
     }
 
+// Temporary: Disables tests in standalone trunk builds (https://fogbugz.unity3d.com/f/cases/1410131/)
+#if !UNITY_STANDALONE_OSX || !TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
     [Test]
     [Category("Devices")]
     public void Devices_SupportXboxWirelessControllerOnOSX()
@@ -230,6 +232,8 @@ internal class XInputTests : CoreTestsFixture
         Assert.That(gamepad.leftTrigger.IsActuated(), Is.False);
         Assert.That(gamepad.leftTrigger.CheckStateIsAtDefault());
     }
+
+#endif // TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
 
 #endif
 

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -44,6 +44,11 @@
             "name": "Unity",
             "expression": "[2022.1,2022.2)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2022.2.0a1,2022.2.0a10)",
+            "define": "TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST"
         }
     ],
     "noEngineReferences": false

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -52,6 +52,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed no devices being available in `Start` and `Awake` methods if, in the player, any `InputSystem` API was accessed during the `SubsystemRegistration` phase ([case 1392358](https://issuetracker.unity3d.com/issues/inputsystem-does-not-initialize-properly-in-a-build-when-accessed-early)).
 - Fixed dropdown for "Supported Devices" in settings not showing all device layouts.
 - Fixed "STAT event with state format TOUC cannot be used with device 'Touchscreen:/Touchscreen'" when more than max supported amount of fingers, currently 10, are present on the screen at a same time (case 1395648).
+- Fixed missing tooltips in PlayerInputManagerEditor for the Player Limit and Fixed Splitscreen sizes labels ([case 1396945](https://issuetracker.unity3d.com/issues/player-input-manager-pops-up-placeholder-text-when-hovering-over-it)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -32,19 +32,19 @@ namespace UnityEngine.InputSystem.Editor
             InputUser.onChange += OnUserChange;
 
             // Look up properties.
-            m_ActionsProperty = serializedObject.FindProperty("m_Actions");
-            m_DefaultControlSchemeProperty = serializedObject.FindProperty("m_DefaultControlScheme");
-            m_NeverAutoSwitchControlSchemesProperty = serializedObject.FindProperty("m_NeverAutoSwitchControlSchemes");
-            m_DefaultActionMapProperty = serializedObject.FindProperty("m_DefaultActionMap");
-            m_NotificationBehaviorProperty = serializedObject.FindProperty("m_NotificationBehavior");
-            m_CameraProperty = serializedObject.FindProperty("m_Camera");
-            m_ActionEventsProperty = serializedObject.FindProperty("m_ActionEvents");
-            m_DeviceLostEventProperty = serializedObject.FindProperty("m_DeviceLostEvent");
-            m_DeviceRegainedEventProperty = serializedObject.FindProperty("m_DeviceRegainedEvent");
-            m_ControlsChangedEventProperty = serializedObject.FindProperty("m_ControlsChangedEvent");
+            m_ActionsProperty = serializedObject.FindProperty(nameof(PlayerInput.m_Actions));
+            m_DefaultControlSchemeProperty = serializedObject.FindProperty(nameof(PlayerInput.m_DefaultControlScheme));
+            m_NeverAutoSwitchControlSchemesProperty = serializedObject.FindProperty(nameof(PlayerInput.m_NeverAutoSwitchControlSchemes));
+            m_DefaultActionMapProperty = serializedObject.FindProperty(nameof(PlayerInput.m_DefaultActionMap));
+            m_NotificationBehaviorProperty = serializedObject.FindProperty(nameof(PlayerInput.m_NotificationBehavior));
+            m_CameraProperty = serializedObject.FindProperty(nameof(PlayerInput.m_Camera));
+            m_ActionEventsProperty = serializedObject.FindProperty(nameof(PlayerInput.m_ActionEvents));
+            m_DeviceLostEventProperty = serializedObject.FindProperty(nameof(PlayerInput.m_DeviceLostEvent));
+            m_DeviceRegainedEventProperty = serializedObject.FindProperty(nameof(PlayerInput.m_DeviceRegainedEvent));
+            m_ControlsChangedEventProperty = serializedObject.FindProperty(nameof(PlayerInput.m_ControlsChangedEvent));
 
             #if UNITY_INPUT_SYSTEM_ENABLE_UI
-            m_UIInputModuleProperty = serializedObject.FindProperty("m_UIInputModule");
+            m_UIInputModuleProperty = serializedObject.FindProperty(nameof(PlayerInput.m_UIInputModule));
             #endif
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -100,6 +100,15 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         public bool maintainAspectRatioInSplitScreen => m_MaintainAspectRatioInSplitScreen;
 
+        /// <summary>
+        /// If <see cref="splitScreen"/> is enabled, this property determines how many screen divisions there will be.
+        /// </summary>
+        /// <remarks>
+        /// This is only used if <see cref="splitScreen"/> is true.
+        ///
+        /// By default this is set to -1 which means the screen will automatically be divided to best fit the
+        /// current number of players i.e. the highest player index in <see cref="PlayerInput"/>
+        /// </remarks>
         public int fixedNumberOfSplitScreens => m_FixedNumberOfSplitScreens;
 
         /// <summary>
@@ -455,6 +464,7 @@ namespace UnityEngine.InputSystem
         }
 
         [SerializeField] internal PlayerNotifications m_NotificationBehavior;
+        [Tooltip("Set a limit for the maximum number of players who are able to join.")]
         [SerializeField] internal int m_MaxPlayerCount = -1;
         [SerializeField] internal bool m_AllowJoining = true;
         [SerializeField] internal PlayerJoinBehavior m_JoinBehavior;
@@ -464,6 +474,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] internal GameObject m_PlayerPrefab;
         [SerializeField] internal bool m_SplitScreen;
         [SerializeField] internal bool m_MaintainAspectRatioInSplitScreen;
+        [Tooltip("Explicitly set a fixed number of screens or otherwise allow the screen to be divided automatically to best fit the number of players.")]
         [SerializeField] internal int m_FixedNumberOfSplitScreens = -1;
         [SerializeField] internal Rect m_SplitScreenRect = new Rect(0, 0, 1, 1);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
@@ -48,7 +48,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void DoNotificationSectionUI()
         {
-            var notificationBehaviorProperty = serializedObject.FindProperty("m_NotificationBehavior");
+            var notificationBehaviorProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_NotificationBehavior));
             EditorGUILayout.PropertyField(notificationBehaviorProperty);
             switch ((PlayerNotifications)notificationBehaviorProperty.intValue)
             {
@@ -70,8 +70,8 @@ namespace UnityEngine.InputSystem.Editor
                     m_EventsExpanded = EditorGUILayout.Foldout(m_EventsExpanded, m_EventsLabel, toggleOnLabelClick: true);
                     if (m_EventsExpanded)
                     {
-                        var playerJoinedEventProperty = serializedObject.FindProperty("m_PlayerJoinedEvent");
-                        var playerLeftEventProperty = serializedObject.FindProperty("m_PlayerLeftEvent");
+                        var playerJoinedEventProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_PlayerJoinedEvent));
+                        var playerLeftEventProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_PlayerLeftEvent));
 
                         EditorGUILayout.PropertyField(playerJoinedEventProperty);
                         EditorGUILayout.PropertyField(playerLeftEventProperty);
@@ -85,7 +85,7 @@ namespace UnityEngine.InputSystem.Editor
             EditorGUILayout.LabelField(m_JoiningGroupLabel, EditorStyles.boldLabel);
 
             // Join behavior
-            var joinBehaviorProperty = serializedObject.FindProperty("m_JoinBehavior");
+            var joinBehaviorProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_JoinBehavior));
             EditorGUILayout.PropertyField(joinBehaviorProperty);
             if ((PlayerJoinBehavior)joinBehaviorProperty.intValue != PlayerJoinBehavior.JoinPlayersManually)
             {
@@ -95,12 +95,12 @@ namespace UnityEngine.InputSystem.Editor
                 if ((PlayerJoinBehavior)joinBehaviorProperty.intValue ==
                     PlayerJoinBehavior.JoinPlayersWhenJoinActionIsTriggered)
                 {
-                    var joinActionProperty = serializedObject.FindProperty("m_JoinAction");
+                    var joinActionProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_JoinAction));
                     EditorGUILayout.PropertyField(joinActionProperty);
                 }
 
                 // Player prefab.
-                var playerPrefabProperty = serializedObject.FindProperty("m_PlayerPrefab");
+                var playerPrefabProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_PlayerPrefab));
                 EditorGUILayout.PropertyField(playerPrefabProperty);
 
                 ValidatePlayerPrefab(joinBehaviorProperty, playerPrefabProperty);
@@ -109,13 +109,13 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Enabled-by-default.
-            var allowJoiningProperty = serializedObject.FindProperty("m_AllowJoining");
+            var allowJoiningProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_AllowJoining));
             if (m_AllowingJoiningLabel == null)
                 m_AllowingJoiningLabel = new GUIContent("Joining Enabled By Default", allowJoiningProperty.GetTooltip());
             EditorGUILayout.PropertyField(allowJoiningProperty, m_AllowingJoiningLabel);
 
             // Max player count.
-            var maxPlayerCountProperty = serializedObject.FindProperty("m_MaxPlayerCount");
+            var maxPlayerCountProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_MaxPlayerCount));
             if (m_EnableMaxPlayerCountLabel == null)
                 m_EnableMaxPlayerCountLabel = EditorGUIUtility.TrTextContent("Limit Number of Players", maxPlayerCountProperty.GetTooltip());
             if (maxPlayerCountProperty.intValue > 0)
@@ -168,7 +168,7 @@ namespace UnityEngine.InputSystem.Editor
             EditorGUILayout.LabelField(m_SplitScreenGroupLabel, EditorStyles.boldLabel);
 
             // Split-screen toggle.
-            var splitScreenProperty = serializedObject.FindProperty("m_SplitScreen");
+            var splitScreenProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_SplitScreen));
             if (m_SplitScreenLabel == null)
                 m_SplitScreenLabel = new GUIContent("Enable Split-Screen", splitScreenProperty.GetTooltip());
             EditorGUILayout.PropertyField(splitScreenProperty, m_SplitScreenLabel);
@@ -178,14 +178,14 @@ namespace UnityEngine.InputSystem.Editor
             ++EditorGUI.indentLevel;
 
             // Maintain-aspect-ratio toggle.
-            var maintainAspectRatioProperty = serializedObject.FindProperty("m_MaintainAspectRatioInSplitScreen");
+            var maintainAspectRatioProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_MaintainAspectRatioInSplitScreen));
             if (m_MaintainAspectRatioLabel == null)
                 m_MaintainAspectRatioLabel =
                     new GUIContent("Maintain Aspect Ratio", maintainAspectRatioProperty.GetTooltip());
             EditorGUILayout.PropertyField(maintainAspectRatioProperty, m_MaintainAspectRatioLabel);
 
             // Fixed-number toggle.
-            var fixedNumberProperty = serializedObject.FindProperty("m_FixedNumberOfSplitScreens");
+            var fixedNumberProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_FixedNumberOfSplitScreens));
             if (m_EnableFixedNumberOfSplitScreensLabel == null)
                 m_EnableFixedNumberOfSplitScreensLabel = EditorGUIUtility.TrTextContent("Set Fixed Number", fixedNumberProperty.GetTooltip());
             if (fixedNumberProperty.intValue > 0)
@@ -209,7 +209,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Split-screen area.
-            var splitScreenAreaProperty = serializedObject.FindProperty("m_SplitScreenRect");
+            var splitScreenAreaProperty = serializedObject.FindProperty(nameof(PlayerInputManager.m_SplitScreenRect));
             if (m_SplitScreenAreaLabel == null)
                 m_SplitScreenAreaLabel = new GUIContent("Screen Rectangle", splitScreenAreaProperty.GetTooltip());
             EditorGUILayout.PropertyField(splitScreenAreaProperty, m_SplitScreenAreaLabel);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManagerEditor.cs
@@ -116,6 +116,8 @@ namespace UnityEngine.InputSystem.Editor
 
             // Max player count.
             var maxPlayerCountProperty = serializedObject.FindProperty("m_MaxPlayerCount");
+            if (m_EnableMaxPlayerCountLabel == null)
+                m_EnableMaxPlayerCountLabel = EditorGUIUtility.TrTextContent("Limit Number of Players", maxPlayerCountProperty.GetTooltip());
             if (maxPlayerCountProperty.intValue > 0)
                 m_MaxPlayerCountEnabled = true;
             m_MaxPlayerCountEnabled = EditorGUILayout.Toggle(m_EnableMaxPlayerCountLabel, m_MaxPlayerCountEnabled);
@@ -184,6 +186,8 @@ namespace UnityEngine.InputSystem.Editor
 
             // Fixed-number toggle.
             var fixedNumberProperty = serializedObject.FindProperty("m_FixedNumberOfSplitScreens");
+            if (m_EnableFixedNumberOfSplitScreensLabel == null)
+                m_EnableFixedNumberOfSplitScreensLabel = EditorGUIUtility.TrTextContent("Set Fixed Number", fixedNumberProperty.GetTooltip());
             if (fixedNumberProperty.intValue > 0)
                 m_FixedNumberOfSplitScreensEnabled = true;
             m_FixedNumberOfSplitScreensEnabled = EditorGUILayout.Toggle(m_EnableFixedNumberOfSplitScreensLabel,
@@ -252,10 +256,8 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private GUIContent m_MaintainAspectRatioLabel;
         [NonSerialized] private GUIContent m_SplitScreenAreaLabel;
         [NonSerialized] private GUIContent m_FixedNumberOfSplitScreensLabel;
-        [NonSerialized] private readonly GUIContent m_EnableMaxPlayerCountLabel =
-            EditorGUIUtility.TrTextContent("Limit Number of Players", "TODO");
-        [NonSerialized] private readonly GUIContent m_EnableFixedNumberOfSplitScreensLabel =
-            EditorGUIUtility.TrTextContent("Set Fixed Number", "TODO");
+        [NonSerialized] private GUIContent m_EnableMaxPlayerCountLabel;
+        [NonSerialized] private GUIContent m_EnableFixedNumberOfSplitScreensLabel;
     }
 }
 #endif // UNITY_EDITOR


### PR DESCRIPTION
### Description

Replace placeholder tooltip descriptions with real text in the PlayerInputManager Editor

### Changes made

- Added tooltips for m_MaxPlayerCount and m_FixedNumberOfSplitScreens properties
- Added some missing Xmldoc for the fixedNumberOfSplitScreens property 

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
