### PR TITLE
Add Tracking State support to TrackedPoseDriver

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Added
+- Added support for reading Tracking State in [TrackedPoseDriver](xref:UnityEngine.InputSystem.XR.TrackedPoseDriver) to constrain whether the input pose is applied to the Transform. This should be used when the device supports valid flags for the position and rotation values, which is the case for XR poses.
+
 ### Fixed
 - Fixed composite bindings incorrectly getting a control scheme assigned when pasting into input asset editor with a control scheme selected.
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -362,37 +362,31 @@ namespace UnityEngine.InputSystem.XR
 
         void OnPositionPerformed(InputAction.CallbackContext context)
         {
-            Debug.Assert(m_PositionBound, this);
             m_CurrentPosition = context.ReadValue<Vector3>();
         }
 
         void OnPositionCanceled(InputAction.CallbackContext context)
         {
-            Debug.Assert(m_PositionBound, this);
             m_CurrentPosition = Vector3.zero;
         }
 
         void OnRotationPerformed(InputAction.CallbackContext context)
         {
-            Debug.Assert(m_RotationBound, this);
             m_CurrentRotation = context.ReadValue<Quaternion>();
         }
 
         void OnRotationCanceled(InputAction.CallbackContext context)
         {
-            Debug.Assert(m_RotationBound, this);
             m_CurrentRotation = Quaternion.identity;
         }
 
         void OnTrackingStatePerformed(InputAction.CallbackContext context)
         {
-            Debug.Assert(m_TrackingStateBound, this);
             m_CurrentTrackingState = (TrackingStates)context.ReadValue<int>();
         }
 
         void OnTrackingStateCanceled(InputAction.CallbackContext context)
         {
-            Debug.Assert(m_TrackingStateBound, this);
             m_CurrentTrackingState = TrackingStates.None;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -542,7 +542,6 @@ namespace UnityEngine.InputSystem.XR
         /// Must support reading a value of type <see cref="Vector3"/>.
         /// </summary>
         /// <seealso cref="positionInput"/>
-        [Obsolete("positionAction has been deprecated. Use positionInput instead.")]
         public InputAction positionAction
         {
             get => m_PositionInput.action;
@@ -557,7 +556,6 @@ namespace UnityEngine.InputSystem.XR
         /// Must support reading a value of type <see cref="Quaternion"/>.
         /// </summary>
         /// <seealso cref="rotationInput"/>
-        [Obsolete("rotationAction has been deprecated. Use rotationInput instead.")]
         public InputAction rotationAction
         {
             get => m_RotationInput.action;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -527,14 +527,14 @@ namespace UnityEngine.InputSystem.XR
 
             if (rotationValid &&
                 (m_TrackingType == TrackingType.RotationAndPosition ||
-                m_TrackingType == TrackingType.RotationOnly))
+                 m_TrackingType == TrackingType.RotationOnly))
             {
                 transform.localRotation = newRotation;
             }
 
-            if (positionValid && 
+            if (positionValid &&
                 (m_TrackingType == TrackingType.RotationAndPosition ||
-                m_TrackingType == TrackingType.PositionOnly))
+                 m_TrackingType == TrackingType.PositionOnly))
             {
                 transform.localPosition = newPosition;
             }


### PR DESCRIPTION
### Description

This adds support for constraining the `TrackedPoseDriver` to only update the Transform if the XR device reports the position and rotation values are valid. An XR device may indicate that the position and/or rotation values are not valid if tracking is lost, so users should typically not update the Transform to match garbage data and instead keep it unchanged.

This is a replacement for the old PR https://github.com/Unity-Technologies/InputSystem/pull/1481 which had many open comments.

### Changes made

Added `public bool ignoreTrackingState` and `public InputActionProperty trackingStateInput` properties to `TrackedPoseDriver`, which requires a bump in minor version. The `Reset` method also applies expected control types of the input actions for ease of configuration by users.

### Notes

The default value of `ignoreTrackingState = true` keeps the existing functionality where the updating of the Transform is unconstrained by Tracking State.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
