### PR TITLE
Filtering out axis jitter on Switch Pro / DualShock 4 / DualSense gamepads connected via HID

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -262,5 +262,149 @@ internal class DualShockTests : CoreTestsFixture
         Assert.That(receivedCommand.Value.blueColor, Is.EqualTo((byte)(0.5f * 255)));
     }
 
+    [Test]
+    [Category("Devices")]
+    public void Devices_DualSense_AxisJitter_DoesntMakeDeviceCurrent()
+    {
+        var device1 = InputSystem.AddDevice<DualSenseGamepadHID>();
+        var device2 = InputSystem.AddDevice<DualSenseGamepadHID>();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state that is with-in axis dead zone doesn't make device current
+        InputSystem.QueueStateEvent(device1,
+            new DualSenseHIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons0 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state that is outside of dead zone makes device current
+        InputSystem.QueueStateEvent(device1,
+            new DualSenseHIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow - 1,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons0 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+
+        // reset test
+        device2.MakeCurrent();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state with button change makes device current
+        InputSystem.QueueStateEvent(device1,
+            new DualSenseHIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons1 = 1,
+                buttons0 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+
+        // reset test
+        device2.MakeCurrent();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state with trigger change makes device current
+        InputSystem.QueueStateEvent(device1,
+            new DualSenseHIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons1 = 1,
+                leftTrigger = 1,
+                buttons0 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+    }
+
+    [Test]
+    [Category("Devices")]
+    public void Devices_DualShock4_AxisJitter_DoesntMakeDeviceCurrent()
+    {
+        var device1 = InputSystem.AddDevice<DualShock4GamepadHID>();
+        var device2 = InputSystem.AddDevice<DualShock4GamepadHID>();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state that is with-in axis dead zone doesn't make device current
+        InputSystem.QueueStateEvent(device1,
+            new DualShock4HIDInputReport()
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons1 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state that is outside of dead zone makes device current
+        InputSystem.QueueStateEvent(device1,
+            new DualShock4HIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow - 1,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons1 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+
+        // reset test
+        device2.MakeCurrent();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state with button change makes device current
+        InputSystem.QueueStateEvent(device1,
+            new DualShock4HIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons2 = 1,
+                buttons1 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+
+        // reset test
+        device2.MakeCurrent();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state with trigger change makes device current
+        InputSystem.QueueStateEvent(device1,
+            new DualShock4HIDInputReport
+            {
+                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
+                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                buttons2 = 1,
+                leftTrigger = 1,
+                buttons1 = 8 // default dpad is at 8
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+    }
+
 #endif
 }

--- a/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/DualShockTests.cs
@@ -274,10 +274,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualSenseHIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualSenseGamepadHID.JitterMaskLow,
+                leftStickY = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickX = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickY = DualSenseGamepadHID.JitterMaskLow,
                 buttons0 = 8 // default dpad is at 8
             });
         InputSystem.Update();
@@ -287,10 +287,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualSenseHIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow - 1,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualSenseGamepadHID.JitterMaskLow - 1,
+                leftStickY = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickX = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickY = DualSenseGamepadHID.JitterMaskLow,
                 buttons0 = 8 // default dpad is at 8
             });
         InputSystem.Update();
@@ -304,10 +304,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualSenseHIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualSenseGamepadHID.JitterMaskLow,
+                leftStickY = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickX = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickY = DualSenseGamepadHID.JitterMaskLow,
                 buttons1 = 1,
                 buttons0 = 8 // default dpad is at 8
             });
@@ -322,10 +322,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualSenseHIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualSenseGamepadHID.JitterMaskLow,
+                leftStickY = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickX = DualSenseGamepadHID.JitterMaskHigh,
+                rightStickY = DualSenseGamepadHID.JitterMaskLow,
                 buttons1 = 1,
                 leftTrigger = 1,
                 buttons0 = 8 // default dpad is at 8
@@ -346,10 +346,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualShock4HIDInputReport()
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualShock4GamepadHID.JitterMaskLow,
+                leftStickY = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickX = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickY = DualShock4GamepadHID.JitterMaskLow,
                 buttons1 = 8 // default dpad is at 8
             });
         InputSystem.Update();
@@ -359,10 +359,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualShock4HIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow - 1,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualShock4GamepadHID.JitterMaskLow - 1,
+                leftStickY = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickX = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickY = DualShock4GamepadHID.JitterMaskLow,
                 buttons1 = 8 // default dpad is at 8
             });
         InputSystem.Update();
@@ -376,10 +376,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualShock4HIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualShock4GamepadHID.JitterMaskLow,
+                leftStickY = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickX = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickY = DualShock4GamepadHID.JitterMaskLow,
                 buttons2 = 1,
                 buttons1 = 8 // default dpad is at 8
             });
@@ -394,10 +394,10 @@ internal class DualShockTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new DualShock4HIDInputReport
             {
-                leftStickX = DualSenseGamepadHID.AxisDeadZoneLow,
-                leftStickY = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickX = DualSenseGamepadHID.AxisDeadZoneHigh,
-                rightStickY = DualSenseGamepadHID.AxisDeadZoneLow,
+                leftStickX = DualShock4GamepadHID.JitterMaskLow,
+                leftStickY = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickX = DualShock4GamepadHID.JitterMaskHigh,
+                rightStickY = DualShock4GamepadHID.JitterMaskLow,
                 buttons2 = 1,
                 leftTrigger = 1,
                 buttons1 = 8 // default dpad is at 8

--- a/Assets/Tests/InputSystem/SwitchTests.cs
+++ b/Assets/Tests/InputSystem/SwitchTests.cs
@@ -92,10 +92,10 @@ internal class SwitchTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new SwitchProControllerHIDInputState
             {
-                leftStickX = SwitchProControllerHID.AxisDeadZoneLow,
-                leftStickY = SwitchProControllerHID.AxisDeadZoneHigh,
-                rightStickX = SwitchProControllerHID.AxisDeadZoneHigh,
-                rightStickY = SwitchProControllerHID.AxisDeadZoneLow,
+                leftStickX = SwitchProControllerHID.JitterMaskLow,
+                leftStickY = SwitchProControllerHID.JitterMaskHigh,
+                rightStickX = SwitchProControllerHID.JitterMaskHigh,
+                rightStickY = SwitchProControllerHID.JitterMaskLow,
             });
         InputSystem.Update();
         Assert.That(Gamepad.current, Is.EqualTo(device2));
@@ -104,10 +104,10 @@ internal class SwitchTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new SwitchProControllerHIDInputState
             {
-                leftStickX = SwitchProControllerHID.AxisDeadZoneLow - 1,
-                leftStickY = SwitchProControllerHID.AxisDeadZoneHigh,
-                rightStickX = SwitchProControllerHID.AxisDeadZoneHigh,
-                rightStickY = SwitchProControllerHID.AxisDeadZoneLow,
+                leftStickX = SwitchProControllerHID.JitterMaskLow - 1,
+                leftStickY = SwitchProControllerHID.JitterMaskHigh,
+                rightStickX = SwitchProControllerHID.JitterMaskHigh,
+                rightStickY = SwitchProControllerHID.JitterMaskLow,
             });
         InputSystem.Update();
         Assert.That(Gamepad.current, Is.EqualTo(device1));
@@ -120,10 +120,10 @@ internal class SwitchTests : CoreTestsFixture
         InputSystem.QueueStateEvent(device1,
             new SwitchProControllerHIDInputState
             {
-                leftStickX = SwitchProControllerHID.AxisDeadZoneLow,
-                leftStickY = SwitchProControllerHID.AxisDeadZoneHigh,
-                rightStickX = SwitchProControllerHID.AxisDeadZoneHigh,
-                rightStickY = SwitchProControllerHID.AxisDeadZoneLow,
+                leftStickX = SwitchProControllerHID.JitterMaskLow,
+                leftStickY = SwitchProControllerHID.JitterMaskHigh,
+                rightStickX = SwitchProControllerHID.JitterMaskHigh,
+                rightStickY = SwitchProControllerHID.JitterMaskLow,
             }.WithButton(SwitchProControllerHIDInputState.Button.A));
         InputSystem.Update();
         Assert.That(Gamepad.current, Is.EqualTo(device1));

--- a/Assets/Tests/InputSystem/SwitchTests.cs
+++ b/Assets/Tests/InputSystem/SwitchTests.cs
@@ -82,6 +82,55 @@ internal class SwitchTests : CoreTestsFixture
 
     [Test]
     [Category("Devices")]
+    public void Devices_SwitchPro_AxisJitter_DoesntMakeDeviceCurrent()
+    {
+        var device1 = InputSystem.AddDevice<SwitchProControllerHID>();
+        var device2 = InputSystem.AddDevice<SwitchProControllerHID>();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state that is with-in axis dead zone doesn't make device current
+        InputSystem.QueueStateEvent(device1,
+            new SwitchProControllerHIDInputState
+            {
+                leftStickX = SwitchProControllerHID.AxisDeadZoneLow,
+                leftStickY = SwitchProControllerHID.AxisDeadZoneHigh,
+                rightStickX = SwitchProControllerHID.AxisDeadZoneHigh,
+                rightStickY = SwitchProControllerHID.AxisDeadZoneLow,
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state that is outside of dead zone makes device current
+        InputSystem.QueueStateEvent(device1,
+            new SwitchProControllerHIDInputState
+            {
+                leftStickX = SwitchProControllerHID.AxisDeadZoneLow - 1,
+                leftStickY = SwitchProControllerHID.AxisDeadZoneHigh,
+                rightStickX = SwitchProControllerHID.AxisDeadZoneHigh,
+                rightStickY = SwitchProControllerHID.AxisDeadZoneLow,
+            });
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+
+        // reset test
+        device2.MakeCurrent();
+        Assert.That(Gamepad.current, Is.EqualTo(device2));
+
+        // queuing state with button change makes device current
+        InputSystem.QueueStateEvent(device1,
+            new SwitchProControllerHIDInputState
+            {
+                leftStickX = SwitchProControllerHID.AxisDeadZoneLow,
+                leftStickY = SwitchProControllerHID.AxisDeadZoneHigh,
+                rightStickX = SwitchProControllerHID.AxisDeadZoneHigh,
+                rightStickY = SwitchProControllerHID.AxisDeadZoneLow,
+            }.WithButton(SwitchProControllerHIDInputState.Button.A));
+        InputSystem.Update();
+        Assert.That(Gamepad.current, Is.EqualTo(device1));
+    }
+
+    [Test]
+    [Category("Devices")]
     [TestCase(0x0f0d, 0x0092)]
     [TestCase(0x0f0d, 0x00aa)]
     [TestCase(0x0f0d, 0x00c1)]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed composite bindings incorrectly getting a control scheme assigned when pasting into input asset editor with a control scheme selected.
 - Fixed an issue on PS5 where device disconnected events that happen while the app is in the background are missed causing orphaned devices to hang around forever and exceptions when the same device is added again ([case UUM-7842](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744)).
+- Fixed Switch Pro, DualShock 4, DualSense gamepads becoming current on PC/macOS when no controls are changing ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))).
 
 ### Actions
 - Extended input action code generator (`InputActionCodeGenerator.cs`) to support optional registration and unregistration of callbacks for multiple callback instances via `AddCallbacks(...)` and `RemoveCallbacks(...)` part of the generated code. Contribution by [Ramobo](https://github.com/Ramobo) in [#889](https://github.com/Unity-Technologies/InputSystem/pull/889).

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3319,7 +3319,7 @@ namespace UnityEngine.InputSystem
 
         private bool m_ShouldMakeCurrentlyUpdatingDeviceCurrent;
 
-        // This is a dirty hot fix to expose entropy from device back to input manager to make choose if we want to make device current or not.
+        // This is a dirty hot fix to expose entropy from device back to input manager to make a choice if we want to make device current or not.
         // A proper fix would be to change IInputStateCallbackReceiver.OnStateEvent to return bool to make device current or not.
         internal void DontMakeCurrentlyUpdatingDeviceCurrent()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3172,9 +3172,12 @@ namespace UnityEngine.InputSystem
                             var haveChangedStateOtherThanNoise = true;
                             if (deviceIsStateCallbackReceiver)
                             {
+                                m_ShouldMakeCurrentlyUpdatingDeviceCurrent = true;
                                 // NOTE: We leave it to the device to make sure the event has the right format. This allows the
                                 //       device to handle multiple different incoming formats.
                                 ((IInputStateCallbackReceiver)device).OnStateEvent(eventPtr);
+
+                                haveChangedStateOtherThanNoise = m_ShouldMakeCurrentlyUpdatingDeviceCurrent;
                             }
                             else
                             {
@@ -3312,6 +3315,15 @@ namespace UnityEngine.InputSystem
 
             DelegateHelpers.InvokeCallbacksSafe(ref m_AfterUpdateListeners,
                 "InputSystem.onAfterUpdate");
+        }
+
+        private bool m_ShouldMakeCurrentlyUpdatingDeviceCurrent;
+
+        // This is a dirty hot fix to expose entropy from device back to input manager to make choose if we want to make device current or not.
+        // A proper fix would be to change IInputStateCallbackReceiver.OnStateEvent to return bool to make device current or not.
+        internal void DontMakeCurrentlyUpdatingDeviceCurrent()
+        {
+            m_ShouldMakeCurrentlyUpdatingDeviceCurrent = false;
         }
 
         internal unsafe bool UpdateState(InputDevice device, InputEvent* eventPtr, InputUpdateType updateType)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -557,8 +557,8 @@ namespace UnityEngine.InputSystem.DualShock
         }
 
         // filter out three lower bits as jitter noise
-        internal const byte AxisDeadZoneLow = 0b01111000;
-        internal const byte AxisDeadZoneHigh = 0b10000111;
+        internal const byte JitterMaskLow = 0b01111000;
+        internal const byte JitterMaskHigh = 0b10000111;
 
         public unsafe void OnStateEvent(InputEventPtr eventPtr)
         {
@@ -569,14 +569,14 @@ namespace UnityEngine.InputSystem.DualShock
 
                 var actuated =
                     // we need to make device current if axes are outside of deadzone specifying hardware jitter of sticks around zero point
-                    newState->leftStickX<AxisDeadZoneLow
-                                         || newState->leftStickX> AxisDeadZoneHigh
-                    || newState->leftStickY<AxisDeadZoneLow
-                                            || newState->leftStickY> AxisDeadZoneHigh
-                    || newState->rightStickX<AxisDeadZoneLow
-                                             || newState->rightStickX> AxisDeadZoneHigh
-                    || newState->rightStickY<AxisDeadZoneLow
-                                             || newState->rightStickY> AxisDeadZoneHigh
+                    newState->leftStickX<JitterMaskLow
+                                         || newState->leftStickX> JitterMaskHigh
+                    || newState->leftStickY<JitterMaskLow
+                                            || newState->leftStickY> JitterMaskHigh
+                    || newState->rightStickX<JitterMaskLow
+                                             || newState->rightStickX> JitterMaskHigh
+                    || newState->rightStickY<JitterMaskLow
+                                             || newState->rightStickY> JitterMaskHigh
                     // we need to make device current if triggers or buttons state change
                     || newState->leftTrigger != currentState->leftTrigger
                     || newState->rightTrigger != currentState->rightTrigger
@@ -892,8 +892,8 @@ namespace UnityEngine.InputSystem.DualShock
         }
 
         // filter out three lower bits as jitter noise
-        internal const byte AxisDeadZoneLow = 0b01111000;
-        internal const byte AxisDeadZoneHigh = 0b10000111;
+        internal const byte JitterMaskLow = 0b01111000;
+        internal const byte JitterMaskHigh = 0b10000111;
 
         public unsafe void OnStateEvent(InputEventPtr eventPtr)
         {
@@ -904,14 +904,14 @@ namespace UnityEngine.InputSystem.DualShock
 
                 var actuatedOrChanged =
                     // we need to make device current if axes are outside of deadzone specifying hardware jitter of sticks around zero point
-                    newState->leftStickX<AxisDeadZoneLow
-                                         || newState->leftStickX> AxisDeadZoneHigh
-                    || newState->leftStickY<AxisDeadZoneLow
-                                            || newState->leftStickY> AxisDeadZoneHigh
-                    || newState->rightStickX<AxisDeadZoneLow
-                                             || newState->rightStickX> AxisDeadZoneHigh
-                    || newState->rightStickY<AxisDeadZoneLow
-                                             || newState->rightStickY> AxisDeadZoneHigh
+                    newState->leftStickX<JitterMaskLow
+                                         || newState->leftStickX> JitterMaskHigh
+                    || newState->leftStickY<JitterMaskLow
+                                            || newState->leftStickY> JitterMaskHigh
+                    || newState->rightStickX<JitterMaskLow
+                                             || newState->rightStickX> JitterMaskHigh
+                    || newState->rightStickY<JitterMaskLow
+                                             || newState->rightStickY> JitterMaskHigh
                     // we need to make device current if triggers or buttons state change
                     || newState->leftTrigger != currentState->leftTrigger
                     || newState->rightTrigger != currentState->rightTrigger

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -334,7 +334,7 @@ namespace UnityEngine.InputSystem.DualShock
     /// PS5 DualSense controller that is interfaced to a HID backend.
     /// </summary>
     [InputControlLayout(stateType = typeof(DualSenseHIDInputReport), displayName = "DualSense HID")]
-    public class DualSenseGamepadHID : DualShockGamepad, IEventMerger, IEventPreProcessor
+    public class DualSenseGamepadHID : DualShockGamepad, IEventMerger, IEventPreProcessor, IInputStateCallbackReceiver
     {
         // Gamepad might send 3 types of input reports:
         // - Minimal report, first byte is 0x01, observed size is 78, also can be 10
@@ -516,6 +516,9 @@ namespace UnityEngine.InputSystem.DualShock
                 return eventPtr.type != DeltaStateEvent.Type; // only skip delta state events
 
             var stateEvent = StateEvent.FromUnchecked(eventPtr);
+            if (stateEvent->stateFormat == DualSenseHIDInputReport.Format)
+                return true; // if someone queued DSVS directly, just use as-is
+
             var size = stateEvent->stateSizeInBytes;
             if (stateEvent->stateFormat != DualSenseHIDGenericInputReport.Format || size < sizeof(DualSenseHIDInputReport))
                 return false; // skip unrecognized state events otherwise they will corrupt control states
@@ -547,6 +550,50 @@ namespace UnityEngine.InputSystem.DualShock
             }
             else
                 return false; // skip unrecognized reportId
+        }
+
+        public void OnNextUpdate()
+        {
+        }
+
+        // filter out three lower bits as jitter noise
+        internal const byte AxisDeadZoneLow = 0b01111000;
+        internal const byte AxisDeadZoneHigh = 0b10000111;
+
+        public unsafe void OnStateEvent(InputEventPtr eventPtr)
+        {
+            if (eventPtr.type == StateEvent.Type && eventPtr.stateFormat == DualSenseHIDInputReport.Format)
+            {
+                var currentState = (DualSenseHIDInputReport*)((byte*)currentStatePtr + m_StateBlock.byteOffset);
+                var newState = (DualSenseHIDInputReport*)StateEvent.FromUnchecked(eventPtr)->state;
+
+                var actuated =
+                    // we need to make device current if axes are outside of deadzone specifying hardware jitter of sticks around zero point
+                    newState->leftStickX<AxisDeadZoneLow
+                                         || newState->leftStickX> AxisDeadZoneHigh
+                    || newState->leftStickY<AxisDeadZoneLow
+                                            || newState->leftStickY> AxisDeadZoneHigh
+                    || newState->rightStickX<AxisDeadZoneLow
+                                             || newState->rightStickX> AxisDeadZoneHigh
+                    || newState->rightStickY<AxisDeadZoneLow
+                                             || newState->rightStickY> AxisDeadZoneHigh
+                    // we need to make device current if triggers or buttons state change
+                    || newState->leftTrigger != currentState->leftTrigger
+                    || newState->rightTrigger != currentState->rightTrigger
+                    || newState->buttons0 != currentState->buttons0
+                    || newState->buttons1 != currentState->buttons1
+                    || newState->buttons2 != currentState->buttons2;
+
+                if (!actuated)
+                    InputSystem.s_Manager.DontMakeCurrentlyUpdatingDeviceCurrent();
+            }
+
+            InputState.Change(this, eventPtr);
+        }
+
+        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset)
+        {
+            return false;
         }
 
         [StructLayout(LayoutKind.Explicit)]
@@ -665,7 +712,7 @@ namespace UnityEngine.InputSystem.DualShock
     /// PS4 DualShock controller that is interfaced to a HID backend.
     /// </summary>
     [InputControlLayout(stateType = typeof(DualShock4HIDInputReport), hideInUI = true, isNoisy = true)]
-    public class DualShock4GamepadHID : DualShockGamepad, IEventPreProcessor
+    public class DualShock4GamepadHID : DualShockGamepad, IEventPreProcessor, IInputStateCallbackReceiver
     {
         public ButtonControl leftTriggerButton { get; protected set; }
         public ButtonControl rightTriggerButton { get; protected set; }
@@ -791,8 +838,10 @@ namespace UnityEngine.InputSystem.DualShock
                 return eventPtr.type != DeltaStateEvent.Type; // only skip delta state events
 
             var stateEvent = StateEvent.FromUnchecked(eventPtr);
-            var size = stateEvent->stateSizeInBytes;
+            if (stateEvent->stateFormat == DualShock4HIDInputReport.Format)
+                return true; // if someone queued D4VS directly, just use as-is
 
+            var size = stateEvent->stateSizeInBytes;
             if (stateEvent->stateFormat != DualShock4HIDGenericInputReport.Format || size < sizeof(DualShock4HIDGenericInputReport))
                 return false; // skip unrecognized state events otherwise they will corrupt control states
 
@@ -836,6 +885,50 @@ namespace UnityEngine.InputSystem.DualShock
                 default:
                     return false; // skip unrecognized reportId
             }
+        }
+
+        public void OnNextUpdate()
+        {
+        }
+
+        // filter out three lower bits as jitter noise
+        internal const byte AxisDeadZoneLow = 0b01111000;
+        internal const byte AxisDeadZoneHigh = 0b10000111;
+
+        public unsafe void OnStateEvent(InputEventPtr eventPtr)
+        {
+            if (eventPtr.type == StateEvent.Type && eventPtr.stateFormat == DualShock4HIDInputReport.Format)
+            {
+                var currentState = (DualShock4HIDInputReport*)((byte*)currentStatePtr + m_StateBlock.byteOffset);
+                var newState = (DualShock4HIDInputReport*)StateEvent.FromUnchecked(eventPtr)->state;
+
+                var actuatedOrChanged =
+                    // we need to make device current if axes are outside of deadzone specifying hardware jitter of sticks around zero point
+                    newState->leftStickX<AxisDeadZoneLow
+                                         || newState->leftStickX> AxisDeadZoneHigh
+                    || newState->leftStickY<AxisDeadZoneLow
+                                            || newState->leftStickY> AxisDeadZoneHigh
+                    || newState->rightStickX<AxisDeadZoneLow
+                                             || newState->rightStickX> AxisDeadZoneHigh
+                    || newState->rightStickY<AxisDeadZoneLow
+                                             || newState->rightStickY> AxisDeadZoneHigh
+                    // we need to make device current if triggers or buttons state change
+                    || newState->leftTrigger != currentState->leftTrigger
+                    || newState->rightTrigger != currentState->rightTrigger
+                    || newState->buttons1 != currentState->buttons1
+                    || newState->buttons2 != currentState->buttons2
+                    || newState->buttons3 != currentState->buttons3;
+
+                if (!actuatedOrChanged)
+                    InputSystem.s_Manager.DontMakeCurrentlyUpdatingDeviceCurrent();
+            }
+
+            InputState.Change(this, eventPtr);
+        }
+
+        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref uint offset)
+        {
+            return false;
         }
 
         [StructLayout(LayoutKind.Explicit)]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Switch/SwitchProControllerHID.cs
@@ -228,8 +228,8 @@ namespace UnityEngine.InputSystem.Switch
         }
 
         // filter out three lower bits as jitter noise
-        internal const byte AxisDeadZoneLow = 0b01111000;
-        internal const byte AxisDeadZoneHigh = 0b10000111;
+        internal const byte JitterMaskLow = 0b01111000;
+        internal const byte JitterMaskHigh = 0b10000111;
 
         public unsafe void OnStateEvent(InputEventPtr eventPtr)
         {
@@ -240,14 +240,14 @@ namespace UnityEngine.InputSystem.Switch
 
                 var actuated =
                     // we need to make device current if axes are outside of deadzone specifying hardware jitter of sticks around zero point
-                    newState->leftStickX<AxisDeadZoneLow
-                                         || newState->leftStickX> AxisDeadZoneHigh
-                    || newState->leftStickY<AxisDeadZoneLow
-                                            || newState->leftStickY> AxisDeadZoneHigh
-                    || newState->rightStickX<AxisDeadZoneLow
-                                             || newState->rightStickX> AxisDeadZoneHigh
-                    || newState->rightStickY<AxisDeadZoneLow
-                                             || newState->rightStickY> AxisDeadZoneHigh
+                    newState->leftStickX<JitterMaskLow
+                                         || newState->leftStickX> JitterMaskHigh
+                    || newState->leftStickY<JitterMaskLow
+                                            || newState->leftStickY> JitterMaskHigh
+                    || newState->rightStickX<JitterMaskLow
+                                             || newState->rightStickX> JitterMaskHigh
+                    || newState->rightStickY<JitterMaskLow
+                                             || newState->rightStickY> JitterMaskHigh
                     // we need to make device current if buttons state change
                     || newState->buttons1 != currentState->buttons1
                     || newState->buttons2 != currentState->buttons2;


### PR DESCRIPTION
### Description

This is a continuation of #1585 with a much more robust way to compute if gamepads are significantly actuated or changed to mark them as current devices.

Most gamepads have noisy stick controls. And this makes them become `Gamepad.current` when user doesn't actuate any controls, which in result is problematic if two or more gamepads connected to the system.

### Changes made

- Added a terrible way to communicate back to InputManager if device _should not_ be set as current. This defies good programming practices, but unfortunately I see no other easy way to do that without breaking API (there are some hard ways to do it though).

### Notes

3 bits selected empirically myself observing live state from gamepads connected to my system. Value might not be optimal.
