### PR TITLE
FIX: 'Type of instance in array does not match expected type' assertion (ISXB-282)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -2328,6 +2328,30 @@ internal class PlayerInputTests : CoreTestsFixture
         }
     ";
 
+    [Test]
+    [Category("PlayerInput")]
+    public void PlayerInput_CanDisableAfterAssigningAction_WithControlSchemesAndInteractions()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        var actions = ScriptableObject.CreateInstance<InputActionAsset>();
+        var action = actions.AddActionMap("map").AddAction("action", interactions: "Tap(duration=0.123)");
+        action.AddBinding("<Gamepad>/buttonSouth", groups: "Gamepad");
+        action.AddBinding("<Keyboard>/space", groups: "Keyboard");
+        actions.AddControlScheme("Gamepad")
+            .WithRequiredDevice<Gamepad>();
+        actions.AddControlScheme("Keyboard")
+            .WithRequiredDevice<Keyboard>();
+        actions.Enable();
+
+        var player = new GameObject();
+        var playerInput = player.AddComponent<PlayerInput>();
+        playerInput.defaultControlScheme = "Keyboard";
+        playerInput.actions = actions;
+        player.SetActive(false); // Should cause full rebinding and not assert
+    }
+
     private struct Message : IEquatable<Message>
     {
         public string name { get; set; }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
 - Fixed `{fileID: 0}` getting appended to `ProjectSettings.asset` file when building a project ([case ISXB-296](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-296)).
+- Fixed `Type of instance in array does not match expected type` assertion when using PlayerInput in combination with Control Schemes and Interactions ([case ISXB-282](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-282)).
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1189,7 +1189,7 @@ namespace UnityEngine.InputSystem
             // created. Unfortunately, this can lead to some unnecessary re-resolving.
 
             needToResolveBindings = true;
-            bindingResolutionNeedsFullReResolve = fullResolve;
+            bindingResolutionNeedsFullReResolve |= fullResolve;
 
             if (s_DeferBindingResolution > 0)
                 return false;


### PR DESCRIPTION
### Description

This (one character) fix prevents the `Type of instance in array does not match expected type` assertion triggering under certain circumstances.
Those circumstances being: disabling a PlayerInput component which has an action attached which contains both an Interaction and a Control Scheme.

### Changes made

Ensure that during deferred binding resolution, if any change requested a full binding resolution, this could not be erased if subsequent binding resolution request were made that did not require it.
(In this case `InputActionAsset.bindingMask` property setter followed by `InputActionAsset.devices` property setter would trigger this)

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
