### PR TITLE
Fixing unclosed profiler marker

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,10 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unclosed profiler marker in `InvokeCallbacksSafe_AnyCallbackReturnsTrue` which would lead to eventually broken profiler traces in some cases like using `PlayerInput` (case ISXB-393).
+
 ## [1.5.0] - 2023-01-24
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
@@ -95,7 +95,11 @@ namespace UnityEngine.InputSystem.Utilities
                 try
                 {
                     if (callbacks[i](argument1, argument2))
+                    {
+                        callbacks.UnlockForChanges();
+                        Profiler.EndSample();
                         return true;
+                    }
                 }
                 catch (Exception exception)
                 {


### PR DESCRIPTION
### Description

In one of the invoke delegates methods we forgot to close the profiler marker.