### PR TITLE
Added a setting to enable Windows.Gaming.Input on relevant platforms

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/UseWindowsGamingInputCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/UseWindowsGamingInputCommand.cs
@@ -1,0 +1,37 @@
+using System.Runtime.InteropServices;
+using UnityEngine.InputSystem.Utilities;
+
+namespace UnityEngine.InputSystem.LowLevel
+{
+    /// <summary>
+    // Command to enable or disable Windows.Gaming.Input native backend.
+    // Send it to deviceId 0 as it's a special "global" IOCTL that gets routed internally.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = kSize)]
+    internal struct UseWindowsGamingInputCommand : IInputDeviceCommandInfo
+    {
+        public static FourCC Type { get { return new FourCC('U', 'W', 'G', 'I'); } }
+
+        internal const int kSize = InputDeviceCommand.kBaseCommandSize + sizeof(byte);
+
+        [FieldOffset(0)]
+        public InputDeviceCommand baseCommand;
+
+        [FieldOffset(InputDeviceCommand.kBaseCommandSize)]
+        public byte enable;
+
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
+
+        public static UseWindowsGamingInputCommand Create(bool enable)
+        {
+            return new UseWindowsGamingInputCommand
+            {
+                baseCommand = new InputDeviceCommand(Type, kSize),
+                enable = (byte)(enable ? 1 : 0)
+            };
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/UseWindowsGamingInputCommand.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/UseWindowsGamingInputCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f03e7044c375b7046b274ba59c850b2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
@@ -4,5 +4,6 @@ namespace UnityEngine.InputSystem
     {
         public const string kRunPlayerUpdatesInEditMode = "RUN_PLAYER_UPDATES_IN_EDIT_MODE";
         public const string kDisableUnityRemoteSupport = "DISABLE_UNITY_REMOTE_SUPPORT";
+        public const string kUseWindowsGamingInputBackend = "USE_WINDOWS_GAMING_INPUT_BACKEND";
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2725,6 +2725,13 @@ namespace UnityEngine.InputSystem
                 #if UNITY_EDITOR
                 runPlayerUpdatesInEditMode = m_Settings.IsFeatureEnabled(InputFeatureNames.kRunPlayerUpdatesInEditMode);
                 #endif
+
+                if (m_Settings.IsFeatureEnabled(InputFeatureNames.kUseWindowsGamingInputBackend))
+                {
+                    var command = UseWindowsGamingInputCommand.Create(true);
+                    if (ExecuteGlobalCommand(ref command) < 0)
+                        Debug.LogError($"Could not enable Windows.Gaming.Input");
+                }
             }
 
             // Cache some values.
@@ -2738,6 +2745,14 @@ namespace UnityEngine.InputSystem
             // Let listeners know.
             DelegateHelpers.InvokeCallbacksSafe(ref m_SettingsChangedListeners,
                 "InputSystem.onSettingsChange");
+        }
+
+        internal unsafe long ExecuteGlobalCommand<TCommand>(ref TCommand command)
+            where TCommand : struct, IInputDeviceCommandInfo
+        {
+            var ptr = (InputDeviceCommand*)UnsafeUtility.AddressOf(ref command);
+            // device id is irrelevant as we route it based on fourcc internally
+            return InputRuntime.s_Instance.DeviceCommand(0, ptr);
         }
 
         internal void AddAvailableDevicesThatAreNowRecognized()


### PR DESCRIPTION
### Description

When native part lands one will be able to enable it via `InputSystem.settings.SetInternalFeatureFlag("USE_WINDOWS_GAMING_INPUT_BACKEND", true);`

### Changes made

Added an internal IOCTL and internal feature flag

### Notes

Pending tests/changelog


