### PR TITLE
FIX: Device disconnected events are missed when running in the background

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed composite bindings incorrectly getting a control scheme assigned when pasting into input asset editor with a control scheme selected.
+- Fixed an issue on PS5 where device disconnected events that happen while the app is in the background are missed causing orphaned devices to hang around forever and exceptions when the same device is added again ([case UUM-7842](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744)).
 
 ### Actions
 - Extended input action code generator (`InputActionCodeGenerator.cs`) to support optional registration and unregistration of callbacks for multiple callback instances via `AddCallbacks(...)` and `RemoveCallbacks(...)` part of the generated code. Contribution by [Ramobo](https://github.com/Ramobo) in [#889](https://github.com/Unity-Technologies/InputSystem/pull/889).

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -227,7 +227,11 @@ namespace UnityEngine.InputSystem.LowLevel
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
         public float unscaledGameTime => Time.unscaledTime;
 
-        public bool runInBackground => Application.runInBackground;
+        public bool runInBackground => Application.runInBackground ||
+        // certain platforms ignore the runInBackground flag and always run. Make sure we're
+        // not running on one of those.
+        // TODO: Add more platforms here as they're discovered.
+        Application.platform == RuntimePlatform.PS5;
 
         private Action m_ShutdownMethod;
         private InputUpdateDelegate m_OnUpdate;


### PR DESCRIPTION
### Description

Some platforms ignore the runInBackground flag and just always run. The Input System, however, respects that flag and when it is false, and that application doesn't have focus, it can early-out of the event processing loop and flush the event buffer. If this happens when a device disconnected event is in the buffer, that device won't be disconnected and the backend won't send another event, resulting in orphaned devices and exceptions when the an attempt is made to add the same device again.

### Changes made

Forced the runInBackground flag to true on PS5.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.