### PR TITLE
Hot path optimization for ReadValue/WriteValueIntoState for most used controls

### DIFF
--- a/Assets/Tests/InputSystem/CorePerformanceTests.cs
+++ b/Assets/Tests/InputSystem/CorePerformanceTests.cs
@@ -546,18 +546,18 @@ internal class CorePerformanceTests : CoreTestsFixture
     {
         var useOptimizedControls = testSetup == OptimizedControlsTest.OptimizedControls;
         InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseOptimizedControls, useOptimizedControls);
-        
+
         var mouse = InputSystem.AddDevice<Mouse>();
         Assert.That(mouse.position.x.optimizedControlDataType, Is.EqualTo(useOptimizedControls ? InputStateBlock.FormatFloat : InputStateBlock.FormatInvalid));
         Assert.That(mouse.position.y.optimizedControlDataType, Is.EqualTo(useOptimizedControls ? InputStateBlock.FormatFloat : InputStateBlock.FormatInvalid));
         Assert.That(mouse.position.optimizedControlDataType, Is.EqualTo(useOptimizedControls ? InputStateBlock.FormatVector2 : InputStateBlock.FormatInvalid));
 
         Measure.Method(() =>
-            {
-                var pos = new Vector2();
-                for(var i = 0; i < 100000; ++i)
-                    pos += mouse.position.ReadValue();
-            })
+        {
+            var pos = new Vector2();
+            for (var i = 0; i < 100000; ++i)
+                pos += mouse.position.ReadValue();
+        })
             .MeasurementCount(100)
             .WarmupCount(5)
             .Run();
@@ -576,20 +576,21 @@ internal class CorePerformanceTests : CoreTestsFixture
         runtime.ReportNewInputDevice(XRTests.PoseDeviceState.CreateDeviceDescription().ToJson());
 
         InputSystem.Update();
-        
+
         var device = InputSystem.devices[0];
 
         var poseControl = device["posecontrol"] as UnityEngine.InputSystem.XR.PoseControl;
         Assert.That(poseControl.optimizedControlDataType, Is.EqualTo(useOptimizedControls ? InputStateBlock.FormatPose : InputStateBlock.FormatInvalid));
 
         Measure.Method(() =>
-            {
-                for(var i = 0; i < 4000; ++i)
-                    poseControl.ReadValue();
-            })
+        {
+            for (var i = 0; i < 4000; ++i)
+                poseControl.ReadValue();
+        })
             .MeasurementCount(100)
             .WarmupCount(5)
             .Run();
     }
+
 #endif
 }

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1378,4 +1378,45 @@ partial class CoreTests
         Assert.That(UnsafeUtility.SizeOf<TouchState>(), Is.EqualTo(TouchState.kSizeInBytes));
         Assert.That(touchscreen.touches[0].stateBlock.alignedSizeInBytes, Is.EqualTo(TouchState.kSizeInBytes));
     }
+
+    [Test]
+    [Category("Controls")]
+    public void Controls_OptimizedControls_TrivialControlsAreOptimized()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseOptimizedControls, false);
+        Assert.That(mouse.position.x.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.position.y.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.position.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.leftButton.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+
+        InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseOptimizedControls, true);
+        Assert.That(mouse.position.x.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatFloat));
+        Assert.That(mouse.position.y.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatFloat));
+        Assert.That(mouse.position.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatVector2));
+        Assert.That(mouse.leftButton.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+
+        InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseOptimizedControls, false);
+        Assert.That(mouse.position.x.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.position.y.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.position.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.leftButton.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+    }
+
+    [Test]
+    [Category("Controls")]
+    public void Controls_OptimizedControls_ParentChangesOptimization_IfChildIsNoLongerOptimized()
+    {
+        InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseOptimizedControls, true);
+
+        var mouse = InputSystem.AddDevice<Mouse>();
+
+        mouse.position.x.invert = true;
+        mouse.position.x.ApplyParameterChanges();
+
+        Assert.That(mouse.position.x.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+        Assert.That(mouse.position.y.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatFloat));
+        Assert.That(mouse.position.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+    }
 }

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -1123,5 +1123,20 @@ internal class XRTests : CoreTestsFixture
         Assert.That((device["Vector2/x"] as AxisControl).EvaluateMagnitude(), Is.EqualTo(1f).Within(0.0001f));
         Assert.That((device["Vector2/y"] as AxisControl).EvaluateMagnitude(), Is.EqualTo(1f).Within(0.0001f));
     }
+
+    [Test]
+    [Category("Controls")]
+    public void Controls_OptimizedControls_PoseControl_IsOptimized()
+    {
+        InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseOptimizedControls, true);
+
+        runtime.ReportNewInputDevice(PoseDeviceState.CreateDeviceDescription().ToJson());
+
+        InputSystem.Update();
+
+        var device = InputSystem.devices[0];
+
+        Assert.That((device["posecontrol"] as PoseControl).optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatPose));
+    }
 }
 #endif

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -1021,7 +1021,7 @@ internal class XRTests : CoreTestsFixture
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    unsafe struct PoseDeviceState : IInputStateTypeInfo
+    internal unsafe struct PoseDeviceState : IInputStateTypeInfo
     {
         [FieldOffset(0)] public byte isTracked;
         [FieldOffset(4)] public uint trackingState;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 - Added support for reading Tracking State in [TrackedPoseDriver](xref:UnityEngine.InputSystem.XR.TrackedPoseDriver) to constrain whether the input pose is applied to the Transform. This should be used when the device supports valid flags for the position and rotation values, which is the case for XR poses.
 - Added `InputSettings.shortcutKeysConsumeInput`. This allows programmatic access to opt-in to the enhanced shortcut key behaviour ([case ISXB-254](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-254))).
+- Significantly optimized cost of `ReadValue`/`ReadUnprocessedValueFromState`/`WriteValueIntoState` for some control types. Optimization is opt-in for now, please call `InputSystem.settings.SetInternalFeatureFlag("USE_OPTIMIZED_CONTROLS", true);` in your project to enable it. You can observe which controls are optimized by looking at new optimized column in device debugger. You will need to call a new `InputControl.ApplyParameterChanges()` method if the code is changing `AxisControl` fields after initial setup is done.
 
 ### Fixed
 - Fixed composite bindings incorrectly getting a control scheme assigned when pasting into input asset editor with a control scheme selected.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -5,6 +5,8 @@ using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: change 'clampToConstant' to simply 'clampToMin'?
 
+////TODO: if AxisControl fields where properties, we wouldn't need ApplyParameterChanges, maybe it's ok breaking change? 
+
 namespace UnityEngine.InputSystem.Controls
 {
     /// <summary>
@@ -237,8 +239,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatFloat:
@@ -257,8 +257,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(float value, void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatFloat:

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -1,5 +1,7 @@
+using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
+using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: change 'clampToConstant' to simply 'clampToMin'?
 
@@ -177,6 +179,7 @@ namespace UnityEngine.InputSystem.Controls
         /// <seealso cref="normalize"/>
         /// <seealso cref="scale"/>
         /// <seealso cref="invert"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected float Preprocess(float value)
         {
             if (scale)
@@ -234,16 +237,41 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe float ReadUnprocessedValueFromState(void* statePtr)
         {
-            var value = stateBlock.ReadFloat(statePtr);
-            ////REVIEW: this isn't very raw
-            return Preprocess(value);
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatFloat:
+                    return *(float*)((byte*)statePtr + m_StateBlock.m_ByteOffset);
+                case InputStateBlock.kFormatByte:
+                    return *((byte*)statePtr + m_StateBlock.m_ByteOffset) != 0 ? 1.0f : 0.0f;
+                default:
+                {
+                    var value = stateBlock.ReadFloat(statePtr);
+                    ////REVIEW: this isn't very raw
+                    return Preprocess(value);
+                }
+            }
         }
 
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(float value, void* statePtr)
         {
-            value = Unpreprocess(value);
-            stateBlock.WriteFloat(statePtr, value);
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatFloat:
+                    *(float*)((byte*)statePtr + m_StateBlock.m_ByteOffset) = value;
+                    break;
+                case InputStateBlock.kFormatByte:
+                    *((byte*)statePtr + m_StateBlock.m_ByteOffset) = (byte)(value >= 0.5f ? 1 : 0);
+                    break;
+                default:
+                    value = Unpreprocess(value);
+                    stateBlock.WriteFloat(statePtr, value);
+                    break;
+            }
         }
 
         /// <inheritdoc />
@@ -276,6 +304,29 @@ namespace UnityEngine.InputSystem.Controls
             }
 
             return NormalizeProcessor.Normalize(value, min, max, 0);
+        }
+
+        protected override FourCC CalculateOptimizedControlDataType()
+        {
+            var noProcessingNeeded =
+                clamp == Clamp.None &&
+                invert == false &&
+                normalize == false &&
+                scale == false;
+
+            if (noProcessingNeeded &&
+                m_StateBlock.format == InputStateBlock.FormatFloat &&
+                m_StateBlock.sizeInBits == 32 &&
+                m_StateBlock.bitOffset == 0)
+                return InputStateBlock.FormatFloat;
+            if (noProcessingNeeded &&
+                m_StateBlock.format == InputStateBlock.FormatBit &&
+                // has to be 8, otherwise we might be mapping to a state which only represents first bit in the byte, while other bits might map to some other controls
+                // like in the mouse where LMB/RMB map to the same byte, just LMB maps to first bit and RMB maps to second bit
+                m_StateBlock.sizeInBits == 8 &&
+                m_StateBlock.bitOffset == 0)
+                return InputStateBlock.FormatByte;
+            return InputStateBlock.FormatInvalid;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -5,7 +5,7 @@ using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: change 'clampToConstant' to simply 'clampToMin'?
 
-////TODO: if AxisControl fields where properties, we wouldn't need ApplyParameterChanges, maybe it's ok breaking change? 
+////TODO: if AxisControl fields where properties, we wouldn't need ApplyParameterChanges, maybe it's ok breaking change?
 
 namespace UnityEngine.InputSystem.Controls
 {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.Scripting;
 
@@ -75,6 +76,7 @@ namespace UnityEngine.InputSystem.Controls
         /// <returns>True if <paramref name="value"/> crosses the threshold to be considered pressed.</returns>
         /// <seealso cref="pressPoint"/>
         /// <seealso cref="InputSettings.defaultButtonPressPoint"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public new bool IsValueConsideredPressed(float value)
         {
             return value >= pressPointOrDefault;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;  
+using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
@@ -869,7 +869,7 @@ namespace UnityEngine.InputSystem
         /// you can cast the Vector3Control state memory directly to Vector3 without calling ReadUnprocessedValueFromState on x/y/z axes.
         ///
         /// The value returned for any given control is computed automatically by the Input System, when the control's setup configuration changes. <see cref="InputControl.CalculateOptimizedControlDataType"/>
-        /// There are some parameter changes which don't trigger a configuration change (such as the clamp, invert, normalize, and scale parameters on AxisControl), 
+        /// There are some parameter changes which don't trigger a configuration change (such as the clamp, invert, normalize, and scale parameters on AxisControl),
         /// so if you modify these, the optimized data type is not automatically updated. In this situation, you should manually update it by calling <see cref="InputControl.ApplyParameterChanges"/>.
         /// </remarks>
         public FourCC optimizedControlDataType => m_OptimizedControlDataType;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;  
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
@@ -857,26 +857,27 @@ namespace UnityEngine.InputSystem
         internal FourCC m_OptimizedControlDataType;
 
         /// <summary>
-        /// For some controls it's possible to safely read/write state memory directly
-        /// instead of calling ReadUnprocessedValueFromState/WriteValueIntoState.
-        /// This value will represent a type that should be used for reading/writing directly.
-        /// Or be InputStateBlock.kFormatInvalid if no casting is possible.
+        /// For some types of control you can safely read/write state memory directly
+        /// which is much faster than calling ReadUnprocessedValueFromState/WriteValueIntoState.
+        /// This method returns a type that you can use for reading/writing the control directly,
+        /// or it returns InputStateBlock.kFormatInvalid if it's not possible for this type of control.
         /// </summary>
         /// <remarks>
-        /// For example AxisControl might be a "float" in state memory, and if no processing applied during reading (e.g. no invert/scale/etc),
-        /// then it could be read as float in memory directly without calling ReadUnprocessedValueFromState.
-        /// If then Vector3Control has 3 AxisControls as consecutive floats in memory,
-        /// then we can cast Vector3Control state memory directly to Vector3 without calling ReadUnprocessedValueFromState on x/y/z axes.
+        /// For example, AxisControl might be a "float" in state memory, and if no processing is applied during reading (e.g. no invert/scale/etc),
+        /// then you could read it as float in memory directly without calling ReadUnprocessedValueFromState, which is faster.
+        /// Additionally, if you have a Vector3Control which uses 3 AxisControls as consecutive floats in memory,
+        /// you can cast the Vector3Control state memory directly to Vector3 without calling ReadUnprocessedValueFromState on x/y/z axes.
         ///
-        /// Value is computed by automatically calling <see cref="InputControl.CalculateOptimizedControlDataType"/> when system believes control changes setup configuration.
-        /// Value can be updated manually by calling <see cref="InputControl.ApplyParameterChanges"/>.
+        /// The value returned for any given control is computed automatically by the Input System, when the control's setup configuration changes. <see cref="InputControl.CalculateOptimizedControlDataType"/>
+        /// There are some parameter changes which don't trigger a configuration change (such as the clamp, invert, normalize, and scale parameters on AxisControl), 
+        /// so if you modify these, the optimized data type is not automatically updated. In this situation, you should manually update it by calling <see cref="InputControl.ApplyParameterChanges"/>.
         /// </remarks>
         public FourCC optimizedControlDataType => m_OptimizedControlDataType;
 
         /// <summary>
-        /// Calculate and return a type that can represent control value in memory directly.
-        /// Value then is cached in <see cref="InputControl.optimizedControlDataType"/>.
-        /// Function shouldn't be called manually.
+        /// Calculates and returns a optimized data type that can represent a control's value in memory directly.
+        /// The value then is cached in <see cref="InputControl.optimizedControlDataType"/>.
+        /// This method is for internal use only, you should not call this from your own code.
         /// </summary>
         protected virtual FourCC CalculateOptimizedControlDataType()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/IntegerControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/IntegerControl.cs
@@ -21,8 +21,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc/>
         public override unsafe int ReadUnprocessedValueFromState(void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatInt:
@@ -35,8 +33,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc/>
         public override unsafe void WriteValueIntoState(int value, void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatInt:

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
@@ -67,8 +67,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc/>
         public override unsafe Quaternion ReadUnprocessedValueFromState(void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatQuaternion:
@@ -85,8 +83,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc/>
         public override unsafe void WriteValueIntoState(Quaternion value, void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatQuaternion:

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
@@ -1,5 +1,6 @@
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: expose euler angle subcontrols?
 
@@ -66,17 +67,61 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc/>
         public override unsafe Quaternion ReadUnprocessedValueFromState(void* statePtr)
         {
-            return new Quaternion(x.ReadValueFromState(statePtr), y.ReadValueFromState(statePtr), z.ReadValueFromState(statePtr),
-                w.ReadUnprocessedValueFromState(statePtr));
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatQuaternion:
+                    return *(Quaternion*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
+                default:
+                    return new Quaternion(
+                        x.ReadValueFromState(statePtr),
+                        y.ReadValueFromState(statePtr),
+                        z.ReadValueFromState(statePtr),
+                        w.ReadUnprocessedValueFromState(statePtr));
+            }
         }
 
         /// <inheritdoc/>
         public override unsafe void WriteValueIntoState(Quaternion value, void* statePtr)
         {
-            x.WriteValueIntoState(value.x, statePtr);
-            y.WriteValueIntoState(value.y, statePtr);
-            z.WriteValueIntoState(value.z, statePtr);
-            w.WriteValueIntoState(value.w, statePtr);
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatQuaternion:
+                    *(Quaternion*)((byte*)statePtr + (int)m_StateBlock.byteOffset) = value;
+                    break;
+                default:
+                    x.WriteValueIntoState(value.x, statePtr);
+                    y.WriteValueIntoState(value.y, statePtr);
+                    z.WriteValueIntoState(value.z, statePtr);
+                    w.WriteValueIntoState(value.w, statePtr);
+                    break;
+            }
+        }
+
+        protected override FourCC CalculateOptimizedControlDataType()
+        {
+            if (
+                m_StateBlock.sizeInBits == sizeof(float) * 4 * 8 &&
+                m_StateBlock.bitOffset == 0 &&
+                x.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                y.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                z.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                w.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                y.m_StateBlock.byteOffset == x.m_StateBlock.byteOffset + 4 &&
+                z.m_StateBlock.byteOffset == x.m_StateBlock.byteOffset + 8 &&
+                w.m_StateBlock.byteOffset == x.m_StateBlock.byteOffset + 12 &&
+                // For some unknown reason ReadUnprocessedValueFromState here uses ReadValueFromState on x/y/z (but not w)
+                // which means we can't optimize if there any processors on x/y/z
+                x.m_ProcessorStack.length == 0 &&
+                y.m_ProcessorStack.length == 0 &&
+                z.m_ProcessorStack.length == 0
+            )
+                return InputStateBlock.FormatQuaternion;
+
+            return InputStateBlock.FormatInvalid;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
@@ -1,5 +1,6 @@
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Controls
 {
@@ -55,16 +56,34 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe Vector2 ReadUnprocessedValueFromState(void* statePtr)
         {
-            return new Vector2(
-                x.ReadUnprocessedValueFromState(statePtr),
-                y.ReadUnprocessedValueFromState(statePtr));
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatVector2:
+                    return *(Vector2*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
+                default:
+                    return new Vector2(
+                        x.ReadUnprocessedValueFromState(statePtr),
+                        y.ReadUnprocessedValueFromState(statePtr));
+            }
         }
 
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(Vector2 value, void* statePtr)
         {
-            x.WriteValueIntoState(value.x, statePtr);
-            y.WriteValueIntoState(value.y, statePtr);
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatVector2:
+                    *(Vector2*)((byte*)statePtr + (int)m_StateBlock.byteOffset) = value;
+                    break;
+                default:
+                    x.WriteValueIntoState(value.x, statePtr);
+                    y.WriteValueIntoState(value.y, statePtr);
+                    break;
+            }
         }
 
         /// <inheritdoc />
@@ -72,6 +91,20 @@ namespace UnityEngine.InputSystem.Controls
         {
             ////REVIEW: this can go beyond 1; that okay?
             return ReadValueFromState(statePtr).magnitude;
+        }
+
+        protected override FourCC CalculateOptimizedControlDataType()
+        {
+            if (
+                m_StateBlock.sizeInBits == sizeof(float) * 2 * 8 &&
+                m_StateBlock.bitOffset == 0 &&
+                x.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                y.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                y.m_StateBlock.byteOffset == x.m_StateBlock.byteOffset + 4
+            )
+                return InputStateBlock.FormatVector2;
+
+            return InputStateBlock.FormatInvalid;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector2Control.cs
@@ -56,8 +56,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe Vector2 ReadUnprocessedValueFromState(void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatVector2:
@@ -72,8 +70,6 @@ namespace UnityEngine.InputSystem.Controls
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(Vector2 value, void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatVector2:

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
@@ -1,5 +1,6 @@
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Controls
 {
@@ -31,23 +32,57 @@ namespace UnityEngine.InputSystem.Controls
 
         public override unsafe Vector3 ReadUnprocessedValueFromState(void* statePtr)
         {
-            return new Vector3(
-                x.ReadUnprocessedValueFromState(statePtr),
-                y.ReadUnprocessedValueFromState(statePtr),
-                z.ReadUnprocessedValueFromState(statePtr));
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatVector3:
+                    return *(Vector3*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
+                default:
+                    return new Vector3(
+                        x.ReadUnprocessedValueFromState(statePtr),
+                        y.ReadUnprocessedValueFromState(statePtr),
+                        z.ReadUnprocessedValueFromState(statePtr));
+            }
         }
 
         public override unsafe void WriteValueIntoState(Vector3 value, void* statePtr)
         {
-            x.WriteValueIntoState(value.x, statePtr);
-            y.WriteValueIntoState(value.y, statePtr);
-            z.WriteValueIntoState(value.z, statePtr);
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatVector3:
+                    *(Vector3*)((byte*)statePtr + (int)m_StateBlock.byteOffset) = value;
+                    break;
+                default:
+                    x.WriteValueIntoState(value.x, statePtr);
+                    y.WriteValueIntoState(value.y, statePtr);
+                    z.WriteValueIntoState(value.z, statePtr);
+                    break;
+            }
         }
 
         public override unsafe float EvaluateMagnitude(void* statePtr)
         {
             ////REVIEW: this can go beyond 1; that okay?
             return ReadValueFromState(statePtr).magnitude;
+        }
+
+        protected override FourCC CalculateOptimizedControlDataType()
+        {
+            if (
+                m_StateBlock.sizeInBits == sizeof(float) * 3 * 8 &&
+                m_StateBlock.bitOffset == 0 &&
+                x.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                y.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                z.optimizedControlDataType == InputStateBlock.FormatFloat &&
+                y.m_StateBlock.byteOffset == x.m_StateBlock.byteOffset + 4 &&
+                z.m_StateBlock.byteOffset == x.m_StateBlock.byteOffset + 8
+            )
+                return InputStateBlock.FormatVector3;
+
+            return InputStateBlock.FormatInvalid;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Vector3Control.cs
@@ -32,8 +32,6 @@ namespace UnityEngine.InputSystem.Controls
 
         public override unsafe Vector3 ReadUnprocessedValueFromState(void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatVector3:
@@ -48,8 +46,6 @@ namespace UnityEngine.InputSystem.Controls
 
         public override unsafe void WriteValueIntoState(Vector3 value, void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatVector3:

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -836,18 +836,24 @@ namespace UnityEngine.InputSystem
 
         internal bool RequestSync()
         {
+            SetOptimizedControlDataTypeRecursively();
+
             var syncCommand = RequestSyncCommand.Create();
             return device.ExecuteCommand(ref syncCommand) >= 0;
         }
 
         internal bool RequestReset()
         {
+            SetOptimizedControlDataTypeRecursively();
+
             var resetCommand = RequestResetCommand.Create();
             return device.ExecuteCommand(ref resetCommand) >= 0;
         }
 
         internal bool ExecuteEnableCommand()
         {
+            SetOptimizedControlDataTypeRecursively();
+
             var command = EnableDeviceCommand.Create();
             return device.ExecuteCommand(ref command) >= 0;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
@@ -5,5 +5,6 @@ namespace UnityEngine.InputSystem
         public const string kRunPlayerUpdatesInEditMode = "RUN_PLAYER_UPDATES_IN_EDIT_MODE";
         public const string kDisableUnityRemoteSupport = "DISABLE_UNITY_REMOTE_SUPPORT";
         public const string kUseWindowsGamingInputBackend = "USE_WINDOWS_GAMING_INPUT_BACKEND";
+        public const string kUseOptimizedControls = "USE_OPTIMIZED_CONTROLS";
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2529,6 +2529,10 @@ namespace UnityEngine.InputSystem
             ButtonControl.s_GlobalDefaultButtonPressPoint = Mathf.Clamp(settings.defaultButtonPressPoint, ButtonControl.kMinButtonPressPoint, float.MaxValue);
             ButtonControl.s_GlobalDefaultButtonReleaseThreshold = settings.buttonReleaseThreshold;
 
+            // Update devices control optimization
+            foreach (var device in devices)
+                device.SetOptimizedControlDataTypeRecursively();
+
             // Let listeners know.
             DelegateHelpers.InvokeCallbacksSafe(ref m_SettingsChangedListeners,
                 "InputSystem.onSettingsChange");

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2825,6 +2825,10 @@ namespace UnityEngine.InputSystem
 
             m_CurrentUpdate = updateType;
             InputUpdate.OnUpdate(updateType);
+            
+            // Ensure optimized controls are in valid state
+            foreach (var device in devices)
+                device.EnsureOptimizationTypeHasNotChanged();
 
             var shouldProcessActionTimeouts = updateType.IsPlayerUpdate() && gameIsPlaying;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2825,7 +2825,7 @@ namespace UnityEngine.InputSystem
 
             m_CurrentUpdate = updateType;
             InputUpdate.OnUpdate(updateType);
-            
+
             // Ensure optimized controls are in valid state
             foreach (var device in devices)
                 device.EnsureOptimizationTypeHasNotChanged();

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -701,6 +701,13 @@ namespace UnityEngine.InputSystem
             if (string.IsNullOrEmpty(featureName))
                 throw new ArgumentNullException(nameof(featureName));
 
+            if (featureName == InputFeatureNames.kUseOptimizedControls)
+            {
+                optimizedControlsFeatureEnabled = enabled;
+                OnChange();
+                return;
+            }
+
             if (m_FeatureFlags == null)
                 m_FeatureFlags = new HashSet<string>();
 
@@ -746,6 +753,9 @@ namespace UnityEngine.InputSystem
         {
             return m_FeatureFlags != null && m_FeatureFlags.Contains(featureName.ToUpperInvariant());
         }
+
+        // Needs a static field because feature check is in the hot path
+        internal static bool optimizedControlsFeatureEnabled = false;
 
         internal void OnChange()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
@@ -211,8 +211,6 @@ namespace UnityEngine.InputSystem.XR
         /// <inheritdoc />
         public override unsafe PoseState ReadUnprocessedValueFromState(void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatPose:
@@ -233,8 +231,6 @@ namespace UnityEngine.InputSystem.XR
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(PoseState value, void* statePtr)
         {
-            EnsureOptimizationTypeHasNotChanged();
-
             switch (m_OptimizedControlDataType)
             {
                 case InputStateBlock.kFormatPose:

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
@@ -24,12 +24,14 @@ namespace UnityEngine.InputSystem.XR
     {
         internal const int kSizeInBytes = 60;
 
+        internal static readonly FourCC s_Format = new FourCC('P', 'o', 's', 'e');
+
         /// <summary>
         /// Memory format tag for PoseState.
         /// </summary>
         /// <value>Returns "Pose".</value>
         /// <seealso cref="InputStateBlock.format"/>
-        public FourCC format => new FourCC('P', 'o', 's', 'e');
+        public FourCC format => s_Format;
 
         /// <summary>
         /// Constructor for PoseStates.
@@ -58,7 +60,7 @@ namespace UnityEngine.InputSystem.XR
         /// <remarks>
         /// Fully tracked means that the pose is accurate and not using any simulated or extrapolated positions, and the system tracking this pose is able to confidently track this object.
         /// </remarks>
-        [FieldOffset(0), InputControl(displayName = "Is Tracked", layout = "Button")]
+        [FieldOffset(0), InputControl(displayName = "Is Tracked", layout = "Button", sizeInBits = 8 /* needed to ensure optimization kicks-in */)]
         public bool isTracked;
 
         /// <summary>
@@ -190,7 +192,7 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
         public PoseControl()
         {
-            m_StateBlock.format = new FourCC('P', 'o', 's', 'e');
+            m_StateBlock.format = PoseState.s_Format;
         }
 
         /// <inheritdoc />
@@ -209,26 +211,66 @@ namespace UnityEngine.InputSystem.XR
         /// <inheritdoc />
         public override unsafe PoseState ReadUnprocessedValueFromState(void* statePtr)
         {
-            return new PoseState()
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
             {
-                isTracked = isTracked.ReadUnprocessedValueFromState(statePtr) > 0.5f,
-                trackingState = (TrackingState)trackingState.ReadUnprocessedValueFromState(statePtr),
-                position = position.ReadUnprocessedValueFromState(statePtr),
-                rotation = rotation.ReadUnprocessedValueFromState(statePtr),
-                velocity = velocity.ReadUnprocessedValueFromState(statePtr),
-                angularVelocity = angularVelocity.ReadUnprocessedValueFromState(statePtr),
-            };
+                case InputStateBlock.kFormatPose:
+                    return *(PoseState*)((byte*)statePtr + (int)m_StateBlock.byteOffset);
+                default:
+                    return new PoseState()
+                    {
+                        isTracked = isTracked.ReadUnprocessedValueFromState(statePtr) > 0.5f,
+                        trackingState = (TrackingState)trackingState.ReadUnprocessedValueFromState(statePtr),
+                        position = position.ReadUnprocessedValueFromState(statePtr),
+                        rotation = rotation.ReadUnprocessedValueFromState(statePtr),
+                        velocity = velocity.ReadUnprocessedValueFromState(statePtr),
+                        angularVelocity = angularVelocity.ReadUnprocessedValueFromState(statePtr),
+                    };
+            }
         }
 
         /// <inheritdoc />
         public override unsafe void WriteValueIntoState(PoseState value, void* statePtr)
         {
-            isTracked.WriteValueIntoState(value.isTracked, statePtr);
-            trackingState.WriteValueIntoState((uint)value.trackingState, statePtr);
-            position.WriteValueIntoState(value.position, statePtr);
-            rotation.WriteValueIntoState(value.rotation, statePtr);
-            velocity.WriteValueIntoState(value.velocity, statePtr);
-            angularVelocity.WriteValueIntoState(value.angularVelocity, statePtr);
+            EnsureOptimizationTypeHasNotChanged();
+
+            switch (m_OptimizedControlDataType)
+            {
+                case InputStateBlock.kFormatPose:
+                    *(PoseState*)((byte*)statePtr + (int)m_StateBlock.byteOffset) = value;
+                    break;
+                default:
+                    isTracked.WriteValueIntoState(value.isTracked, statePtr);
+                    trackingState.WriteValueIntoState((uint)value.trackingState, statePtr);
+                    position.WriteValueIntoState(value.position, statePtr);
+                    rotation.WriteValueIntoState(value.rotation, statePtr);
+                    velocity.WriteValueIntoState(value.velocity, statePtr);
+                    angularVelocity.WriteValueIntoState(value.angularVelocity, statePtr);
+                    break;
+            }
+        }
+
+        protected override FourCC CalculateOptimizedControlDataType()
+        {
+            if (
+                m_StateBlock.sizeInBits == PoseState.kSizeInBytes * 8 &&
+                m_StateBlock.bitOffset == 0 &&
+                isTracked.optimizedControlDataType == InputStateBlock.kFormatByte &&
+                trackingState.optimizedControlDataType == InputStateBlock.kFormatInt &&
+                position.optimizedControlDataType == InputStateBlock.kFormatVector3 &&
+                rotation.optimizedControlDataType == InputStateBlock.kFormatQuaternion &&
+                velocity.optimizedControlDataType == InputStateBlock.kFormatVector3 &&
+                angularVelocity.optimizedControlDataType == InputStateBlock.kFormatVector3 &&
+                trackingState.m_StateBlock.byteOffset == isTracked.m_StateBlock.byteOffset + 4 &&
+                position.m_StateBlock.byteOffset == isTracked.m_StateBlock.byteOffset + 8 &&
+                rotation.m_StateBlock.byteOffset == isTracked.m_StateBlock.byteOffset + 20 &&
+                velocity.m_StateBlock.byteOffset == isTracked.m_StateBlock.byteOffset + 36 &&
+                angularVelocity.m_StateBlock.byteOffset == isTracked.m_StateBlock.byteOffset + 48
+            )
+                return InputStateBlock.kFormatPose;
+
+            return InputStateBlock.kFormatInvalid;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBlock.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.Utilities;
 
@@ -44,6 +45,13 @@ namespace UnityEngine.InputSystem.LowLevel
     {
         public const uint InvalidOffset = 0xffffffff;
         public const uint AutomaticOffset = 0xfffffffe;
+
+        /// <summary>
+        /// Format code for invalid value type
+        /// </summary>
+        /// <seealso cref="format"/>
+        public static readonly FourCC FormatInvalid = new FourCC(0);
+        internal const int kFormatInvalid = 0;
 
         /// <summary>
         /// Format code for a variable-width bitfield representing an unsigned value,
@@ -134,12 +142,17 @@ namespace UnityEngine.InputSystem.LowLevel
 
         ////REVIEW: are these really useful?
         public static readonly FourCC FormatVector2 = new FourCC('V', 'E', 'C', '2');
+        internal const int kFormatVector2 = 'V' << 24 | 'E' << 16 | 'C' << 8 | '2';
         public static readonly FourCC FormatVector3 = new FourCC('V', 'E', 'C', '3');
+        internal const int kFormatVector3 = 'V' << 24 | 'E' << 16 | 'C' << 8 | '3';
         public static readonly FourCC FormatQuaternion = new FourCC('Q', 'U', 'A', 'T');
+        internal const int kFormatQuaternion = 'Q' << 24 | 'U' << 16 | 'A' << 8 | 'T';
         public static readonly FourCC FormatVector2Short = new FourCC('V', 'C', '2', 'S');
         public static readonly FourCC FormatVector3Short = new FourCC('V', 'C', '3', 'S');
         public static readonly FourCC FormatVector2Byte = new FourCC('V', 'C', '2', 'B');
         public static readonly FourCC FormatVector3Byte = new FourCC('V', 'C', '3', 'B');
+        public static readonly FourCC FormatPose = new FourCC('P', 'o', 's', 'e');
+        internal const int kFormatPose = 'P' << 24 | 'o' << 16 | 's' << 8 | 'e';
 
         public static int GetSizeOfPrimitiveFormatInBits(FourCC type)
         {
@@ -221,7 +234,17 @@ namespace UnityEngine.InputSystem.LowLevel
         // During setup, this can be InvalidOffset to indicate a control that should be placed
         // at an offset automatically; otherwise it denotes a fixed offset relative to the
         // parent control.
-        public uint byteOffset { get; set; }
+        public uint byteOffset
+        {
+            get => m_ByteOffset;
+            set
+            {
+                m_ByteOffset = value;
+            }
+        }
+
+        // Needed for fast access to avoid a call to getter in some places
+        internal uint m_ByteOffset;
 
         // Bit offset from the given byte offset. Also zero-based (i.e. first bit is at bit
         // offset #0).

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace UnityEngine.InputSystem.Utilities
 {
@@ -72,6 +73,7 @@ namespace UnityEngine.InputSystem.Utilities
         /// <returns>The four characters of the code packed into one <c>int</c>. Character order is
         /// little endian. "ABCD" is stored with A in the highest order 8 bits and D in the
         /// lowest order 8 bits.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator int(FourCC fourCC)
         {
             return fourCC.m_Code;
@@ -84,6 +86,7 @@ namespace UnityEngine.InputSystem.Utilities
         /// little endian. "ABCD" is stored with A in the highest order 8 bits and D in the
         /// lowest order 8 bits.</param>
         /// <returns>The FourCC converted from <paramref name="i"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator FourCC(int i)
         {
             return new FourCC(i);
@@ -105,6 +108,7 @@ namespace UnityEngine.InputSystem.Utilities
         /// <param name="other">Another FourCC.</param>
         /// <returns>True if the two FourCCs are equal, i.e. have the same exact
         /// character codes.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Equals(FourCC other)
         {
             return m_Code == other.m_Code;
@@ -139,6 +143,7 @@ namespace UnityEngine.InputSystem.Utilities
         /// <param name="right">Second FourCC.</param>
         /// <returns>True if the two FourCCs are equal, i.e. have the same exact
         /// character codes.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator==(FourCC left, FourCC right)
         {
             return left.m_Code == right.m_Code;
@@ -151,17 +156,20 @@ namespace UnityEngine.InputSystem.Utilities
         /// <param name="right">Second FourCC.</param>
         /// <returns>True if the two FourCCs are not equal, i.e. do not have the same exact
         /// character codes.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool operator!=(FourCC left, FourCC right)
         {
             return left.m_Code != right.m_Code;
         }
 
         // Make annoying Microsoft code analyzer happy.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static FourCC FromInt32(int i)
         {
             return i;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int ToInt32(FourCC fourCC)
         {
             return fourCC.m_Code;


### PR DESCRIPTION
### Description

Current performance of `ReadValue` leaves a lot to be desired.

This PR is based on observation that for majority of controls:
- Memory layout is typical for the type, e.g. `AxisControl` is byte aligned float, `QuaternionControl` is byte aligned `Quaternion`, etc.
- No extra processing is applied.

### Changes made

- If memory layout is expected typical layout for the control type, we short circuit `ReadValue` to cast state pointer directly to expected type, bypassing `InputStateBlock` reading all together for selected controls. Same for `WriteValueIntoState`.
- Added control debugger visibility to check if control got hot path optimized or not.
- Require `ApplyParameterChanges` for application of control changes that change optimization status, like `AxisControl` processors parameters (e.g. `invert`, etc).

### Notes

We plan to land this feature as opt-in for now. And make it opt-out after some rigorous testing.