### PR TITLE
Handling InputActionAsset in InputActionTrace

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -2004,8 +2004,6 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_CanCreateActionAssetWithMultipleActionMaps()
     {
-        var gamepad = InputSystem.AddDevice<Gamepad>();
-
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
 
         var map1 = new InputActionMap("map1");
@@ -2042,6 +2040,8 @@ partial class CoreTests
             // Enable only map1.
             map1.Enable();
 
+            // Creating gamepad after maps are enabled to test trace catching binding resolve. Case ISXB-29.
+            var gamepad = InputSystem.AddDevice<Gamepad>();
             Set(gamepad.leftStick, new Vector2(0.123f, 0.234f), startTime + 0.123);
 
             // map1/action1 should have been started and performed.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `{fileID: 0}` getting appended to `ProjectSettings.asset` file when building a project ([case ISXB-296](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-296)).
 - Fixed `Type of instance in array does not match expected type` assertion when using PlayerInput in combination with Control Schemes and Interactions ([case ISXB-282](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-282)).
 - Fixed an InvalidOperationException when using Hold interaction, and by extension any interaction that changes to performed state after a timeout ([case ISXB-332](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-330)).
+- Fixed `Given object is neither an InputAction nor an InputActionMap` when using `InputActionTrace` on input action from an input action asset ([case ISXB-29](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-29)).
 
 ## [1.4.3] - 2022-09-23
 
@@ -44,7 +45,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [1.4.1] - 2022-05-30
 
 ### Fixed
-- Fixed composite touchscreen controls were not firing an action if screen was touched before enabling the action ([case ISXB-98](https://jira.unity3d.com/browse/ISXB-98)).
+- Fixed composite touchscreen controls were not firing an action if screen was touched before enabling the action ([case ISXB-98](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-98)).
 
 ## [1.4.0] - 2022-04-10
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionTrace.cs
@@ -475,7 +475,7 @@ namespace UnityEngine.InputSystem.Utilities
             else if (actionOrMapOrAsset is InputActionMap actionMap)
                 CloneActionStateBeforeBindingsChange(actionMap);
             else if (actionOrMapOrAsset is InputActionAsset actionAsset)
-                foreach(var actionMapInAsset in actionAsset.actionMaps)
+                foreach (var actionMapInAsset in actionAsset.actionMaps)
                     CloneActionStateBeforeBindingsChange(actionMapInAsset);
             else
                 Debug.Assert(false, "Expected InputAction, InputActionMap or InputActionAsset");


### PR DESCRIPTION
### Description

If  binding resolution triggers (due to adding new device, etc) when `InputActionTrace` is used on `InputAction` from `InputActionAsset`, we fail with debug exception that the provided object in `onActionChange` is unexpected.

Because in this case `onActionChange` is invoked with `InputActionAsset` object and not `InputAction` or `InputActionMap`, which is not handled by `InputActionTrace`.

### Changes made

- Added branch in `InputActionTrace` to handle `InputActionAsset`, and clone all relevant states from the asset.
- Modified the test to trigger the branch.

### Notes

I don't know why we have `m_ActionMapStateClones`, they don't seem to be used? Are they needed because `InputAction` indirectly uses memory from them?
