### PR TITLE
FIX: Ensure update always continues when BackgroundBehavior.IgnoreFocus is set

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -54,6 +54,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "STAT event with state format TOUC cannot be used with device 'Touchscreen:/Touchscreen'" when more than max supported amount of fingers, currently 10, are present on the screen at a same time (case 1395648).
 - Fixed missing tooltips in PlayerInputManagerEditor for the Player Limit and Fixed Splitscreen sizes labels ([case 1396945](https://issuetracker.unity3d.com/issues/player-input-manager-pops-up-placeholder-text-when-hovering-over-it)).
 - Fixed DualShock 4 controllers not working in some scenarios by adding support for extended mode HID reports ([case 1281633](https://issuetracker.unity3d.com/issues/input-system-dualshock4-controller-returns-random-input-values-when-connected-via-bluetooth-while-steam-is-running), case 1409867).
+- Fixed `BackgroundBehavior.IgnoreFocus` so that it keeps the input update alive if runInBackground is false ([case 1400456](https://issuetracker.unity3d.com/issues/xr-head-tracking-lost-when-lost-focus-with-action-based-trackedposedriver-on-android)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -54,7 +54,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "STAT event with state format TOUC cannot be used with device 'Touchscreen:/Touchscreen'" when more than max supported amount of fingers, currently 10, are present on the screen at a same time (case 1395648).
 - Fixed missing tooltips in PlayerInputManagerEditor for the Player Limit and Fixed Splitscreen sizes labels ([case 1396945](https://issuetracker.unity3d.com/issues/player-input-manager-pops-up-placeholder-text-when-hovering-over-it)).
 - Fixed DualShock 4 controllers not working in some scenarios by adding support for extended mode HID reports ([case 1281633](https://issuetracker.unity3d.com/issues/input-system-dualshock4-controller-returns-random-input-values-when-connected-via-bluetooth-while-steam-is-running), case 1409867).
-- Fixed `BackgroundBehavior.IgnoreFocus` so that it keeps the input update alive if runInBackground is false ([case 1400456](https://issuetracker.unity3d.com/issues/xr-head-tracking-lost-when-lost-focus-with-action-based-trackedposedriver-on-android)).
+- Fixed `BackgroundBehavior.IgnoreFocus` having no effect when `Application.runInBackground` was false ([case 1400456](https://issuetracker.unity3d.com/issues/xr-head-tracking-lost-when-lost-focus-with-action-based-trackedposedriver-on-android)).
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -256,7 +256,7 @@ namespace UnityEngine.InputSystem
 
         private bool gameHasFocus =>
 #if UNITY_EDITOR
-            m_RunPlayerUpdatesInEditMode || m_HasFocus || gameShouldGetInputRegardlessOfFocus;
+                     m_RunPlayerUpdatesInEditMode || m_HasFocus || gameShouldGetInputRegardlessOfFocus;
 #else
             m_HasFocus || gameShouldGetInputRegardlessOfFocus;
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -256,9 +256,9 @@ namespace UnityEngine.InputSystem
 
         private bool gameHasFocus =>
 #if UNITY_EDITOR
-                     m_RunPlayerUpdatesInEditMode || m_HasFocus;
+            m_RunPlayerUpdatesInEditMode || m_HasFocus || gameShouldGetInputRegardlessOfFocus;
 #else
-            m_HasFocus;
+            m_HasFocus || gameShouldGetInputRegardlessOfFocus;
 #endif
 
         private bool gameShouldGetInputRegardlessOfFocus =>
@@ -1128,7 +1128,7 @@ namespace UnityEngine.InputSystem
             #if UNITY_EDITOR
             isPlaying = m_Runtime.isInPlayMode;
             #endif
-            if (isPlaying && !m_HasFocus
+            if (isPlaying && !gameHasFocus
                 && m_Settings.backgroundBehavior != InputSettings.BackgroundBehavior.IgnoreFocus
                 && m_Runtime.runInBackground
                 && device.QueryEnabledStateFromRuntime()
@@ -2630,6 +2630,8 @@ namespace UnityEngine.InputSystem
             var backgroundBehavior = m_Settings.backgroundBehavior;
             if (backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus && runInBackground)
             {
+                // If runInBackground is true, no device changes should happen, even when focus is gained. So early out.
+                // If runInBackground is false, we still want to sync devices when focus is gained. So we need to continue further.
                 m_HasFocus = focus;
                 return;
             }
@@ -2841,7 +2843,7 @@ namespace UnityEngine.InputSystem
                     (!m_Runtime.runInBackground ||
                         m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.ResetAndDisableAllDevices))
 #else
-                || (!m_HasFocus && !m_Runtime.runInBackground)
+                || (!gameHasFocus && !m_Runtime.runInBackground)
 #endif
             ;
             var canEarlyOut =


### PR DESCRIPTION
### Description

Ensure that that the input update loop continues to run for the case that `runInBackground == false` and `BackgroundBehaviour.IgnoreFocus` is set.

Input processing currently stops because OnUpdate() will early-out if `m_HasFocus == false && runInBackground == false`.  (canFlushBuffer will be true there).
In this particular instance the Android backend is reporting that runInBackground is false but then expects the Head Tracking to continue running in the background. Until that is resolved we can force `BackgroundBehaviour.IgnoreFocus` to allow updates to continue.

### Changes made

- onUpdate (and some other places) shouldn't use m_HasFocus directly but instead query the gameHasFocus property.
- Tests modified to ensure devices sync on focus gained in `runInBackground==false` case, but not the `true` case. (As per Behavior matrix in documentation)

### Notes
- This changes the behavior described in the matrix. Now for IgnoreFocus with `runInBackground==false` it should technically say 'Input is processed normally while the app is not in the foreground'

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
