### PR TITLE
FIX: first player's UI controls stop working after a second player joins (ISXB-125)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where the Input Action asset icon would not be visible during asset creation ([case ISXB-6](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-6)).
 - Fixed DualSense low frequency motor speed being always set to min value.
 - Fixed an issue where `ReadUnprocessedValueFromState` in PoseControl always returning default values.
+- Fix Player 1's UI controls stop working after second player joins ([case ISXB-125](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-125)))
+
 
 ## [1.4.1] - 2022-05-30
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1100,6 +1100,7 @@ namespace UnityEngine.InputSystem
             {
                 instance = Object.Instantiate(prefab);
 
+                #if UNITY_INPUT_SYSTEM_ENABLE_UI
                 // When cloning the UIInputModule it will also copy the references to actions in the
                 // prefab UIInputModule, which we don't want. Each player needs their own individual actions
                 // otherwise they can modify other player's actions (e.g. when enabling/disabling).
@@ -1108,6 +1109,7 @@ namespace UnityEngine.InputSystem
                 var clonedPlayerInput = instance.GetComponentInChildren<PlayerInput>();
                 if (clonedPlayerInput && clonedPlayerInput.uiInputModule != null)
                     clonedPlayerInput.uiInputModule.CloneActions();
+                #endif
 
                 instance.SetActive(true);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1099,6 +1099,24 @@ namespace UnityEngine.InputSystem
             try
             {
                 instance = Object.Instantiate(prefab);
+
+                // When cloning the UIInputModule it will also copy the references to actions in the
+                // prefab UIInputModule, which we don't want. Each player needs their own individual actions
+                // otherwise they can modify other player's actions (e.g. when enabling/disabling).
+                // Using the property setters to replace the actions with new ones would invoke unwanted
+                // side effects on the existing ones, therefore we just create a fresh new UIModule here.
+                var clonedPlayerInput = instance.GetComponentInChildren<PlayerInput>();
+                if (clonedPlayerInput && clonedPlayerInput.m_UIInputModule != null)
+                {
+                    var existingUIModule = instance.GetComponentInChildren<InputSystemUIInputModule>();
+                    if (existingUIModule != null && existingUIModule == clonedPlayerInput.m_UIInputModule)
+                        DestroyImmediate(existingUIModule);
+
+                    var clonedUIModule = instance.AddComponent<InputSystemUIInputModule>();
+                    clonedUIModule.AssignDefaultActions();
+                    clonedPlayerInput.m_UIInputModule = clonedUIModule;
+                }
+
                 instance.SetActive(true);
             }
             finally

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1104,18 +1104,10 @@ namespace UnityEngine.InputSystem
                 // prefab UIInputModule, which we don't want. Each player needs their own individual actions
                 // otherwise they can modify other player's actions (e.g. when enabling/disabling).
                 // Using the property setters to replace the actions with new ones would invoke unwanted
-                // side effects on the existing ones, therefore we just create a fresh new UIModule here.
+                // side effects on the existing ones.
                 var clonedPlayerInput = instance.GetComponentInChildren<PlayerInput>();
-                if (clonedPlayerInput && clonedPlayerInput.m_UIInputModule != null)
-                {
-                    var existingUIModule = instance.GetComponentInChildren<InputSystemUIInputModule>();
-                    if (existingUIModule != null && existingUIModule == clonedPlayerInput.m_UIInputModule)
-                        DestroyImmediate(existingUIModule);
-
-                    var clonedUIModule = instance.AddComponent<InputSystemUIInputModule>();
-                    clonedUIModule.AssignDefaultActions();
-                    clonedPlayerInput.m_UIInputModule = clonedUIModule;
-                }
+                if (clonedPlayerInput && clonedPlayerInput.uiInputModule != null)
+                    clonedPlayerInput.uiInputModule.CloneActions();
 
                 instance.SetActive(true);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1196,7 +1196,6 @@ namespace UnityEngine.InputSystem
             if (m_Actions == null)
                 return;
 
-            ////REVIEW: should we *always* Instantiate()?
             // Check if we need to duplicate our actions by looking at all other players. If any
             // has the same actions, duplicate.
             for (var i = 0; i < s_AllActivePlayersCount; ++i)
@@ -1215,24 +1214,7 @@ namespace UnityEngine.InputSystem
 
             #if UNITY_INPUT_SYSTEM_ENABLE_UI
             if (uiInputModule != null)
-            {
-                // Check that no other player is sharing the uiInputModule actions, *before* we do the assignment.
-                // Using the actionAsset setter will cause side effects on the other players if it is shared
-                // I.e. will cause their actions to become disabled and remove their state monitors.
-                if (uiInputModule.actionsAsset != null)
-                {
-                    for (var i = 0; i < s_AllActivePlayersCount; ++i)
-                    {
-                        if (s_AllActivePlayers[i].uiInputModule.actionsAsset == uiInputModule.actionsAsset && s_AllActivePlayers[i] != this)
-                        {
-                            uiInputModule.CloneActions(); // Create new, independent action state that doesn't reference other players actions
-                            break;
-                        }
-                    }
-                }
-
                 uiInputModule.actionsAsset = m_Actions;
-            }
             #endif
 
             switch (m_NotificationBehavior)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1508,16 +1508,16 @@ namespace UnityEngine.InputSystem.UI
 
         private void DisableAllActions()
         {
-            DisableInputAction(m_PointAction);
-            DisableInputAction(m_LeftClickAction);
-            DisableInputAction(m_RightClickAction);
-            DisableInputAction(m_MiddleClickAction);
-            DisableInputAction(m_MoveAction);
-            DisableInputAction(m_SubmitAction);
-            DisableInputAction(m_CancelAction);
-            DisableInputAction(m_ScrollWheelAction);
-            DisableInputAction(m_TrackedDeviceOrientationAction);
-            DisableInputAction(m_TrackedDevicePositionAction);
+            DisableInputAction(m_PointAction, true);
+            DisableInputAction(m_LeftClickAction, true);
+            DisableInputAction(m_RightClickAction, true);
+            DisableInputAction(m_MiddleClickAction, true);
+            DisableInputAction(m_MoveAction, true);
+            DisableInputAction(m_SubmitAction, true);
+            DisableInputAction(m_CancelAction, true);
+            DisableInputAction(m_ScrollWheelAction, true);
+            DisableInputAction(m_TrackedDeviceOrientationAction, true);
+            DisableInputAction(m_TrackedDevicePositionAction, true);
         }
 
         private void EnableInputAction(InputActionReference inputActionReference)
@@ -1539,26 +1539,21 @@ namespace UnityEngine.InputSystem.UI
                 s_InputActionReferenceCounts.Add(action, referenceState);
             }
 
-            // This instance took part in incrementing the refCount
-            m_InputActionEnabledByThis[action] = true;
-
             action.Enable();
         }
 
-        private void DisableInputAction(InputActionReference inputActionReference)
+        private void DisableInputAction(InputActionReference inputActionReference, bool onDisableComponent = false)
         {
             var action = inputActionReference?.action;
             if (action == null)
                 return;
 
-            // If this instance was not responsible for enabling/incrementing refCount, then it should
-            // not be responsible for decrementing the refCount either.
-            if (!m_InputActionEnabledByThis.TryGetValue(action, out bool enableByThis))
+            // Don't decrement refCount when we were not responsible for incrementing it.
+            // I.e. when we were not enabled yet. When OnDisabled is called, isActiveAndEnabled will
+            // already have been set to false. In that case we pass onDisableComponent to check if we
+            // came from OnDisabled and therefore need to allow disabling.
+            if (!isActiveAndEnabled && !onDisableComponent)
                 return;
-            if (enableByThis == false)
-                return;
-
-            m_InputActionEnabledByThis[action] = false;
 
             if (!s_InputActionReferenceCounts.TryGetValue(action, out var referenceState))
                 return;
@@ -2289,7 +2284,7 @@ namespace UnityEngine.InputSystem.UI
         [SerializeField, HideInInspector] internal CursorLockBehavior m_CursorLockBehavior = CursorLockBehavior.OutsideScreen;
 
         private static Dictionary<InputAction, InputActionReferenceState> s_InputActionReferenceCounts = new Dictionary<InputAction, InputActionReferenceState>();
-        private Dictionary<InputAction, bool> m_InputActionEnabledByThis = new Dictionary<InputAction, bool>();
+
         private struct InputActionReferenceState
         {
             public int refCount;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -2218,10 +2218,6 @@ namespace UnityEngine.InputSystem.UI
             if (oldAction == null)
                 return null;
 
-            var oldActionEnabled = oldAction.enabled;
-            if (oldActionEnabled)
-                DisableInputAction(actionReference);
-
             var oldActionMap = oldAction.actionMap;
             Debug.Assert(oldActionMap != null, "Not expected to end up with a singleton action here");
 
@@ -2233,11 +2229,7 @@ namespace UnityEngine.InputSystem.UI
             if (newAction == null)
                 return null;
 
-            var reference = InputActionReference.Create(newAction);
-            if (oldActionEnabled)
-                EnableInputAction(reference);
-
-            return reference;
+            return InputActionReference.Create(newAction);
         }
 
         public InputActionAsset actionsAsset

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -857,7 +857,7 @@ namespace UnityEngine.InputSystem.UI
             var oldActionNull = property?.action == null;
             var oldActionEnabled = property?.action != null && property.action.enabled;
 
-            DisableInputAction(property);
+            TryDisableInputAction(property);
             property = newValue;
 
             #if DEBUG
@@ -1508,16 +1508,16 @@ namespace UnityEngine.InputSystem.UI
 
         private void DisableAllActions()
         {
-            DisableInputAction(m_PointAction, true);
-            DisableInputAction(m_LeftClickAction, true);
-            DisableInputAction(m_RightClickAction, true);
-            DisableInputAction(m_MiddleClickAction, true);
-            DisableInputAction(m_MoveAction, true);
-            DisableInputAction(m_SubmitAction, true);
-            DisableInputAction(m_CancelAction, true);
-            DisableInputAction(m_ScrollWheelAction, true);
-            DisableInputAction(m_TrackedDeviceOrientationAction, true);
-            DisableInputAction(m_TrackedDevicePositionAction, true);
+            TryDisableInputAction(m_PointAction, true);
+            TryDisableInputAction(m_LeftClickAction, true);
+            TryDisableInputAction(m_RightClickAction, true);
+            TryDisableInputAction(m_MiddleClickAction, true);
+            TryDisableInputAction(m_MoveAction, true);
+            TryDisableInputAction(m_SubmitAction, true);
+            TryDisableInputAction(m_CancelAction, true);
+            TryDisableInputAction(m_ScrollWheelAction, true);
+            TryDisableInputAction(m_TrackedDeviceOrientationAction, true);
+            TryDisableInputAction(m_TrackedDevicePositionAction, true);
         }
 
         private void EnableInputAction(InputActionReference inputActionReference)
@@ -1542,7 +1542,7 @@ namespace UnityEngine.InputSystem.UI
             action.Enable();
         }
 
-        private void DisableInputAction(InputActionReference inputActionReference, bool onDisableComponent = false)
+        private void TryDisableInputAction(InputActionReference inputActionReference, bool isComponentDisabling = false)
         {
             var action = inputActionReference?.action;
             if (action == null)
@@ -1550,9 +1550,9 @@ namespace UnityEngine.InputSystem.UI
 
             // Don't decrement refCount when we were not responsible for incrementing it.
             // I.e. when we were not enabled yet. When OnDisabled is called, isActiveAndEnabled will
-            // already have been set to false. In that case we pass onDisableComponent to check if we
+            // already have been set to false. In that case we pass isComponentDisabling to check if we
             // came from OnDisabled and therefore need to allow disabling.
-            if (!isActiveAndEnabled && !onDisableComponent)
+            if (!isActiveAndEnabled && !isComponentDisabling)
                 return;
 
             if (!s_InputActionReferenceCounts.TryGetValue(action, out var referenceState))


### PR DESCRIPTION
### Description

For multiplayer games where 2 or more players are being spawned from PlayerInputManager and each had their own UIInputModule, the players who joined later would disable the UIInputModule actions of the existing players.
This turned out to be just because 1) internally UIInputModule holds references to the actions which are then cloned and shared amongst the other players 2) setting new actions on UIInputModule causes the existing (shared) actions to be unhooked and disabled.

### Changes made

- Prevent a case when a UIInputModule is cloned in a disabled state would still attempt to disable (shared) actions when assigning a new actions asset. 
- Prevent double disabling/enabling occurring when assigning action assets (When SwapAction and UpdateReferenceForNewAction are combined in property assignment).


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
