### PR TITLE
[XR] Change ReadValues and WriteValues for PoseControl to read/write every values separately

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed issue when using MultiplayerEventSystems where the visual state of UI controls would change due to constant toggling of CanvasGroup.interactable on and off ([case ISXB-112](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-112)).
 - Fixed an issue where the Input Action asset icon would not be visible during asset creation ([case ISXB-6](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-6)).
 - Fixed DualSense low frequency motor speed being always set to min value.
+- Fixed an issue where `ReadUnprocessedValueFromState` in PoseControl always returning default values.
 
 ## [1.4.1] - 2022-05-30
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
@@ -209,15 +209,26 @@ namespace UnityEngine.InputSystem.XR
         /// <inheritdoc />
         public override unsafe PoseState ReadUnprocessedValueFromState(void* statePtr)
         {
-            var valuePtr = (PoseState*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
-            return *valuePtr;
+            return new PoseState()
+            {
+                isTracked = isTracked.ReadUnprocessedValueFromState(statePtr) > 0.5f,
+                trackingState = (TrackingState)trackingState.ReadUnprocessedValueFromState(statePtr),
+                position = position.ReadUnprocessedValueFromState(statePtr),
+                rotation = rotation.ReadUnprocessedValueFromState(statePtr),
+                velocity = velocity.ReadUnprocessedValueFromState(statePtr),
+                angularVelocity = angularVelocity.ReadUnprocessedValueFromState(statePtr),
+            };
         }
 
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(PoseState value, void* statePtr)
         {
-            var valuePtr = (PoseState*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
-            UnsafeUtility.MemCpy(valuePtr, UnsafeUtility.AddressOf(ref value), UnsafeUtility.SizeOf<PoseState>());
+            isTracked.WriteValueIntoState(value.isTracked, statePtr);
+            trackingState.WriteValueIntoState((uint)value.trackingState, statePtr);
+            position.WriteValueIntoState(value.position, statePtr);
+            rotation.WriteValueIntoState(value.rotation, statePtr);
+            velocity.WriteValueIntoState(value.velocity, statePtr);
+            angularVelocity.WriteValueIntoState(value.angularVelocity, statePtr);
         }
     }
 }


### PR DESCRIPTION
### Description
From the discussion on Slack devs-input channel, create this PR to solve PoseState read data issue (https://unity.slack.com/archives/C09Q7LYP9/p1656354803035949?thread_ts=1655252231.528869&cid=C09Q7LYP9):

In our OpenXR package, we defined our own Pose and PoseControl class (https://github.cds.internal.unity3d.com/unity/xr.sdk.openxr/blob/master/com.unity.xr.openxr/Runtime/input/PoseControl.cs#L48), which is duplicated as the ones in Input System package (https://github.com/Unity-Technologies/InputSystem/blob/develop/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs#L126)

We tried to deprecated those in OpenXR package and used the ones in input system instead (**OpenXR PR for reference**: https://github.cds.internal.unity3d.com/unity/xr.sdk.openxr/pull/723). However, we hit an issue when reading the poseState values back from `ReadUnprocessedValueFromState()`, all the values are default values. 

### Changes made
Modify `ReadUnprocessedValueFromState()` and `WriteValueIntoState()` to ready/write each Pose value separately, so it doesn't rely on a specific binary layout and can support any memory layout. Same implementation as OpenXR package: https://github.cds.internal.unity3d.com/unity/xr.sdk.openxr/blob/master/com.unity.xr.openxr/Runtime/input/PoseControl.cs#L120


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
