### PR TITLE
FIX: Workaround for System.CodeDom test failures relating to Unity 2022 and .NET Standard

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -3070,7 +3070,15 @@ partial class CoreTests
         if (cr.Errors.HasErrors)
         {
             if (!Encoding.UTF8.GetBytes(cr.Errors[0].ErrorText).SequenceEqual(Encoding.UTF8.GetPreamble()))
-                Assert.Fail($"Compilation failed: {cr.Errors}");
+            {
+                var sb = new StringBuilder("Compilation of generated code failed:\n");
+                for (var i = 0; i < cr.Errors.Count; ++i)
+                {
+                    var error = cr.Errors[i];
+                    sb.Append("\n").Append(error.ErrorText).Append(" in ").Append(error.FileName).Append(':').Append(error.Line);
+                }
+                Assert.Fail(sb.ToString());
+            }
 
             foreach (var tempFile in cr.TempFiles)
             {
@@ -3088,8 +3096,8 @@ partial class CoreTests
         return type;
     }
 
-#endif
-#endif
+#endif // !TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK
+#endif // UNITY_STANDALONE
 
     [Test]
     [Category("Editor")]

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2181,9 +2181,9 @@ partial class CoreTests
         Assert.That(tree["map/action"].children[0].displayName, Is.EqualTo("1D Axis"));
     }
 
-    #if UNITY_STANDALONE // CodeDom API not available in most players. We only build and run this in the editor but we're
-                         // still affected by the current platform.
-#if !TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK // Temporary: Disables tests while net-profile passed from UTR to trunk is overridden to netstandard (missing CodeDom)
+#if UNITY_STANDALONE // CodeDom API not available in most players. We only build and run this in the editor but we're
+    // still affected by the current platform.
+#if !NET_STANDARD_2_0 // Not possible to run when using .NET standard at the moment.
     [Test]
     [Category("Editor")]
     [TestCase("MyControls (2)", "MyNamespace", "", "MyNamespace.MyControls2")]
@@ -2223,9 +2223,8 @@ partial class CoreTests
         Assert.That(set1map.ToJson(), Is.EqualTo(map1.ToJson()));
     }
 
+#endif // !NET_STANDARD_2_0
 #endif
-#endif
-
     // Can take any given registered layout and generate a cross-platform C# struct for it
     // that collects all the control values from both proper and optional controls (based on
     // all derived layouts).
@@ -2881,7 +2880,7 @@ partial class CoreTests
     }
 
 #if UNITY_STANDALONE // CodeDom API not available in most players.
-#if !TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK // Temporary: Disables tests while net-profile passed from UTR to trunk is overridden to netstandard (missing CodeDom)
+#if !NET_STANDARD_2_0 // Not possible to run when using .NET standard at the moment.
     [Test]
     [Category("Editor")]
     [TestCase("Mouse", typeof(Mouse))]
@@ -3061,6 +3060,12 @@ partial class CoreTests
         var cp = new CompilerParameters { CompilerOptions = options };
         cp.ReferencedAssemblies.Add($"{EditorApplication.applicationContentsPath}/Managed/UnityEngine/UnityEngine.CoreModule.dll");
         cp.ReferencedAssemblies.Add("Library/ScriptAssemblies/Unity.InputSystem.dll");
+#if UNITY_2022
+        // Currently there is are cross-references to netstandard, e.g. System.IEquatable<UnityEngine.Vector2>, System.IFormattable
+        // causing compilation failure for 2022 versions. This is a workaround for running these tests.
+        var netstandard = Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51");
+        cp.ReferencedAssemblies.Add(netstandard.Location);
+#endif
         var cr = codeProvider.CompileAssemblyFromSource(cp, code);
 
         var assembly = cr.CompiledAssembly;
@@ -3096,7 +3101,7 @@ partial class CoreTests
         return type;
     }
 
-#endif // !TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK
+#endif // !NET_STANDARD_2_0
 #endif // UNITY_STANDALONE
 
     [Test]

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -3076,12 +3076,9 @@ partial class CoreTests
         {
             if (!Encoding.UTF8.GetBytes(cr.Errors[0].ErrorText).SequenceEqual(Encoding.UTF8.GetPreamble()))
             {
-                var sb = new StringBuilder("Compilation of generated code failed:\n");
+                var sb = new StringBuilder("Compilation of generated code failed:");
                 for (var i = 0; i < cr.Errors.Count; ++i)
-                {
-                    var error = cr.Errors[i];
-                    sb.Append("\n").Append(error.ErrorText).Append(" in ").Append(error.FileName).Append(':').Append(error.Line);
-                }
+                    sb.Append("\n").Append(cr.Errors[i].ErrorText);
                 Assert.Fail(sb.ToString());
             }
 

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -32,11 +32,6 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.2.0a1,2022.2.0a10)",
-            "define": "TEMP_DISABLE_EDITOR_TESTS_ON_TRUNK"
-        },
-        {
-            "name": "Unity",
             "expression": "[2021.2,2021.3)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -59,7 +59,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed missing tooltips in PlayerInputManagerEditor for the Player Limit and Fixed Splitscreen sizes labels ([case 1396945](https://issuetracker.unity3d.com/issues/player-input-manager-pops-up-placeholder-text-when-hovering-over-it)).
 - Fixed DualShock 4 controllers not working in some scenarios by adding support for extended mode HID reports ([case 1281633](https://issuetracker.unity3d.com/issues/input-system-dualshock4-controller-returns-random-input-values-when-connected-via-bluetooth-while-steam-is-running), case 1409867).
 - Fixed `BackgroundBehavior.IgnoreFocus` having no effect when `Application.runInBackground` was false ([case 1400456](https://issuetracker.unity3d.com/issues/xr-head-tracking-lost-when-lost-focus-with-action-based-trackedposedriver-on-android)).
-- Fixed a problem that would result in compilation errors if Input System test project was modified to .NET Standard API profile or test failures if tested against Unity 2022.
 
 #### Actions
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -59,6 +59,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed missing tooltips in PlayerInputManagerEditor for the Player Limit and Fixed Splitscreen sizes labels ([case 1396945](https://issuetracker.unity3d.com/issues/player-input-manager-pops-up-placeholder-text-when-hovering-over-it)).
 - Fixed DualShock 4 controllers not working in some scenarios by adding support for extended mode HID reports ([case 1281633](https://issuetracker.unity3d.com/issues/input-system-dualshock4-controller-returns-random-input-values-when-connected-via-bluetooth-while-steam-is-running), case 1409867).
 - Fixed `BackgroundBehavior.IgnoreFocus` having no effect when `Application.runInBackground` was false ([case 1400456](https://issuetracker.unity3d.com/issues/xr-head-tracking-lost-when-lost-focus-with-action-based-trackedposedriver-on-android)).
+- Fixed a problem that would result in compilation errors if Input System test project was modified to .NET Standard API profile or test failures if tested against Unity 2022.
 
 #### Actions
 


### PR DESCRIPTION
### Description

We have suffered from failing CI on tests using System.CodeDom (https://docs.microsoft.com/en-us/dotnet/api/system.codedom?view=dotnet-plat-ext-6.0) on Unity 2022.x. This was previously suppressed and unresolved after conversations and previous investigations. Looking into this again it turns out that failure is due to cross referenced types from net-standard even when configured for net-framework. This cross-reference is within Unity and will be investigated further separately.

Symptoms was failures like:

```
The type `System.IEquatable`1<UnityEngine.Vector2>' is defined in an assembly that is not referenced. Consider adding a reference to assembly `netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' in C:\Users\unity\AppData\Local\Temp\fnfqb8m3.0.cs:207
The type `System.IFormattable' is defined in an assembly that is not referenced. Consider adding a reference to assembly `netstandard, Version=2.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' in C:\Users\unity\AppData\Local\Temp\fnfqb8m3.0.cs:207
```

which where hidden from logs due to incorrect formatting of codedom compiler error messages.

Another symptom was that switching API profile for the Input project would result in compilation failure due to missing reference on net-standard.

### Changes made

- Fixed string formatting of codedom compiler failures so that all errors are included in the test assertion failure and hence logs.
- Explicitly load netstandard assembly (workaround) for Unity 2022 and add it to list of referenced assemblies from CodeDom compiler. This makes compilation possible.
- Removed previous symbols to disable editor tests on trunk.
- Added preprocessor defines to conditionally include these tests when not using .NET standard (default for our project). This yields successful compilation also when configured for .NET standard but results in less test coverage.

### Notes

Cross-references should be investigated separately and may eliminate the need for this workaround in the future.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
