### PR TITLE
FIX: the typo in AddAction method summary

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -135,7 +135,7 @@ namespace UnityEngine.InputSystem
         ////TODO: add method to add an existing InputAction to a map
 
         /// <summary>
-        /// Ad a new <see cref="InputAction"/> to the given <paramref name="map"/>.
+        /// Add a new <see cref="InputAction"/> to the given <paramref name="map"/>.
         /// </summary>
         /// <param name="map">Action map to add the action to. The action will be appended to
         /// <see cref="InputActionMap.actions"/> of the map. The map must be disabled (see


### PR DESCRIPTION
### Description

This pull request address a typo in the summary of AddAction method

### Changes made

The "Add" word was misspelled in the summary. 

### Notes

-

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
