### PR TITLE
FIX: Bump Package Validation Exceptions version to 1.5.0

### DIFF
--- a/Packages/com.unity.inputsystem/ValidationExceptions.json
+++ b/Packages/com.unity.inputsystem/ValidationExceptions.json
@@ -3,11 +3,11 @@
         {
             "ValidationTest": "API Validation",
             "ExceptionMessage": "Breaking changes require a new major version.",
-            "PackageVersion": "1.4.0"
+            "PackageVersion": "1.5.0"
         },
         {
              "ValidationTest": "API Updater Configuration Validation",
-             "PackageVersion": "1.4.0"
+             "PackageVersion": "1.5.0"
         }
     ],
     "WarningExceptions": []


### PR DESCRIPTION
### Description

Attempt to fix CI validation issues by extending the validation exceptions to new version (1.5.0)

### Changes made

Bump version to 1.5.0 in the ValidationExceptions.json file

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
