### PR TITLE
Fix display names of InputActionMap serialized fields in the inspector

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed issue when using MultiplayerEventSystems where the visual state of UI controls would change due to constant toggling of CanvasGroup.interactable on and off ([case ISXB-112](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-112)).
 - Fixed an issue where the Input Action asset icon would not be visible during asset creation ([case ISXB-6](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-6)).
 - Fixed DualSense low frequency motor speed being always set to min value.
+- Fixed display names of serialized InputActionMap fields in the inspector ([case ISXB-50](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-50)).
 
 ## [1.4.1] - 2022-05-30
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -100,7 +100,8 @@ namespace UnityEngine.InputSystem.Editor
         private static string GetPropertyTitle(SerializedProperty property)
         {
             if (property.GetParentProperty() == null && property.displayName != null &&
-                property.displayName.Length > 0 && property.type == nameof(InputAction))
+                property.displayName.Length > 0 &&
+                (property.type == nameof(InputAction) || property.type == nameof(InputActionMap)))
             {
                 return $"{property.displayName}";
             }


### PR DESCRIPTION
[Jira](https://jira.unity3d.com/browse/ISXB-50)
[Issue Tracker](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-50)

### Description

Display names of serialized InputActionMap fields were showing in the inspector as "Input Action Map" instead of showing the name of the field.

### Changes made

Minor change to property drawer code to make sure the display name is used instead of the default.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
