### PR TITLE
Filtering out most of jittery bits on some gamepads

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,7 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where Input Action name would not display correctly in Inspector if serialized as `[SerializedProperty]` within a class not derived from `MonoBehavior` ([case ISXB-124](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-124).
 - Fix an issue where users could end up with the wrong device assignments when using the InputUser API directly and removing a user ([case ISXB-274](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-231)).
 - Fixed an issue where PlayerInput behavior description was not updated when changing action assset ([case ISXB-286](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-286)).
-- Greatly improved the situation with an issue where a gamepad becomes current when no controls are actuated ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))). 
+- Greatly improved the situation with an issue where a gamepad becomes current when no controls are actuated ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))).
 
 ### Changed
 - Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where Input Action name would not display correctly in Inspector if serialized as `[SerializedProperty]` within a class not derived from `MonoBehavior` ([case ISXB-124](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-124).
 - Fix an issue where users could end up with the wrong device assignments when using the InputUser API directly and removing a user ([case ISXB-274](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-231)).
 - Fixed an issue where PlayerInput behavior description was not updated when changing action assset ([case ISXB-286](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-286)).
+- Greatly improved the situation with an issue where a gamepad becomes current when no controls are actuated ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))). 
 
 ### Changed
 - Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -359,6 +359,12 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        internal ulong jitterMask
+        {
+            get => m_JitterMask;
+            set => m_JitterMask = value;
+        }
+
         /// <summary>
         /// Whether the control is considered synthetic.
         /// </summary>
@@ -847,6 +853,7 @@ namespace UnityEngine.InputSystem
         internal int m_ChildCount;
         internal int m_ChildStartIndex;
         internal ControlFlags m_ControlFlags;
+        internal ulong m_JitterMask;
 
         ////REVIEW: store these in arrays in InputDevice instead?
         internal PrimitiveValue m_DefaultState;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlAttribute.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlAttribute.cs
@@ -286,6 +286,18 @@ namespace UnityEngine.InputSystem.Layouts
         public int arraySize { get; set; }
 
         /// <summary>
+        /// Mark some control bits as noisy to avoid setting device ".current" field when they change. 
+        /// </summary>
+        /// <value>Bit mask, up to 64 bits.</value>
+        /// <remarks>
+        /// We determine if control was updated by checking if any of the control memory bits changed.
+        /// This property allows to ignore changes in specified bits (set as 1 in this mask) as noise,
+        /// which allows to essentially ignore some jitter in controls like sticks or triggers.
+        /// </remarks>
+        /// <seealso cref="InputControl.noisy"/>
+        public ulong jitterMask { get; set; }
+
+        /// <summary>
         /// Display name to assign to the control.
         /// </summary>
         /// <value>Display name for the control.</value>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlAttribute.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlAttribute.cs
@@ -286,7 +286,7 @@ namespace UnityEngine.InputSystem.Layouts
         public int arraySize { get; set; }
 
         /// <summary>
-        /// Mark some control bits as noisy to avoid setting device ".current" field when they change. 
+        /// Mark some control bits as noisy to avoid setting device ".current" field when they change.
         /// </summary>
         /// <value>Bit mask, up to 64 bits.</value>
         /// <remarks>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1753,6 +1753,13 @@ namespace UnityEngine.InputSystem
                 control.noisy = value;
                 return this;
             }
+            
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public ControlBuilder WithJitterMask(ulong jitterMask)
+            {
+                control.jitterMask = jitterMask;
+                return this;
+            }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public ControlBuilder IsSynthetic(bool value)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs
@@ -1753,7 +1753,7 @@ namespace UnityEngine.InputSystem
                 control.noisy = value;
                 return this;
             }
-            
+
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public ControlBuilder WithJitterMask(ulong jitterMask)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -225,9 +225,9 @@ namespace UnityEngine.InputSystem.Layouts
                         flags &= ~Flags.IsNoisy;
                 }
             }
-            
+
             /// <summary>
-            /// Mark some control bits as noisy to avoid setting device ".current" field when they change. 
+            /// Mark some control bits as noisy to avoid setting device ".current" field when they change.
             /// </summary>
             /// <value>Bit mask, up to 64 bits.</value>
             /// <remarks>
@@ -771,7 +771,7 @@ namespace UnityEngine.InputSystem.Layouts
                     builder.m_Controls[index].isNoisy = value;
                     return this;
                 }
-                
+
                 public ControlBuilder WithJitterMask(ulong value)
                 {
                     builder.m_Controls[index].jitterMask = value;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceBuilder.cs
@@ -409,10 +409,11 @@ namespace UnityEngine.InputSystem.Layouts
 
             // Set flags and misc things.
             control.noisy = controlItem.isNoisy;
+            control.jitterMask = controlItem.jitterMask;
             control.synthetic = controlItem.isSynthetic;
             control.usesStateFromOtherControl = !string.IsNullOrEmpty(controlItem.useStateFrom);
             control.dontReset = (control.noisy || controlItem.dontReset) && !control.usesStateFromOtherControl; // Imply dontReset for noisy controls.
-            if (control.noisy)
+            if (control.noisy || control.jitterMask > 0)
                 m_Device.noisy = true;
             control.isButton = control is ButtonControl;
             if (control.dontReset)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
@@ -286,6 +286,8 @@ namespace UnityEngine.InputSystem.Editor
                 writer.WriteLine($"    .WithAliases({control.m_AliasStartIndex}, {control.m_AliasCount})");
             if (control.noisy)
                 writer.WriteLine("    .IsNoisy(true)");
+            if (control.jitterMask != 0)
+                writer.WriteLine($"    .WithJitterMask({control.jitterMask}UL)");
             if (control.synthetic)
                 writer.WriteLine("    .IsSynthetic(true)");
             if (control.dontReset)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2178,6 +2178,24 @@ namespace UnityEngine.InputSystem
                     if (control.dontReset)
                         MemoryHelpers.SetBitsInBuffer(resetMaskBuffer, (int)stateBlock.byteOffset, (int)stateBlock.bitOffset,
                             (int)stateBlock.sizeInBits, false);
+
+                    // If control has jitter bits, toggle jitter bits *off* in the noise mask.
+                    if (control.jitterMask != 0)
+                    {
+                        if (stateBlock.sizeInBits > 64)
+                        {
+                            Debug.LogError($"jitterMask is not supported for controls over 64 bits in size ('{control.name}')");
+                        }
+                        else
+                        {
+                            ////TODO: this is quite slow
+                            for (var i = 0; i < stateBlock.sizeInBits; ++i)
+                            {
+                                var value = (control.jitterMask & (1UL << i)) != 0;
+                                MemoryHelpers.SetBitsInBuffer(noiseMaskBuffer, (int)stateBlock.byteOffset, (int)stateBlock.bitOffset + i, 1, !value);
+                            }
+                        }
+                    }
                 }
 
                 // If control has default state, write it into to the device's default state.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -23,20 +23,20 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         public FourCC format => Format;
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
-        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "leftStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "leftStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(0)] public byte leftStickX;
         [FieldOffset(1)] public byte leftStickY;
 
         [InputControl(name = "rightStick", layout = "Stick", format = "VC2B")]
-        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "rightStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "rightStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(2)] public byte rightStickX;
@@ -153,20 +153,20 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         public FourCC format => Format;
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
-        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "leftStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "leftStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(0)] public byte leftStickX;
         [FieldOffset(1)] public byte leftStickY;
 
         [InputControl(name = "rightStick", layout = "Stick", format = "VC2B")]
-        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "rightStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "rightStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(2)] public byte rightStickX;
@@ -333,7 +333,7 @@ namespace UnityEngine.InputSystem.DualShock
     /// <summary>
     /// PS5 DualSense controller that is interfaced to a HID backend.
     /// </summary>
-    [InputControlLayout(stateType = typeof(DualSenseHIDInputReport), displayName = "DualSense HID")]
+    [InputControlLayout(stateType = typeof(DualSenseHIDInputReport), displayName = "DualSense HID", isNoisy = true)]
     public class DualSenseGamepadHID : DualShockGamepad, IEventMerger, IEventPreProcessor
     {
         // Gamepad might send 3 types of input reports:

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -24,20 +24,20 @@ namespace UnityEngine.InputSystem.Switch.LowLevel
         public FourCC format => Format;
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2B")]
-        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "leftStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.15,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=0.85")]
-        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "leftStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.15,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=0.85,invert=false")]
         [FieldOffset(0)] public byte leftStickX;
         [FieldOffset(1)] public byte leftStickY;
 
         [InputControl(name = "rightStick", layout = "Stick", format = "VC2B")]
-        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "rightStick/left", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/right", offset = 0, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/y", offset = 1, format = "BYTE", parameters = "invert,normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5", jitterMask = 0b00000111)]
         [InputControl(name = "rightStick/up", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.15,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/down", offset = 1, format = "BYTE", parameters = "normalize,normalizeMin=0.15,normalizeMax=0.85,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=0.85,invert=false")]
         [FieldOffset(2)] public byte rightStickX;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -147,7 +147,7 @@ namespace UnityEngine.InputSystem.Switch
     /// A Nintendo Switch Pro controller connected to a desktop mac/windows PC using the HID interface.
     /// </summary>
     [InputControlLayout(stateType = typeof(SwitchProControllerHIDInputState), displayName = "Switch Pro Controller")]
-    public class SwitchProControllerHID : Gamepad, IInputStateCallbackReceiver, IEventPreProcessor
+    public class SwitchProControllerHID : Gamepad, IInputUpdateCallbackReceiver, IEventPreProcessor
     {
         [InputControl(name = "capture", displayName = "Capture")]
         public ButtonControl captureButton { get; protected set; }
@@ -222,19 +222,9 @@ namespace UnityEngine.InputSystem.Switch
             ExecuteCommand(ref commandUsb);
         }
 
-        public void OnNextUpdate()
+        public void OnUpdate()
         {
             HandshakeTick();
-        }
-
-        public void OnStateEvent(InputEventPtr eventPtr)
-        {
-            InputState.Change(this, eventPtr);
-        }
-
-        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset)
-        {
-            return false;
         }
 
         public unsafe bool PreProcessEvent(InputEventPtr eventPtr)


### PR DESCRIPTION
### Description

Most gamepads have noisy stick controls. And this makes them become `Gamepad.current` when user doesn't actuate any controls, which in result is problematic if two or more gamepads connected to the system.

### Changes made

- Added notion of `jitterMask`, which can mark standalone bits in the control state as noise.
- Filtered out lower 3 bits on axes of DualShock4/DualSense/SwitchPro controllers.
- Moved Switch Pro controller to different update tick, so we don't set it current on every event (this is a weird sideeffect of `IInputStateCallbackReceiver` contract, and I couldn't fix it properly because resetting of delta controls depends on it apparently).

### Notes

Unfortunately this is not a complete fix, but it does improve the situation by quite a bit.
A proper fix would be doing LPF filtering on incoming data to observe magnitude of change, rather than individual bits.
This fix breaks where value goes between 0x7f and 0x80, this is because all 8 bits then change, and filtering on just noisy bits is no longer effective.
