### PR TITLE
Build against trunk again

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -25,16 +25,16 @@ platforms:
     netinstall: choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes --Source https://bfartifactory.bf.unity3d.com/artifactory/api/nuget/unity-choco-local
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:latest
     flavor: m1.mac
   - name: mac_standalone
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:latest
     flavor: m1.mac
     runtime: StandaloneOSX
   - name: mac_standalone_il2cpp
     type: Unity::VM::osx
-    image: package-ci/mac:stable
+    image: package-ci/macos-12:latest
     flavor: m1.mac
     runtime: StandaloneOSX
     scripting-backend: Il2Cpp

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -2,7 +2,7 @@ editors:
   - version: 2019.4
   - version: 2020.3
   - version: 2021.2
-  - version: 2022.2.0a10
+  - version: trunk
 platforms:
   - name: win
     type: Unity::VM

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -46,7 +46,7 @@ build_ios_{{ editor.version }}:
   name: Build Tests on {{ editor.version }} on ios
   agent:
     type: Unity::VM::osx
-    image: mobile/macos-10.15-testing:stable
+    image: package-ci/macos-12-mobile:stable
     flavor: b1.large
   commands:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple
@@ -66,7 +66,7 @@ run_ios_{{ editor.version }}:
   name: Run Tests on {{ editor.version }} on ios
   agent:
       type: Unity::mobile::iPhone
-      image: mobile/macos-10.15-testing:stable
+      image: package-ci/macos-12-mobile:stable
       flavor: b1.medium
   skip_checkout: true
   dependencies:
@@ -87,7 +87,7 @@ build_tvos_{{ editor.version }}:
   name: Build Tests on {{ editor.version }} on tvos
   agent:
     type: Unity::VM::osx
-    image: mobile/macos-10.15-testing:stable
+    image: package-ci/macos-12-mobile:stable
     flavor: b1.large
   commands:
     - pip install unity-downloader-cli --index-url https://artifactory.prd.it.unity3d.com/artifactory/api/pypi/pypi/simple

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -3060,7 +3060,7 @@ partial class CoreTests
         var cp = new CompilerParameters { CompilerOptions = options };
         cp.ReferencedAssemblies.Add($"{EditorApplication.applicationContentsPath}/Managed/UnityEngine/UnityEngine.CoreModule.dll");
         cp.ReferencedAssemblies.Add("Library/ScriptAssemblies/Unity.InputSystem.dll");
-#if UNITY_2022
+#if UNITY_2022_1_OR_NEWER
         // Currently there is are cross-references to netstandard, e.g. System.IEquatable<UnityEngine.Vector2>, System.IFormattable
         // causing compilation failure for 2022 versions. This is a workaround for running these tests.
         var netstandard = Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51");

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -37,12 +37,12 @@
         },
         {
             "name": "Unity",
-            "expression": "[2022.2.0a1,2022.2.0b16)",
+            "expression": "2023.1.0a1",
             "define": "TEMP_DISABLE_UITOOLKIT_TEST"
         },
         {
             "name": "Unity",
-            "expression": "[2022.2.0a1,2022.2.0a12)",
+            "expression": "2023.1.0a1",
             "define": "TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST"
         }
     ],


### PR DESCRIPTION
The IL2CPP issues seems to be fixed, so moving back to trunk for builds against latest