### PR TITLE
CHANGE: Make 'Both' the default 'Active Input Handling'.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -37,7 +37,9 @@ however, it has to be formatted properly to pass verification tests.
   * If, for example, an action was bound to `<Gamepad>/buttonSouth` and was enabled, adding a second `Gamepad` would lead to the action being temporarily disabled, then updated, and finally re-enabled.
   * This was especially noticeable if the action was currently in progress as it would get cancelled and then subsequently resumed.
   * Now, an in-progress action will get cancelled if the device of its active control is removed. If its active control is not affected, however, the action will keep going regardless of whether controls are added or removed from its `InputAction.controls` list.
-- Added the 'Cursor Lock Behavior' setting to InputSystemUIInputModule to control the origin point of UI raycasts when the cursor is locked. This enables the use of PhysicsRaycaster when the cursor is locked to the center of the screen ([case 1395281](https://issuetracker.unity3d.com/product/unity/issues/guid/1395281/)).
+- Installing the package for the first time will now set `"Active Input Handling"` to `"Both"` rather than `"Input System Package"`.
+  * This means, that by default, both the old and the new input system will run side by side where supported.
+  * This can be manually switched by going to `Edit >> Project Settings >> Player >> Active Input Handling`.
 
 ### Fixed
 
@@ -78,6 +80,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added support for Game Core platforms to XR layouts, devices, and input controls. These classes were previously only enabled on platforms where `ENABLE_VR` is defined.
 - Added a new `DeltaControl` control type that is now used for delta-style controls such as `Mouse.delta` and `Mouse.scroll`.
   * Like `StickControl`, this control has individual `up`, `down`, `left`, and `right` controls (as well as `x` and `y` that it inherits from `Vector2Control`). This means it is now possible to directly bind to individual scroll directions (such as `<Mouse>/scroll/up`).
+- Added the 'Cursor Lock Behavior' setting to InputSystemUIInputModule to control the origin point of UI raycasts when the cursor is locked. This enables the use of PhysicsRaycaster when the cursor is locked to the center of the screen ([case 1395281](https://issuetracker.unity3d.com/product/unity/issues/guid/1395281/)).
 - Added support for using the Unity Remote app with the input system.
   * Requires Unity 2021.2.18 or later.
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/GUIHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/GUIHelpers.cs
@@ -45,7 +45,7 @@ namespace UnityEngine.InputSystem.Editor
             var skinPrefix = EditorGUIUtility.isProSkin ? "d_" : "";
             var scale = Mathf.Clamp((int)EditorGUIUtility.pixelsPerPoint, 0, 4);
             var scalePostFix = scale > 1 ? $"@{scale}x" : "";
-            if (name.IndexOfAny(Path.GetInvalidFileNameChars())>-1) 
+            if (name.IndexOfAny(Path.GetInvalidFileNameChars()) > -1)
                 name = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));
             var path = Path.Combine(kIconPath, skinPrefix + name + scalePostFix + ".png");
             return AssetDatabase.LoadAssetAtPath<Texture2D>(path);

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3254,12 +3254,11 @@ namespace UnityEngine.InputSystem
             {
                 const string dialogText = "This project is using the new input system package but the native platform backends for the new input system are not enabled in the player settings. " +
                     "This means that no input from native devices will come through." +
-                    "\n\nDo you want to enable the backends? Doing so will *RESTART* the editor and will *DISABLE* the old UnityEngine.Input APIs.";
+                    "\n\nDo you want to enable the backends? Doing so will *RESTART* the editor.";
 
                 if (EditorUtility.DisplayDialog("Warning", dialogText, "Yes", "No"))
                 {
                     EditorPlayerSettingHelpers.newSystemBackendsEnabled = true;
-                    EditorPlayerSettingHelpers.oldSystemBackendsEnabled = false;
                     EditorHelpers.RestartEditorAndRecompileScripts();
                 }
             }


### PR DESCRIPTION
### Description

For packages having `com.unity.inputsystem` as a dependency, us cutting off `UnityEngine.Input` when installing the input system package has been a problem. Given that we are moving to a world where the two systems are becoming one anyway, let's remove this barrier.

Also, the majority of users are actually running with a setting of `"Both"` so even more of a reason to just go with that as a default.

### Changes made

`"Active Input Handling"` is now set to `"Both"` on installation instead of `"Input System Package"`.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
