### PR TITLE
FIX: controls excluded from rebinding could be still suppressed during interactive rebinding

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Rebinding.cs
@@ -1152,13 +1152,23 @@ internal partial class CoreTests
         using (new InputActionRebindingExtensions.RebindingOperation()
                .WithAction(action)
                .WithControlsExcluding("<Pointer>/position")
-               .WithMatchingEventsBeingSuppressed().Start())
+               .WithControlsExcluding("<Pointer>/press")
+               .WithControlsExcluding("<Mouse>/leftButton")
+               .WithControlsExcluding("<Gamepad>/buttonEast")
+               .WithMatchingEventsBeingSuppressed()
+               .Start()
+        )
         {
+            // Non-bindable controls should not be suppressed and continue working as normal
             Set(mouse.position, new Vector2(123, 234));
-            Press(gamepad.buttonSouth);
+            Press(mouse.leftButton);
+            Press(gamepad.buttonEast);
 
+            Press(gamepad.buttonSouth);
             Assert.That(action.bindings[0].overridePath, Is.EqualTo("<Gamepad>/buttonSouth"));
+            Assert.That(mouse.leftButton.isPressed, Is.True);
             Assert.That(gamepad.buttonSouth.isPressed, Is.False);
+            Assert.That(gamepad.buttonEast.isPressed, Is.True);
             Assert.That(mouse.position.ReadValue(), Is.EqualTo(new Vector2(123, 234)).Using(Vector2EqualityComparer.Instance));
         }
     }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue on PS5 where device disconnected events that happen while the app is in the background are missed causing orphaned devices to hang around forever and exceptions when the same device is added again ([case UUM-7842](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744)).
 - Fixed Switch Pro, DualShock 4, DualSense gamepads becoming current on PC/macOS when no controls are changing ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))).
 - Fixed an issue that made OnScreenStick unusable when used in conjunction with PlayerInput in Auto-Switch devices mode, or with any code that changes user/device pairing on unsued device activity being detected ([case ISXB-48](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-48)).
+- Fixed issue where input events were being suppressed during interactive action rebinding even when when their controls were excluded ([case ISXB-367](https://issuetracker.unity3d.com/issues/mouse-position-and-mouse-click-input-not-recognized-when-rebinding-is-active)).
 
 ### Actions
 - Extended input action code generator (`InputActionCodeGenerator.cs`) to support optional registration and unregistration of callbacks for multiple callback instances via `AddCallbacks(...)` and `RemoveCallbacks(...)` part of the generated code. Contribution by [Ramobo](https://github.com/Ramobo) in [#889](https://github.com/Unity-Technologies/InputSystem/pull/889).
@@ -39,8 +40,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an InvalidOperationException when using Hold interaction, and by extension any interaction that changes to performed state after a timeout ([case ISXB-332](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-330)).
 - Fixed `Given object is neither an InputAction nor an InputActionMap` when using `InputActionTrace` on input action from an input action asset ([case ISXB-29](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-29)).
 - Fixing devices not being removed if unplugged during domain reload (entering or exiting play mode) ([case ISXB-232](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-232)).
-- Fixed issue where input events were being suppressed during interactive action rebinding even when when their controls were excluded ([case ISXB-367](https://issuetracker.unity3d.com/issues/mouse-position-and-mouse-click-input-not-recognized-when-rebinding-is-active)).
-
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -35,6 +35,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an InvalidOperationException when using Hold interaction, and by extension any interaction that changes to performed state after a timeout ([case ISXB-332](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-330)).
 - Fixed `Given object is neither an InputAction nor an InputActionMap` when using `InputActionTrace` on input action from an input action asset ([case ISXB-29](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-29)).
 - Fixing devices not being removed if unplugged during domain reload (entering or exiting play mode) ([case ISXB-232](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-232)).
+- Fixed issue where input events were being suppressed during interactive action rebinding even when when their controls were excluded ([case ISXB-367](https://issuetracker.unity3d.com/issues/mouse-position-and-mouse-click-input-not-recognized-when-rebinding-is-active)).
+
 
 ## [1.4.3] - 2022-09-23
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -2304,9 +2304,6 @@ namespace UnityEngine.InputSystem
                     if (m_ExcludePathCount > 0 && HavePathMatch(control, m_ExcludePaths, m_ExcludePathCount))
                         continue;
 
-                    // The control is not explicitly excluded so we suppress the event, if that's enabled.
-                    suppressEvent = true;
-
                     // If controls have to match a certain path, check if this one does.
                     if (m_IncludePathCount > 0 && !HavePathMatch(control, m_IncludePaths, m_IncludePathCount))
                         continue;
@@ -2346,6 +2343,9 @@ namespace UnityEngine.InputSystem
 
                         continue;
                     }
+
+                    // At this point the control is a potential candidate for rebinding and therefore the event may need to be suppressed, if that's enabled.
+                    suppressEvent = true;
 
                     var magnitude = control.EvaluateMagnitude(statePtr);
                     if (magnitude >= 0)


### PR DESCRIPTION
### Description

Fixes an issue that mouse click events would be marked as `handled` (suppressed) by the interactive rebinder, even though mouse clicks were explicitly being excluded from rebinding.

This is caused because a flag was being, if any single control was found which wasn't excluded.
As we check all the controls in the event, a mouse event would contain all mouse controls and unless all of those were excluded then suppression logic would trigger.

### Changes made

Move suppression logic to later, when the rebinding logic actually considers the control as belonging to the potential set of rebind-able controls.
Improve the suppression during rebinding test.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
