### PR TITLE
FIX: memory alignment issue when deserializing InputEventTraces (ISXB-317)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
 - Fixed `{fileID: 0}` getting appended to `ProjectSettings.asset` file when building a project ([case ISXB-296](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-296)).
 - Fixed `Type of instance in array does not match expected type` assertion when using PlayerInput in combination with Control Schemes and Interactions ([case ISXB-282](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-282)).
+- Fixed Memory alignment issue with deserialized InputEventTraces that could cause infinite loops when playing back replays ([case ISXB-317](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-317)).
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -373,9 +373,8 @@ namespace UnityEngine.InputSystem.LowLevel
                         fixed(byte* tempBufferPtr = tempBuffer)
                         UnsafeUtility.MemCpy(tailPtr, tempBufferPtr, remainingSize);
 
-                        var alignedSizeInBytes = remainingSize.AlignToMultipleOf(InputEvent.kAlignment);
-                        tailPtr += alignedSizeInBytes;
-                        totalEventSize += eventSizeInBytes;
+                        tailPtr += remainingSize.AlignToMultipleOf(InputEvent.kAlignment);
+                        totalEventSize += eventSizeInBytes.AlignToMultipleOf(InputEvent.kAlignment);
 
                         if (tailPtr >= endPtr)
                             break;

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -373,7 +373,8 @@ namespace UnityEngine.InputSystem.LowLevel
                         fixed(byte* tempBufferPtr = tempBuffer)
                         UnsafeUtility.MemCpy(tailPtr, tempBufferPtr, remainingSize);
 
-                        tailPtr += remainingSize;
+                        var alignedSizeInBytes = remainingSize.AlignToMultipleOf(4);
+                        tailPtr += alignedSizeInBytes;
                         totalEventSize += eventSizeInBytes;
 
                         if (tailPtr >= endPtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -342,7 +342,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 }
                 else
                 {
-                    buffer = (byte*)UnsafeUtility.Malloc((long)totalEventSizeInBytes, 4, Allocator.Persistent);
+                    buffer = (byte*)UnsafeUtility.Malloc((long)totalEventSizeInBytes, InputEvent.kAlignment, Allocator.Persistent);
                     m_EventBufferSize = (long)totalEventSizeInBytes;
                 }
                 try
@@ -373,7 +373,7 @@ namespace UnityEngine.InputSystem.LowLevel
                         fixed(byte* tempBufferPtr = tempBuffer)
                         UnsafeUtility.MemCpy(tailPtr, tempBufferPtr, remainingSize);
 
-                        var alignedSizeInBytes = remainingSize.AlignToMultipleOf(4);
+                        var alignedSizeInBytes = remainingSize.AlignToMultipleOf(InputEvent.kAlignment);
                         tailPtr += alignedSizeInBytes;
                         totalEventSize += eventSizeInBytes;
 
@@ -502,7 +502,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 newMaxBufferSize = newBufferSize;
 
             // Allocate.
-            var newEventBuffer = (byte*)UnsafeUtility.Malloc(newBufferSize, 4, Allocator.Persistent);
+            var newEventBuffer = (byte*)UnsafeUtility.Malloc(newBufferSize, InputEvent.kAlignment, Allocator.Persistent);
             if (newEventBuffer == default)
                 return false;
 
@@ -522,7 +522,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     for (var i = 0; i < m_EventCount; ++i)
                     {
                         var eventSizeInBytes = fromPtr.sizeInBytes;
-                        var alignedEventSizeInBytes = eventSizeInBytes.AlignToMultipleOf(4);
+                        var alignedEventSizeInBytes = eventSizeInBytes.AlignToMultipleOf(InputEvent.kAlignment);
 
                         // We only start copying once we know that the remaining events we have fit in the new buffer.
                         // This way we get the newest events and not the oldest ones.
@@ -754,7 +754,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         private void Allocate()
         {
-            m_EventBuffer = (byte*)UnsafeUtility.Malloc(m_EventBufferSize, 4, Allocator.Persistent);
+            m_EventBuffer = (byte*)UnsafeUtility.Malloc(m_EventBufferSize, InputEvent.kAlignment, Allocator.Persistent);
         }
 
         private void Release()
@@ -806,7 +806,7 @@ namespace UnityEngine.InputSystem.LowLevel
             if (m_EventBuffer == default)
                 return;
 
-            var bytesNeeded = inputEvent.sizeInBytes.AlignToMultipleOf(4);
+            var bytesNeeded = inputEvent.sizeInBytes.AlignToMultipleOf(InputEvent.kAlignment);
 
             // Make sure we can fit the event at all.
             if (bytesNeeded > m_MaxEventBufferSize)
@@ -831,7 +831,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 // If we haven't reached the max size yet, grow the buffer.
                 if (m_EventBufferSize < m_MaxEventBufferSize && !m_HasWrapped)
                 {
-                    var increment = Math.Max(m_GrowIncrementSize, bytesNeeded.AlignToMultipleOf(4));
+                    var increment = Math.Max(m_GrowIncrementSize, bytesNeeded.AlignToMultipleOf(InputEvent.kAlignment));
                     var newBufferSize = m_EventBufferSize + increment;
                     if (newBufferSize > m_MaxEventBufferSize)
                         newBufferSize = m_MaxEventBufferSize;


### PR DESCRIPTION
### Description

Fix memory alignment when deserializing Input Event Traces (fixes a possible infinite loop when playing back traces).

### Changes made
Ensure each event is 4 byte aligned when reading from binary data with `ReadFrom()`.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
