### PR TITLE
Update to InputSystem package to distinguish pointer events for multidisplay

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,9 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
 
+### Changed
+- Exposed `displayIndex` property for `Pointer`, `Touchscreen`, `TouchControl`, `TouchState`, `Mouse`, `MouseState`; Enable multi-display input for all platforms that implement it;
+
 ## [1.4.3] - 2022-09-23
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/TouchControl.cs
@@ -36,6 +36,11 @@ namespace UnityEngine.InputSystem.Controls
         public TouchPressControl press { get; set; }
 
         /// <summary>
+        /// Gets the index of the display that was touched.
+        /// </summary>
+        public IntegerControl displayIndex { get; set; }
+        
+        /// <summary>
         /// The ID of the touch contact as reported by the underlying system.
         /// </summary>
         /// <value>Control reading out the ID of the touch.</value>
@@ -202,6 +207,7 @@ namespace UnityEngine.InputSystem.Controls
         protected override void FinishSetup()
         {
             press = GetChildControl<TouchPressControl>("press");
+            displayIndex = GetChildControl<IntegerControl>("displayIndex");
             touchId = GetChildControl<IntegerControl>("touchId");
             position = GetChildControl<Vector2Control>("position");
             delta = GetChildControl<DeltaControl>("delta");

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Mouse.cs
@@ -79,17 +79,19 @@ namespace UnityEngine.InputSystem.LowLevel
         [InputControl(name = "pointerId", layout = "Digital", format = "BIT", sizeInBits = 1, offset = InputStateBlock.AutomaticOffset)] // Will stay at 0.
         public ushort buttons;
 
-        // Not currently used, but still needed in this struct for padding,
-        // as il2cpp does not implement FieldOffset.
+        /// <summary>
+        /// The index of the display that was moused.
+        /// </summary>
+        [InputControl(name = "displayIndex", layout = "Integer", displayName = "Display Index")]
         [FieldOffset(26)]
-        ushort displayIndex;
+        public ushort displayIndex;
 
         /// <summary>
         /// Number of clicks performed in succession.
         /// </summary>
         /// <value>Successive click count.</value>
         /// <seealso cref="Mouse.clickCount"/>
-        [InputControl(layout = "Integer", displayName = "Click Count", synthetic = true)]
+        [InputControl(name = "clickCount", layout = "Integer", displayName = "Click Count", synthetic = true)]
         [FieldOffset(28)]
         public ushort clickCount;
 
@@ -286,6 +288,7 @@ namespace UnityEngine.InputSystem
             rightButton = GetChildControl<ButtonControl>("rightButton");
             forwardButton = GetChildControl<ButtonControl>("forwardButton");
             backButton = GetChildControl<ButtonControl>("backButton");
+            displayIndex = GetChildControl<IntegerControl>("displayIndex");
             clickCount = GetChildControl<IntegerControl>("clickCount");
             base.FinishSetup();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Pointer.cs
@@ -181,6 +181,11 @@ namespace UnityEngine.InputSystem
         public ButtonControl press { get; protected set; }
 
         /// <summary>
+        /// The index of the display that was pointed.
+        /// </summary>
+        public virtual IntegerControl displayIndex { get; protected set; }
+
+        /// <summary>
         /// The pointer that was added or used last by the user or <c>null</c> if there is no pointer
         /// device connected to the system.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.cs
@@ -24,10 +24,10 @@ namespace UnityEngine.InputSystem
         public const string metadata = "AutoWindowSpace;Vector2;Delta;Button;Axis;Digital;Integer;Mouse;Pointer";
         public FastMouse()
         {
-            var builder = this.Setup(29, 10, 2)
+            var builder = this.Setup(30, 10, 2)
                 .WithName("Mouse")
                 .WithDisplayName("Mouse")
-                .WithChildren(0, 13)
+                .WithChildren(0, 14)
                 .WithLayout(new InternedString("Mouse"))
                 .WithStateBlock(new InputStateBlock { format = new FourCC(1297044819), sizeInBits = 392 });
 
@@ -73,6 +73,9 @@ namespace UnityEngine.InputSystem
 
             // /Mouse/pointerId
             var ctrlMousepointerId = Initialize_ctrlMousepointerId(kDigitalLayout, this);
+
+            // /Mouse/displayIndex
+            var ctrlMousedisplayIndex = Initialize_ctrlMousedisplayIndex(kIntegerLayout, this);
 
             // /Mouse/clickCount
             var ctrlMouseclickCount = Initialize_ctrlMouseclickCount(kIntegerLayout, this);
@@ -154,6 +157,7 @@ namespace UnityEngine.InputSystem
             this.radius = ctrlMouseradius;
             this.pressure = ctrlMousepressure;
             this.press = ctrlMousepress;
+            this.displayIndex = ctrlMousedisplayIndex;
             ctrlMouseposition.x = ctrlMousepositionx;
             ctrlMouseposition.y = ctrlMousepositiony;
             ctrlMousedelta.up = ctrlMousedeltaup;
@@ -174,9 +178,9 @@ namespace UnityEngine.InputSystem
             // State offset to control index map.
             builder.WithStateOffsetToControlIndexMap(new uint[]
             {
-                32781u, 16809998u, 33587217u, 33587218u, 33587219u, 50364431u, 50364432u, 50364436u, 67141655u, 67141656u
-                , 67141657u, 83918869u, 83918870u, 83918874u, 100664323u, 100664324u, 101188613u, 101712902u, 102237191u, 102761480u
-                , 117456908u, 134250505u, 167804955u, 184582172u, 201327627u
+                32782u, 16809999u, 33587218u, 33587219u, 33587220u, 50364432u, 50364433u, 50364437u, 67141656u, 67141657u
+                , 67141658u, 83918870u, 83918871u, 83918875u, 100664323u, 100664324u, 101188613u, 101712902u, 102237191u, 102761480u
+                , 109068300u, 117456909u, 134250505u, 167804956u, 184582173u, 201327627u
             });
 
             builder.Finish();
@@ -188,7 +192,7 @@ namespace UnityEngine.InputSystem
             ctrlMouseposition.Setup()
                 .At(this, 0)
                 .WithParent(parent)
-                .WithChildren(13, 2)
+                .WithChildren(14, 2)
                 .WithName("position")
                 .WithDisplayName("Position")
                 .WithLayout(kVector2Layout)
@@ -214,7 +218,7 @@ namespace UnityEngine.InputSystem
             ctrlMousedelta.Setup()
                 .At(this, 1)
                 .WithParent(parent)
-                .WithChildren(15, 6)
+                .WithChildren(16, 6)
                 .WithName("delta")
                 .WithDisplayName("Delta")
                 .WithLayout(kDeltaLayout)
@@ -236,7 +240,7 @@ namespace UnityEngine.InputSystem
             ctrlMousescroll.Setup()
                 .At(this, 2)
                 .WithParent(parent)
-                .WithChildren(21, 6)
+                .WithChildren(22, 6)
                 .WithName("scroll")
                 .WithDisplayName("Scroll")
                 .WithLayout(kDeltaLayout)
@@ -419,7 +423,7 @@ namespace UnityEngine.InputSystem
             ctrlMouseradius.Setup()
                 .At(this, 10)
                 .WithParent(parent)
-                .WithChildren(27, 2)
+                .WithChildren(28, 2)
                 .WithName("radius")
                 .WithDisplayName("Radius")
                 .WithLayout(kVector2Layout)
@@ -455,11 +459,31 @@ namespace UnityEngine.InputSystem
             return ctrlMousepointerId;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlMousedisplayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlMousedisplayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlMousedisplayIndex.Setup()
+                .At(this, 12)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1431521364),
+                    byteOffset = 26,
+                    bitOffset = 0,
+                    sizeInBits = 16
+                })
+                .Finish();
+            return ctrlMousedisplayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlMouseclickCount(InternedString kIntegerLayout, InputControl parent)
         {
             var ctrlMouseclickCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlMouseclickCount.Setup()
-                .At(this, 12)
+                .At(this, 13)
                 .WithParent(parent)
                 .WithName("clickCount")
                 .WithDisplayName("Click Count")
@@ -480,7 +504,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousepositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousepositionx.Setup()
-                .At(this, 13)
+                .At(this, 14)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Position X")
@@ -502,7 +526,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousepositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousepositiony.Setup()
-                .At(this, 14)
+                .At(this, 15)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Position Y")
@@ -524,7 +548,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlMousedeltaup.Setup()
-                .At(this, 15)
+                .At(this, 16)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Delta Up")
@@ -546,7 +570,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlMousedeltadown.Setup()
-                .At(this, 16)
+                .At(this, 17)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Delta Down")
@@ -568,7 +592,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlMousedeltaleft.Setup()
-                .At(this, 17)
+                .At(this, 18)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Delta Left")
@@ -590,7 +614,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlMousedeltaright.Setup()
-                .At(this, 18)
+                .At(this, 19)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Delta Right")
@@ -612,7 +636,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousedeltax.Setup()
-                .At(this, 19)
+                .At(this, 20)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Delta X")
@@ -633,7 +657,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousedeltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousedeltay.Setup()
-                .At(this, 20)
+                .At(this, 21)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Delta Y")
@@ -654,7 +678,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrollup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlMousescrollup.Setup()
-                .At(this, 21)
+                .At(this, 22)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Scroll Up")
@@ -676,7 +700,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrolldown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlMousescrolldown.Setup()
-                .At(this, 22)
+                .At(this, 23)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Scroll Down")
@@ -698,7 +722,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrollleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlMousescrollleft.Setup()
-                .At(this, 23)
+                .At(this, 24)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Scroll Left")
@@ -720,7 +744,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrollright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlMousescrollright.Setup()
-                .At(this, 24)
+                .At(this, 25)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Scroll Right")
@@ -742,7 +766,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrollx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousescrollx.Setup()
-                .At(this, 25)
+                .At(this, 26)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Scroll Left/Right")
@@ -765,7 +789,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMousescrolly = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMousescrolly.Setup()
-                .At(this, 26)
+                .At(this, 27)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Scroll Up/Down")
@@ -788,7 +812,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMouseradiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMouseradiusx.Setup()
-                .At(this, 27)
+                .At(this, 28)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Radius X")
@@ -809,7 +833,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlMouseradiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlMouseradiusy.Setup()
-                .At(this, 28)
+                .At(this, 29)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Radius Y")

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastTouchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastTouchscreen.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.InputSystem
         public const string metadata = "AutoWindowSpace;Touch;Vector2;Delta;Analog;TouchPress;Button;Axis;Integer;TouchPhase;Double;Touchscreen;Pointer";
         public FastTouchscreen()
         {
-            var builder = this.Setup(290, 5, 0)
+            var builder = this.Setup(301, 5, 0)
                 .WithName("Touchscreen")
                 .WithDisplayName("Touchscreen")
                 .WithChildren(0, 16)
@@ -113,6 +113,9 @@ namespace UnityEngine.InputSystem
 
             // /Touchscreen/primaryTouch/tapCount
             var ctrlTouchscreenprimaryTouchtapCount = Initialize_ctrlTouchscreenprimaryTouchtapCount(kIntegerLayout, ctrlTouchscreenprimaryTouch);
+
+            // /Touchscreen/primaryTouch/displayIndex
+            var ctrlTouchscreenprimaryTouchdisplayIndex = Initialize_ctrlTouchscreenprimaryTouchdisplayIndex(kIntegerLayout, ctrlTouchscreenprimaryTouch);
 
             // /Touchscreen/primaryTouch/indirectTouch
             var ctrlTouchscreenprimaryTouchindirectTouch = Initialize_ctrlTouchscreenprimaryTouchindirectTouch(kButtonLayout, ctrlTouchscreenprimaryTouch);
@@ -216,6 +219,9 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch0/tapCount
             var ctrlTouchscreentouch0tapCount = Initialize_ctrlTouchscreentouch0tapCount(kIntegerLayout, ctrlTouchscreentouch0);
 
+            // /Touchscreen/touch0/displayIndex
+            var ctrlTouchscreentouch0displayIndex = Initialize_ctrlTouchscreentouch0displayIndex(kIntegerLayout, ctrlTouchscreentouch0);
+
             // /Touchscreen/touch0/indirectTouch
             var ctrlTouchscreentouch0indirectTouch = Initialize_ctrlTouchscreentouch0indirectTouch(kButtonLayout, ctrlTouchscreentouch0);
 
@@ -287,6 +293,9 @@ namespace UnityEngine.InputSystem
 
             // /Touchscreen/touch1/tapCount
             var ctrlTouchscreentouch1tapCount = Initialize_ctrlTouchscreentouch1tapCount(kIntegerLayout, ctrlTouchscreentouch1);
+
+            // /Touchscreen/touch1/displayIndex
+            var ctrlTouchscreentouch1displayIndex = Initialize_ctrlTouchscreentouch1displayIndex(kIntegerLayout, ctrlTouchscreentouch1);
 
             // /Touchscreen/touch1/indirectTouch
             var ctrlTouchscreentouch1indirectTouch = Initialize_ctrlTouchscreentouch1indirectTouch(kButtonLayout, ctrlTouchscreentouch1);
@@ -360,6 +369,9 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch2/tapCount
             var ctrlTouchscreentouch2tapCount = Initialize_ctrlTouchscreentouch2tapCount(kIntegerLayout, ctrlTouchscreentouch2);
 
+            // /Touchscreen/touch2/displayIndex
+            var ctrlTouchscreentouch2displayIndex = Initialize_ctrlTouchscreentouch2displayIndex(kIntegerLayout, ctrlTouchscreentouch2);
+
             // /Touchscreen/touch2/indirectTouch
             var ctrlTouchscreentouch2indirectTouch = Initialize_ctrlTouchscreentouch2indirectTouch(kButtonLayout, ctrlTouchscreentouch2);
 
@@ -431,6 +443,9 @@ namespace UnityEngine.InputSystem
 
             // /Touchscreen/touch3/tapCount
             var ctrlTouchscreentouch3tapCount = Initialize_ctrlTouchscreentouch3tapCount(kIntegerLayout, ctrlTouchscreentouch3);
+
+            // /Touchscreen/touch3/displayIndex
+            var ctrlTouchscreentouch3displayIndex = Initialize_ctrlTouchscreentouch3displayIndex(kIntegerLayout, ctrlTouchscreentouch3);
 
             // /Touchscreen/touch3/indirectTouch
             var ctrlTouchscreentouch3indirectTouch = Initialize_ctrlTouchscreentouch3indirectTouch(kButtonLayout, ctrlTouchscreentouch3);
@@ -504,6 +519,9 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch4/tapCount
             var ctrlTouchscreentouch4tapCount = Initialize_ctrlTouchscreentouch4tapCount(kIntegerLayout, ctrlTouchscreentouch4);
 
+            // /Touchscreen/touch4/displayIndex
+            var ctrlTouchscreentouch4displayIndex = Initialize_ctrlTouchscreentouch4displayIndex(kIntegerLayout, ctrlTouchscreentouch4);
+
             // /Touchscreen/touch4/indirectTouch
             var ctrlTouchscreentouch4indirectTouch = Initialize_ctrlTouchscreentouch4indirectTouch(kButtonLayout, ctrlTouchscreentouch4);
 
@@ -575,6 +593,9 @@ namespace UnityEngine.InputSystem
 
             // /Touchscreen/touch5/tapCount
             var ctrlTouchscreentouch5tapCount = Initialize_ctrlTouchscreentouch5tapCount(kIntegerLayout, ctrlTouchscreentouch5);
+
+            // /Touchscreen/touch5/displayIndex
+            var ctrlTouchscreentouch5displayIndex = Initialize_ctrlTouchscreentouch5displayIndex(kIntegerLayout, ctrlTouchscreentouch5);
 
             // /Touchscreen/touch5/indirectTouch
             var ctrlTouchscreentouch5indirectTouch = Initialize_ctrlTouchscreentouch5indirectTouch(kButtonLayout, ctrlTouchscreentouch5);
@@ -648,6 +669,9 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch6/tapCount
             var ctrlTouchscreentouch6tapCount = Initialize_ctrlTouchscreentouch6tapCount(kIntegerLayout, ctrlTouchscreentouch6);
 
+            // /Touchscreen/touch6/displayIndex
+            var ctrlTouchscreentouch6displayIndex = Initialize_ctrlTouchscreentouch6displayIndex(kIntegerLayout, ctrlTouchscreentouch6);
+
             // /Touchscreen/touch6/indirectTouch
             var ctrlTouchscreentouch6indirectTouch = Initialize_ctrlTouchscreentouch6indirectTouch(kButtonLayout, ctrlTouchscreentouch6);
 
@@ -719,6 +743,9 @@ namespace UnityEngine.InputSystem
 
             // /Touchscreen/touch7/tapCount
             var ctrlTouchscreentouch7tapCount = Initialize_ctrlTouchscreentouch7tapCount(kIntegerLayout, ctrlTouchscreentouch7);
+
+            // /Touchscreen/touch7/displayIndex
+            var ctrlTouchscreentouch7displayIndex = Initialize_ctrlTouchscreentouch7displayIndex(kIntegerLayout, ctrlTouchscreentouch7);
 
             // /Touchscreen/touch7/indirectTouch
             var ctrlTouchscreentouch7indirectTouch = Initialize_ctrlTouchscreentouch7indirectTouch(kButtonLayout, ctrlTouchscreentouch7);
@@ -792,6 +819,9 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch8/tapCount
             var ctrlTouchscreentouch8tapCount = Initialize_ctrlTouchscreentouch8tapCount(kIntegerLayout, ctrlTouchscreentouch8);
 
+            // /Touchscreen/touch8/displayIndex
+            var ctrlTouchscreentouch8displayIndex = Initialize_ctrlTouchscreentouch8displayIndex(kIntegerLayout, ctrlTouchscreentouch8);
+
             // /Touchscreen/touch8/indirectTouch
             var ctrlTouchscreentouch8indirectTouch = Initialize_ctrlTouchscreentouch8indirectTouch(kButtonLayout, ctrlTouchscreentouch8);
 
@@ -864,6 +894,9 @@ namespace UnityEngine.InputSystem
             // /Touchscreen/touch9/tapCount
             var ctrlTouchscreentouch9tapCount = Initialize_ctrlTouchscreentouch9tapCount(kIntegerLayout, ctrlTouchscreentouch9);
 
+            // /Touchscreen/touch9/displayIndex
+            var ctrlTouchscreentouch9displayIndex = Initialize_ctrlTouchscreentouch9displayIndex(kIntegerLayout, ctrlTouchscreentouch9);
+
             // /Touchscreen/touch9/indirectTouch
             var ctrlTouchscreentouch9indirectTouch = Initialize_ctrlTouchscreentouch9indirectTouch(kButtonLayout, ctrlTouchscreentouch9);
 
@@ -932,12 +965,14 @@ namespace UnityEngine.InputSystem
             this.touchControlArray[8] = ctrlTouchscreentouch8;
             this.touchControlArray[9] = ctrlTouchscreentouch9;
             this.primaryTouch = ctrlTouchscreenprimaryTouch;
+            this.displayIndex = ctrlTouchscreenprimaryTouchdisplayIndex;
             this.position = ctrlTouchscreenposition;
             this.delta = ctrlTouchscreendelta;
             this.radius = ctrlTouchscreenradius;
             this.pressure = ctrlTouchscreenpressure;
             this.press = ctrlTouchscreenpress;
             ctrlTouchscreenprimaryTouch.press = ctrlTouchscreenprimaryTouchpress;
+            ctrlTouchscreenprimaryTouch.displayIndex = ctrlTouchscreenprimaryTouchdisplayIndex;
             ctrlTouchscreenprimaryTouch.touchId = ctrlTouchscreenprimaryTouchtouchId;
             ctrlTouchscreenprimaryTouch.position = ctrlTouchscreenprimaryTouchposition;
             ctrlTouchscreenprimaryTouch.delta = ctrlTouchscreenprimaryTouchdelta;
@@ -960,6 +995,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenradius.x = ctrlTouchscreenradiusx;
             ctrlTouchscreenradius.y = ctrlTouchscreenradiusy;
             ctrlTouchscreentouch0.press = ctrlTouchscreentouch0press;
+            ctrlTouchscreentouch0.displayIndex = ctrlTouchscreentouch0displayIndex;
             ctrlTouchscreentouch0.touchId = ctrlTouchscreentouch0touchId;
             ctrlTouchscreentouch0.position = ctrlTouchscreentouch0position;
             ctrlTouchscreentouch0.delta = ctrlTouchscreentouch0delta;
@@ -972,6 +1008,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch0.startTime = ctrlTouchscreentouch0startTime;
             ctrlTouchscreentouch0.startPosition = ctrlTouchscreentouch0startPosition;
             ctrlTouchscreentouch1.press = ctrlTouchscreentouch1press;
+            ctrlTouchscreentouch1.displayIndex = ctrlTouchscreentouch1displayIndex;
             ctrlTouchscreentouch1.touchId = ctrlTouchscreentouch1touchId;
             ctrlTouchscreentouch1.position = ctrlTouchscreentouch1position;
             ctrlTouchscreentouch1.delta = ctrlTouchscreentouch1delta;
@@ -984,6 +1021,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch1.startTime = ctrlTouchscreentouch1startTime;
             ctrlTouchscreentouch1.startPosition = ctrlTouchscreentouch1startPosition;
             ctrlTouchscreentouch2.press = ctrlTouchscreentouch2press;
+            ctrlTouchscreentouch2.displayIndex = ctrlTouchscreentouch2displayIndex;
             ctrlTouchscreentouch2.touchId = ctrlTouchscreentouch2touchId;
             ctrlTouchscreentouch2.position = ctrlTouchscreentouch2position;
             ctrlTouchscreentouch2.delta = ctrlTouchscreentouch2delta;
@@ -996,6 +1034,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch2.startTime = ctrlTouchscreentouch2startTime;
             ctrlTouchscreentouch2.startPosition = ctrlTouchscreentouch2startPosition;
             ctrlTouchscreentouch3.press = ctrlTouchscreentouch3press;
+            ctrlTouchscreentouch3.displayIndex = ctrlTouchscreentouch3displayIndex;
             ctrlTouchscreentouch3.touchId = ctrlTouchscreentouch3touchId;
             ctrlTouchscreentouch3.position = ctrlTouchscreentouch3position;
             ctrlTouchscreentouch3.delta = ctrlTouchscreentouch3delta;
@@ -1008,6 +1047,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch3.startTime = ctrlTouchscreentouch3startTime;
             ctrlTouchscreentouch3.startPosition = ctrlTouchscreentouch3startPosition;
             ctrlTouchscreentouch4.press = ctrlTouchscreentouch4press;
+            ctrlTouchscreentouch4.displayIndex = ctrlTouchscreentouch4displayIndex;
             ctrlTouchscreentouch4.touchId = ctrlTouchscreentouch4touchId;
             ctrlTouchscreentouch4.position = ctrlTouchscreentouch4position;
             ctrlTouchscreentouch4.delta = ctrlTouchscreentouch4delta;
@@ -1020,6 +1060,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch4.startTime = ctrlTouchscreentouch4startTime;
             ctrlTouchscreentouch4.startPosition = ctrlTouchscreentouch4startPosition;
             ctrlTouchscreentouch5.press = ctrlTouchscreentouch5press;
+            ctrlTouchscreentouch5.displayIndex = ctrlTouchscreentouch5displayIndex;
             ctrlTouchscreentouch5.touchId = ctrlTouchscreentouch5touchId;
             ctrlTouchscreentouch5.position = ctrlTouchscreentouch5position;
             ctrlTouchscreentouch5.delta = ctrlTouchscreentouch5delta;
@@ -1032,6 +1073,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch5.startTime = ctrlTouchscreentouch5startTime;
             ctrlTouchscreentouch5.startPosition = ctrlTouchscreentouch5startPosition;
             ctrlTouchscreentouch6.press = ctrlTouchscreentouch6press;
+            ctrlTouchscreentouch6.displayIndex = ctrlTouchscreentouch6displayIndex;
             ctrlTouchscreentouch6.touchId = ctrlTouchscreentouch6touchId;
             ctrlTouchscreentouch6.position = ctrlTouchscreentouch6position;
             ctrlTouchscreentouch6.delta = ctrlTouchscreentouch6delta;
@@ -1044,6 +1086,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch6.startTime = ctrlTouchscreentouch6startTime;
             ctrlTouchscreentouch6.startPosition = ctrlTouchscreentouch6startPosition;
             ctrlTouchscreentouch7.press = ctrlTouchscreentouch7press;
+            ctrlTouchscreentouch7.displayIndex = ctrlTouchscreentouch7displayIndex;
             ctrlTouchscreentouch7.touchId = ctrlTouchscreentouch7touchId;
             ctrlTouchscreentouch7.position = ctrlTouchscreentouch7position;
             ctrlTouchscreentouch7.delta = ctrlTouchscreentouch7delta;
@@ -1056,6 +1099,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch7.startTime = ctrlTouchscreentouch7startTime;
             ctrlTouchscreentouch7.startPosition = ctrlTouchscreentouch7startPosition;
             ctrlTouchscreentouch8.press = ctrlTouchscreentouch8press;
+            ctrlTouchscreentouch8.displayIndex = ctrlTouchscreentouch8displayIndex;
             ctrlTouchscreentouch8.touchId = ctrlTouchscreentouch8touchId;
             ctrlTouchscreentouch8.position = ctrlTouchscreentouch8position;
             ctrlTouchscreentouch8.delta = ctrlTouchscreentouch8delta;
@@ -1068,6 +1112,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch8.startTime = ctrlTouchscreentouch8startTime;
             ctrlTouchscreentouch8.startPosition = ctrlTouchscreentouch8startPosition;
             ctrlTouchscreentouch9.press = ctrlTouchscreentouch9press;
+            ctrlTouchscreentouch9.displayIndex = ctrlTouchscreentouch9displayIndex;
             ctrlTouchscreentouch9.touchId = ctrlTouchscreentouch9touchId;
             ctrlTouchscreentouch9.position = ctrlTouchscreentouch9position;
             ctrlTouchscreentouch9.delta = ctrlTouchscreentouch9delta;
@@ -1215,30 +1260,31 @@ namespace UnityEngine.InputSystem
             // State offset to control index map.
             builder.WithStateOffsetToControlIndexMap(new uint[]
             {
-                32784u, 16810012u, 16810024u, 33587229u, 33587241u, 50364448u, 50364449u, 50364450u, 50364460u, 50364461u
-                , 50364462u, 67141662u, 67141663u, 67141667u, 67141674u, 67141675u, 67141679u, 83918851u, 83918867u, 100696100u
-                , 100696112u, 117473317u, 117473329u, 134225925u, 134225941u, 134225942u, 138420247u, 146801688u, 148898841u, 167837722u
-                , 201359398u, 218136615u, 234913842u, 251691070u, 268468287u, 285245506u, 285245507u, 285245508u, 302022720u, 302022721u
-                , 302022725u, 318799925u, 335577158u, 352354375u, 369106999u, 369107000u, 373301305u, 381682746u, 383779899u, 402718780u
-                , 436240456u, 453017673u, 469794890u, 486572118u, 503349335u, 520126554u, 520126555u, 520126556u, 536903768u, 536903769u
-                , 536903773u, 553680973u, 570458206u, 587235423u, 603988047u, 603988048u, 608182353u, 616563794u, 618660947u, 637599828u
-                , 671121504u, 687898721u, 704675938u, 721453166u, 738230383u, 755007602u, 755007603u, 755007604u, 771784816u, 771784817u
-                , 771784821u, 788562021u, 805339254u, 822116471u, 838869095u, 838869096u, 843063401u, 851444842u, 853541995u, 872480876u
-                , 906002552u, 922779769u, 939556986u, 956334214u, 973111431u, 989888650u, 989888651u, 989888652u, 1006665864u, 1006665865u
-                , 1006665869u, 1023443069u, 1040220302u, 1056997519u, 1073750143u, 1073750144u, 1077944449u, 1086325890u, 1088423043u, 1107361924u
-                , 1140883600u, 1157660817u, 1174438034u, 1191215262u, 1207992479u, 1224769698u, 1224769699u, 1224769700u, 1241546912u, 1241546913u
-                , 1241546917u, 1258324117u, 1275101350u, 1291878567u, 1308631191u, 1308631192u, 1312825497u, 1321206938u, 1323304091u, 1342242972u
-                , 1375764648u, 1392541865u, 1409319082u, 1426096310u, 1442873527u, 1459650746u, 1459650747u, 1459650748u, 1476427960u, 1476427961u
-                , 1476427965u, 1493205165u, 1509982398u, 1526759615u, 1543512239u, 1543512240u, 1547706545u, 1556087986u, 1558185139u, 1577124020u
-                , 1610645696u, 1627422913u, 1644200130u, 1660977358u, 1677754575u, 1694531794u, 1694531795u, 1694531796u, 1711309008u, 1711309009u
-                , 1711309013u, 1728086213u, 1744863446u, 1761640663u, 1778393287u, 1778393288u, 1782587593u, 1790969034u, 1793066187u, 1812005068u
-                , 1845526744u, 1862303961u, 1879081178u, 1895858406u, 1912635623u, 1929412842u, 1929412843u, 1929412844u, 1946190056u, 1946190057u
-                , 1946190061u, 1962967261u, 1979744494u, 1996521711u, 2013274335u, 2013274336u, 2017468641u, 2025850082u, 2027947235u, 2046886116u
-                , 2080407792u, 2097185009u, 2113962226u, 2130739454u, 2147516671u, 2164293890u, 2164293891u, 2164293892u, 2181071104u, 2181071105u
-                , 2181071109u, 2197848309u, 2214625542u, 2231402759u, 2248155383u, 2248155384u, 2252349689u, 2260731130u, 2262828283u, 2281767164u
-                , 2315288840u, 2332066057u, 2348843274u, 2365620502u, 2382397719u, 2399174938u, 2399174939u, 2399174940u, 2415952152u, 2415952153u
-                , 2415952157u, 2432729357u, 2449506590u, 2466283807u, 2483036431u, 2483036432u, 2487230737u, 2495612178u, 2497709331u, 2516648212u
-                , 2550169888u, 2566947105u
+                32784u, 16810013u, 16810025u, 33587230u, 33587242u, 50364449u, 50364450u, 50364451u, 50364461u, 50364462u
+                , 50364463u, 67141663u, 67141664u, 67141668u, 67141675u, 67141676u, 67141680u, 83918851u, 83918867u, 100696101u
+                , 100696113u, 117473318u, 117473330u, 134225925u, 134225941u, 134225942u, 138420247u, 142614552u, 146801689u, 148898842u
+                , 167837723u, 201359399u, 218136616u, 234913843u, 251691072u, 268468289u, 285245508u, 285245509u, 285245510u, 302022722u
+                , 302022723u, 302022727u, 318799926u, 335577160u, 352354377u, 369107000u, 369107001u, 373301306u, 377495611u, 381682748u
+                , 383779901u, 402718782u, 436240458u, 453017675u, 469794892u, 486572121u, 503349338u, 520126557u, 520126558u, 520126559u
+                , 536903771u, 536903772u, 536903776u, 553680975u, 570458209u, 587235426u, 603988049u, 603988050u, 608182355u, 612376660u
+                , 616563797u, 618660950u, 637599831u, 671121507u, 687898724u, 704675941u, 721453170u, 738230387u, 755007606u, 755007607u
+                , 755007608u, 771784820u, 771784821u, 771784825u, 788562024u, 805339258u, 822116475u, 838869098u, 838869099u, 843063404u
+                , 847257709u, 851444846u, 853541999u, 872480880u, 906002556u, 922779773u, 939556990u, 956334219u, 973111436u, 989888655u
+                , 989888656u, 989888657u, 1006665869u, 1006665870u, 1006665874u, 1023443073u, 1040220307u, 1056997524u, 1073750147u, 1073750148u
+                , 1077944453u, 1082138758u, 1086325895u, 1088423048u, 1107361929u, 1140883605u, 1157660822u, 1174438039u, 1191215268u, 1207992485u
+                , 1224769704u, 1224769705u, 1224769706u, 1241546918u, 1241546919u, 1241546923u, 1258324122u, 1275101356u, 1291878573u, 1308631196u
+                , 1308631197u, 1312825502u, 1317019807u, 1321206944u, 1323304097u, 1342242978u, 1375764654u, 1392541871u, 1409319088u, 1426096317u
+                , 1442873534u, 1459650753u, 1459650754u, 1459650755u, 1476427967u, 1476427968u, 1476427972u, 1493205171u, 1509982405u, 1526759622u
+                , 1543512245u, 1543512246u, 1547706551u, 1551900856u, 1556087993u, 1558185146u, 1577124027u, 1610645703u, 1627422920u, 1644200137u
+                , 1660977366u, 1677754583u, 1694531802u, 1694531803u, 1694531804u, 1711309016u, 1711309017u, 1711309021u, 1728086220u, 1744863454u
+                , 1761640671u, 1778393294u, 1778393295u, 1782587600u, 1786781905u, 1790969042u, 1793066195u, 1812005076u, 1845526752u, 1862303969u
+                , 1879081186u, 1895858415u, 1912635632u, 1929412851u, 1929412852u, 1929412853u, 1946190065u, 1946190066u, 1946190070u, 1962967269u
+                , 1979744503u, 1996521720u, 2013274343u, 2013274344u, 2017468649u, 2021662954u, 2025850091u, 2027947244u, 2046886125u, 2080407801u
+                , 2097185018u, 2113962235u, 2130739464u, 2147516681u, 2164293900u, 2164293901u, 2164293902u, 2181071114u, 2181071115u, 2181071119u
+                , 2197848318u, 2214625552u, 2231402769u, 2248155392u, 2248155393u, 2252349698u, 2256544003u, 2260731140u, 2262828293u, 2281767174u
+                , 2315288850u, 2332066067u, 2348843284u, 2365620513u, 2382397730u, 2399174949u, 2399174950u, 2399174951u, 2415952163u, 2415952164u
+                , 2415952168u, 2432729367u, 2449506601u, 2466283818u, 2483036441u, 2483036442u, 2487230747u, 2491425052u, 2495612189u, 2497709342u
+                , 2516648223u, 2550169899u, 2566947116u
             });
 
             builder.Finish();
@@ -1250,7 +1296,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouch.Setup()
                 .At(this, 0)
                 .WithParent(parent)
-                .WithChildren(16, 12)
+                .WithChildren(16, 13)
                 .WithName("primaryTouch")
                 .WithDisplayName("Primary Touch")
                 .WithLayout(kTouchLayout)
@@ -1272,7 +1318,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenposition.Setup()
                 .At(this, 1)
                 .WithParent(parent)
-                .WithChildren(40, 2)
+                .WithChildren(41, 2)
                 .WithName("position")
                 .WithDisplayName("Position")
                 .WithLayout(kVector2Layout)
@@ -1298,7 +1344,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreendelta.Setup()
                 .At(this, 2)
                 .WithParent(parent)
-                .WithChildren(42, 6)
+                .WithChildren(43, 6)
                 .WithName("delta")
                 .WithDisplayName("Delta")
                 .WithLayout(kDeltaLayout)
@@ -1342,7 +1388,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenradius.Setup()
                 .At(this, 4)
                 .WithParent(parent)
-                .WithChildren(48, 2)
+                .WithChildren(49, 2)
                 .WithName("radius")
                 .WithDisplayName("Radius")
                 .WithLayout(kVector2Layout)
@@ -1387,7 +1433,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch0.Setup()
                 .At(this, 6)
                 .WithParent(parent)
-                .WithChildren(50, 12)
+                .WithChildren(51, 13)
                 .WithName("touch0")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1408,7 +1454,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch1.Setup()
                 .At(this, 7)
                 .WithParent(parent)
-                .WithChildren(74, 12)
+                .WithChildren(76, 13)
                 .WithName("touch1")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1429,7 +1475,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch2.Setup()
                 .At(this, 8)
                 .WithParent(parent)
-                .WithChildren(98, 12)
+                .WithChildren(101, 13)
                 .WithName("touch2")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1450,7 +1496,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch3.Setup()
                 .At(this, 9)
                 .WithParent(parent)
-                .WithChildren(122, 12)
+                .WithChildren(126, 13)
                 .WithName("touch3")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1471,7 +1517,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch4.Setup()
                 .At(this, 10)
                 .WithParent(parent)
-                .WithChildren(146, 12)
+                .WithChildren(151, 13)
                 .WithName("touch4")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1492,7 +1538,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch5.Setup()
                 .At(this, 11)
                 .WithParent(parent)
-                .WithChildren(170, 12)
+                .WithChildren(176, 13)
                 .WithName("touch5")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1513,7 +1559,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch6.Setup()
                 .At(this, 12)
                 .WithParent(parent)
-                .WithChildren(194, 12)
+                .WithChildren(201, 13)
                 .WithName("touch6")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1534,7 +1580,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch7.Setup()
                 .At(this, 13)
                 .WithParent(parent)
-                .WithChildren(218, 12)
+                .WithChildren(226, 13)
                 .WithName("touch7")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1555,7 +1601,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch8.Setup()
                 .At(this, 14)
                 .WithParent(parent)
-                .WithChildren(242, 12)
+                .WithChildren(251, 13)
                 .WithName("touch8")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1576,7 +1622,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreentouch9.Setup()
                 .At(this, 15)
                 .WithParent(parent)
-                .WithChildren(266, 12)
+                .WithChildren(276, 13)
                 .WithName("touch9")
                 .WithDisplayName("Touch")
                 .WithLayout(kTouchLayout)
@@ -1620,7 +1666,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouchposition.Setup()
                 .At(this, 17)
                 .WithParent(parent)
-                .WithChildren(28, 2)
+                .WithChildren(29, 2)
                 .WithName("position")
                 .WithDisplayName("Primary Touch Position")
                 .WithShortDisplayName("Primary Touch Position")
@@ -1643,7 +1689,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouchdelta.Setup()
                 .At(this, 18)
                 .WithParent(parent)
-                .WithChildren(30, 6)
+                .WithChildren(31, 6)
                 .WithName("delta")
                 .WithDisplayName("Primary Touch Delta")
                 .WithShortDisplayName("Primary Touch Delta")
@@ -1686,7 +1732,7 @@ namespace UnityEngine.InputSystem
             ctrlTouchscreenprimaryTouchradius.Setup()
                 .At(this, 20)
                 .WithParent(parent)
-                .WithChildren(36, 2)
+                .WithChildren(37, 2)
                 .WithName("radius")
                 .WithDisplayName("Primary Touch Radius")
                 .WithShortDisplayName("Primary Touch Radius")
@@ -1768,11 +1814,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreenprimaryTouchtapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreenprimaryTouchdisplayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreenprimaryTouchdisplayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreenprimaryTouchdisplayIndex.Setup()
+                .At(this, 24)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Primary Touch Display Index")
+                .WithShortDisplayName("Primary Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 34,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreenprimaryTouchdisplayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreenprimaryTouchindirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreenprimaryTouchindirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreenprimaryTouchindirectTouch.Setup()
-                .At(this, 24)
+                .At(this, 25)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Primary Touch Indirect Touch?")
@@ -1796,7 +1863,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchtap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreenprimaryTouchtap.Setup()
-                .At(this, 25)
+                .At(this, 26)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Primary Touch Tap")
@@ -1820,7 +1887,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchstartTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreenprimaryTouchstartTime.Setup()
-                .At(this, 26)
+                .At(this, 27)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Primary Touch Start Time")
@@ -1842,9 +1909,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchstartPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreenprimaryTouchstartPosition.Setup()
-                .At(this, 27)
+                .At(this, 28)
                 .WithParent(parent)
-                .WithChildren(38, 2)
+                .WithChildren(39, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Primary Touch Start Position")
                 .WithShortDisplayName("Primary Touch Start Position")
@@ -1865,7 +1932,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchpositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchpositionx.Setup()
-                .At(this, 28)
+                .At(this, 29)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Position X")
@@ -1887,7 +1954,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchpositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchpositiony.Setup()
-                .At(this, 29)
+                .At(this, 30)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Position Y")
@@ -1909,7 +1976,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreenprimaryTouchdeltaup.Setup()
-                .At(this, 30)
+                .At(this, 31)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Primary Touch Primary Touch Delta Up")
@@ -1931,7 +1998,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreenprimaryTouchdeltadown.Setup()
-                .At(this, 31)
+                .At(this, 32)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Primary Touch Primary Touch Delta Down")
@@ -1953,7 +2020,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreenprimaryTouchdeltaleft.Setup()
-                .At(this, 32)
+                .At(this, 33)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Primary Touch Primary Touch Delta Left")
@@ -1975,7 +2042,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreenprimaryTouchdeltaright.Setup()
-                .At(this, 33)
+                .At(this, 34)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Primary Touch Primary Touch Delta Right")
@@ -1997,7 +2064,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchdeltax.Setup()
-                .At(this, 34)
+                .At(this, 35)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Delta X")
@@ -2018,7 +2085,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchdeltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchdeltay.Setup()
-                .At(this, 35)
+                .At(this, 36)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Delta Y")
@@ -2039,7 +2106,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchradiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchradiusx.Setup()
-                .At(this, 36)
+                .At(this, 37)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Radius X")
@@ -2060,7 +2127,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchradiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchradiusy.Setup()
-                .At(this, 37)
+                .At(this, 38)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Radius Y")
@@ -2081,7 +2148,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchstartPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchstartPositionx.Setup()
-                .At(this, 38)
+                .At(this, 39)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Primary Touch Primary Touch Start Position X")
@@ -2102,7 +2169,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenprimaryTouchstartPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenprimaryTouchstartPositiony.Setup()
-                .At(this, 39)
+                .At(this, 40)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Primary Touch Primary Touch Start Position Y")
@@ -2123,7 +2190,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenpositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenpositionx.Setup()
-                .At(this, 40)
+                .At(this, 41)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Position X")
@@ -2145,7 +2212,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenpositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenpositiony.Setup()
-                .At(this, 41)
+                .At(this, 42)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Position Y")
@@ -2167,7 +2234,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreendeltaup.Setup()
-                .At(this, 42)
+                .At(this, 43)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Delta Up")
@@ -2189,7 +2256,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreendeltadown.Setup()
-                .At(this, 43)
+                .At(this, 44)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Delta Down")
@@ -2211,7 +2278,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreendeltaleft.Setup()
-                .At(this, 44)
+                .At(this, 45)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Delta Left")
@@ -2233,7 +2300,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreendeltaright.Setup()
-                .At(this, 45)
+                .At(this, 46)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Delta Right")
@@ -2255,7 +2322,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreendeltax.Setup()
-                .At(this, 46)
+                .At(this, 47)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Delta X")
@@ -2276,7 +2343,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreendeltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreendeltay.Setup()
-                .At(this, 47)
+                .At(this, 48)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Delta Y")
@@ -2297,7 +2364,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenradiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenradiusx.Setup()
-                .At(this, 48)
+                .At(this, 49)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Radius X")
@@ -2318,7 +2385,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreenradiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreenradiusy.Setup()
-                .At(this, 49)
+                .At(this, 50)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Radius Y")
@@ -2339,7 +2406,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch0touchId.Setup()
-                .At(this, 50)
+                .At(this, 51)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -2362,9 +2429,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch0position.Setup()
-                .At(this, 51)
+                .At(this, 52)
                 .WithParent(parent)
-                .WithChildren(62, 2)
+                .WithChildren(64, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -2385,9 +2452,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch0delta.Setup()
-                .At(this, 52)
+                .At(this, 53)
                 .WithParent(parent)
-                .WithChildren(64, 6)
+                .WithChildren(66, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -2407,7 +2474,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0pressure.Setup()
-                .At(this, 53)
+                .At(this, 54)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -2428,9 +2495,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch0radius.Setup()
-                .At(this, 54)
+                .At(this, 55)
                 .WithParent(parent)
-                .WithChildren(70, 2)
+                .WithChildren(72, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -2450,7 +2517,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch0phase.Setup()
-                .At(this, 55)
+                .At(this, 56)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -2472,7 +2539,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch0press.Setup()
-                .At(this, 56)
+                .At(this, 57)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -2495,7 +2562,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch0tapCount.Setup()
-                .At(this, 57)
+                .At(this, 58)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -2512,11 +2579,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch0tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch0displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch0displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch0displayIndex.Setup()
+                .At(this, 59)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 90,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch0displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch0indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch0indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch0indirectTouch.Setup()
-                .At(this, 58)
+                .At(this, 60)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -2540,7 +2628,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch0tap.Setup()
-                .At(this, 59)
+                .At(this, 61)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -2563,7 +2651,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch0startTime.Setup()
-                .At(this, 60)
+                .At(this, 62)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -2585,9 +2673,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch0startPosition.Setup()
-                .At(this, 61)
+                .At(this, 63)
                 .WithParent(parent)
-                .WithChildren(72, 2)
+                .WithChildren(74, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -2608,7 +2696,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0positionx.Setup()
-                .At(this, 62)
+                .At(this, 64)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -2630,7 +2718,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0positiony.Setup()
-                .At(this, 63)
+                .At(this, 65)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -2652,7 +2740,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch0deltaup.Setup()
-                .At(this, 64)
+                .At(this, 66)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -2674,7 +2762,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch0deltadown.Setup()
-                .At(this, 65)
+                .At(this, 67)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -2696,7 +2784,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch0deltaleft.Setup()
-                .At(this, 66)
+                .At(this, 68)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -2718,7 +2806,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch0deltaright.Setup()
-                .At(this, 67)
+                .At(this, 69)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -2740,7 +2828,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0deltax.Setup()
-                .At(this, 68)
+                .At(this, 70)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -2761,7 +2849,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0deltay.Setup()
-                .At(this, 69)
+                .At(this, 71)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -2782,7 +2870,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0radiusx.Setup()
-                .At(this, 70)
+                .At(this, 72)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -2803,7 +2891,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0radiusy.Setup()
-                .At(this, 71)
+                .At(this, 73)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -2824,7 +2912,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0startPositionx.Setup()
-                .At(this, 72)
+                .At(this, 74)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -2845,7 +2933,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch0startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch0startPositiony.Setup()
-                .At(this, 73)
+                .At(this, 75)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -2866,7 +2954,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch1touchId.Setup()
-                .At(this, 74)
+                .At(this, 76)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -2889,9 +2977,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch1position.Setup()
-                .At(this, 75)
+                .At(this, 77)
                 .WithParent(parent)
-                .WithChildren(86, 2)
+                .WithChildren(89, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -2912,9 +3000,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch1delta.Setup()
-                .At(this, 76)
+                .At(this, 78)
                 .WithParent(parent)
-                .WithChildren(88, 6)
+                .WithChildren(91, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -2934,7 +3022,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1pressure.Setup()
-                .At(this, 77)
+                .At(this, 79)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -2955,9 +3043,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch1radius.Setup()
-                .At(this, 78)
+                .At(this, 80)
                 .WithParent(parent)
-                .WithChildren(94, 2)
+                .WithChildren(97, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -2977,7 +3065,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch1phase.Setup()
-                .At(this, 79)
+                .At(this, 81)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -2999,7 +3087,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch1press.Setup()
-                .At(this, 80)
+                .At(this, 82)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -3022,7 +3110,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch1tapCount.Setup()
-                .At(this, 81)
+                .At(this, 83)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -3039,11 +3127,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch1tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch1displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch1displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch1displayIndex.Setup()
+                .At(this, 84)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 146,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch1displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch1indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch1indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch1indirectTouch.Setup()
-                .At(this, 82)
+                .At(this, 85)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -3067,7 +3176,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch1tap.Setup()
-                .At(this, 83)
+                .At(this, 86)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -3090,7 +3199,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch1startTime.Setup()
-                .At(this, 84)
+                .At(this, 87)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -3112,9 +3221,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch1startPosition.Setup()
-                .At(this, 85)
+                .At(this, 88)
                 .WithParent(parent)
-                .WithChildren(96, 2)
+                .WithChildren(99, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -3135,7 +3244,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1positionx.Setup()
-                .At(this, 86)
+                .At(this, 89)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -3157,7 +3266,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1positiony.Setup()
-                .At(this, 87)
+                .At(this, 90)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -3179,7 +3288,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch1deltaup.Setup()
-                .At(this, 88)
+                .At(this, 91)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -3201,7 +3310,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch1deltadown.Setup()
-                .At(this, 89)
+                .At(this, 92)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -3223,7 +3332,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch1deltaleft.Setup()
-                .At(this, 90)
+                .At(this, 93)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -3245,7 +3354,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch1deltaright.Setup()
-                .At(this, 91)
+                .At(this, 94)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -3267,7 +3376,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1deltax.Setup()
-                .At(this, 92)
+                .At(this, 95)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -3288,7 +3397,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1deltay.Setup()
-                .At(this, 93)
+                .At(this, 96)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -3309,7 +3418,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1radiusx.Setup()
-                .At(this, 94)
+                .At(this, 97)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -3330,7 +3439,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1radiusy.Setup()
-                .At(this, 95)
+                .At(this, 98)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -3351,7 +3460,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1startPositionx.Setup()
-                .At(this, 96)
+                .At(this, 99)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -3372,7 +3481,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch1startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch1startPositiony.Setup()
-                .At(this, 97)
+                .At(this, 100)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -3393,7 +3502,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch2touchId.Setup()
-                .At(this, 98)
+                .At(this, 101)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -3416,9 +3525,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch2position.Setup()
-                .At(this, 99)
+                .At(this, 102)
                 .WithParent(parent)
-                .WithChildren(110, 2)
+                .WithChildren(114, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -3439,9 +3548,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch2delta.Setup()
-                .At(this, 100)
+                .At(this, 103)
                 .WithParent(parent)
-                .WithChildren(112, 6)
+                .WithChildren(116, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -3461,7 +3570,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2pressure.Setup()
-                .At(this, 101)
+                .At(this, 104)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -3482,9 +3591,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch2radius.Setup()
-                .At(this, 102)
+                .At(this, 105)
                 .WithParent(parent)
-                .WithChildren(118, 2)
+                .WithChildren(122, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -3504,7 +3613,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch2phase.Setup()
-                .At(this, 103)
+                .At(this, 106)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -3526,7 +3635,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch2press.Setup()
-                .At(this, 104)
+                .At(this, 107)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -3549,7 +3658,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch2tapCount.Setup()
-                .At(this, 105)
+                .At(this, 108)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -3566,11 +3675,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch2tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch2displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch2displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch2displayIndex.Setup()
+                .At(this, 109)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 202,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch2displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch2indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch2indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch2indirectTouch.Setup()
-                .At(this, 106)
+                .At(this, 110)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -3594,7 +3724,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch2tap.Setup()
-                .At(this, 107)
+                .At(this, 111)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -3617,7 +3747,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch2startTime.Setup()
-                .At(this, 108)
+                .At(this, 112)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -3639,9 +3769,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch2startPosition.Setup()
-                .At(this, 109)
+                .At(this, 113)
                 .WithParent(parent)
-                .WithChildren(120, 2)
+                .WithChildren(124, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -3662,7 +3792,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2positionx.Setup()
-                .At(this, 110)
+                .At(this, 114)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -3684,7 +3814,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2positiony.Setup()
-                .At(this, 111)
+                .At(this, 115)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -3706,7 +3836,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch2deltaup.Setup()
-                .At(this, 112)
+                .At(this, 116)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -3728,7 +3858,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch2deltadown.Setup()
-                .At(this, 113)
+                .At(this, 117)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -3750,7 +3880,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch2deltaleft.Setup()
-                .At(this, 114)
+                .At(this, 118)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -3772,7 +3902,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch2deltaright.Setup()
-                .At(this, 115)
+                .At(this, 119)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -3794,7 +3924,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2deltax.Setup()
-                .At(this, 116)
+                .At(this, 120)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -3815,7 +3945,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2deltay.Setup()
-                .At(this, 117)
+                .At(this, 121)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -3836,7 +3966,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2radiusx.Setup()
-                .At(this, 118)
+                .At(this, 122)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -3857,7 +3987,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2radiusy.Setup()
-                .At(this, 119)
+                .At(this, 123)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -3878,7 +4008,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2startPositionx.Setup()
-                .At(this, 120)
+                .At(this, 124)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -3899,7 +4029,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch2startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch2startPositiony.Setup()
-                .At(this, 121)
+                .At(this, 125)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -3920,7 +4050,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch3touchId.Setup()
-                .At(this, 122)
+                .At(this, 126)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -3943,9 +4073,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch3position.Setup()
-                .At(this, 123)
+                .At(this, 127)
                 .WithParent(parent)
-                .WithChildren(134, 2)
+                .WithChildren(139, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -3966,9 +4096,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch3delta.Setup()
-                .At(this, 124)
+                .At(this, 128)
                 .WithParent(parent)
-                .WithChildren(136, 6)
+                .WithChildren(141, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -3988,7 +4118,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3pressure.Setup()
-                .At(this, 125)
+                .At(this, 129)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -4009,9 +4139,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch3radius.Setup()
-                .At(this, 126)
+                .At(this, 130)
                 .WithParent(parent)
-                .WithChildren(142, 2)
+                .WithChildren(147, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -4031,7 +4161,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch3phase.Setup()
-                .At(this, 127)
+                .At(this, 131)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -4053,7 +4183,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch3press.Setup()
-                .At(this, 128)
+                .At(this, 132)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -4076,7 +4206,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch3tapCount.Setup()
-                .At(this, 129)
+                .At(this, 133)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -4093,11 +4223,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch3tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch3displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch3displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch3displayIndex.Setup()
+                .At(this, 134)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 258,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch3displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch3indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch3indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch3indirectTouch.Setup()
-                .At(this, 130)
+                .At(this, 135)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -4121,7 +4272,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch3tap.Setup()
-                .At(this, 131)
+                .At(this, 136)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -4144,7 +4295,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch3startTime.Setup()
-                .At(this, 132)
+                .At(this, 137)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -4166,9 +4317,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch3startPosition.Setup()
-                .At(this, 133)
+                .At(this, 138)
                 .WithParent(parent)
-                .WithChildren(144, 2)
+                .WithChildren(149, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -4189,7 +4340,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3positionx.Setup()
-                .At(this, 134)
+                .At(this, 139)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -4211,7 +4362,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3positiony.Setup()
-                .At(this, 135)
+                .At(this, 140)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -4233,7 +4384,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch3deltaup.Setup()
-                .At(this, 136)
+                .At(this, 141)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -4255,7 +4406,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch3deltadown.Setup()
-                .At(this, 137)
+                .At(this, 142)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -4277,7 +4428,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch3deltaleft.Setup()
-                .At(this, 138)
+                .At(this, 143)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -4299,7 +4450,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch3deltaright.Setup()
-                .At(this, 139)
+                .At(this, 144)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -4321,7 +4472,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3deltax.Setup()
-                .At(this, 140)
+                .At(this, 145)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -4342,7 +4493,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3deltay.Setup()
-                .At(this, 141)
+                .At(this, 146)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -4363,7 +4514,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3radiusx.Setup()
-                .At(this, 142)
+                .At(this, 147)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -4384,7 +4535,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3radiusy.Setup()
-                .At(this, 143)
+                .At(this, 148)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -4405,7 +4556,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3startPositionx.Setup()
-                .At(this, 144)
+                .At(this, 149)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -4426,7 +4577,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch3startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch3startPositiony.Setup()
-                .At(this, 145)
+                .At(this, 150)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -4447,7 +4598,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch4touchId.Setup()
-                .At(this, 146)
+                .At(this, 151)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -4470,9 +4621,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch4position.Setup()
-                .At(this, 147)
+                .At(this, 152)
                 .WithParent(parent)
-                .WithChildren(158, 2)
+                .WithChildren(164, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -4493,9 +4644,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch4delta.Setup()
-                .At(this, 148)
+                .At(this, 153)
                 .WithParent(parent)
-                .WithChildren(160, 6)
+                .WithChildren(166, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -4515,7 +4666,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4pressure.Setup()
-                .At(this, 149)
+                .At(this, 154)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -4536,9 +4687,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch4radius.Setup()
-                .At(this, 150)
+                .At(this, 155)
                 .WithParent(parent)
-                .WithChildren(166, 2)
+                .WithChildren(172, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -4558,7 +4709,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch4phase.Setup()
-                .At(this, 151)
+                .At(this, 156)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -4580,7 +4731,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch4press.Setup()
-                .At(this, 152)
+                .At(this, 157)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -4603,7 +4754,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch4tapCount.Setup()
-                .At(this, 153)
+                .At(this, 158)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -4620,11 +4771,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch4tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch4displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch4displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch4displayIndex.Setup()
+                .At(this, 159)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 314,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch4displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch4indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch4indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch4indirectTouch.Setup()
-                .At(this, 154)
+                .At(this, 160)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -4648,7 +4820,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch4tap.Setup()
-                .At(this, 155)
+                .At(this, 161)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -4671,7 +4843,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch4startTime.Setup()
-                .At(this, 156)
+                .At(this, 162)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -4693,9 +4865,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch4startPosition.Setup()
-                .At(this, 157)
+                .At(this, 163)
                 .WithParent(parent)
-                .WithChildren(168, 2)
+                .WithChildren(174, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -4716,7 +4888,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4positionx.Setup()
-                .At(this, 158)
+                .At(this, 164)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -4738,7 +4910,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4positiony.Setup()
-                .At(this, 159)
+                .At(this, 165)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -4760,7 +4932,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch4deltaup.Setup()
-                .At(this, 160)
+                .At(this, 166)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -4782,7 +4954,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch4deltadown.Setup()
-                .At(this, 161)
+                .At(this, 167)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -4804,7 +4976,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch4deltaleft.Setup()
-                .At(this, 162)
+                .At(this, 168)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -4826,7 +4998,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch4deltaright.Setup()
-                .At(this, 163)
+                .At(this, 169)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -4848,7 +5020,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4deltax.Setup()
-                .At(this, 164)
+                .At(this, 170)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -4869,7 +5041,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4deltay.Setup()
-                .At(this, 165)
+                .At(this, 171)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -4890,7 +5062,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4radiusx.Setup()
-                .At(this, 166)
+                .At(this, 172)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -4911,7 +5083,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4radiusy.Setup()
-                .At(this, 167)
+                .At(this, 173)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -4932,7 +5104,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4startPositionx.Setup()
-                .At(this, 168)
+                .At(this, 174)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -4953,7 +5125,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch4startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch4startPositiony.Setup()
-                .At(this, 169)
+                .At(this, 175)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -4974,7 +5146,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch5touchId.Setup()
-                .At(this, 170)
+                .At(this, 176)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -4997,9 +5169,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch5position.Setup()
-                .At(this, 171)
+                .At(this, 177)
                 .WithParent(parent)
-                .WithChildren(182, 2)
+                .WithChildren(189, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -5020,9 +5192,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch5delta.Setup()
-                .At(this, 172)
+                .At(this, 178)
                 .WithParent(parent)
-                .WithChildren(184, 6)
+                .WithChildren(191, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -5042,7 +5214,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5pressure.Setup()
-                .At(this, 173)
+                .At(this, 179)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -5063,9 +5235,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch5radius.Setup()
-                .At(this, 174)
+                .At(this, 180)
                 .WithParent(parent)
-                .WithChildren(190, 2)
+                .WithChildren(197, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -5085,7 +5257,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch5phase.Setup()
-                .At(this, 175)
+                .At(this, 181)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -5107,7 +5279,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch5press.Setup()
-                .At(this, 176)
+                .At(this, 182)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -5130,7 +5302,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch5tapCount.Setup()
-                .At(this, 177)
+                .At(this, 183)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -5147,11 +5319,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch5tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch5displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch5displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch5displayIndex.Setup()
+                .At(this, 184)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 370,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch5displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch5indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch5indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch5indirectTouch.Setup()
-                .At(this, 178)
+                .At(this, 185)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -5175,7 +5368,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch5tap.Setup()
-                .At(this, 179)
+                .At(this, 186)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -5198,7 +5391,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch5startTime.Setup()
-                .At(this, 180)
+                .At(this, 187)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -5220,9 +5413,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch5startPosition.Setup()
-                .At(this, 181)
+                .At(this, 188)
                 .WithParent(parent)
-                .WithChildren(192, 2)
+                .WithChildren(199, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -5243,7 +5436,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5positionx.Setup()
-                .At(this, 182)
+                .At(this, 189)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -5265,7 +5458,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5positiony.Setup()
-                .At(this, 183)
+                .At(this, 190)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -5287,7 +5480,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch5deltaup.Setup()
-                .At(this, 184)
+                .At(this, 191)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -5309,7 +5502,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch5deltadown.Setup()
-                .At(this, 185)
+                .At(this, 192)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -5331,7 +5524,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch5deltaleft.Setup()
-                .At(this, 186)
+                .At(this, 193)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -5353,7 +5546,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch5deltaright.Setup()
-                .At(this, 187)
+                .At(this, 194)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -5375,7 +5568,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5deltax.Setup()
-                .At(this, 188)
+                .At(this, 195)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -5396,7 +5589,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5deltay.Setup()
-                .At(this, 189)
+                .At(this, 196)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -5417,7 +5610,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5radiusx.Setup()
-                .At(this, 190)
+                .At(this, 197)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -5438,7 +5631,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5radiusy.Setup()
-                .At(this, 191)
+                .At(this, 198)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -5459,7 +5652,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5startPositionx.Setup()
-                .At(this, 192)
+                .At(this, 199)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -5480,7 +5673,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch5startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch5startPositiony.Setup()
-                .At(this, 193)
+                .At(this, 200)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -5501,7 +5694,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch6touchId.Setup()
-                .At(this, 194)
+                .At(this, 201)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -5524,9 +5717,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch6position.Setup()
-                .At(this, 195)
+                .At(this, 202)
                 .WithParent(parent)
-                .WithChildren(206, 2)
+                .WithChildren(214, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -5547,9 +5740,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch6delta.Setup()
-                .At(this, 196)
+                .At(this, 203)
                 .WithParent(parent)
-                .WithChildren(208, 6)
+                .WithChildren(216, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -5569,7 +5762,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6pressure.Setup()
-                .At(this, 197)
+                .At(this, 204)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -5590,9 +5783,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch6radius.Setup()
-                .At(this, 198)
+                .At(this, 205)
                 .WithParent(parent)
-                .WithChildren(214, 2)
+                .WithChildren(222, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -5612,7 +5805,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch6phase.Setup()
-                .At(this, 199)
+                .At(this, 206)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -5634,7 +5827,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch6press.Setup()
-                .At(this, 200)
+                .At(this, 207)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -5657,7 +5850,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch6tapCount.Setup()
-                .At(this, 201)
+                .At(this, 208)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -5674,11 +5867,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch6tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch6displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch6displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch6displayIndex.Setup()
+                .At(this, 209)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 426,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch6displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch6indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch6indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch6indirectTouch.Setup()
-                .At(this, 202)
+                .At(this, 210)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -5702,7 +5916,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch6tap.Setup()
-                .At(this, 203)
+                .At(this, 211)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -5725,7 +5939,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch6startTime.Setup()
-                .At(this, 204)
+                .At(this, 212)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -5747,9 +5961,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch6startPosition.Setup()
-                .At(this, 205)
+                .At(this, 213)
                 .WithParent(parent)
-                .WithChildren(216, 2)
+                .WithChildren(224, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -5770,7 +5984,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6positionx.Setup()
-                .At(this, 206)
+                .At(this, 214)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -5792,7 +6006,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6positiony.Setup()
-                .At(this, 207)
+                .At(this, 215)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -5814,7 +6028,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch6deltaup.Setup()
-                .At(this, 208)
+                .At(this, 216)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -5836,7 +6050,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch6deltadown.Setup()
-                .At(this, 209)
+                .At(this, 217)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -5858,7 +6072,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch6deltaleft.Setup()
-                .At(this, 210)
+                .At(this, 218)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -5880,7 +6094,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch6deltaright.Setup()
-                .At(this, 211)
+                .At(this, 219)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -5902,7 +6116,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6deltax.Setup()
-                .At(this, 212)
+                .At(this, 220)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -5923,7 +6137,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6deltay.Setup()
-                .At(this, 213)
+                .At(this, 221)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -5944,7 +6158,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6radiusx.Setup()
-                .At(this, 214)
+                .At(this, 222)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -5965,7 +6179,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6radiusy.Setup()
-                .At(this, 215)
+                .At(this, 223)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -5986,7 +6200,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6startPositionx.Setup()
-                .At(this, 216)
+                .At(this, 224)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -6007,7 +6221,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch6startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch6startPositiony.Setup()
-                .At(this, 217)
+                .At(this, 225)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -6028,7 +6242,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch7touchId.Setup()
-                .At(this, 218)
+                .At(this, 226)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -6051,9 +6265,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch7position.Setup()
-                .At(this, 219)
+                .At(this, 227)
                 .WithParent(parent)
-                .WithChildren(230, 2)
+                .WithChildren(239, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -6074,9 +6288,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch7delta.Setup()
-                .At(this, 220)
+                .At(this, 228)
                 .WithParent(parent)
-                .WithChildren(232, 6)
+                .WithChildren(241, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -6096,7 +6310,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7pressure.Setup()
-                .At(this, 221)
+                .At(this, 229)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -6117,9 +6331,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch7radius.Setup()
-                .At(this, 222)
+                .At(this, 230)
                 .WithParent(parent)
-                .WithChildren(238, 2)
+                .WithChildren(247, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -6139,7 +6353,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch7phase.Setup()
-                .At(this, 223)
+                .At(this, 231)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -6161,7 +6375,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch7press.Setup()
-                .At(this, 224)
+                .At(this, 232)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -6184,7 +6398,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch7tapCount.Setup()
-                .At(this, 225)
+                .At(this, 233)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -6201,11 +6415,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch7tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch7displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch7displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch7displayIndex.Setup()
+                .At(this, 234)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 482,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch7displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch7indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch7indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch7indirectTouch.Setup()
-                .At(this, 226)
+                .At(this, 235)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -6229,7 +6464,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch7tap.Setup()
-                .At(this, 227)
+                .At(this, 236)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -6252,7 +6487,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch7startTime.Setup()
-                .At(this, 228)
+                .At(this, 237)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -6274,9 +6509,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch7startPosition.Setup()
-                .At(this, 229)
+                .At(this, 238)
                 .WithParent(parent)
-                .WithChildren(240, 2)
+                .WithChildren(249, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -6297,7 +6532,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7positionx.Setup()
-                .At(this, 230)
+                .At(this, 239)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -6319,7 +6554,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7positiony.Setup()
-                .At(this, 231)
+                .At(this, 240)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -6341,7 +6576,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch7deltaup.Setup()
-                .At(this, 232)
+                .At(this, 241)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -6363,7 +6598,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch7deltadown.Setup()
-                .At(this, 233)
+                .At(this, 242)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -6385,7 +6620,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch7deltaleft.Setup()
-                .At(this, 234)
+                .At(this, 243)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -6407,7 +6642,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch7deltaright.Setup()
-                .At(this, 235)
+                .At(this, 244)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -6429,7 +6664,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7deltax.Setup()
-                .At(this, 236)
+                .At(this, 245)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -6450,7 +6685,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7deltay.Setup()
-                .At(this, 237)
+                .At(this, 246)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -6471,7 +6706,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7radiusx.Setup()
-                .At(this, 238)
+                .At(this, 247)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -6492,7 +6727,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7radiusy.Setup()
-                .At(this, 239)
+                .At(this, 248)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -6513,7 +6748,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7startPositionx.Setup()
-                .At(this, 240)
+                .At(this, 249)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -6534,7 +6769,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch7startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch7startPositiony.Setup()
-                .At(this, 241)
+                .At(this, 250)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -6555,7 +6790,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch8touchId.Setup()
-                .At(this, 242)
+                .At(this, 251)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -6578,9 +6813,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch8position.Setup()
-                .At(this, 243)
+                .At(this, 252)
                 .WithParent(parent)
-                .WithChildren(254, 2)
+                .WithChildren(264, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -6601,9 +6836,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch8delta.Setup()
-                .At(this, 244)
+                .At(this, 253)
                 .WithParent(parent)
-                .WithChildren(256, 6)
+                .WithChildren(266, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -6623,7 +6858,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8pressure.Setup()
-                .At(this, 245)
+                .At(this, 254)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -6644,9 +6879,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch8radius.Setup()
-                .At(this, 246)
+                .At(this, 255)
                 .WithParent(parent)
-                .WithChildren(262, 2)
+                .WithChildren(272, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -6666,7 +6901,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch8phase.Setup()
-                .At(this, 247)
+                .At(this, 256)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -6688,7 +6923,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch8press.Setup()
-                .At(this, 248)
+                .At(this, 257)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -6711,7 +6946,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch8tapCount.Setup()
-                .At(this, 249)
+                .At(this, 258)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -6728,11 +6963,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch8tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch8displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch8displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch8displayIndex.Setup()
+                .At(this, 259)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 538,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch8displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch8indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch8indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch8indirectTouch.Setup()
-                .At(this, 250)
+                .At(this, 260)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -6756,7 +7012,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch8tap.Setup()
-                .At(this, 251)
+                .At(this, 261)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -6779,7 +7035,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch8startTime.Setup()
-                .At(this, 252)
+                .At(this, 262)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -6801,9 +7057,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch8startPosition.Setup()
-                .At(this, 253)
+                .At(this, 263)
                 .WithParent(parent)
-                .WithChildren(264, 2)
+                .WithChildren(274, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -6824,7 +7080,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8positionx.Setup()
-                .At(this, 254)
+                .At(this, 264)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -6846,7 +7102,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8positiony.Setup()
-                .At(this, 255)
+                .At(this, 265)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -6868,7 +7124,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch8deltaup.Setup()
-                .At(this, 256)
+                .At(this, 266)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -6890,7 +7146,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch8deltadown.Setup()
-                .At(this, 257)
+                .At(this, 267)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -6912,7 +7168,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch8deltaleft.Setup()
-                .At(this, 258)
+                .At(this, 268)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -6934,7 +7190,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch8deltaright.Setup()
-                .At(this, 259)
+                .At(this, 269)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -6956,7 +7212,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8deltax.Setup()
-                .At(this, 260)
+                .At(this, 270)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -6977,7 +7233,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8deltay.Setup()
-                .At(this, 261)
+                .At(this, 271)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -6998,7 +7254,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8radiusx.Setup()
-                .At(this, 262)
+                .At(this, 272)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -7019,7 +7275,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8radiusy.Setup()
-                .At(this, 263)
+                .At(this, 273)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -7040,7 +7296,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8startPositionx.Setup()
-                .At(this, 264)
+                .At(this, 274)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -7061,7 +7317,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch8startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch8startPositiony.Setup()
-                .At(this, 265)
+                .At(this, 275)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")
@@ -7082,7 +7338,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9touchId = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch9touchId.Setup()
-                .At(this, 266)
+                .At(this, 276)
                 .WithParent(parent)
                 .WithName("touchId")
                 .WithDisplayName("Touch Touch ID")
@@ -7105,9 +7361,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9position = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch9position.Setup()
-                .At(this, 267)
+                .At(this, 277)
                 .WithParent(parent)
-                .WithChildren(278, 2)
+                .WithChildren(289, 2)
                 .WithName("position")
                 .WithDisplayName("Touch Position")
                 .WithShortDisplayName("Touch Position")
@@ -7128,9 +7384,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9delta = new UnityEngine.InputSystem.Controls.DeltaControl();
             ctrlTouchscreentouch9delta.Setup()
-                .At(this, 268)
+                .At(this, 278)
                 .WithParent(parent)
-                .WithChildren(280, 6)
+                .WithChildren(291, 6)
                 .WithName("delta")
                 .WithDisplayName("Touch Delta")
                 .WithShortDisplayName("Touch Delta")
@@ -7150,7 +7406,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9pressure = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9pressure.Setup()
-                .At(this, 269)
+                .At(this, 279)
                 .WithParent(parent)
                 .WithName("pressure")
                 .WithDisplayName("Touch Pressure")
@@ -7171,9 +7427,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9radius = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch9radius.Setup()
-                .At(this, 270)
+                .At(this, 280)
                 .WithParent(parent)
-                .WithChildren(286, 2)
+                .WithChildren(297, 2)
                 .WithName("radius")
                 .WithDisplayName("Touch Radius")
                 .WithShortDisplayName("Touch Radius")
@@ -7193,7 +7449,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9phase = new UnityEngine.InputSystem.Controls.TouchPhaseControl();
             ctrlTouchscreentouch9phase.Setup()
-                .At(this, 271)
+                .At(this, 281)
                 .WithParent(parent)
                 .WithName("phase")
                 .WithDisplayName("Touch Touch Phase")
@@ -7215,7 +7471,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9press = new UnityEngine.InputSystem.Controls.TouchPressControl();
             ctrlTouchscreentouch9press.Setup()
-                .At(this, 272)
+                .At(this, 282)
                 .WithParent(parent)
                 .WithName("press")
                 .WithDisplayName("Touch Touch Contact?")
@@ -7238,7 +7494,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9tapCount = new UnityEngine.InputSystem.Controls.IntegerControl();
             ctrlTouchscreentouch9tapCount.Setup()
-                .At(this, 273)
+                .At(this, 283)
                 .WithParent(parent)
                 .WithName("tapCount")
                 .WithDisplayName("Touch Tap Count")
@@ -7255,11 +7511,32 @@ namespace UnityEngine.InputSystem
             return ctrlTouchscreentouch9tapCount;
         }
 
+        private UnityEngine.InputSystem.Controls.IntegerControl Initialize_ctrlTouchscreentouch9displayIndex(InternedString kIntegerLayout, InputControl parent)
+        {
+            var ctrlTouchscreentouch9displayIndex = new UnityEngine.InputSystem.Controls.IntegerControl();
+            ctrlTouchscreentouch9displayIndex.Setup()
+                .At(this, 284)
+                .WithParent(parent)
+                .WithName("displayIndex")
+                .WithDisplayName("Touch Display Index")
+                .WithShortDisplayName("Touch Display Index")
+                .WithLayout(kIntegerLayout)
+                .WithStateBlock(new InputStateBlock
+                {
+                    format = new FourCC(1113150533),
+                    byteOffset = 594,
+                    bitOffset = 0,
+                    sizeInBits = 8
+                })
+                .Finish();
+            return ctrlTouchscreentouch9displayIndex;
+        }
+
         private UnityEngine.InputSystem.Controls.ButtonControl Initialize_ctrlTouchscreentouch9indirectTouch(InternedString kButtonLayout, InputControl parent)
         {
             var ctrlTouchscreentouch9indirectTouch = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch9indirectTouch.Setup()
-                .At(this, 274)
+                .At(this, 285)
                 .WithParent(parent)
                 .WithName("indirectTouch")
                 .WithDisplayName("Touch Indirect Touch?")
@@ -7283,7 +7560,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9tap = new UnityEngine.InputSystem.Controls.ButtonControl();
             ctrlTouchscreentouch9tap.Setup()
-                .At(this, 275)
+                .At(this, 286)
                 .WithParent(parent)
                 .WithName("tap")
                 .WithDisplayName("Touch Tap")
@@ -7306,7 +7583,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startTime = new UnityEngine.InputSystem.Controls.DoubleControl();
             ctrlTouchscreentouch9startTime.Setup()
-                .At(this, 276)
+                .At(this, 287)
                 .WithParent(parent)
                 .WithName("startTime")
                 .WithDisplayName("Touch Start Time")
@@ -7328,9 +7605,9 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startPosition = new UnityEngine.InputSystem.Controls.Vector2Control();
             ctrlTouchscreentouch9startPosition.Setup()
-                .At(this, 277)
+                .At(this, 288)
                 .WithParent(parent)
-                .WithChildren(288, 2)
+                .WithChildren(299, 2)
                 .WithName("startPosition")
                 .WithDisplayName("Touch Start Position")
                 .WithShortDisplayName("Touch Start Position")
@@ -7351,7 +7628,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9positionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9positionx.Setup()
-                .At(this, 278)
+                .At(this, 289)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Position X")
@@ -7373,7 +7650,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9positiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9positiony.Setup()
-                .At(this, 279)
+                .At(this, 290)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Position Y")
@@ -7395,7 +7672,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltaup = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch9deltaup.Setup()
-                .At(this, 280)
+                .At(this, 291)
                 .WithParent(parent)
                 .WithName("up")
                 .WithDisplayName("Touch Touch Delta Up")
@@ -7417,7 +7694,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltadown = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch9deltadown.Setup()
-                .At(this, 281)
+                .At(this, 292)
                 .WithParent(parent)
                 .WithName("down")
                 .WithDisplayName("Touch Touch Delta Down")
@@ -7439,7 +7716,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltaleft = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMin = -3.402823E+38f, invert = true };
             ctrlTouchscreentouch9deltaleft.Setup()
-                .At(this, 282)
+                .At(this, 293)
                 .WithParent(parent)
                 .WithName("left")
                 .WithDisplayName("Touch Touch Delta Left")
@@ -7461,7 +7738,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltaright = new UnityEngine.InputSystem.Controls.AxisControl { clamp = UnityEngine.InputSystem.Controls.AxisControl.Clamp.BeforeNormalize, clampMax = 3.402823E+38f };
             ctrlTouchscreentouch9deltaright.Setup()
-                .At(this, 283)
+                .At(this, 294)
                 .WithParent(parent)
                 .WithName("right")
                 .WithDisplayName("Touch Touch Delta Right")
@@ -7483,7 +7760,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltax = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9deltax.Setup()
-                .At(this, 284)
+                .At(this, 295)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Delta X")
@@ -7504,7 +7781,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9deltay = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9deltay.Setup()
-                .At(this, 285)
+                .At(this, 296)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Delta Y")
@@ -7525,7 +7802,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9radiusx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9radiusx.Setup()
-                .At(this, 286)
+                .At(this, 297)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Radius X")
@@ -7546,7 +7823,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9radiusy = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9radiusy.Setup()
-                .At(this, 287)
+                .At(this, 298)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Radius Y")
@@ -7567,7 +7844,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startPositionx = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9startPositionx.Setup()
-                .At(this, 288)
+                .At(this, 299)
                 .WithParent(parent)
                 .WithName("x")
                 .WithDisplayName("Touch Touch Start Position X")
@@ -7588,7 +7865,7 @@ namespace UnityEngine.InputSystem
         {
             var ctrlTouchscreentouch9startPositiony = new UnityEngine.InputSystem.Controls.AxisControl();
             ctrlTouchscreentouch9startPositiony.Setup()
-                .At(this, 289)
+                .At(this, 300)
                 .WithParent(parent)
                 .WithName("y")
                 .WithDisplayName("Touch Touch Start Position Y")

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Touchscreen.cs
@@ -157,10 +157,12 @@ namespace UnityEngine.InputSystem.LowLevel
         [FieldOffset(33)]
         public byte tapCount;
 
-        // Not currently used, but still needed in this struct for padding,
-        // as il2cpp does not implement FieldOffset.
+        /// <summary>
+        /// The index of the display that was touched.
+        /// </summary>
+        [InputControl(name = "displayIndex", displayName = "Display Index", layout = "Integer")]
         [FieldOffset(34)]
-        byte displayIndex;
+        public byte displayIndex;
 
         [InputControl(name = "indirectTouch", displayName = "Indirect Touch?", layout = "Button", bit = 0, synthetic = true)]
         [InputControl(name = "tap", displayName = "Tap", layout = "Button", bit = 4)]
@@ -506,6 +508,22 @@ namespace UnityEngine.InputSystem
         /// has been lifted off the screen.
         /// </remarks>
         public TouchControl primaryTouch { get; protected set; }
+
+		/// <summary>
+        /// Gets the index of the display that was touched.
+        /// </summary>
+        public override IntegerControl displayIndex
+        {
+            get
+            {
+                return primaryTouch.displayIndex;
+            }
+
+            protected set
+            {
+                primaryTouch.displayIndex = value;
+            }
+        }
 
         /// <summary>
         /// Array of all <see cref="TouchControl"/>s on the device.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/TouchSimulation.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/TouchSimulation.cs
@@ -85,6 +85,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             var numPointers = m_NumPointers;
             ArrayHelpers.AppendWithCapacity(ref m_Pointers, ref m_NumPointers, pointer);
             ArrayHelpers.AppendWithCapacity(ref m_CurrentPositions, ref numPointers, default);
+            ArrayHelpers.AppendWithCapacity(ref m_CurrentDisplayIndices, ref numPointers, default);
 
             InputSystem.DisableDevice(pointer, keepSendingEvents: true);
         }
@@ -113,6 +114,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             var numPointers = m_NumPointers;
             m_Pointers.EraseAtWithCapacity(ref m_NumPointers, pointerIndex);
             m_CurrentPositions.EraseAtWithCapacity(ref numPointers, pointerIndex);
+            m_CurrentDisplayIndices.EraseAtWithCapacity(ref numPointers, pointerIndex);
 
             // Re-enable the device (only in case it's still added to the system).
             if (pointer.added)
@@ -134,11 +136,19 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
             ////REVIEW: should we have specialized paths for MouseState and PenState here? (probably can only use for StateEvents)
 
+            Pointer pointer = m_Pointers[pointerIndex];
+
             // Read pointer position.
-            var positionControl = m_Pointers[pointerIndex].position;
+            var positionControl = pointer.position;
             var positionStatePtr = positionControl.GetStatePtrFromStateEventUnchecked(eventPtr, eventType);
             if (positionStatePtr != null)
                 m_CurrentPositions[pointerIndex] = positionControl.ReadValueFromState(positionStatePtr);
+
+            // Read display index.
+            var displayIndexControl = pointer.displayIndex;
+            var displayIndexStatePtr = displayIndexControl.GetStatePtrFromStateEventUnchecked(eventPtr, eventType);
+            if (displayIndexStatePtr != null)
+                m_CurrentDisplayIndices[pointerIndex] = displayIndexControl.ReadValueFromState(displayIndexStatePtr);
 
             // End touches for which buttons are no longer pressed.
             ////REVIEW: There must be a better way to do this
@@ -280,11 +290,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
 
         private unsafe void UpdateTouch(int touchIndex, int pointerIndex, TouchPhase phase, InputEventPtr eventPtr = default)
         {
-            var position = m_CurrentPositions[pointerIndex];
+            Vector2 position = m_CurrentPositions[pointerIndex];
+            byte displayIndex = (byte)m_CurrentDisplayIndices[pointerIndex];
+
             var touch = new TouchState
             {
                 phase = phase,
-                position = position
+                position = position,
+                displayIndex = displayIndex
             };
             var time = eventPtr.valid ? eventPtr.time : InputState.currentTime;
 
@@ -335,6 +348,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         [NonSerialized] private int m_NumPointers;
         [NonSerialized] private Pointer[] m_Pointers;
         [NonSerialized] private Vector2[] m_CurrentPositions;
+        [NonSerialized] private int[] m_CurrentDisplayIndices;
         [NonSerialized] private ButtonControl[] m_Touches;
 
         [NonSerialized] private int m_LastTouchId;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions
@@ -349,6 +349,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "DisplayIndex",
+                    "type": "Value",
+                    "id": "88f8c633-3b59-4b4c-a0f2-451449b14501",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
                 }
             ],
             "bindings": [
@@ -767,6 +776,17 @@
                     "processors": "",
                     "groups": "XR",
                     "action": "TrackedDeviceOrientation",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "bb37490a-7df9-4e1e-a748-d834007e085a",
+                    "path": "<Touchscreen>/primaryTouch/displayIndex",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "DisplayIndex",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1660,13 +1660,28 @@ namespace UnityEngine.InputSystem.UI
                 touchId = touchscreen.primaryTouch.touchId.ReadValue();
                 touchPosition = touchscreen.primaryTouch.position.ReadValue();
             }
+
+            int displayIndex = 0;
+#if UNITY_INPUT_SYSTEM_ENABLE_MULTIDISPLAY
+            if (device is Pointer pointerCast)
+            {
+                displayIndex = pointerCast.displayIndex.ReadValue();
+            }
+#endif
+
             if (touchId != 0)
                 pointerId = ExtendedPointerEventData.MakePointerIdForTouch(pointerId, touchId);
 
             // Early out if it's the last used pointer.
             // NOTE: Can't just compare by device here because of touchscreens potentially having multiple associated pointers.
             if (m_CurrentPointerId == pointerId)
+            {
+#if UNITY_INPUT_SYSTEM_ENABLE_MULTIDISPLAY
+				ref var state = ref GetPointerStateForIndex(m_CurrentPointerIndex);
+                state.eventData.displayIndex = displayIndex;
+#endif
                 return m_CurrentPointerIndex;
+            }
 
             // Search m_PointerIds for an existing entry.
             // NOTE: This is a linear search but m_PointerIds is only IDs and the number of concurrent pointers
@@ -1736,7 +1751,7 @@ namespace UnityEngine.InputSystem.UI
             {
                 if (m_CurrentPointerIndex == -1)
                 {
-                    m_CurrentPointerIndex = AllocatePointer(pointerId, touchId, pointerType, control, device, touchId != 0 ? controlParent : null);
+                    m_CurrentPointerIndex = AllocatePointer(pointerId, displayIndex, touchId, pointerType, control, device, touchId != 0 ? controlParent : null);
                 }
                 else
                 {
@@ -1751,6 +1766,11 @@ namespace UnityEngine.InputSystem.UI
                     eventData.device = device;
                     eventData.pointerType = pointerType;
                     eventData.pointerId = pointerId;
+
+#if UNITY_INPUT_SYSTEM_ENABLE_MULTIDISPLAY
+                    eventData.displayIndex = displayIndex;
+#endif
+
                     eventData.touchId = touchId;
 
                     // Make sure these don't linger around when we switch to a different kind of pointer.
@@ -1773,7 +1793,7 @@ namespace UnityEngine.InputSystem.UI
             if (pointerType != UIPointerType.None)
             {
                 // Device has an associated position input. Create a new pointer record.
-                index = AllocatePointer(pointerId, touchId, pointerType, control, device, touchId != 0 ? controlParent : null);
+                index = AllocatePointer(pointerId, displayIndex, touchId, pointerType, control, device, touchId != 0 ? controlParent : null);
             }
             else
             {
@@ -1795,7 +1815,7 @@ namespace UnityEngine.InputSystem.UI
                 if (pointerDevice != null && !(pointerDevice is Touchscreen)) // Touchscreen only temporarily allocate pointer states.
                 {
                     // Create MouseOrPen style pointer.
-                    index = AllocatePointer(pointerDevice.deviceId, 0, UIPointerType.MouseOrPen, pointControls.Value[0], pointerDevice);
+                    index = AllocatePointer(pointerDevice.deviceId, displayIndex, 0, UIPointerType.MouseOrPen, pointControls.Value[0], pointerDevice);
                 }
                 else
                 {
@@ -1807,13 +1827,13 @@ namespace UnityEngine.InputSystem.UI
                     if (trackedDevice != null)
                     {
                         // Create a Tracked style pointer.
-                        index = AllocatePointer(trackedDevice.deviceId, 0, UIPointerType.Tracked, positionControls.Value[0], trackedDevice);
+                        index = AllocatePointer(trackedDevice.deviceId, displayIndex, 0, UIPointerType.Tracked, positionControls.Value[0], trackedDevice);
                     }
                     else
                     {
                         // We got input from a non-pointer device and apparently there's no pointer we can route the
                         // input into. Just create a pointer state for the device and leave it at that.
-                        index = AllocatePointer(pointerId, 0, UIPointerType.None, control, device);
+                        index = AllocatePointer(pointerId, displayIndex, 0, UIPointerType.None, control, device);
                     }
                 }
             }
@@ -1828,7 +1848,7 @@ namespace UnityEngine.InputSystem.UI
             return index;
         }
 
-        private int AllocatePointer(int pointerId, int touchId, UIPointerType pointerType, InputControl control, InputDevice device, InputControl touchControl = null)
+        private int AllocatePointer(int pointerId, int displayIndex, int touchId, UIPointerType pointerType, InputControl control, InputDevice device, InputControl touchControl = null)
         {
             // Recover event instance from previous record.
             var eventData = default(ExtendedPointerEventData);
@@ -1845,6 +1865,11 @@ namespace UnityEngine.InputSystem.UI
                 eventData = new ExtendedPointerEventData(eventSystem);
 
             eventData.pointerId = pointerId;
+
+#if UNITY_INPUT_SYSTEM_ENABLE_MULTIDISPLAY
+            eventData.displayIndex = displayIndex;
+#endif
+
             eventData.touchId = touchId;
             eventData.pointerType = pointerType;
             eventData.control = control;

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -55,6 +55,11 @@
             "name": "com.unity.ugui",
             "expression": "1.0.0",
             "define": "UNITY_INPUT_SYSTEM_ENABLE_UI"
+        },
+        {
+            "name": "com.unity.ugui",
+            "expression": "1.1.0",
+            "define": "UNITY_INPUT_SYSTEM_ENABLE_MULTIDISPLAY"
         }
     ],
     "noEngineReferences": false

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "1.4.4",
+	"version": "1.5.0",
 	"unity": "2019.4",
 	"description": "A new input system which can be used as a more extensible and customizable alternative to Unity's classic input system in UnityEngine.Input.",
 	"keywords": [


### PR DESCRIPTION
*Purpose of this PR*:

New input system has a displayIndex field for generic devices Mouse, Pen, and Touchscreen, which represents the display that the input of any of these devices came from. Currently, this property only being set in certain Player build targets that support multidisplay. Specifically, this feature is only implemented on Windows. There is also no implementation that properly passes this index over for any of the Editor or Android build targets.

*Release Notes*:

Improved @joel.barba:
Input System: Touch input is handled from USB secondary capacitive touch screens on Android

*Functional Testing status*:

Test project was created with a customized version of InputSystem packages that make displayIndex for Touchscreen and Mouse public and blitted fields. There is also a customized version of UGUI that was changed to recognize UI elements on different displays. The project has a sample scene with two cameras for display 0 and display 1, and a script that enables multi-display. The script also prints out mouse display index and the position of the mouse.

Tests in Android Player include:
* Plugging in secondary monitor while Unity app is running.
* Unplugging in secondary monitor while Unity app is running.
* Plugging in secondary monitor while Unity app is not running and running the app.
* Unplugging in secondary monitor while Unity app is not running and running the app.
* Alternating between plugging and unplugging 100 times while app is running to note memory consumption over time.
* Pressing hardware touchscreen 1 while hardware touchscreen 2 is plugged in.
* Alternating between touching touchscreen 1 and 2 while touchscreen 2 is plugged in and noting that touches have a complete begin/update/end-cancel cycle.
* Testing the regions of the screen with a cursor image, including ensuring that corners and edge are properly recognized and mapped.
* Testing that a modified UGUI package can properly handle touches from display index 0 and 1 on the proper screens that the UI is displayed on.
* Testing that UGUI and Input System packages that are unmodified will return the original display index value of zero.
Insuring that touch gestures tuch as tapping and dragging are recognized for both touchscreen 1 and 2.
* Insuring that calls to screen ray casting works on touchscreen 1 and 2 to return proper values.
* testing that New Input system Action mapping recognizes display index as a action mapping target.

Tests in the Editors include:
* Editor is laid out so that there are no GameViews.
* Editor is laid out so there is only one GameView set to Display 1 target in a docked area on hardware monitor 1.
* Editor is laid out so there is only one GameView set to Display 2 target in a docked area on hardware monitor  1.
* Editor is laid out so there is only one GameView set to Display 1 target in a docked area on hardware monitor  2.
* Editor is laid out so there is only one GameView set to Display 2 target in a docked area between hardware monitor  1 and 2.
* Editor is laid out so there is only one GameView set to Display 1 target in a docked area between hardware monitor 1 and 2.
* Editor is laid out so there is only one GameView set to Display 2 target in a docked area between hardware monitor 1 and 2.
* Editor is laid out so there is only one GameView set to Display 1 target in a undocked area on hardware monitor 1.
* Editor is laid out so there is only one GameView set to Display 1 target in a undocked area on hardware monitor  1.
* Editor is laid out so there is only one GameView set to Display 2 target in a undocked area on hardware monitor  2.
* Editor is laid out so there is only one GameView set to Display 1 target in a undocked area on hardware monitor  2.
* Editor is laid out so there is only one GameView set to Display 1 target in a undocked area between hardware monitor 1 and 2.
* Editor is laid out so there is only one GameView set to Display 1 target in a undocked area between hardware monitor  1 and 2.
* One GameView that is set to Display 1 is docked if undocked on hardware monitor 1.
* One GameView that is set to Display 2 is docked if undocked on hardware monitor 1.
* One GameView that is set to Display 1 is docked if undocked on hardware monitor 2.
* One GameView that is set to Display 2 is docked if undocked on hardware monitor 2.
* One GameView that is set to Display 1 is docked if undocked between hardware monitor 1 and 2.
* One GameView that is set to Display 2 is docked if undocked between hardware monitor 1 and 2.
* One GameView that is set to Display 1 is undocked if docked on hardware monitor 1.
* One GameView that is set to Display 2 is undocked if docked on hardware monitor 1.
* One GameView that is set to Display 1 is undocked if docked on hardware monitor 2.
* One GameView that is set to Display 2 is undocked if docked on hardware monitor 2.
* One GameView that is set to Display 1 is undocked if docked between hardware monitor 1 and 2.
* One GameView that is set to Display 2 is undocked if docked between hardware monitor 1 and 2.
* One GameView that is set to Display 1 is undocked if docked on hardware monitor 1 and moved to hardware monitor 2, left undocked.
* One GameView that is set to Display 2 is undocked if docked on hardware monitor 1 and moved to hardware monitor 2, left undocked.
* One GameView that is set to Display 1 is undocked if docked on hardware monitor 2 and moved to hardware monitor 1, left undocked.
* One GameView that is set to Display 2 is undocked if docked on hardware monitor 2 and moved to hardware monitor 1, left undocked.
* One GameView that is set to Display 1 is undocked if docked on hardware monitor 1 and moved to hardware monitor 2, and docked.
* One GameView that is set to Display 2 is undocked if docked on hardware monitor 1 and moved to hardware monitor 2, and docked.
* One GameView that is set to Display 1 is undocked if docked on hardware monitor 2 and moved to hardware monitor 1, and docked.
* One GameView that is set to Display 2 is undocked if docked on hardware monitor 2 and moved to hardware monitor 1, and docked.

Perform all previous tests, but with two Game Views present, with the following configurations:
* Both GameViews are set to Display 1 and visible at the same time, undocked on separate windows.
* Both GameViews are set to Display 2 and visible at the same time, undocked on separate windows.
* Both GameView 1 is set to Display 1 and GameView 2 is set to Display 2 and visible at the same time, undocked on separate windows.
* Both GameView 1 is set to Display 2 and GameView 2 is set to Display 1 and visible at the same time, undocked on separate windows.
* Both GameViews are set to Display 1 and visible at the same time, docked side-by-side on the same window.
* Both GameViews are set to Display 2 and visible at the same time, docked side-by-side on the same window.
* Both GameView 1 is set to Display 1 and GameView 2 is set to Display 2 and visible at the same time, docked side-by-side on the same window.
* Both GameView 1 is set to Display 2 and GameView 2 is set to Display 1 and visible at the same time, docked side-by-side on the same window.
* Both GameViews are set to Display 1 and visible at the same time, docked in different tabs on the same window.
* Both GameViews are set to Display 2 and visible at the same time, docked in different tabs on the same window.
* Both GameView 1 is set to Display 1 and GameView 2 is set to Display 2 and visible at the same time, docked in different tabs on the same window.
* Both GameView 1 is set to Display 2 and GameView 2 is set to Display 1 and visible at the same time, docked in different tabs on the same window.

After testing each configuration above, the following tests are performed.
* One GameView is alternated between Display 1 and Display 2 target.
* Ensure that the value only changes in Play mode.
* Observe that the position and display index are correct, and that they only change when a new GameView is focused on.
* Ensure that the display index defaults back to original behavior when a non-GameView EditorWindow is clicked on.
* Ensure that there are no errors thrown throughout the process.

Since we were affecting Editor and some Player targets, the behavior before the change was tested and so was the behavior after the change, for all relevant build targets. These targets were:

- WinEditor on Windows 10 (Alienware M15)
- WinPlayer on Windows 10 (Alienware M15)
- MacEditor on OSX Monterrey and OSX Mojave (MacBook Pro 15" 2019)
- MacPlayer on Monterrey (Parallels on MacBook Pro 15" 2019)
- LinuxEditor on Ubuntu 20 LTS (Alienware M15)
- LinuxPlayer on Ubuntu 20 LTS (Alienware M15)
- AndroidPlayer on Android 9 (Galaxy S9+), 10 (S10+), 11 (S21 Ultra), 12 (S21 Ultra, ZFold3)

*Performance Testing Status*:

Addition of display height abstraction will change input handling of Touchscreen in a minor way.
Behavior of secondary screens on Android platforms to include input handling, which may alter performance or battery.

Win Player, Mac Player performance should be minimal negligent. Source code that is affected creates minimal to no locality of reference changes, and most major code is creates effects in Editor build targets.

Caching GUIView display index was a instance field and then referencing it may create performance changes, as this is a value that requires fetching, but performance changes would be minimal negligent.

*Overall Product Risks*:

Complexity: Minimal Addition of display height abstraction will change input handling of Touchscreen in a negligible way. Will change the behavior of secondary screens on Android platforms.

Halo Effect: Low affects multiple platforms

Technical Risk: 0

Halo Effect: 1