### PR TITLE
FIX: some actions not being triggered when other duplicate control bindings exist (ISXB-254).

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -10204,9 +10204,6 @@ partial class CoreTests
     [TestCase(false)]
     public void Actions_ImprovedShortcutSupport_ConsumesWASD(bool shortcutsEnabled)
     {
-        if (shortcutsEnabled)
-            LogAssert.Expect(LogType.Warning, new Regex("Please note that the use of SetInternalFeatureFlag"));
-
         InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kDisableShortcutSupport, !shortcutsEnabled);
 
         var keyboard = InputSystem.AddDevice<Keyboard>();

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -10245,7 +10245,7 @@ partial class CoreTests
         action3.started += ctx => action3Count++;
 
         Press(keyboard.wKey);
-        if (shortcutsEnabled )
+        if (shortcutsEnabled)
         {
             // First action with the most bindings is the ONLY one to trigger
             Assert.That(action1Count, Is.EqualTo(1));
@@ -10260,7 +10260,6 @@ partial class CoreTests
             Assert.That(action3Count, Is.EqualTo(1));
         }
     }
-
 
     [Test]
     [Category("Actions")]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
 - Fixed `{fileID: 0}` getting appended to `ProjectSettings.asset` file when building a project ([case ISXB-296](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-296)).
 - Fixed `Type of instance in array does not match expected type` assertion when using PlayerInput in combination with Control Schemes and Interactions ([case ISXB-282](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-282)).
+- Reverted the `InputActions consume their inputs` behaviour introduced in v1.4. This shortcut support feature can still be enabled by is switched off by default for now ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254))).
 
 ## [1.4.3] - 2022-09-23
 
@@ -26,7 +27,6 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.
-- Disable shortcut support by default. This restores the behaviour from v1.3 and fixes the case of actions not triggering if multiple actions are enabled using the same controls ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254))).
 
 ## [1.4.2] - 2022-08-12
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,7 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed `ArgumentNullException` when opening the Prefab Overrides window and selecting a component with an `InputAction`.
 - Fixed `{fileID: 0}` getting appended to `ProjectSettings.asset` file when building a project ([case ISXB-296](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-296)).
 - Fixed `Type of instance in array does not match expected type` assertion when using PlayerInput in combination with Control Schemes and Interactions ([case ISXB-282](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-282)).
-- Reverted the `InputActions consume their inputs` behaviour introduced in v1.4. This shortcut support feature can still be enabled by is switched off by default for now ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254))).
+- The `InputActions consume their inputs` behaviour for shortcut support introduced in v1.4 is opt-in now and can be enabled via the project settings ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254))).
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Improved performance of HID descriptor parsing by moving json parsing to a simple custom predicitve parser instead of relying on Unity's json parsing. This should improve domain reload times when there are many HID devices connected to a machine.
+- Disable shortcut support by default. This restores the behaviour from v1.3 and fixes the case of actions not triggering if multiple actions are enabled using the same controls ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254))).
 
 ## [1.4.2] - 2022-08-12
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -145,6 +145,17 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.Space();
                 EditorGUILayout.PropertyField(m_EditorInputBehaviorInPlayMode, m_EditorInputBehaviorInPlayModeContent);
 
+                EditorGUILayout.Space();
+                EditorGUILayout.LabelField("Shortcut support", EditorStyles.boldLabel);
+                EditorGUILayout.Space();
+                EditorGUILayout.PropertyField(m_ImprovedShortcutSupportEnabled, m_ImprovedShortcutSupportContent);
+
+                EditorGUILayout.HelpBox("Please note that enabling Improved Shortcut Support will cause actions to consume and block any other actions which are enabled and sharing the same controls. "
+                    + "E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time, which would be the expected result in this example. "
+                    + "However, in other cases this might not give the desired result. E.g. if the 'W', 'A', 'S' and 'D' keys are bound to different actions which are all enabled at the same time, then only one of those actions will trigger. "
+                    + "Therefore if you enable this feature, be sure to remove any of these duplicate control bindings so that controls are only ever bound to a single action. Alternatively, you can disable actions or action maps at runtime to remove these conflicts."
+                    , MessageType.None);
+
                 if (EditorGUI.EndChangeCheck())
                     Apply();
             }
@@ -268,6 +279,7 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTime = m_SettingsObject.FindProperty("m_DefaultHoldTime");
             m_TapRadius = m_SettingsObject.FindProperty("m_TapRadius");
             m_MultiTapDelayTime = m_SettingsObject.FindProperty("m_MultiTapDelayTime");
+            m_ImprovedShortcutSupportEnabled = m_SettingsObject.FindProperty("m_ImprovedShortcutSupportEnabled");
 
             m_UpdateModeContent = new GUIContent("Update Mode", "When should the Input System be updated?");
             m_CompensateForScreenOrientationContent = new GUIContent("Compensate Orientation", "Whether sensor input on mobile devices should be transformed to be relative to the current device orientation.");
@@ -295,6 +307,7 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTimeContent = new GUIContent("Default Hold Time", "Default duration to be used for Hold interactions.");
             m_TapRadiusContent = new GUIContent("Tap Radius", "Maximum distance between two finger taps on a touch screen device allowed for the system to consider this a tap of the same touch (as opposed to a new touch).");
             m_MultiTapDelayTimeContent = new GUIContent("MultiTap Delay Time", "Default delay to be allowed between taps for MultiTap interactions. Also used by by touch devices to count multi taps.");
+            m_ImprovedShortcutSupportContent = new GUIContent("Improved Shortcut Support", "Actions are exclusively triggered and will consume/block other actions sharing the same input. E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time.");
 
             // Initialize ReorderableList for list of supported devices.
             var supportedDevicesProperty = m_SettingsObject.FindProperty("m_SupportedDevices");
@@ -404,6 +417,7 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private SerializedProperty m_DefaultHoldTime;
         [NonSerialized] private SerializedProperty m_TapRadius;
         [NonSerialized] private SerializedProperty m_MultiTapDelayTime;
+        [NonSerialized] private SerializedProperty m_ImprovedShortcutSupportEnabled;
 
         [NonSerialized] private ReorderableList m_SupportedDevices;
         [NonSerialized] private string[] m_AvailableInputSettingsAssets;
@@ -426,6 +440,7 @@ namespace UnityEngine.InputSystem.Editor
         private GUIContent m_DefaultHoldTimeContent;
         private GUIContent m_TapRadiusContent;
         private GUIContent m_MultiTapDelayTimeContent;
+        private GUIContent m_ImprovedShortcutSupportContent;
 
         [NonSerialized] private InputSettingsiOSProvider m_iOSProvider;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -148,8 +148,8 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("Improved Shortcut Support", EditorStyles.boldLabel);
                 EditorGUILayout.Space();
-                EditorGUILayout.PropertyField(m_ImprovedShortcutSupportEnabled, m_ImprovedShortcutSupportContent);
-                if (m_ImprovedShortcutSupportEnabled.boolValue)
+                EditorGUILayout.PropertyField(m_ShortcutKeysConsumeInputs, m_ShortcutKeysConsumeInputsContent);
+                if (m_ShortcutKeysConsumeInputs.boolValue)
                     EditorGUILayout.HelpBox("Please note that enabling Improved Shortcut Support will cause actions with composite bindings to consume input and block any other actions which are enabled and sharing the same controls. "
                         + "Input consumption is performed in priority order, with the action containing the greatest number of bindings checked first. "
                         + "Therefore actions requiring less keypresses will not be triggered if an action using more keypresses is triggered and has overlapping controls. "
@@ -281,7 +281,7 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTime = m_SettingsObject.FindProperty("m_DefaultHoldTime");
             m_TapRadius = m_SettingsObject.FindProperty("m_TapRadius");
             m_MultiTapDelayTime = m_SettingsObject.FindProperty("m_MultiTapDelayTime");
-            m_ImprovedShortcutSupportEnabled = m_SettingsObject.FindProperty("m_ImprovedShortcutSupportEnabled");
+            m_ShortcutKeysConsumeInputs = m_SettingsObject.FindProperty("m_ShortcutKeysConsumeInputs");
 
             m_UpdateModeContent = new GUIContent("Update Mode", "When should the Input System be updated?");
             m_CompensateForScreenOrientationContent = new GUIContent("Compensate Orientation", "Whether sensor input on mobile devices should be transformed to be relative to the current device orientation.");
@@ -309,7 +309,7 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTimeContent = new GUIContent("Default Hold Time", "Default duration to be used for Hold interactions.");
             m_TapRadiusContent = new GUIContent("Tap Radius", "Maximum distance between two finger taps on a touch screen device allowed for the system to consider this a tap of the same touch (as opposed to a new touch).");
             m_MultiTapDelayTimeContent = new GUIContent("MultiTap Delay Time", "Default delay to be allowed between taps for MultiTap interactions. Also used by by touch devices to count multi taps.");
-            m_ImprovedShortcutSupportContent = new GUIContent("Enable Input Consumption", "Actions are exclusively triggered and will consume/block other actions sharing the same input. E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time.");
+            m_ShortcutKeysConsumeInputsContent = new GUIContent("Enable Input Consumption", "Actions are exclusively triggered and will consume/block other actions sharing the same input. E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time.");
 
             // Initialize ReorderableList for list of supported devices.
             var supportedDevicesProperty = m_SettingsObject.FindProperty("m_SupportedDevices");
@@ -419,7 +419,7 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private SerializedProperty m_DefaultHoldTime;
         [NonSerialized] private SerializedProperty m_TapRadius;
         [NonSerialized] private SerializedProperty m_MultiTapDelayTime;
-        [NonSerialized] private SerializedProperty m_ImprovedShortcutSupportEnabled;
+        [NonSerialized] private SerializedProperty m_ShortcutKeysConsumeInputs;
 
         [NonSerialized] private ReorderableList m_SupportedDevices;
         [NonSerialized] private string[] m_AvailableInputSettingsAssets;
@@ -442,7 +442,7 @@ namespace UnityEngine.InputSystem.Editor
         private GUIContent m_DefaultHoldTimeContent;
         private GUIContent m_TapRadiusContent;
         private GUIContent m_MultiTapDelayTimeContent;
-        private GUIContent m_ImprovedShortcutSupportContent;
+        private GUIContent m_ShortcutKeysConsumeInputsContent;
 
         [NonSerialized] private InputSettingsiOSProvider m_iOSProvider;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -146,15 +146,17 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.PropertyField(m_EditorInputBehaviorInPlayMode, m_EditorInputBehaviorInPlayModeContent);
 
                 EditorGUILayout.Space();
-                EditorGUILayout.LabelField("Shortcut support", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField("Improved Shortcut Support", EditorStyles.boldLabel);
                 EditorGUILayout.Space();
                 EditorGUILayout.PropertyField(m_ImprovedShortcutSupportEnabled, m_ImprovedShortcutSupportContent);
-
-                EditorGUILayout.HelpBox("Please note that enabling Improved Shortcut Support will cause actions to consume and block any other actions which are enabled and sharing the same controls. "
-                    + "E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time, which would be the expected result in this example. "
-                    + "However, in other cases this might not give the desired result. E.g. if the 'W', 'A', 'S' and 'D' keys are bound to different actions which are all enabled at the same time, then only one of those actions will trigger. "
-                    + "Therefore if you enable this feature, be sure to remove any of these duplicate control bindings so that controls are only ever bound to a single action. Alternatively, you can disable actions or action maps at runtime to remove these conflicts."
-                    , MessageType.None);
+                if (m_ImprovedShortcutSupportEnabled.boolValue)
+                    EditorGUILayout.HelpBox("Please note that enabling Improved Shortcut Support will cause actions with composite bindings to consume input and block any other actions which are enabled and sharing the same controls. "
+                        + "Input consumption is performed in priority order, with the action containing the greatest number of bindings checked first. "
+                        + "Therefore actions requiring less keypresses will not be triggered if an action using more keypresses is triggered and has overlapping controls. "
+                        + "This works for shortcut keys, however in other cases this might not give the desired result, especially where there are actions with the exact same number of composite controls, in which case it is non-deterministic which action will be triggered. "
+                        + "These conflicts may occur even between actions which belong to different Action Maps e.g. if using an UIInputModule with the Arrow Keys bound to the Navigate Action in the UI Action Map, this would interfere with other Action Maps using those keys. "
+                        + "Since event consumption only occurs for enabled actions, you can resolve unexpected issues by ensuring that only those Actions or Action Maps that are relevant to your game's current context are enabled. Enabling or disabling actions as your game or application moves between different contexts. "
+                        , MessageType.None);
 
                 if (EditorGUI.EndChangeCheck())
                     Apply();
@@ -307,7 +309,7 @@ namespace UnityEngine.InputSystem.Editor
             m_DefaultHoldTimeContent = new GUIContent("Default Hold Time", "Default duration to be used for Hold interactions.");
             m_TapRadiusContent = new GUIContent("Tap Radius", "Maximum distance between two finger taps on a touch screen device allowed for the system to consider this a tap of the same touch (as opposed to a new touch).");
             m_MultiTapDelayTimeContent = new GUIContent("MultiTap Delay Time", "Default delay to be allowed between taps for MultiTap interactions. Also used by by touch devices to count multi taps.");
-            m_ImprovedShortcutSupportContent = new GUIContent("Improved Shortcut Support", "Actions are exclusively triggered and will consume/block other actions sharing the same input. E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time.");
+            m_ImprovedShortcutSupportContent = new GUIContent("Enable Input Consumption", "Actions are exclusively triggered and will consume/block other actions sharing the same input. E.g. when pressing the 'Shift+B' keys, the associated action would trigger but any action bound to just the 'B' key would be prevented from triggering at the same time.");
 
             // Initialize ReorderableList for list of supported devices.
             var supportedDevicesProperty = m_SettingsObject.FindProperty("m_SupportedDevices");

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -676,7 +676,13 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentNullException(nameof(featureName));
 
             if (m_FeatureFlags == null)
+            {
                 m_FeatureFlags = new HashSet<string>();
+
+                // REMOVE: this is a temporary crutch to disable shortcut support by default but while also preserving the
+                // existing flag name, as users are aware of that now.
+                m_FeatureFlags.Add(InputFeatureNames.kDisableShortcutSupport.ToUpperInvariant());
+            }
 
             if (enabled)
                 m_FeatureFlags.Add(featureName.ToUpperInvariant());
@@ -717,6 +723,10 @@ namespace UnityEngine.InputSystem
 
         internal bool IsFeatureEnabled(string featureName)
         {
+            // REMOVE: this is a temporary crutch to disable shortcut support by default but while also preserving the
+            // existing flag name, as users are aware of that now.
+            if (m_FeatureFlags == null && featureName == InputFeatureNames.kDisableShortcutSupport) return true;
+
             return m_FeatureFlags != null && m_FeatureFlags.Contains(featureName.ToUpperInvariant());
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -675,14 +675,19 @@ namespace UnityEngine.InputSystem
             if (string.IsNullOrEmpty(featureName))
                 throw new ArgumentNullException(nameof(featureName));
 
-            if (m_FeatureFlags == null)
+            // REMOVE: this is a temporary crutch to disable shortcut support by default but while also preserving the
+            // existing flag name, as users are aware of that now.
+            if (featureName == InputFeatureNames.kDisableShortcutSupport)
             {
-                m_FeatureFlags = new HashSet<string>();
-
-                // REMOVE: this is a temporary crutch to disable shortcut support by default but while also preserving the
-                // existing flag name, as users are aware of that now.
-                m_FeatureFlags.Add(InputFeatureNames.kDisableShortcutSupport.ToUpperInvariant());
+                if (m_ImprovedShortcutSupportEnabled == !enabled) return;
+                Debug.LogWarning("Please note that the use of SetInternalFeatureFlag(\"DISABLE_SHORTCUT_SUPPORT\", ...) is unsupported and will be removed in future releases. Enabling Improved Shortcut Support via the 'Project Settings - Input System Package' panel will remove this message.");
+                m_ImprovedShortcutSupportEnabled = !enabled;
+                OnChange();
+                return;
             }
+
+            if (m_FeatureFlags == null)
+                m_FeatureFlags = new HashSet<string>();
 
             if (enabled)
                 m_FeatureFlags.Add(featureName.ToUpperInvariant());
@@ -718,14 +723,15 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_TapRadius = 5;
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
         [SerializeField] private bool m_DisableRedundantEventsMerging = false;
+        [SerializeField] private bool m_ImprovedShortcutSupportEnabled = false; // This is the shortcut support from v1.4. Temporarily moved here as an opt-in feature, while it's issues are investigated.
 
         [NonSerialized] internal HashSet<string> m_FeatureFlags;
 
         internal bool IsFeatureEnabled(string featureName)
         {
             // REMOVE: this is a temporary crutch to disable shortcut support by default but while also preserving the
-            // existing flag name, as users are aware of that now.
-            if (m_FeatureFlags == null && featureName == InputFeatureNames.kDisableShortcutSupport) return true;
+            // existing flag name, as some users are aware of that now.
+            if (featureName == InputFeatureNames.kDisableShortcutSupport) return !m_ImprovedShortcutSupportEnabled;
 
             return m_FeatureFlags != null && m_FeatureFlags.Contains(featureName.ToUpperInvariant());
         }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -680,7 +680,6 @@ namespace UnityEngine.InputSystem
             if (featureName == InputFeatureNames.kDisableShortcutSupport)
             {
                 if (m_ImprovedShortcutSupportEnabled == !enabled) return;
-                Debug.LogWarning("Please note that the use of SetInternalFeatureFlag(\"DISABLE_SHORTCUT_SUPPORT\", ...) is unsupported and will be removed in future releases. Enabling Improved Shortcut Support via the 'Project Settings - Input System Package' panel will remove this message.");
                 m_ImprovedShortcutSupportEnabled = !enabled;
                 OnChange();
                 return;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -679,8 +679,8 @@ namespace UnityEngine.InputSystem
             // existing flag name, as users are aware of that now.
             if (featureName == InputFeatureNames.kDisableShortcutSupport)
             {
-                if (m_ImprovedShortcutSupportEnabled == !enabled) return;
-                m_ImprovedShortcutSupportEnabled = !enabled;
+                if (m_ShortcutKeysConsumeInputs == !enabled) return;
+                m_ShortcutKeysConsumeInputs = !enabled;
                 OnChange();
                 return;
             }
@@ -722,7 +722,7 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_TapRadius = 5;
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
         [SerializeField] private bool m_DisableRedundantEventsMerging = false;
-        [SerializeField] private bool m_ImprovedShortcutSupportEnabled = false; // This is the shortcut support from v1.4. Temporarily moved here as an opt-in feature, while it's issues are investigated.
+        [SerializeField] private bool m_ShortcutKeysConsumeInputs = false; // This is the shortcut support from v1.4. Temporarily moved here as an opt-in feature, while it's issues are investigated.
 
         [NonSerialized] internal HashSet<string> m_FeatureFlags;
 
@@ -730,7 +730,7 @@ namespace UnityEngine.InputSystem
         {
             // REMOVE: this is a temporary crutch to disable shortcut support by default but while also preserving the
             // existing flag name, as some users are aware of that now.
-            if (featureName == InputFeatureNames.kDisableShortcutSupport) return !m_ImprovedShortcutSupportEnabled;
+            if (featureName == InputFeatureNames.kDisableShortcutSupport) return !m_ShortcutKeysConsumeInputs;
 
             return m_FeatureFlags != null && m_FeatureFlags.Contains(featureName.ToUpperInvariant());
         }


### PR DESCRIPTION
### Description

In v1.4 we improved shortcut support by having actions consuming their inputs. This meant, for example, that SHIFT+B would trigger it's action but any action bound to the 'B' key would be blocked.
However we have been receiving many reports that users are not getting the expected behaviour in their projects that may have unknowingly (or knowingly) multiple actions bound to the same controls.
E.g. the issues with WASD keys, with the UIInputModule Navigate action conflicting with Player controls, if both action maps were enabled and many other similar cases that were reported.

This PR restores the previous behaviour by default and makes the the new event consumption behaviour (shortcut support) opt-in now and accessible as a toggle via project settings. 


### Changes made

Added a toggle in project settings with the default value `false`.
Modified the `SetInternalFeatureFlag` and `IsFeatureEnabled` to use this new value when queried for `kDisableShortcutSupport`. It was deliberately done this way to preserve the current (non-public) API, as users are aware of it now. Rather than doing the natural thing of changing `kDisableShortcutSupport` to `kEnableShortcutSupport` or removing it entirely, which would have been cleaner.


### Notes
`InputSystem.settings.SetInternalFeatureFlag("DISABLE_SHORTCUT_SUPPORT", true);` is still available here as some users are aware of it now, but a deprecation warning is being emitted.
The setting a private field, but it does need to be saved in the asset.
I am preparing a v1.5 version of this with that removed and cleans up the settings code with proper api.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
