### PR TITLE
FIX: Ensure callback arrays are unlocked when invoked and returning true

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -2242,6 +2242,37 @@ internal class PlayerInputTests : CoreTestsFixture
         Assert.That(playerInput.devices[0], !Is.SameAs(gamepad)); // expected replacement (by design, not a requirement)
         Assert.That(playerInput.devices[0].name, Is.EqualTo(gamepad.name));
     }
+    
+    [Test]
+    [Category("PlayerInput")]
+    public void PlayerInput_CanJoinPlayersThroughButtonPress_AfterAutoSwitchedPlayerDeleted()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        
+        var prefab = new GameObject();
+        prefab.SetActive(false);
+        
+        var prefabPlayerInput = prefab.AddComponent<PlayerInput>();
+        prefabPlayerInput.actions = InputActionAsset.FromJson(kActions);
+        prefabPlayerInput.neverAutoSwitchControlSchemes = false;
+
+        var player = PlayerInput.Instantiate(prefab);
+        
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        
+        Press(gamepad.buttonSouth);
+
+        Object.DestroyImmediate(player);
+
+        var manager = new GameObject();
+        manager.SetActive(false); // Delay OnEnable() until we have all components.
+
+        var managerComponent = manager.AddComponent<PlayerInputManager>();
+        
+        manager.SetActive(true);
+        
+        Press(gamepad.buttonSouth);
+    }
 
     // An action is either
     //   (a) button-like, or

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
+- Fixed `ArgumentOutOfRangeException` when a Player Input that has been auto switched is deleted, and then a Player Input Manager attempts to join a new player.
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
@@ -95,7 +95,11 @@ namespace UnityEngine.InputSystem.Utilities
                 try
                 {
                     if (callbacks[i](argument1, argument2))
+                    {
+                        callbacks.UnlockForChanges();
+                        Profiler.EndSample();
                         return true;
+                    }
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
### Description

In `DelegateHelpers.InvokeCallbacksSafe_AnyCallbackReturnsTrue`, returning true bypasses unlocking the callback array. This causes an error when a Player Input that has been auto switched is deleted, and then a Player Input Manager attempts to join a new player.

### Changes made

Added a test to replicate the error, and then fixed the issue by ensuring the callback array is always unlocked before returning from `InvokeCallbacksSafe_AnyCallbackReturnsTrue`.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
