### PR TITLE
Not adding temp settings object to preloaded assets, and actually setting dirty flag so editor saves asset on exit

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
+- Fixed `{fileID: 0}` getting appended to `ProjectSettings.asset` file when building a project ([case ISXB-296](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-296)).
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsBuildProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsBuildProvider.cs
@@ -16,11 +16,10 @@ namespace UnityEngine.InputSystem.Editor
             if (InputSystem.settings == null)
                 return;
 
-            // If there is no asset and we operate on temporary object,
-            // adding it would result in preloadedAssets containing null object "{fileID: 0}",
-            // which then we can't easily remove from the list in post build.
+            // If we operate on temporary object instead of input setting asset,
+            // adding temporary asset would result in preloadedAssets containing null object "{fileID: 0}".
             // Hence we ignore adding temporary objects to preloaded assets.
-            if (string.IsNullOrEmpty(AssetDatabase.GetAssetPath(InputSystem.settings)))
+            if (!EditorUtility.IsPersistent(InputSystem.settings))
                 return;
 
             // Add InputSettings object assets, if it's not in there already.
@@ -33,7 +32,7 @@ namespace UnityEngine.InputSystem.Editor
         }
 
         public void OnPostprocessBuild(BuildReport report)
-        { 
+        {
             // Revert back to original state by removing all input settings from preloaded assets.
             var preloadedAssets = PlayerSettings.GetPreloadedAssets();
             while(preloadedAssets != null && preloadedAssets.Length > 0)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsBuildProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsBuildProvider.cs
@@ -35,7 +35,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             // Revert back to original state by removing all input settings from preloaded assets.
             var preloadedAssets = PlayerSettings.GetPreloadedAssets();
-            while(preloadedAssets != null && preloadedAssets.Length > 0)
+            while (preloadedAssets != null && preloadedAssets.Length > 0)
             {
                 var index = preloadedAssets.IndexOf(x => x is InputSettings);
                 if (index != -1)


### PR DESCRIPTION
### Description

- Adding a temp setting object to preloaded assets would add `{fileID: 0}` to saves project settings preloaded assets field, that then deserializes to null object, which we don't have a good way to deal with ... e.g. do we remove it? do we ignore it? what else?
- IL2CPP build pipeline forcefully saves project settings between `OnPreprocessBuild` and `OnPostprocessBuild`, so if we modify preloaded assets in both, what happens is project settings get saves before the build, then we modify it after the build but because dirty flag is cleared, project setting never get saved unless someone modifies them. So we get a dangling asset reference there.

### Changes made

- Ignoring temp setting object all together, there seem to be no point to try to add it to preloaded assets as there is no corresponding asset AFAIK.
- Leaving dirty flags as-is, that way project settings will be at least saved on unity shutdown.

### Notes

Maybe we need to force save project settings after the build?
