### PR TITLE
Fixing devices not being removed when unplugged during domain reload

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -303,7 +303,7 @@ partial class CoreTests
     {
         Assert.Fail();
     }
-    
+
     [Test]
     [Category("Editor")]
     public void Editor_DomainReload_CanRemoveDevicesDuringDomainReload()

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -303,6 +303,27 @@ partial class CoreTests
     {
         Assert.Fail();
     }
+    
+    [Test]
+    [Category("Editor")]
+    public void Editor_DomainReload_CanRemoveDevicesDuringDomainReload()
+    {
+        var device = InputSystem.AddDevice<Gamepad>();
+        InputSystem.AddDevice<Keyboard>(); // just to make sure keyboard stays as-is
+
+        currentTime = 1;
+        InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingEditMode);
+
+        runtime.ReportInputDeviceRemoved(device);
+
+        currentTime = 2;
+        InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredPlayMode);
+
+        InputSystem.Update();
+
+        Assert.That(InputSystem.devices, Has.Count.EqualTo(1));
+        Assert.That(InputSystem.devices[0], Is.AssignableTo<Keyboard>());
+    }
 
     [Test]
     [Category("Editor")]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Memory alignment issue with deserialized InputEventTraces that could cause infinite loops when playing back replays ([case ISXB-317](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-317)).
 - Fixed an InvalidOperationException when using Hold interaction, and by extension any interaction that changes to performed state after a timeout ([case ISXB-332](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-330)).
 - Fixed `Given object is neither an InputAction nor an InputActionMap` when using `InputActionTrace` on input action from an input action asset ([case ISXB-29](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-29)).
+- Fixing devices not being removed if unplugged during domain reload (entering or exiting play mode) ([case ISXB-232](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-232)).
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2948,7 +2948,9 @@ namespace UnityEngine.InputSystem
                     //       Could be that ultimately we need to issue a full reset of all devices at the beginning of
                     //       play mode in the editor.
 #if UNITY_EDITOR
-                    if ((updateType & InputUpdateType.Editor) == 0 &&
+                    if ((currentEventType == StateEvent.Type ||
+                         currentEventType == DeltaStateEvent.Type) &&
+                        (updateType & InputUpdateType.Editor) == 0 &&
                         InputSystem.s_SystemObject.exitEditModeTime > 0 &&
                         currentEventTimeInternal >= InputSystem.s_SystemObject.exitEditModeTime &&
                         (currentEventTimeInternal < InputSystem.s_SystemObject.enterPlayModeTime ||


### PR DESCRIPTION
### Description

Device removal events where ignored during domain reload.

By pure luck, the way how Windows editor HID handling was implemented, meant that HID removal events where postponed after domain reload happened (due to windows message queue is not pumped during domain reload).

But on macOS situation is different and device removal events happen as expected during domain reload.

### Changes made

Only ignore state and delta state events that happened during domain reload, and process everything else.

PS. not sure if we do want to ignore text events as well then?
