### PR TITLE
Fixing XBox One controller on macOS

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -52,6 +52,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed no devices being available in `Start` and `Awake` methods if, in the player, any `InputSystem` API was accessed during the `SubsystemRegistration` phase ([case 1392358](https://issuetracker.unity3d.com/issues/inputsystem-does-not-initialize-properly-in-a-build-when-accessed-early)).
 - Fixed dropdown for "Supported Devices" in settings not showing all device layouts.
 - Fixed "STAT event with state format TOUC cannot be used with device 'Touchscreen:/Touchscreen'" when more than max supported amount of fingers, currently 10, are present on the screen at a same time (case 1395648).
+- Xbox One reporting invalid controls before first actuation of any control (case TBA).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -206,8 +206,20 @@ namespace UnityEngine.InputSystem.XInput
     /// to work.
     /// </remarks>
     [InputControlLayout(displayName = "Xbox Controller", stateType = typeof(XInputControllerOSXState), hideInUI = true)]
-    public class XboxGamepadMacOS : XInputController
+    public class XboxGamepadMacOS : XInputController, IEventPreProcessor
     {
+        unsafe bool IEventPreProcessor.PreProcessEvent(InputEventPtr eventPtr)
+        {
+            if (eventPtr.type != StateEvent.Type)
+                return true;
+
+            var stateEvent = StateEvent.FromUnchecked(eventPtr);
+            var binaryData = (byte*)stateEvent->state;
+
+            // magic, don't ask
+            // only pass known data packets, ignore the rest
+            return (stateEvent->stateSizeInBytes == 0) || ((stateEvent->stateSizeInBytes > 0) && (binaryData[0] == 0x01 || binaryData[0] == 0x20));
+        }
     }
 
     /// <summary>
@@ -220,8 +232,20 @@ namespace UnityEngine.InputSystem.XInput
     /// Unlike wired controllers, bluetooth-cabable Xbox One controllers do not need a custom driver to work on macOS.
     /// </remarks>
     [InputControlLayout(displayName = "Wireless Xbox Controller", stateType = typeof(XInputControllerWirelessOSXState), hideInUI = true)]
-    public class XboxOneGampadMacOSWireless : XInputController
+    public class XboxOneGampadMacOSWireless : XInputController, IEventPreProcessor
     {
+        unsafe bool IEventPreProcessor.PreProcessEvent(InputEventPtr eventPtr)
+        {
+            if (eventPtr.type != StateEvent.Type)
+                return true;
+
+            var stateEvent = StateEvent.FromUnchecked(eventPtr);
+            var binaryData = (byte*)stateEvent->state;
+
+            // magic, don't ask
+            // only pass known data packets, ignore the rest
+            return (stateEvent->stateSizeInBytes == 0) || ((stateEvent->stateSizeInBytes > 0) && (binaryData[0] == 0x01 || binaryData[0] == 0x20));
+        }
     }
 }
 #endif // UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX


### PR DESCRIPTION
### Description

Xbox gamepad is much more sophisticated than what we currently have in code.

It sends a variety of different reports, one of which is part of a handshake, and it doesn't map to what we currently have in the struct.

### Changes made

A hot fix to ignore all packets but ones that we know contain control reports (0x01 and 0x20).
