### PR TITLE
FIX: Filter out enum value__ special values from API test

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -173,7 +173,7 @@ class APIVerificationTests
     public void API_DoesNotHaveDisallowedPublicFields()
     {
         #if HAVE_DOCTOOLS_INSTALLED
-        var disallowedPublicFields = GetInputSystemPublicFields().Where(field => !field.HasConstant && !(field.IsInitOnly && field.IsStatic) && !IsTypeWhichCanHavePublicFields(field.DeclaringType));
+        var disallowedPublicFields = GetInputSystemPublicFields().Where(field => !field.HasConstant && !(field.IsInitOnly && field.IsStatic) && !IsTypeWhichCanHavePublicFields(field.DeclaringType) && !field.IsSpecialName);
         Assert.That(disallowedPublicFields, Is.Empty);
         #endif
     }


### PR DESCRIPTION
### Description

Latest trunk (2022.2.0a12) mono version seems be introducing the reserved value__ fields for enums to our public interface. We should ignore these in our API tests.

### Changes made

Filter out special fields from our public interface check


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
