### PR TITLE
[XR] Proposal to hide legacy XR HMD/controllers layout in Editor UI dropdowns

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,8 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased]
 
 ### Changed
-- Readded OnDisable() member to MultiplayerEventSystem which was previously removed from the API
+- Readded OnDisable() member to MultiplayerEventSystem which was previously removed from the API.
+- Hide XR legacy HMD and controllers layouts from Editor UI dropdown.
 
 ### Fixed
 - Fix UI sometimes ignoring the first mouse click event after losing and regaining focus ([case ISXB-127](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-127).

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/GoogleVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/GoogleVR.cs
@@ -10,7 +10,7 @@ namespace Unity.XR.GoogleVr
     /// <summary>
     /// A head-mounted display powered by Google Daydream.
     /// </summary>
-    [InputControlLayout(displayName = "Daydream Headset")]
+    [InputControlLayout(displayName = "Daydream Headset", hideInUI = true)]
     public class DaydreamHMD : XRHMD
     {
     }
@@ -18,7 +18,7 @@ namespace Unity.XR.GoogleVr
     /// <summary>
     /// An XR controller powered by Google Daydream.
     /// </summary>
-    [InputControlLayout(displayName = "Daydream Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Daydream Controller", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class DaydreamController : XRController
     {
         [InputControl]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/Oculus.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/Oculus.cs
@@ -11,7 +11,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// An Oculus VR headset (such as the Oculus Rift series of devices).
     /// </summary>
-    [InputControlLayout(displayName = "Oculus Headset")]
+    [InputControlLayout(displayName = "Oculus Headset", hideInUI = true)]
     public class OculusHMD : XRHMD
     {
         [InputControl]
@@ -67,7 +67,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// An Oculus Touch controller.
     /// </summary>
-    [InputControlLayout(displayName = "Oculus Touch Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Oculus Touch Controller", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class OculusTouchController : XRControllerWithRumble
     {
         [InputControl(aliases = new[] { "Primary2DAxis", "Joystick" })]
@@ -156,7 +156,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// An Oculus Remote controller.
     /// </summary>
-    [InputControlLayout(displayName = "Oculus Remote")]
+    [InputControlLayout(displayName = "Oculus Remote", hideInUI = true)]
     public class OculusRemote : InputDevice
     {
         [InputControl]
@@ -179,7 +179,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// A Standalone VR headset that includes on-headset controls.
     /// </summary>
-    [InputControlLayout(displayName = "Oculus Headset (w/ on-headset controls)")]
+    [InputControlLayout(displayName = "Oculus Headset (w/ on-headset controls)", hideInUI = true)]
     public class OculusHMDExtended : OculusHMD
     {
         [InputControl]
@@ -199,7 +199,7 @@ namespace Unity.XR.Oculus.Input
     /// <summary>
     /// A Gear VR controller.
     /// </summary>
-    [InputControlLayout(displayName = "GearVR Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "GearVR Controller", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class GearVRTrackedController : XRController
     {
         [InputControl]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
@@ -8,7 +8,7 @@ using UnityEngine.InputSystem.XR;
 
 namespace Unity.XR.OpenVR
 {
-    [InputControlLayout(displayName = "OpenVR Headset")]
+    [InputControlLayout(displayName = "OpenVR Headset", hideInUI = true)]
     public class OpenVRHMD : XRHMD
     {
         [InputControl(noisy = true)]
@@ -43,7 +43,7 @@ namespace Unity.XR.OpenVR
         }
     }
 
-    [InputControlLayout(displayName = "Windows MR Controller (OpenVR)", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Windows MR Controller (OpenVR)", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class OpenVRControllerWMR : XRController
     {
         [InputControl(noisy = true)]
@@ -96,7 +96,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An HTC Vive Wand controller.
     /// </summary>
-    [InputControlLayout(displayName = "Vive Wand", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Vive Wand", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class ViveWand : XRControllerWithRumble
     {
         [InputControl]
@@ -142,7 +142,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An HTC Vive lighthouse.
     /// </summary>
-    [InputControlLayout(displayName = "Vive Lighthouse")]
+    [InputControlLayout(displayName = "Vive Lighthouse", hideInUI = true)]
     public class ViveLighthouse : TrackedDevice
     {
     }
@@ -167,7 +167,7 @@ namespace Unity.XR.OpenVR
         }
     }
 
-    [InputControlLayout(displayName = "Handed Vive Tracker", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Handed Vive Tracker", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class HandedViveTracker : ViveTracker
     {
         [InputControl]
@@ -196,7 +196,7 @@ namespace Unity.XR.OpenVR
     /// <summary>
     /// An Oculus Touch controller.
     /// </summary>
-    [InputControlLayout(displayName = "Oculus Touch Controller (OpenVR)", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Oculus Touch Controller (OpenVR)", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class OpenVROculusTouchController : XRControllerWithRumble
     {
         [InputControl]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/WindowsMR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/WindowsMR.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.XR.WindowsMR.Input
     /// <summary>
     /// A Windows Mixed Reality XR headset.
     /// </summary>
-    [InputControlLayout(displayName = "Windows MR Headset")]
+    [InputControlLayout(displayName = "Windows MR Headset", hideInUI = true)]
     public class WMRHMD : XRHMD
     {
         [InputControl]
@@ -29,7 +29,7 @@ namespace UnityEngine.XR.WindowsMR.Input
     /// <summary>
     /// A Windows Mixed Reality XR controller.
     /// </summary>
-    [InputControlLayout(displayName = "HoloLens Hand", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "HoloLens Hand", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class HololensHand : XRController
     {
         [InputControl(noisy = true, aliases = new[] { "gripVelocity" })]
@@ -52,7 +52,7 @@ namespace UnityEngine.XR.WindowsMR.Input
         }
     }
 
-    [InputControlLayout(displayName = "Windows MR Controller", commonUsages = new[] { "LeftHand", "RightHand" })]
+    [InputControlLayout(displayName = "Windows MR Controller", commonUsages = new[] { "LeftHand", "RightHand" }, hideInUI = true)]
     public class WMRSpatialController : XRControllerWithRumble
     {
         [InputControl(aliases = new[] { "Primary2DAxis", "thumbstickaxes" })]


### PR DESCRIPTION
### Description
Slack thread: https://unity.slack.com/archives/C09Q7LYP9/p1658192082808959
When users are using Editor UI dropdowns to set up input bindings for XR controllers, a default list of legacy XR HMD/controllers always appear like below. This default legacy list kinda make it harder/confusing for users to choose the correct ones from XR SDKs and we received couple requests to remove them or hide them.

![image](https://user-images.githubusercontent.com/67297280/180854123-4a4e0f98-8c70-407d-bc44-5faed297628a.png)


### Changes made
Added` HideInUI ` attribute for legacy XR controller layout within path: InputSystem/Plugins/XR/Devices/*.cs, so they don't appear in the Editor dropdown list.

### Notes


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
