### PR TITLE
FIX: Performance Improvements

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fix for mitigating symptoms reported in ([case UUM-10774](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-10774) effectively avoiding reenabling mouse, pen or touch devices in `InputSystemPlugin.OnDestroy()` if currently quitting the editor. The fix avoids editor crashing if closed when Simulator Window is open. Note that the actual issue needs a separate fix in Unity and this package fix is only to avoid running into the issue.
 - Fixed an issue where Input Action name would not display correctly in Inspector if serialized as `[SerializedProperty]` within a class not derived from `MonoBehavior` ([case ISXB-124](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-124).
 - Fix an issue where users could end up with the wrong device assignments when using the InputUser API directly and removing a user ([case ISXB-274](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-231)).
+- Improved performance of editor and runtime behavior
 
 ## [1.4.2] - 2022-08-12
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1550,10 +1550,7 @@ namespace UnityEngine.InputSystem
             // must be in list.
             var map = GetOrCreateActionMap();
             var deviceList = map.devices;
-            if (deviceList != null && !deviceList.Value.ContainsReference(device))
-                return false;
-
-            return true;
+            return deviceList == null || deviceList.Value.ContainsReference(device);
         }
 
         internal InputBinding? FindEffectiveBindingMask()
@@ -1609,7 +1606,7 @@ namespace UnityEngine.InputSystem
             {
                 ref var binding = ref bindingsInMap[i];
 
-                if (string.Compare(binding.action, actionName, StringComparison.InvariantCultureIgnoreCase) == 0 ||
+                if (string.Equals(binding.action, actionName, StringComparison.InvariantCultureIgnoreCase) ||
                     binding.action == m_Id)
                     ++bindingIndexOnAction;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionAsset.cs
@@ -644,7 +644,7 @@ namespace UnityEngine.InputSystem
             for (var i = 0; i < m_ActionMaps.Length; ++i)
             {
                 var map = m_ActionMaps[i];
-                if (string.Compare(nameOrId, map.name, StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (string.Equals(nameOrId, map.name, StringComparison.InvariantCultureIgnoreCase))
                     return map;
             }
 
@@ -718,7 +718,7 @@ namespace UnityEngine.InputSystem
                 return -1;
 
             for (var i = 0; i < m_ControlSchemes.Length; ++i)
-                if (string.Compare(name, m_ControlSchemes[i].name, StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (string.Equals(name, m_ControlSchemes[i].name, StringComparison.InvariantCultureIgnoreCase))
                     return i;
 
             return -1;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -378,7 +378,7 @@ namespace UnityEngine.InputSystem
             for (var i = 0; i < actionCount; ++i)
             {
                 var action = m_Actions[i];
-                if (action.m_Id == nameOrId || string.Compare(m_Actions[i].m_Name, nameOrId, StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (action.m_Id == nameOrId || string.Equals(m_Actions[i].m_Name, nameOrId, StringComparison.InvariantCultureIgnoreCase))
                     return i;
             }
 
@@ -1723,7 +1723,7 @@ namespace UnityEngine.InputSystem
                     var mapIndex = 0;
                     for (; mapIndex < mapList.Count; ++mapIndex)
                     {
-                        if (string.Compare(mapList[mapIndex].name, mapName, StringComparison.InvariantCultureIgnoreCase) == 0)
+                        if (string.Equals(mapList[mapIndex].name, mapName, StringComparison.InvariantCultureIgnoreCase))
                         {
                             map = mapList[mapIndex];
                             break;
@@ -1774,7 +1774,7 @@ namespace UnityEngine.InputSystem
                     var mapIndex = 0;
                     for (; mapIndex < mapList.Count; ++mapIndex)
                     {
-                        if (string.Compare(mapList[mapIndex].name, mapName, StringComparison.InvariantCultureIgnoreCase) == 0)
+                        if (string.Equals(mapList[mapIndex].name, mapName, StringComparison.InvariantCultureIgnoreCase))
                         {
                             map = mapList[mapIndex];
                             break;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -846,7 +846,7 @@ namespace UnityEngine.InputSystem
             var bindings = action.GetOrCreateActionMap().m_Bindings;
             var bindingCount = bindings.LengthSafe();
             for (var i = 0; i < bindingCount; ++i)
-                if (string.Compare(bindings[i].action, oldName, StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (string.Equals(bindings[i].action, oldName, StringComparison.InvariantCultureIgnoreCase))
                     bindings[i].action = newName;
         }
 
@@ -1368,15 +1368,13 @@ namespace UnityEngine.InputSystem
                 // To find the next binding for a specific action, we may have to jump
                 // over unrelated bindings in-between.
                 var index = m_BindingIndexInMap;
-                while (true)
+                do
                 {
                     index += next ? 1 : -1;
                     if (index < 0 || index >= bindings.Length)
                         return default;
-
-                    if (m_Action == null || bindings[index].TriggersAction(m_Action))
-                        break;
                 }
+                while (m_Action != null && !bindings[index].TriggersAction(m_Action));
 
                 return new BindingSyntax(m_ActionMap, index, m_Action);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputBinding.cs
@@ -751,7 +751,7 @@ namespace UnityEngine.InputSystem
         internal bool TriggersAction(InputAction action)
         {
             // Match both name and ID on binding.
-            return string.Compare(action.name, this.action, StringComparison.InvariantCultureIgnoreCase) == 0
+            return string.Equals(action.name, this.action, StringComparison.InvariantCultureIgnoreCase)
                 || this.action == action.m_Id;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -183,11 +183,8 @@ namespace UnityEngine.InputSystem
             get
             {
                 RefreshConfigurationIfNeeded();
-                if (m_ShortDisplayName != null)
-                    return m_ShortDisplayName;
-                if (m_ShortDisplayNameFromLayout != null)
-                    return m_ShortDisplayNameFromLayout;
-                return null;
+
+                return m_ShortDisplayName != null ? m_ShortDisplayName : m_ShortDisplayNameFromLayout;
             }
             protected set => m_ShortDisplayName = value;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -105,9 +105,7 @@ namespace UnityEngine.InputSystem
                 //
                 // If we're looking for a specific threshold here, consider the control to always
                 // be under. But if not, consider it actuated "by virtue of not being in default state".
-                if (Mathf.Approximately(threshold, 0))
-                    return true;
-                return false;
+                return Mathf.Approximately(threshold, 0);
             }
 
             if (Mathf.Approximately(threshold, 0))

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -583,7 +583,7 @@ namespace UnityEngine.InputSystem.Layouts
             for (var i = 0; i < m_Controls.Length; ++i)
             {
                 ref var control = ref m_Controls[i];
-                if (string.Compare(control.name, path, StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (string.Equals(control.name, path, StringComparison.InvariantCultureIgnoreCase))
                     return control;
 
                 ////FIXME: what this can't handle is "outerArray4/innerArray5"; not sure we care, though

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -751,10 +751,8 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentNullException(nameof(control));
 
             var parser = new PathParser(expected);
-            if (MatchesRecursive(ref parser, control, prefixOnly: true) && parser.isAtEnd)
-                return true;
 
-            return false;
+            return MatchesRecursive(ref parser, control, prefixOnly: true) && parser.isAtEnd;
         }
 
         private static bool MatchesRecursive(ref PathParser parser, InputControl currentControl, bool prefixOnly = false)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
@@ -244,7 +244,7 @@ namespace UnityEngine.InputSystem.Layouts
         /// <seealso cref="Equals(InputDeviceDescription)"/>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
                 return false;
             return obj is InputDeviceDescription description && Equals(description);
         }
@@ -387,9 +387,7 @@ namespace UnityEngine.InputSystem.Layouts
             var json = new JsonParser(deviceDescriptor);
             if (!json.NavigateToProperty(propertyName))
             {
-                if (string.IsNullOrEmpty(propertyValue))
-                    return true;
-                return false;
+                return string.IsNullOrEmpty(propertyValue);
             }
 
             return json.CurrentPropertyHasValueEqualTo(propertyValue);

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -348,7 +348,7 @@ namespace UnityEngine.InputSystem.Layouts
         {
             // String match.
             if (pattern is string str)
-                return string.Compare(str, value, StringComparison.InvariantCultureIgnoreCase) == 0;
+                return string.Equals(str, value, StringComparison.InvariantCultureIgnoreCase);
 
             // Regex match.
             if (pattern is Regex regex)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -367,7 +367,7 @@ namespace UnityEngine.InputSystem.Editor
 
         public void SelectFirstToplevelItem()
         {
-            if (rootItem.children.Any())
+            if (rootItem.children.Count > 0)
                 SetSelection(new[] {rootItem.children[0].id}, TreeViewSelectionOptions.FireSelectionChanged);
         }
 
@@ -773,7 +773,7 @@ namespace UnityEngine.InputSystem.Editor
             if (blocks.Length < 1)
                 return;
 
-            Type CopyTagToType(string tagName)
+            static Type CopyTagToType(string tagName)
             {
                 switch (tagName)
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -347,8 +347,8 @@ namespace UnityEngine.InputSystem.Editor
                 // If the key has a display name that differs from the key name, show it in the UI.
                 var displayName = key.m_DisplayNameFromLayout;
                 var keyDisplayName = key.displayName;
-                if (keyDisplayName.All(x => x.IsPrintable()) && string.Compare(keyDisplayName, displayName,
-                    StringComparison.InvariantCultureIgnoreCase) != 0)
+                if (keyDisplayName.All(x => x.IsPrintable()) && !string.Equals(keyDisplayName, displayName,
+                    StringComparison.InvariantCultureIgnoreCase))
                     displayName = $"{displayName} (Current Layout: {key.displayName})";
 
                 // For left/right modifier keys, prepend artificial combined version.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -590,7 +590,7 @@ namespace UnityEngine.InputSystem.Editor
                     var didRename = false;
                     for (var n = 0; n < numGroups; ++n)
                     {
-                        if (string.Compare(groupsArray[n], oldBindingGroup, StringComparison.InvariantCultureIgnoreCase) != 0)
+                        if (!string.Equals(groupsArray[n], oldBindingGroup, StringComparison.InvariantCultureIgnoreCase))
                             continue;
                         if (string.IsNullOrEmpty(newBindingGroup))
                         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -103,8 +103,7 @@ namespace UnityEngine.InputSystem.Editor
             if (property.GetParentProperty() != null && property.GetParentProperty().isArray)
                 propertyTitleNumeral = $" {property.GetIndexOfArrayElement()}";
 
-            if (property.displayName != null &&
-                property.displayName.Length > 0 &&
+            if (!string.IsNullOrEmpty(property.displayName) &&
                 (property.type == nameof(InputAction) || property.type == nameof(InputActionMap)))
             {
                 return $"{property.displayName}{propertyTitleNumeral}";

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -186,7 +186,7 @@ namespace UnityEngine.InputSystem.Editor
 
             // Make sure it ends with .asset.
             var extension = Path.GetExtension(path);
-            if (string.Compare(extension, ".asset", StringComparison.InvariantCultureIgnoreCase) != 0)
+            if (!string.Equals(extension, ".asset", StringComparison.InvariantCultureIgnoreCase))
                 path += ".asset";
 
             // Create settings file.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Finger.cs
@@ -145,10 +145,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
             // Touchscreen will record a button down and button up on a TouchControl when a tap occurs.
             // We only want to record the button down, not the button up.
-            if (currentTouchState->isTapRelease)
-                return false;
-
-            return true;
+            return !currentTouchState->isTapRelease;
         }
 
         private unsafe void OnTouchRecorded(InputStateHistory.Record record)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -475,8 +475,8 @@ namespace UnityEngine.InputSystem.Editor
                 var name = controlSchemes[i].name;
                 m_ControlSchemeOptions[i + 1] = new GUIContent(name);
 
-                if (selectedDefaultControlScheme != null && string.Compare(name, selectedDefaultControlScheme,
-                    StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (selectedDefaultControlScheme != null && string.Equals(name, selectedDefaultControlScheme,
+                    StringComparison.InvariantCultureIgnoreCase))
                     m_SelectedDefaultControlScheme = i + 1;
             }
             if (m_SelectedDefaultControlScheme <= 0)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamIGAConverter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Steam/SteamIGAConverter.cs
@@ -740,10 +740,9 @@ namespace UnityEngine.InputSystem.Steam.Editor
                 return false;
 
             var assetPath = AssetDatabase.GetAssetPath(Selection.activeObject);
-            if (!string.IsNullOrEmpty(assetPath) && Path.GetExtension(assetPath) == ".vdf")
-                return true;
 
-            return false;
+
+            return !string.IsNullOrEmpty(assetPath) && Path.GetExtension(assetPath) == ".vdf";
         }
 
         ////TODO: support setting class and namespace name

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -713,9 +713,8 @@ namespace UnityEngine.InputSystem.UI
             if (eventSystem.currentSelectedGameObject == null)
                 return true;
 
-            var selectable = eventSystem.currentSelectedGameObject.GetComponent<Selectable>();
-
-            if (selectable == null)
+            
+            if (!eventSystem.currentSelectedGameObject.TryGetComponent<Selectable>(out var selectable))
                 return true;
 
             Selectable navigationTarget = null;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.UI.Editor
             {
                 foreach (var action in actions)
                 {
-                    if (string.Compare(action.action.name, actionName, StringComparison.InvariantCultureIgnoreCase) == 0)
+                    if (string.Equals(action.action.name, actionName, StringComparison.InvariantCultureIgnoreCase))
                         return action;
                 }
             }
@@ -30,8 +30,7 @@ namespace UnityEngine.InputSystem.UI.Editor
 
             var path = AssetDatabase.GetAssetPath(actions);
             var assets = AssetDatabase.LoadAllAssetsAtPath(path);
-            return assets.Where(asset => asset is InputActionReference)
-                .Cast<InputActionReference>()
+            return assets.OfType<InputActionReference>()
                 .OrderBy(x => x.name)
                 .ToArray();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -51,8 +51,7 @@ namespace UnityEngine.InputSystem.UI
         {
             if (m_PlayerRoot == null) return;
 
-            var inputModule = GetComponent<InputSystemUIInputModule>();
-            if (inputModule != null)
+            if (TryGetComponent<InputSystemUIInputModule>(out var inputModule))
                 inputModule.localMultiPlayerRoot = m_PlayerRoot;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -508,8 +508,8 @@ namespace UnityEngine.InputSystem.Users
             var controlSchemes = s_GlobalState.allUserData[index].actions.controlSchemes;
             for (var i = 0; i < controlSchemes.Count; ++i)
             {
-                if (string.Compare(controlSchemes[i].name, schemeName,
-                    StringComparison.InvariantCultureIgnoreCase) == 0)
+                if (string.Equals(controlSchemes[i].name, schemeName,
+                    StringComparison.InvariantCultureIgnoreCase))
                 {
                     scheme = controlSchemes[i];
                     return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/WebGL/WebGLSupport.cs
@@ -31,7 +31,7 @@ namespace UnityEngine.InputSystem.WebGL
             string matchedLayout, InputDeviceExecuteCommandDelegate executeCommandDelegate)
         {
             // If the device isn't a WebGL device, we're not interested.
-            if (string.Compare(description.interfaceName, InterfaceName, StringComparison.InvariantCultureIgnoreCase) != 0)
+            if (!string.Equals(description.interfaceName, InterfaceName, StringComparison.InvariantCultureIgnoreCase))
                 return null;
 
             // If it was matched by the standard mapping, we don't need to fall back to generating a layout.

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
@@ -171,26 +171,26 @@ namespace UnityEngine.InputSystem.Utilities
 
         public static bool operator==(InternedString a, string b)
         {
-            return string.Compare(a.m_StringLowerCase, b.ToLower(CultureInfo.InvariantCulture),
-                StringComparison.InvariantCultureIgnoreCase) == 0;
+            return string.Equals(a.m_StringLowerCase, b.ToLower(CultureInfo.InvariantCulture),
+                StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static bool operator!=(InternedString a, string b)
         {
-            return string.Compare(a.m_StringLowerCase, b.ToLower(CultureInfo.InvariantCulture),
-                StringComparison.InvariantCultureIgnoreCase) != 0;
+            return !string.Equals(a.m_StringLowerCase, b.ToLower(CultureInfo.InvariantCulture),
+                StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static bool operator==(string a, InternedString b)
         {
-            return string.Compare(a.ToLower(CultureInfo.InvariantCulture), b.m_StringLowerCase,
-                StringComparison.InvariantCultureIgnoreCase) == 0;
+            return string.Equals(a.ToLower(CultureInfo.InvariantCulture), b.m_StringLowerCase,
+                StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static bool operator!=(string a, InternedString b)
         {
-            return string.Compare(a.ToLower(CultureInfo.InvariantCulture), b.m_StringLowerCase,
-                StringComparison.InvariantCultureIgnoreCase) != 0;
+            return !string.Equals(a.ToLower(CultureInfo.InvariantCulture), b.m_StringLowerCase,
+                StringComparison.InvariantCultureIgnoreCase);
         }
 
         public static bool operator<(InternedString left, InternedString right)


### PR DESCRIPTION


### Description

Performance improvements. Some are very small, which I think should be considered since input is a big part of every game.


### Changes made

- Use string.Equals instead of string.Compare. More readable and a lot faster when benchmarked
- Merge if statement and return
-  Use do while instead of while(true) with a break
- Use Count instead of Any()
- make methods static when possible for performance
- Use string.IsNullOrEmpty for better performance/readability
- Use TryGetComponent to reduce garbage allocation (a null GetComponent can introduce lag spikes)
- Combine .Where + .Cast into .OfType


### Checklist

Before review:

- [x ] Changelog entry added.

No docs change needed since this is not visible to users.
Basic functionality tested sucesfully. Not major changes done

During merge:

- [x ] Commit message for squash-merge is prefixed with one of the list
