### PR TITLE
Fixed behavior field repaint when switching input actions

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fix for mitigating symptoms reported in ([case UUM-10774](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-10774) effectively avoiding reenabling mouse, pen or touch devices in `InputSystemPlugin.OnDestroy()` if currently quitting the editor. The fix avoids editor crashing if closed when Simulator Window is open. Note that the actual issue needs a separate fix in Unity and this package fix is only to avoid running into the issue.
 - Fixed an issue where Input Action name would not display correctly in Inspector if serialized as `[SerializedProperty]` within a class not derived from `MonoBehavior` ([case ISXB-124](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-124).
 - Fix an issue where users could end up with the wrong device assignments when using the InputUser API directly and removing a user ([case ISXB-274](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-231)).
+- Fixed an issue where PlayerInput behavior description was not updated when changing action assset ([case ISXB-286](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-286)).
 
 ### Changed
 - Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -73,8 +73,13 @@ namespace UnityEngine.InputSystem.Editor
             // Action config section.
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_ActionsProperty);
+            var actionsWereChanged = false;
             if (EditorGUI.EndChangeCheck() || !m_ActionAssetInitialized)
+            {
                 OnActionAssetChange();
+                actionsWereChanged = true;
+            }
+
             ++EditorGUI.indentLevel;
             if (m_ControlSchemeOptions != null && m_ControlSchemeOptions.Length > 1) // Don't show if <Any> is the only option.
             {
@@ -162,7 +167,7 @@ namespace UnityEngine.InputSystem.Editor
             // Notifications/event section.
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_NotificationBehaviorProperty, m_NotificationBehaviorText);
-            if (EditorGUI.EndChangeCheck() || !m_NotificationBehaviorInitialized)
+            if (EditorGUI.EndChangeCheck() || actionsWereChanged || !m_NotificationBehaviorInitialized)
                 OnNotificationBehaviorChange();
             switch ((PlayerNotifications)m_NotificationBehaviorProperty.intValue)
             {


### PR DESCRIPTION
### Description

When switching input action asset in player input, behaviour description was not updating

### Changes made

Adding an extra condition to retrigger behaviour repaint when asset changed

