### PR TITLE
FIX: UI sometimes ignoring the first mouse click event after losing and regaining focus

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3649,6 +3649,7 @@ internal class UITests : CoreTestsFixture
         scene.eventSystem.SendMessage("OnApplicationFocus", true);
 
         yield return null;
+        Assert.That(clicked, Is.False); // No spurious click events during focus changes
 
         // NOTE: We *do* need the pointer up to keep UI state consistent.
 
@@ -3670,6 +3671,25 @@ internal class UITests : CoreTestsFixture
         Assert.That(mouse.position.ReadValue(), Is.EqualTo(mousePosition));
         Assert.That(mouse.leftButton.isPressed, Is.False);
         Assert.That(clicked, Is.EqualTo(canRunInBackground));
+
+        // Ensure that losing and regaining focus doesn't cause the next click to be ignored
+        clicked = false;
+        runtime.PlayerFocusLost();
+        scene.eventSystem.SendMessage("OnApplicationFocus", false);
+        yield return null;
+
+        runtime.PlayerFocusGained();
+        scene.eventSystem.SendMessage("OnApplicationFocus", true);
+        yield return null;
+
+        Assert.That(clicked, Is.False);
+
+        Press(mouse.leftButton);
+        yield return null;
+        Release(mouse.leftButton);
+        yield return null;
+
+        Assert.That(clicked, Is.True);
     }
 
     [UnityTest]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,10 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Fixed
+- Fix UI sometimes ignoring the first mouse click event after losing and regaining focus ([case ISXB-127](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-127).
+
+
 ## [1.4.1] - 2022-05-30
 
 ### Fixed


### PR DESCRIPTION
### Description

We introduced a fix for unwanted click events occurring if Alt-tabbing out and then back in this PR: https://github.com/Unity-Technologies/InputSystem/pull/1324/
That solution was to ignore the first mouse click after returning focus, however this behaviour was happening all the time and causing wanted mouse clicks to be ignored.
This PR attempts to address this by only invoking this behaviour only for the case where a button click is in progress, so we still block the unwanted click on return for that case.

### Changes made

- check if a click was in progress and only perform the ignore click fix then
- added a test which exposes the issue

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
