### PR TITLE
Improve performance of HID descriptor parsing and device matching

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,9 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where Input Action name would not display correctly in Inspector if serialized as `[SerializedProperty]` within a class not derived from `MonoBehavior` ([case ISXB-124](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-124).
 - Fix an issue where users could end up with the wrong device assignments when using the InputUser API directly and removing a user ([case ISXB-274](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-231)).
 
+### Changed
+- Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.
+
 ## [1.4.2] - 2022-08-12
 
 ### Changed

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -348,7 +348,7 @@ namespace UnityEngine.InputSystem.Layouts
         {
             // String match.
             if (pattern is string str)
-                return string.Compare(str, value, StringComparison.InvariantCultureIgnoreCase) == 0;
+                return string.Compare(str, value, StringComparison.OrdinalIgnoreCase) == 0;
 
             // Regex match.
             if (pattern is Regex regex)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -8,6 +8,9 @@ using UnityEngine.InputSystem.Utilities;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.Scripting;
+#if UNITY_2021_2_OR_NEWER
+using UnityEngine.Pool;
+#endif
 
 // HID support is currently broken in 32-bit Windows standalone players. Consider 32bit Windows players unsupported for now.
 #if UNITY_STANDALONE_WIN && !UNITY_64
@@ -974,7 +977,165 @@ namespace UnityEngine.InputSystem.HID
 
             public static HIDDeviceDescriptor FromJson(string json)
             {
+#if UNITY_2021_2_OR_NEWER
+                try
+                {
+                    // HID descriptors, when formatted correctly, are always json strings with no whitespace and a
+                    // predictable order of elements, so we can try and use this simple predictive parser to extract
+                    // the data. If for any reason the data is not formatted correctly, we'll automatically fall back
+                    // to Unity's default json parser.
+                    var descriptor = new HIDDeviceDescriptor();
+
+                    var jsonSpan = json.AsSpan();
+                    var parser = new PredictiveParser();
+                    parser.ExpectSingleChar(jsonSpan, '{');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.vendorId = parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.productId = parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.usage = parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.usagePage = (UsagePage)parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.inputReportSize = parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.outputReportSize = parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    parser.AcceptString(jsonSpan, out _);
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    descriptor.featureReportSize = parser.ExpectInt(jsonSpan);
+                    parser.AcceptSingleChar(jsonSpan, ',');
+
+                    // elements
+                    parser.AcceptString(jsonSpan, out var key);
+                    if (key.ToString() != "elements") return descriptor;
+
+                    parser.ExpectSingleChar(jsonSpan, ':');
+                    parser.ExpectSingleChar(jsonSpan, '[');
+
+                    using var pool = ListPool<HIDElementDescriptor>.Get(out var elements);
+                    while (!parser.AcceptSingleChar(jsonSpan, ']'))
+                    {
+                        parser.AcceptSingleChar(jsonSpan, ',');
+                        parser.ExpectSingleChar(jsonSpan, '{');
+
+                        HIDElementDescriptor elementDesc = default;
+
+
+                        parser.AcceptSingleChar(jsonSpan, '}');
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        // usage
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.usage = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.usagePage = (UsagePage)parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.unit = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.unitExponent = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.logicalMin = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.logicalMax = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.physicalMin = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.physicalMax = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.collectionIndex = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.reportType = (HIDReportType)parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.reportId = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        // reportCount. We don't store this one
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        parser.AcceptInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.reportSizeInBits = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.reportOffsetInBits = parser.ExpectInt(jsonSpan);
+                        parser.AcceptSingleChar(jsonSpan, ',');
+
+                        parser.ExpectString(jsonSpan);
+                        parser.ExpectSingleChar(jsonSpan, ':');
+                        elementDesc.flags = (HIDElementFlags)parser.ExpectInt(jsonSpan);
+
+                        parser.ExpectSingleChar(jsonSpan, '}');
+
+                        elements.Add(elementDesc);
+                    }
+                    descriptor.elements = elements.ToArray();
+
+                    return descriptor;
+                }
+                catch (Exception)
+                {
+                    Debug.LogWarning($"Couldn't parse HID descriptor with fast parser. Using fallback");
+                    return JsonUtility.FromJson<HIDDeviceDescriptor>(json);
+                }
+#else
                 return JsonUtility.FromJson<HIDDeviceDescriptor>(json);
+#endif
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PredictiveParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PredictiveParser.cs
@@ -1,0 +1,148 @@
+using System;
+
+namespace UnityEngine.InputSystem.Utilities
+{
+    // this parser uses Span<T> so it's only available from later unity versions
+#if UNITY_2021_2_OR_NEWER
+    internal struct PredictiveParser
+    {
+        public void ExpectSingleChar(ReadOnlySpan<char> str, char c)
+        {
+            if (str[m_Position] != c)
+                throw new InvalidOperationException($"Expected a '{c}' character at position {m_Position} in : {str.ToString()}");
+
+            ++m_Position;
+        }
+
+        public int ExpectInt(ReadOnlySpan<char> str)
+        {
+            int pos = m_Position;
+
+            int sign = 1;
+            if (str[pos] == '-')
+            {
+                sign = -1;
+                ++pos;
+            }
+
+            int value = 0;
+            for (;;)
+            {
+                var n = str[pos];
+                if (n >= '0' && n <= '9')
+                {
+                    value *= 10;
+                    value += n - '0';
+                    ++pos;
+                }
+                else
+                    break;
+            }
+
+            if (m_Position == pos)
+                throw new InvalidOperationException($"Expected an int at position {m_Position} in {str.ToString()}");
+
+            m_Position = pos;
+            return value * sign;
+        }
+
+        public ReadOnlySpan<char> ExpectString(ReadOnlySpan<char> str)
+        {
+            var startPos = m_Position;
+            if (str[startPos] != '\"')
+                throw new InvalidOperationException($"Expected a '\"' character at position {m_Position} in {str.ToString()}");
+
+            ++m_Position;
+
+            for (;;)
+            {
+                var c = str[m_Position];
+                c |= ' ';
+                if (c >= 'a' && c <= 'z')
+                {
+                    ++m_Position;
+                    continue;
+                }
+
+                break;
+            }
+
+            // if the first non-alpha character is not a quote, throw
+            if (str[m_Position] != '\"')
+                throw new InvalidOperationException($"Expected a closing '\"' character at position {m_Position} in string: {str.ToString()}");
+
+            if (m_Position - startPos == 1)
+                return ReadOnlySpan<char>.Empty;
+
+            var output = str.Slice(startPos + 1, m_Position - startPos - 1);
+
+            ++m_Position;
+            return output;
+        }
+
+        public bool AcceptSingleChar(ReadOnlySpan<char> str, char c)
+        {
+            if (str[m_Position] != c)
+                return false;
+
+            m_Position++;
+            return true;
+        }
+
+        public bool AcceptString(ReadOnlySpan<char> input, out ReadOnlySpan<char> output)
+        {
+            output = default;
+            var startPos = m_Position;
+            var endPos = startPos;
+            if (input[endPos] != '\"')
+                return false;
+
+            ++endPos;
+
+            for (;;)
+            {
+                var c = input[endPos];
+                c |= ' ';
+                if (c >= 'a' && c <= 'z')
+                {
+                    ++endPos;
+                    continue;
+                }
+
+                break;
+            }
+
+            // if the first non-alpha character is not a quote, throw
+            if (input[endPos] != '\"')
+                return false;
+
+            // empty string?
+            if (m_Position - startPos == 1)
+                output = ReadOnlySpan<char>.Empty;
+            else
+                output = input.Slice(startPos + 1, endPos - startPos - 1);
+
+            m_Position = endPos + 1;
+            return true;
+        }
+
+        public void AcceptInt(ReadOnlySpan<char> str)
+        {
+            // skip negative sign
+            if (str[m_Position] == '-')
+                ++m_Position;
+
+            for (;;)
+            {
+                var n = str[m_Position];
+                if (n >= '0' && n <= '9')
+                    ++m_Position;
+                else
+                    break;
+            }
+        }
+
+        private int m_Position;
+    }
+#endif
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PredictiveParser.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PredictiveParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6e4e169a1433dc94cb99eff69a1c6be8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

During domain reloads, and during InputTestFixture test teardown, all device descriptions are parsed to see if the system can add any devices that it knows about but couldn't add previously. For HID devices, that means parsing the HID descriptor, which on later version of Unity, contains quite a lot of data. On machines with many HID devices attached, this parsing can get quite expensive.

### Changes made

This PR replaces the parsing in the HID descriptor FromJson method with a custom predictive parser that depends on the descriptor being well formatted. If it fails, then processing falls back on the previous method. On 2022.1, this change resulted in full test runs going from 144 seconds down to 110. On previous Unity versions the test run improvement is only about two seconds as the HID descriptors have less data in them in those versions. Domain reload time is still improved though.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
