### PR TITLE
FIX: Composite touchscreen controls not firing action after enabling (ISXB-98)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -10151,7 +10151,7 @@ partial class CoreTests
         Assert.That(values.Count, Is.EqualTo(prepopulateTouchesBeforeEnablingAction ? 2 : 0)); // started+performed arrive from OnBeforeUpdate
         values.Clear();
 
-        // Now subsequent touches are ignored
+        // Now subsequent touches should not be ignored
         BeginTouch(200, new Vector2(1, 1));
         Assert.That(values.Count, Is.EqualTo(1));
         Assert.That(values[0].InputId, Is.EqualTo(200));

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -53,7 +53,7 @@ partial class CoreTests
 
         // Enable some actions individually to make sure the code that deals
         // with re-resolution of already enabled bindings handles the enabling
-        // of just individual actions out of the whole set correctlyuk.
+        // of just individual actions out of the whole set correctly.
         action1.Enable();
         action2.Enable();
 
@@ -2077,10 +2077,10 @@ partial class CoreTests
                     .AndThen(Performed(action4,
                         value: new StickDeadzoneProcessor().Process(new Vector2(0.123f, 0.234f)) * new Vector2(1, -1),
                         control: gamepad.leftStick, time: startTime + 0.234))
-                    // map3/action5 should have been started.
-                    .AndThen(Started<TapInteraction>(action5, value: 1f, control: gamepad.buttonSouth, time: startTime + 0.345))
                     // map2/action3 should have been started.
                     .AndThen(Started<TapInteraction>(action3, value: 1f, control: gamepad.buttonSouth, time: startTime + 0.345))
+                    // map3/action5 should have been started.
+                    .AndThen(Started<TapInteraction>(action5, value: 1f, control: gamepad.buttonSouth, time: startTime + 0.345))
                     // map3/action4 should have been performed as the stick has been moved
                     // beyond where it had already moved.
                     .AndThen(Performed(action4,
@@ -7463,7 +7463,10 @@ partial class CoreTests
             InputSystem.QueueStateEvent(gamepad, new GamepadState {rightTrigger = 0.456f});
             InputSystem.Update();
 
-            Assert.That(trace, Performed(action, control: gamepad.rightTrigger, value: 0.456f));
+            // Bit of an odd case. leftTrigger and rightTrigger have both changed state here so
+            // in a way, it's up to the system which one to pick. Might be useful if it was deliberately
+            // picking the control with the highest magnitude but not sure it's worth the effort.
+            Assert.That(trace, Performed(action, control: gamepad.leftTrigger, value: 0.456f));
 
             trace.Clear();
 
@@ -8177,7 +8180,7 @@ partial class CoreTests
         InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A, Key.S));
         InputSystem.Update();
 
-        Assert.That(performedControl, Is.EqualTo(keyboard.aKey));
+        Assert.That(performedControl, Is.EqualTo(keyboard.sKey));
 
         LogAssert.NoUnexpectedReceived();
     }

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -10060,7 +10060,6 @@ partial class CoreTests
         public float? Twist;
     }
 
-    // Straight from demo project
     public class PointerInputComposite : InputBindingComposite<PointerInput>
     {
         [InputControl(layout = "Button")]
@@ -10121,7 +10120,7 @@ partial class CoreTests
         var actionMap = new InputActionMap("test");
         var action = actionMap.AddAction("point", InputActionType.Value);
         for (var i = 0; i < 5; ++i)
-            action.AddCompositeBinding("PointerInput") // todo original binding had Touch0 .. Touch4 name set
+            action.AddCompositeBinding("PointerInput")
                 .With("contact", $"<Touchscreen>/touch{i}/press")
                 .With("position", $"<Touchscreen>/touch{i}/position")
                 .With("radius", $"<Touchscreen>/touch{i}/radius")

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -10047,7 +10047,7 @@ partial class CoreTests
             Assert.AreEqual(40.0f, magnitudes[5]);
         }
     }
-    
+
     // Straight from demo project
     public struct PointerInput
     {
@@ -10106,7 +10106,7 @@ partial class CoreTests
             };
         }
     }
-    
+
     // https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-98
     [Test]
     [Category("Actions")]
@@ -10132,14 +10132,14 @@ partial class CoreTests
         action.started += ctx => values.Add(ctx.ReadValue<PointerInput>());
         action.performed += ctx => values.Add(ctx.ReadValue<PointerInput>());
         action.canceled += ctx => values.Add(ctx.ReadValue<PointerInput>());
-        
+
         if (!prepopulateTouchesBeforeEnablingAction) // normally actions are enabled before any control actuations happen
             actionMap.Enable();
 
         // Start 5 touches, so we fill all slots [touch0, touch4] in Touchscreen with some valid touchId
-        for(var i = 0; i < 2; ++i)
+        for (var i = 0; i < 2; ++i)
             BeginTouch(100 + i, new Vector2(100 * (i + 1), 100 * (i + 1)));
-        for(var i = 0; i < 2; ++i)
+        for (var i = 0; i < 2; ++i)
             EndTouch(100 + i, new Vector2(100 * (i + 1), 100 * (i + 1)));
         Assert.That(values.Count, Is.EqualTo(prepopulateTouchesBeforeEnablingAction ? 0 : 3));
         values.Clear();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,13 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Changed
+
+### Fixed
+- Fixed composite touchscreen controls were not firing an action if screen was touched before enabling the action ([case ISXB-98](https://jira.unity3d.com/browse/ISXB-98)).
+
+### Added
+
 ## [1.4.0] - 2022-04-10
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1333,11 +1333,18 @@ namespace UnityEngine.InputSystem
             ProcessTimeout(time, mapIndex, controlIndex, bindingIndex, interactionIndex);
         }
 
-        // We mangle the various indices we use into a single long for association with state change
-        // monitors. While we could look up map and binding indices from control indices, keeping
-        // all the information together avoids having to unnecessarily jump around in memory to grab
-        // the various pieces of data.
-
+        /// <summary>
+        /// Pack the mapIndex, controlIndex and bindingIndex components into a single monitor index value.
+        /// </summary>
+        /// <param name="mapIndex">Will hold the extracted mapIndex value after the function completes.</param>
+        /// <param name="controlIndex">Will hold the extracted controlIndex value after the function completes.</param>
+        /// <param name="bindingIndex">Will hold the extracted bindingIndex value after the function completes.</param>
+        /// <remarks>
+        /// We mangle the various indices we use into a single long for association with state change
+        /// monitors. While we could look up map and binding indices from control indices, keeping
+        /// all the information together avoids having to unnecessarily jump around in memory to grab
+        /// the various pieces of data.
+        /// </remarks>
         private long ToCombinedMapAndControlAndBindingIndex(int mapIndex, int controlIndex, int bindingIndex)
         {
             // We have limits on the numbers of maps, controls, and bindings we allow in any single
@@ -1350,12 +1357,28 @@ namespace UnityEngine.InputSystem
             return result;
         }
 
+        /// <summary>
+        /// Extract the mapIndex, controlIndex and bindingIndex components from the provided bit packed argument (monitor index).
+        /// </summary>
+        /// <param name="mapControlAndBindingIndex">Represents a monitor index, which is a bit packed field containing multiple components.</param>
+        /// <param name="mapIndex">Will hold the extracted mapIndex value after the function completes.</param>
+        /// <param name="controlIndex">Will hold the extracted controlIndex value after the function completes.</param>
+        /// <param name="bindingIndex">Will hold the extracted bindingIndex value after the function completes.</param>
         private void SplitUpMapAndControlAndBindingIndex(long mapControlAndBindingIndex, out int mapIndex,
             out int controlIndex, out int bindingIndex)
         {
             controlIndex = (int)(mapControlAndBindingIndex & 0x00ffffff);
             bindingIndex = (int)((mapControlAndBindingIndex >> 24) & 0xffff);
             mapIndex = (int)((mapControlAndBindingIndex >> 40) & 0xff);
+        }
+
+        /// <summary>
+        /// Extract the 'complexity' component from the provided bit packed argument (monitor index).
+        /// </summary>
+        /// <param name="mapControlAndBindingIndex">Represents a monitor index, which is a bit packed field containing multiple components.</param>
+        static public int GetComplexityFromMonitorIndex(long mapControlAndBindingIndex)
+        {
+            return (int)((mapControlAndBindingIndex >> 48) & 0xff);
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1334,16 +1334,17 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Pack the mapIndex, controlIndex and bindingIndex components into a single monitor index value.
+        /// Bit pack the mapIndex, controlIndex, bindingIndex and complexity components into a single long monitor index value.
         /// </summary>
-        /// <param name="mapIndex">Will hold the extracted mapIndex value after the function completes.</param>
-        /// <param name="controlIndex">Will hold the extracted controlIndex value after the function completes.</param>
-        /// <param name="bindingIndex">Will hold the extracted bindingIndex value after the function completes.</param>
+        /// <param name="mapIndex">The mapIndex value to pack.</param>
+        /// <param name="controlIndex">The controlIndex value to pack.</param>
+        /// <param name="bindingIndex">The bindingIndex value to pack..</param>
         /// <remarks>
         /// We mangle the various indices we use into a single long for association with state change
         /// monitors. While we could look up map and binding indices from control indices, keeping
         /// all the information together avoids having to unnecessarily jump around in memory to grab
         /// the various pieces of data.
+        /// The complexity component is implicitly derived and does not need to be passed as an argument.
         /// </remarks>
         private long ToCombinedMapAndControlAndBindingIndex(int mapIndex, int controlIndex, int bindingIndex)
         {
@@ -1376,7 +1377,7 @@ namespace UnityEngine.InputSystem
         /// Extract the 'complexity' component from the provided bit packed argument (monitor index).
         /// </summary>
         /// <param name="mapControlAndBindingIndex">Represents a monitor index, which is a bit packed field containing multiple components.</param>
-        static public int GetComplexityFromMonitorIndex(long mapControlAndBindingIndex)
+        internal static int GetComplexityFromMonitorIndex(long mapControlAndBindingIndex)
         {
             return (int)((mapControlAndBindingIndex >> 48) & 0xff);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
@@ -261,8 +261,15 @@ namespace UnityEngine.InputSystem
                 // Insertion sort.
                 for (var i = 1; i < signalled.length; ++i)
                 {
-                    for (var j = i; j > 0 && listeners[j - 1].monitorIndex < listeners[j].monitorIndex; --j)
+                    for (var j = i; j > 0; --j)
                     {
+                        // Sort by complexities only to keep the sort stable
+                        // i.e. don't reverse the order of controls which have the same complexity
+                        var firstComplexity = (int)((listeners[j - 1].monitorIndex >> 48) & 0xff);
+                        var secondComplexity = (int)((listeners[j].monitorIndex >> 48) & 0xff);
+                        if (firstComplexity >= secondComplexity)
+                            break;
+
                         listeners.SwapElements(j, j - 1);
                         memoryRegions.SwapElements(j, j - 1);
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
@@ -265,8 +265,8 @@ namespace UnityEngine.InputSystem
                     {
                         // Sort by complexities only to keep the sort stable
                         // i.e. don't reverse the order of controls which have the same complexity
-                        var firstComplexity = (int)((listeners[j - 1].monitorIndex >> 48) & 0xff);
-                        var secondComplexity = (int)((listeners[j].monitorIndex >> 48) & 0xff);
+                        var firstComplexity = InputActionState.GetComplexityFromMonitorIndex(listeners[j - 1].monitorIndex);
+                        var secondComplexity = InputActionState.GetComplexityFromMonitorIndex(listeners[j].monitorIndex);
                         if (firstComplexity >= secondComplexity)
                             break;
 

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -155,7 +155,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <exception cref="ArgumentNullException"><paramref name="control"/> is <c>null</c> -or- <paramref name="monitor"/> is <c>null</c>.</exception>
         /// <exception cref="ArgumentException">The <see cref="InputDevice"/> of <paramref name="control"/> has not been <see cref="InputDevice.added"/>.</exception>
         /// <remarks>
-        /// All monitors on an <see cref="InputDevice"/> are sorted by their <paramref name="monitorIndex"/> (in decreasing order) and invoked
+        /// All monitors on an <see cref="InputDevice"/> are sorted by the complexity specified in their <paramref name="monitorIndex"/> (in decreasing order) and invoked
         /// in that order.
         ///
         /// Every handler gets an opportunity to set <see cref="InputEventPtr.handled"/> to <c>true</c>. When doing so, all remaining pending monitors


### PR DESCRIPTION
### Description

After the first enabling of an action map that is bound to composite touchscreen controls, the action would not fire if the touchscreen was not in the default state at this point. Which would happen if the screen was ever touched prior to enabling the action. (This is because Touchscreens are never in the default state if they were ever used. E.g. the position never returns to default and is essentially always actuated forever).

The issue was due to sorting behaviour introduced in https://github.com/Unity-Technologies/InputSystem/pull/1405
This sorting would reverse the order of the Touchscreen controls which just happened to work before because the Press Control was first in the list (after sorting everything was reversed; device order was Touch 4, Touch3, Touch 2 etc, and controls within are reversed, with Pressed now last).
This fragile behaviour of the Touchscreen controls always being actuated and the order mattering is not addressed in this PR. What this PR does, is restore the previous ordering but still doing the sorting. As sorting by composite complexity is required for the composite PR #1405 to work.  

### Changes made

- Change sorting to be only based on complexity but otherwise be stable sorting (e.g. no reversing of controls)
- Revert unit test changes that were done in PR #1405 which were only due to the ordering change.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
