### PR TITLE
WIP: CI workaround via extended ignore ranges for UIToolkit and IL2CPP mac issue relating to XBox controller

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3419,9 +3419,9 @@ internal class UITests : CoreTestsFixture
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1
 #if TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN)
-         , Ignore = "Currently fails on MacOS, MacOS standalone, MacOS standalone IL2CPP player on Unity version 2022.2 CI"
+        , Ignore = "Currently fails on MacOS, MacOS standalone, MacOS standalone IL2CPP player on Unity version 2022.2 CI"
 #endif
-    )]
+     )]
     [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
 #if TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX)
             // temporarily disable this test case on OSX player for 2021.2. It only intermittently works and I don't know why!

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3419,7 +3419,7 @@ internal class UITests : CoreTestsFixture
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
     [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
-#if (TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN))
+#if TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN)
             // temporarily disable this test case on OSX player for 2021.2. It only intermittently works and I don't know why!
         , Ignore = "Currently fails on OSX IL2CPP player on Unity version 2021.2"
 #endif

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3417,15 +3417,19 @@ internal class UITests : CoreTestsFixture
 #if UNITY_2021_2_OR_NEWER
     [UnityTest]
     [Category("UI")]
-    [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
-    [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
+    [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1
 #if TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN)
+         , Ignore = "Currently fails on MacOS, MacOS standalone, MacOS standalone IL2CPP player on Unity version 2022.2 CI"
+#endif
+    )]
+    [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
+#if TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX)
             // temporarily disable this test case on OSX player for 2021.2. It only intermittently works and I don't know why!
         , Ignore = "Currently fails on OSX IL2CPP player on Unity version 2021.2"
 #endif
      )]
     [TestCase(UIPointerBehavior.SingleUnifiedPointer, ExpectedResult = 1)]
-#if UNITY_ANDROID || UNITY_IOS || UNITY_TVOS
+#if (UNITY_ANDROID || UNITY_IOS || UNITY_TVOS) || (TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN))
     [Ignore("Currently fails on the farm but succeeds locally on Note 10+; needs looking into.")]
 #endif
     [PrebuildSetup(typeof(UI_CanOperateUIToolkitInterface_UsingInputSystemUIInputModule_Setup))]

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3419,10 +3419,10 @@ internal class UITests : CoreTestsFixture
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
     [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
-    #if UNITY_STANDALONE_OSX && TEMP_DISABLE_UITOOLKIT_TEST
+#if (UNITY_STANDALONE_OSX && TEMP_DISABLE_UITOOLKIT_TEST) || (UNITY_WIN && TEMP_DISABLE_UITOOLKIT_TEST) || (UNITY_STANDALONE_WIN && TEMP_DISABLE_UITOOLKIT_TEST)
             // temporarily disable this test case on OSX player for 2021.2. It only intermittently works and I don't know why!
         , Ignore = "Currently fails on OSX IL2CPP player on Unity version 2021.2"
-    #endif
+#endif
      )]
     [TestCase(UIPointerBehavior.SingleUnifiedPointer, ExpectedResult = 1)]
 #if UNITY_ANDROID || UNITY_IOS || UNITY_TVOS

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3419,7 +3419,7 @@ internal class UITests : CoreTestsFixture
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
     [TestCase(UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack, ExpectedResult = 1
-#if (UNITY_STANDALONE_OSX && TEMP_DISABLE_UITOOLKIT_TEST) || (UNITY_WIN && TEMP_DISABLE_UITOOLKIT_TEST) || (UNITY_STANDALONE_WIN && TEMP_DISABLE_UITOOLKIT_TEST)
+#if (TEMP_DISABLE_UITOOLKIT_TEST && (UNITY_STANDALONE_OSX || UNITY_STANDALONE_WIN))
             // temporarily disable this test case on OSX player for 2021.2. It only intermittently works and I don't know why!
         , Ignore = "Currently fails on OSX IL2CPP player on Unity version 2021.2"
 #endif

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -37,12 +37,12 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1,2022.2)",
+            "expression": "[2022.1,2022.3)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {
             "name": "Unity",
-            "expression": "[2022.2.0a1,2022.2.0a10)",
+            "expression": "[2022.2.0a1,2022.2.0a12)",
             "define": "TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST"
         }
     ],

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -37,11 +37,6 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1.0a1,2022.2.0b16)",
-            "define": "TEMP_DISABLE_UITOOLKIT_TEST"
-        },
-        {
-            "name": "Unity",
             "expression": "[2022.2.0a1,2022.2.0b16)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -37,7 +37,7 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1,2022.3)",
+            "expression": "[2022.1.0a,2022.2.0b16)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -37,12 +37,12 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.1.0a,2022.2.0b16)",
+            "expression": "[2022.1.0a1,2022.2.0b16)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {
             "name": "Unity",
-            "expression": "[2022.2.0a,2022.2.0b16)",
+            "expression": "[2022.2.0a1,2022.2.0b16)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -32,12 +32,17 @@
         },
         {
             "name": "Unity",
-            "expression": "[2021.2,2021.3)",
+            "expression": "[2021.1,2021.2)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {
             "name": "Unity",
             "expression": "[2022.1.0a,2022.2.0b16)",
+            "define": "TEMP_DISABLE_UITOOLKIT_TEST"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2022.2.0a,2022.2.0b16)",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {


### PR DESCRIPTION
### Description

Short-term CI workaround via extended ignore ranges for UIToolkit and IL2CPP mac issue relating to XBox controller while filing tickets and investigating further.

### Changes made

Extended existing ranges for ignored tests for trunk.

### Notes

It turns out expressions cannot be used for alpha, betas as intended. E.g.

Actual version 2022.1.0b14.2951

Relates to: https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html#version-define-expressions

Expression results:
[2022.1.0b14]:true
[2022.1.0a,2022.1.0b15): true
[2022.1.0b,2022.1.0b15): true
[2022.1.0,2022.1.0b15): false
[2022.1.0a10,2022.1.0b15): true
[2022.1.0,2022.2): false

Hence current edits.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
