### PR TITLE
CHANGE: added warnings about potential binding conflicts when shortcuts are enabled

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.
+- Added warnings about potential binding conflicts when the shortcut feature is enabled ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254)).
 
 ## [1.4.2] - 2022-08-12
 


### PR DESCRIPTION
### Description

This PR attempts to give users more feedback when they have the same control bindings attached to multiple different (enabled) actions at the same time.
This is done by checking for this condition when after enabling actions and if discovered prints a warning message in the console.

Discussion: this has a serious issue as discussed in a comment:
For shortcuts, we do actually need to allow binding multiple controls to the same actual e.g. CTRL+Z and Z is valid.
This is solved by excluding the case where the number of bindings are different (2 and 1 respectively). 
However for the case CTRL+Z and SHIFT+Z we are still going to show a warning in the console even though this is perfectly genuine.

### Changes made

Add a function in ActionState to check for this condition and print the message to the console.
This function is called when enabling actions.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
