### PR TITLE
FIX: Remove NotImplementedException when loading outdated binding overrides from json (ISXB-375)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Switch Pro, DualShock 4, DualSense gamepads becoming current on PC/macOS when no controls are changing ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))).
 - Fixed an issue that made OnScreenStick unusable when used in conjunction with PlayerInput in Auto-Switch devices mode, or with any code that changes user/device pairing on unsued device activity being detected ([case ISXB-48](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-48)).
 - Fixed issue where input events were being suppressed during interactive action rebinding even when when their controls were excluded ([case ISXB-367](https://issuetracker.unity3d.com/issues/mouse-position-and-mouse-click-input-not-recognized-when-rebinding-is-active)).
+- Display a warning instead of throwing a NotImplementedException when loading binding overrides from json when some of the entries have become outdated ([case UUM-21774](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-21774)).
 
 ### Actions
 - Extended input action code generator (`InputActionCodeGenerator.cs`) to support optional registration and unregistration of callbacks for multiple callback instances via `AddCallbacks(...)` and `RemoveCallbacks(...)` part of the generated code. Contribution by [Ramobo](https://github.com/Ramobo) in [#889](https://github.com/Unity-Technologies/InputSystem/pull/889).

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,7 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Switch Pro, DualShock 4, DualSense gamepads becoming current on PC/macOS when no controls are changing ([case ISXB-223](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-223))).
 - Fixed an issue that made OnScreenStick unusable when used in conjunction with PlayerInput in Auto-Switch devices mode, or with any code that changes user/device pairing on unsued device activity being detected ([case ISXB-48](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-48)).
 - Fixed issue where input events were being suppressed during interactive action rebinding even when when their controls were excluded ([case ISXB-367](https://issuetracker.unity3d.com/issues/mouse-position-and-mouse-click-input-not-recognized-when-rebinding-is-active)).
-- Display a warning instead of throwing a NotImplementedException when loading binding overrides from json when some of the entries have become outdated ([case UUM-21774](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-21774)).
+- Display a warning instead of throwing a NotImplementedException when loading binding overrides from json when some of the entries have become outdated ([case ISXB-375](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-375)).
 
 ### Actions
 - Extended input action code generator (`InputActionCodeGenerator.cs`) to support optional registration and unregistration of callbacks for multiple callback instances via `AddCallbacks(...)` and `RemoveCallbacks(...)` part of the generated code. Contribution by [Ramobo](https://github.com/Ramobo) in [#889](https://github.com/Unity-Technologies/InputSystem/pull/889).

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -1272,7 +1272,7 @@ namespace UnityEngine.InputSystem
                     }
                 }
 
-                throw new NotImplementedException();
+                Debug.LogWarning("Could not override binding as no existing binding was found with the id: " + entry.id);
             }
         }
 


### PR DESCRIPTION
### Description

Another NotImplementedException. This one triggers if a binding ID that is saved in the override json file no longer exists at runtime (due to modifications in the inputasset) at the time it is reloaded.

Removed and replaced with a warning as the customer correctly argues for on the ticket: this crashes on startup for end-users if the developer pushed an update to them. Also any correct entries in the file will be lost due to one invalid entry terminating the loading early.

### Changes made

Replace exception with a warning.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
