### PR TITLE
Fix controller id leaks

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SupportsConnectionsAsEventsCommand.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SupportsConnectionsAsEventsCommand.cs
@@ -1,0 +1,33 @@
+using System.Runtime.InteropServices;
+using UnityEngine.InputSystem.Utilities;
+
+namespace UnityEngine.InputSystem.LowLevel
+{
+    /// <summary>
+    // Check if native code supports sending connections as events.
+    // Send it to deviceId 0 as it's a special "global" IOCTL that gets routed internally.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit, Size = kSize)]
+    internal struct SupportsConnectionsAsEventsCommand : IInputDeviceCommandInfo
+    {
+        public static FourCC Type { get { return new FourCC('C', 'N', 'E', 'V'); } }
+
+        internal const int kSize = InputDeviceCommand.kBaseCommandSize;
+
+        [FieldOffset(0)]
+        public InputDeviceCommand baseCommand;
+
+        public FourCC typeStatic
+        {
+            get { return Type; }
+        }
+
+        public static SupportsConnectionsAsEventsCommand Create()
+        {
+            return new SupportsConnectionsAsEventsCommand
+            {
+                baseCommand = new InputDeviceCommand(Type, kSize),
+            };
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SupportsConnectionsAsEventsCommand.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Commands/SupportsConnectionsAsEventsCommand.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad900433ff7ae6d4b9d682da3e36430b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeviceInsertEvent.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeviceInsertEvent.cs
@@ -1,0 +1,63 @@
+using System.Runtime.InteropServices;
+using UnityEngine.InputSystem.Utilities;
+
+namespace UnityEngine.InputSystem.LowLevel
+{
+    /// <summary>
+    /// Notifies about the insertion of an input device
+    /// (alternative to SendDeviceDiscoveriesToScript() directly sending NotifyDeviceDiscovered)
+    /// </summary>
+    /// <remarks>
+    /// Device that got connected is the one identified by <see cref="InputEvent.deviceId"/>
+    /// of <see cref="baseEvent"/>.
+    /// </remarks>
+    [StructLayout(LayoutKind.Explicit, Size = InputEvent.kBaseEventSize + 4 + 1)]
+    public unsafe struct DeviceInsertEvent : IInputEventTypeInfo
+    {
+        public const int Type = 0x44494E53; // DINS
+
+        /// <summary>
+        /// Common event data.
+        /// </summary>
+        [FieldOffset(0)] public InputEvent baseEvent;
+
+        [FieldOffset(InputEvent.kBaseEventSize + 0)] public int descriptorLength;
+        [FieldOffset(InputEvent.kBaseEventSize + 4)] public fixed byte descriptorText[1]; // Variable-sized.
+
+        public FourCC typeStatic => Type;
+
+        public string descriptor
+        {
+            get
+            {
+                fixed (byte* data = descriptorText)
+                {
+                    return System.Text.Encoding.ASCII.GetString(data, descriptorLength);
+                }
+            }
+        }
+
+        public InputEventPtr ToEventPtr()
+        {
+            fixed (DeviceInsertEvent* ptr = &this)
+            {
+                return new InputEventPtr((InputEvent*)ptr);
+            }
+        }
+
+        public static DeviceInsertEvent Create(int deviceId, string descriptorText, double time)
+        {
+            var inputEvent =
+                new DeviceInsertEvent { baseEvent = new InputEvent(Type, InputEvent.kBaseEventSize + 4 + descriptorText.Length, deviceId, time) };
+            inputEvent.descriptorLength = descriptorText.Length;
+            byte[] srcByteArray = System.Text.Encoding.ASCII.GetBytes(descriptorText);
+            fixed(byte* srcBytes = srcByteArray)
+            {
+                byte* dstBytes = inputEvent.descriptorText;
+                Marshal.Copy(srcByteArray, 0, (System.IntPtr)dstBytes, descriptorText.Length);
+            }
+
+            return inputEvent;
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Events/DeviceInsertEvent.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/DeviceInsertEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3c5d18d765c8cd34e96ac4b563c424cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2989,7 +2989,11 @@ namespace UnityEngine.InputSystem
                         (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
                          InputSystem.s_SystemObject.enterPlayModeTime == 0))
                     {
-                        if (isInsertEvent)
+                        if (currentEventType == DeviceRemoveEvent.Type)
+                        {
+                            // Retain remove events (happens during backend switches)
+                        }
+                        else if(isInsertEvent)
                         {
                             // Retain insert events
                         }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -1836,9 +1836,30 @@ namespace UnityEngine.InputSystem
                 #endif
             }
 
+            m_SupportsConnectionsAsEvents = false;
+            unsafe
+            {
+                // Check if native code supports "connections as events"
+                var command = SupportsConnectionsAsEventsCommand.Create();
+                if (InputRuntimeExtensions.DeviceCommand(runtime, 0, ref command) < 0)
+                    Debug.Log("Native code does not support connections as events, using legacy hooks");
+                else
+                {
+                    m_SupportsConnectionsAsEvents = true;
+                    Debug.Log("Native code supports connections as events");
+                }
+            }
+
             m_Runtime = runtime;
             m_Runtime.onUpdate = OnUpdate;
-            m_Runtime.onDeviceDiscovered = OnNativeDeviceDiscovered;
+            if (m_SupportsConnectionsAsEvents)
+            {
+                // Don't hook onDeviceDiscovered, we'll generate this from an Event
+                // However, we need to set a handler or c++ SendDeviceDiscoveriesToScript() won't clear its queue
+                m_Runtime.onDeviceDiscovered = DummyOnNativeDeviceDiscovered;
+            }
+            else
+                m_Runtime.onDeviceDiscovered = OnNativeDeviceDiscovered;
             m_Runtime.onPlayerFocusChanged = OnFocusChanged;
             m_Runtime.onShouldRunUpdate = ShouldRunUpdate;
             #if UNITY_EDITOR
@@ -1991,6 +2012,9 @@ namespace UnityEngine.InputSystem
         #if UNITY_EDITOR
         internal IInputDiagnostics m_Diagnostics;
         #endif
+
+        private bool m_SupportsConnectionsAsEvents;
+        private InputDevice m_dummyCreatingDevice = new InputDevice(); // Temporary used exclusively during setup of connection events
 
         ////REVIEW: Make it so that device names *always* have a number appended? (i.e. Gamepad1, Gamepad2, etc. instead of Gamepad, Gamepad1, etc)
 
@@ -2204,6 +2228,10 @@ namespace UnityEngine.InputSystem
                 }
                 #endif
             }
+        }
+
+        private void DummyOnNativeDeviceDiscovered(int deviceId, string deviceDescriptor)
+        {
         }
 
         private void OnNativeDeviceDiscovered(int deviceId, string deviceDescriptor)
@@ -2893,6 +2921,7 @@ namespace UnityEngine.InputSystem
             {
                 m_InputEventStream = new InputEventStream(ref eventBuffer, m_Settings.maxQueuedEventsPerUpdate);
                 var totalEventBytesProcessed = 0U;
+                List<int> queuedInsertDeviceIds = new List<int>();
 
                 InputEvent* skipEventMergingFor = null;
 
@@ -2938,6 +2967,12 @@ namespace UnityEngine.InputSystem
                     var currentEventTimeInternal = currentEventReadPtr->internalTime;
                     var currentEventType = currentEventReadPtr->type;
 
+                    bool isInsertEvent = m_SupportsConnectionsAsEvents && (currentEventType == DeviceInsertEvent.Type);
+                    if (isInsertEvent)
+                    {
+                        device = m_dummyCreatingDevice; // Dummy InputDevice to avoid having to add checks around subsequent 'device' derefs
+                    }
+
                     // In the editor, we discard all input events that occur in-between exiting edit mode and having
                     // entered play mode as otherwise we'll spill a bunch of UI events that have occurred while the
                     // UI was sort of neither in this mode nor in that mode. This would usually lead to the game receiving
@@ -2954,8 +2989,15 @@ namespace UnityEngine.InputSystem
                         (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||
                          InputSystem.s_SystemObject.enterPlayModeTime == 0))
                     {
-                        m_InputEventStream.Advance(false);
-                        continue;
+                        if (isInsertEvent)
+                        {
+                            // Retain insert events
+                        }
+                        else
+                        {
+                            m_InputEventStream.Advance(false);
+                            continue;
+                        }
                     }
 #endif
 
@@ -2971,13 +3013,20 @@ namespace UnityEngine.InputSystem
                         device = TryGetDeviceById(currentEventReadPtr->deviceId);
                     if (device == null)
                     {
+                        if (m_SupportsConnectionsAsEvents && queuedInsertDeviceIds.Contains(currentEventReadPtr->deviceId))
+                        {
+                            // If an insert was queued, we need to make sure events referencing it is also queued (not culled)
+                        }
+                        else
+                        {
 #if UNITY_EDITOR
-                        ////TODO: see if this is a device we haven't created and if so, just ignore
-                        m_Diagnostics?.OnCannotFindDeviceForEvent(new InputEventPtr(currentEventReadPtr));
+                            ////TODO: see if this is a device we haven't created and if so, just ignore
+                            m_Diagnostics?.OnCannotFindDeviceForEvent(new InputEventPtr(currentEventReadPtr));
 #endif
 
-                        m_InputEventStream.Advance(false);
-                        continue;
+                            m_InputEventStream.Advance(false);
+                            continue;
+                        }
                     }
 
                     // In the editor, we may need to bump events from editor updates into player updates
@@ -3007,6 +3056,11 @@ namespace UnityEngine.InputSystem
                                 // Let only pointer and keyboard input through.
                                 if (!isPointerOrKeyboard)
                                 {
+                                    if (isInsertEvent)
+                                    {
+                                        queuedInsertDeviceIds.Add(currentEventReadPtr->deviceId);
+                                    }
+
                                     m_InputEventStream.Advance(true);
                                     continue;
                                 }
@@ -3257,6 +3311,17 @@ namespace UnityEngine.InputSystem
 
                             break;
                         }
+
+                        case DeviceInsertEvent.Type:
+                            if (m_SupportsConnectionsAsEvents)
+                            {
+                                var deviceInsertEventPtr = (DeviceInsertEvent*)currentEventReadPtr;
+                                int id = deviceInsertEventPtr->baseEvent.deviceId;
+                                string descriptor = deviceInsertEventPtr->descriptor;
+                                // Directly call what the c++ would have called via m_Runtime.onDeviceDiscovered
+                                OnNativeDeviceDiscovered(id, descriptor);
+                            }
+                            break;
 
                         case DeviceConfigurationEvent.Type:
                             device.NotifyConfigurationChanged();


### PR DESCRIPTION
### Description

Fix id leaks from backend switch&rapid plug/unplug

### Requirements

native changes in 2020.3/input/fix-controller-id-leaks

### Changes made

these are an overview. detail in Notes below
- wgi can generate multiple add/remove gamepad events within one tick.
  'discovered' are always sent before any 'remove' events which can lead to leaks
  in both m_Devices[] and m_DisconnectedDevices[] due to this reordering.
  so: rework 'discovered' callback into an event.
  InputSystem sends native code an ioctl to query if this new mode is available,
  if it is, we adjust our hooks, otherwise we should work as before.
- 'removed' events during edit mode to play mode transition were dropped (leak).
  also caps for xinput and wgi differ, so the device matching fails anyway.
  fix: allow removed events & make directx caps consistent with wgi

### Notes

- leaks are visible in Input Debugger
- preventing code from filtering insert/removed events causes spurious
  events when backend switches. 
  if this is a problem, suggestions for a fix are in the comments of
  https://github.cds.internal.unity3d.com/unity/unity/commit/ebb779c08de5e26bbc89bd11d14c0ad1f5e8dfbf

detail from original changelists:

**1/fix for InputSystem device leaks from WGI connections**

requires https://github.cds.internal.unity3d.com/unity/unity/commit/6c968ed4f3e597fa6b42ed7ef8ab494b8164b8e2

_Symptom_
- Inactive ids leaked into the m_Devices[] and m_DisconnectedDevices[] arrays
- This is fairly reproducible by jiggling physical USB connectors in and out

_Cause_
- Gamepad discoveries aren’t sent as events (with SendInputEventsToScript()), 
  but are sent separately before (with SendDeviceDiscoveriesToScript()), 
  meaning chronological order is not maintained.
- The WGI thread often generates multiple events for a single gamepad between
  the main thread sending these out leading to cases like
  - Add 1, Remove 1, Add 2: interpreted as Add 1, Add 2, Remove 1. ‘Remove 1’ 
    moves the device to m_DisconnectedDevices, but that’s too late for ‘Add 2’ 
    to be able to recycle it, so we leak it to m_DisconnectedDevices
  - Remove 1, Add 2: Interpreted as Add 2 (doesn’t recycle) then Remove 1 
    (also leaks to m_DisconnectedDevices)

_Fix_
- Native code still sends connections using old SendDeviceDiscoveriesToScript()
  but also queue them as events
- InputSystem sends an IOCTL to the native code to see if it supports the event
  mechanism. 
  If so we don't, nothing changes.
  If we do, unhook the previous mechanism and listen for events instead. 
  When we receive the event, we replicate the previous call.
- Also fixes some unterminated strings which cause problems with my USB speaker

**2/ fix for InputSystem device leaks on backend switch**

requires https://github.cds.internal.unity3d.com/unity/unity/commit/ebb779c08de5e26bbc89bd11d14c0ad1f5e8dfbf

_Symptom_
- device ids leaked for any controllers connected when we switch backends

_Cause_
- Code near "There's a chance the solution here will prove inadequate on 
  the long run" filters out these messages as they come between ending 
  edit mode and entering play mode.

_Fix#1_
- Alter this filtering so it ignores "remove" messages in InputManager.
- However, this presents a new issue; when we get the inserts 
  (note: requires previous fix) the capabilities of the pad have changed 
  due to XInput and WGI differences so it isn't able to match the controller 
  and we leak it into m_DisconnectedDevices[]

_Fix #2_
- Alter XInput capabilities to match WGI ones
  (see code: i can't see a way to do the reverse)

_Note_
- The other fix i tried for this was to extend the DeviceRemoveEvent 
  message with an optional bool indicating "a matching controller won't come 
  back, don't add it to m_DisconnectedDevices[]".
  this also works but isn't as clean.
- This does mean we generate Removed/Disconnect/Add/Reconnected messages
  during this transition

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
