### PR TITLE
Add global events to the InputSystemUIInputModule

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.Events.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.Events.cs
@@ -1,0 +1,96 @@
+#if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
+using System;
+using System.Collections.Generic;
+using UnityEngine.EventSystems;
+
+namespace UnityEngine.InputSystem.UI
+{
+    public abstract partial class InputSystemUIInputModule
+    {
+        /// <summary>
+        /// Calls the methods in its invocation list after the input module collects a list of type <see cref="RaycastResult"/>, but before the results are used.
+        /// Note that not all fields of the event data are still valid or up to date at this point in the UI event processing.
+        /// This event can be used to read, modify, or reorder results.
+        /// After the event, the first result in the list with a non-null GameObject will be used.
+        /// </summary>
+        public event Action<PointerEventData, List<RaycastResult>> onFinalizeRaycastResults;
+
+        /// <summary>
+        /// This occurs when a UI pointer enters an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onPointerEnter;
+
+        /// <summary>
+        /// This occurs when a UI pointer exits an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onPointerExit;
+
+        /// <summary>
+        /// This occurs when a select button down occurs while a UI pointer is hovering an element.
+        /// This event is executed using ExecuteEvents.ExecuteHierarchy when sent to the target element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onPointerDown;
+
+        /// <summary>
+        /// This occurs when a select button up occurs while a UI pointer is hovering an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onPointerUp;
+
+        /// <summary>
+        /// This occurs when a select button click occurs while a UI pointer is hovering an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onPointerClick;
+
+        /// <summary>
+        /// This occurs when a potential drag occurs on an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onInitializePotentialDrag;
+
+        /// <summary>
+        /// This occurs when a drag first occurs on an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onBeginDrag;
+
+        /// <summary>
+        /// This occurs every frame while dragging an element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onDrag;
+
+        /// <summary>
+        /// This occurs on the last frame an element is dragged.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onEndDrag;
+
+        /// <summary>
+        /// This occurs when a dragged element is dropped on a drop handler.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onDrop;
+
+        /// <summary>
+        /// This occurs when an element is scrolled
+        /// This event is executed using ExecuteEvents.ExecuteHierarchy when sent to the target element.
+        /// </summary>
+        public event Action<GameObject, PointerEventData> onScroll;
+
+        /// <summary>
+        /// This occurs on update for the currently selected object.
+        /// </summary>
+        public event Action<GameObject, BaseEventData> onUpdateSelected;
+
+        /// <summary>
+        /// This occurs when the move axis is activated.
+        /// </summary>
+        public event Action<GameObject, AxisEventData> onMove;
+
+        /// <summary>
+        /// This occurs when the submit button is pressed.
+        /// </summary>
+        public event Action<GameObject, BaseEventData> onSubmit;
+
+        /// <summary>
+        /// This occurs when the cancel button is pressed.
+        /// </summary>
+        public event Action<GameObject, BaseEventData> onCancel;
+    }
+}
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.Events.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.Events.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff5ffa6683f79eb45985f588669b4dd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add global events to the `InputSystemUIInputModule` to allow any behavior to subscribe to UI events when not on the UI object itself.

### Goal
Provide existing event functionality to the InputSystemUIInputModule so that the XRUIInputModule can be retired to further our goal of consolidation and reduction of complexity/code-duplication.

### Description
This would allow any subscribers to get events before the EventSystem fires them off to the respective components. This method is currently used in the `XRUIInputModule` to allow non-UI based components to know when events are happening. Some components can modify/update the **eventData** before it gets handed off to the EventSystem. This can also be used for other tools and management scripts to trigger context-specific behaviors external to the UI system without having to apply the behavior to every button/checkbox/etc.

### Changes made
Pulled event definitions from the `XRUIInputModule` over to `InputSystemUIInputModule`.
Wired up events to fire before `ExecuteEvents.Execute()`.

### Notes
This is a conceptual/informational PR and will need unit tests and documentation added to fully support this feature.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
