### PR TITLE
Fix CI trunk failure

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -2,7 +2,7 @@ editors:
   - version: 2019.4
   - version: 2020.3
   - version: 2021.2
-  - version: trunk
+  - version: 2022.2.0a10
 platforms:
   - name: win
     type: Unity::VM


### PR DESCRIPTION
### Description

Standalone IL2CPP builds are failing on trunk versions later than 2022.2.0a10 because of an IL2CPP change introduced after that version. This commit pins trunk builds to 2022.2.0a10 temporarily until a fix is available.
