### PR TITLE
UI controls in MultiplayerEventSystems should not change colour unexpectedly

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -2526,9 +2526,7 @@ internal class UITests : CoreTestsFixture
         Assert.That(players[1].eventSystem.currentSelectedGameObject, Is.SameAs(players[1].leftGameObject));
 
         Assert.That(players[0].leftChildReceiver.events, Is.Empty);
-        Assert.That(players[0].rightChildReceiver.events,
-            EventSequence(
-                OneEvent("type", EventType.Move))); // OnMove will still get called to *attempt* a move.
+        Assert.That(players[0].rightChildReceiver.events, Is.Empty);
 
         players[0].leftChildReceiver.events.Clear();
         players[0].rightChildReceiver.events.Clear();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fix UI sometimes ignoring the first mouse click event after losing and regaining focus ([case ISXB-127](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-127).
+- Fixed issue when using MultiplayerEventSystems where the visual state of UI controls would change due to constant toggling of CanvasGroup.interactable on and off ([case ISXB-112](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-112)).
 
 
 ## [1.4.1] - 2022-05-30

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -1,6 +1,5 @@
 #if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
 using UnityEngine.EventSystems;
-using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.UI
 {
@@ -10,13 +9,13 @@ namespace UnityEngine.InputSystem.UI
     /// </summary>
     /// <remarks>
     /// You can use the <see cref="playerRoot"/> property to specify a part of the hierarchy belonging to the current player.
-    /// Mouse selection will ignore any game objects not within this hierarchy. For gamepad/keyboard selection, you need to make sure that
-    /// the navigation links stay within the player's hierarchy.
+    /// Mouse selection will ignore any game objects not within this hierarchy, and all other navigation, using keyboard or
+    /// gamepad for example, will be constrained to game objects under that hierarchy.
     /// </remarks>
     [HelpURL(InputSystem.kDocUrl + "/manual/UISupport.html#multiplayer-uis")]
     public class MultiplayerEventSystem : EventSystem
     {
-        [Tooltip("If set, only process mouse events for any game objects which are children of this game object.")]
+        [Tooltip("If set, only process mouse and navigation events for any game objects which are children of this game object.")]
         [SerializeField] private GameObject m_PlayerRoot;
 
         /// <summary>
@@ -25,15 +24,6 @@ namespace UnityEngine.InputSystem.UI
         /// <remarks>
         /// This can either be an entire <c>Canvas</c> or just part of the hierarchy of
         /// a specific <c>Canvas</c>.
-        ///
-        /// Note that if the given <c>GameObject</c> has a <c>CanvasGroup</c> component on it, its
-        /// <c>interactable</c> property will be toggled back and forth by <see cref="MultiplayerEventSystem"/>.
-        /// If no such component exists on the <c>GameObject</c>, one will be added automatically.
-        ///
-        /// Only the <c>CanvasGroup</c> corresponding to the <see cref="MultiplayerEventSystem"/> that is currently
-        /// executing its <see cref="Update"/> method (or did so last) will have <c>interactable</c> set to true.
-        /// In other words, only the UI hierarchy corresponding to the player that is currently running a UI
-        /// update (or that did so last) can be interacted with.
         /// </remarks>
         public GameObject playerRoot
         {
@@ -41,70 +31,28 @@ namespace UnityEngine.InputSystem.UI
             set
             {
                 m_PlayerRoot = value;
-                InitializeCanvasGroup();
+                InitializePlayerRoot();
             }
         }
-
-        private CanvasGroup m_CanvasGroup;
-        private bool m_CanvasGroupWasAddedByUs;
-
-        private static int s_MultiplayerEventSystemCount;
-        private static MultiplayerEventSystem[] s_MultiplayerEventSystems;
 
         protected override void OnEnable()
         {
             base.OnEnable();
 
-            ArrayHelpers.AppendWithCapacity(ref s_MultiplayerEventSystems, ref s_MultiplayerEventSystemCount, this);
-
-            InitializeCanvasGroup();
+            InitializePlayerRoot();
         }
 
-        private void InitializeCanvasGroup()
+        private void InitializePlayerRoot()
         {
-            if (m_PlayerRoot != null)
-            {
-                m_CanvasGroup = m_PlayerRoot.GetComponent<CanvasGroup>();
-                if (m_CanvasGroup == null)
-                {
-                    m_CanvasGroup = m_PlayerRoot.AddComponent<CanvasGroup>();
-                    m_CanvasGroupWasAddedByUs = true;
-                }
-                else
-                    m_CanvasGroupWasAddedByUs = false;
-            }
-            else
-            {
-                m_CanvasGroup = null;
-            }
-        }
+            if (m_PlayerRoot == null) return;
 
-        protected override void OnDisable()
-        {
-            var index = s_MultiplayerEventSystems.IndexOfReference(this);
-            if (index != -1)
-                s_MultiplayerEventSystems.EraseAtWithCapacity(ref s_MultiplayerEventSystemCount, index);
-
-            if (m_CanvasGroupWasAddedByUs)
-                Destroy(m_CanvasGroup);
-
-            m_CanvasGroup = default;
-            m_CanvasGroupWasAddedByUs = default;
-
-            base.OnDisable();
+            var inputModule = GetComponent<InputSystemUIInputModule>();
+            if (inputModule != null)
+                inputModule.localMultiPlayerRoot = m_PlayerRoot;
         }
 
         protected override void Update()
         {
-            for (var i = 0; i < s_MultiplayerEventSystemCount; ++i)
-            {
-                var system = s_MultiplayerEventSystems[i];
-                if (system.m_PlayerRoot == null)
-                    continue;
-
-                system.m_CanvasGroup.interactable = system == this;
-            }
-
             var originalCurrent = current;
             current = this; // in order to avoid reimplementing half of the EventSystem class, just temporarily assign this EventSystem to be the globally current one
             try


### PR DESCRIPTION
[Jira](https://jira.unity3d.com/browse/ISXB-112)
[Issue Tracker](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-112)

### Description

This fixes an issue where UI controls would change colour when using MultiplayerEventSystems. The bug was caused by this previous fix (https://github.com/Unity-Technologies/InputSystem/pull/1443) that attempted to keep user navigation from jumping between different player UIs in local multiplayer games, which worked by making sure all UI controls were inside CanvasGroup controls, one for each player UI, and toggling the CanvasGroup interactable property between true and false, depending on what UI was currently updating. Unfortunately toggling the interactable property makes all child UI controls animate between active and disabled states, which changes their colour when transitions have been set.

### Changes made

This fix moves the logic to keep navigation inside a players UI to the InputSystemUIInputModule component, and reverts the previous CanvasGroup related changes to MultiplayerEventSystem. A 'localMultiPlayerRoot' property has been added that can be set when running a local multiplayer game and when executing the Move action, we first speculatively perform the navigation and disallow that move (don't execute the move event) if the target Selectable is outside the player root.

### Notes

With this change, InputSystemUIInputModule takes a reference to UnityEngine.UI, which I think should be ok.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
