### PR TITLE
FIX: Ensure FocusChanged respects IgnoreFocus in all cases

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -54,6 +54,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "STAT event with state format TOUC cannot be used with device 'Touchscreen:/Touchscreen'" when more than max supported amount of fingers, currently 10, are present on the screen at a same time (case 1395648).
 - Fixed missing tooltips in PlayerInputManagerEditor for the Player Limit and Fixed Splitscreen sizes labels ([case 1396945](https://issuetracker.unity3d.com/issues/player-input-manager-pops-up-placeholder-text-when-hovering-over-it)).
 - Fixed DualShock 4 controllers not working in some scenarios by adding support for extended mode HID reports ([case 1281633](https://issuetracker.unity3d.com/issues/input-system-dualshock4-controller-returns-random-input-values-when-connected-via-bluetooth-while-steam-is-running), case 1409867).
+- Fixed `BackgroundBehavior.IgnoreFocus` so that it will always take effect regardless of any other settings ([case 1400456](https://issuetracker.unity3d.com/issues/xr-head-tracking-lost-when-lost-focus-with-action-based-trackedposedriver-on-android)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2814,6 +2814,12 @@ namespace UnityEngine.InputSystem
 
         internal void OnFocusChanged(bool focus)
         {
+            if (m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus)
+            {
+                // NOTE: m_HasFocus is untouched here as we want the OnUpdate() function to continue unaffected by focus changes as well
+                return;
+            }
+
             #if UNITY_EDITOR
             SyncAllDevicesWhenEditorIsActivated();
 
@@ -2840,13 +2846,6 @@ namespace UnityEngine.InputSystem
                 #else
                 m_Runtime.runInBackground;
                 #endif
-
-            var backgroundBehavior = m_Settings.backgroundBehavior;
-            if (backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus && runInBackground)
-            {
-                m_HasFocus = focus;
-                return;
-            }
 
             #if UNITY_EDITOR
             // Set the current update type while we process the focus changes to make sure we


### PR DESCRIPTION
### Description

Ensure OnFocusChanged returns early in all cases when IgnoreFocus is set.
This is to ensure that if runInBackground is somehow set to false but the playerLoop actually continues to run anyway, that we have this escape hatch to completely prevent the state changes. 
In this particular instance the Android backend is reporting that runInBackground is false but then expects the Head Tracking to continue running in the background. Until that is resolved we can use this escape hatch.

### Changes made
Decouple the IgnoreFocus behavior so it's no longer dependant on runInBackground.
I've moved it at the very top of the function so that nothing will be executed if IgnoreFocus is set to true.

### Notes
Please note I do not update m_HasFocus in this case. This is used in many places so maybe there are unintentional side-effects I'm not aware of.
I did this because OnUpdate() will early-out if focus is lost (canFlushBuffer will be true there).


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
