### PR TITLE
Initialize global actions on startup

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_GlobalActions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_GlobalActions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using NUnit.Framework;
 using UnityEditor;
@@ -9,73 +9,73 @@ using Input = UnityEngine.InputSystem.HighLevel.Input;
 
 internal partial class CoreTests
 {
-	private string m_TemplateAssetPath;
+    private string m_TemplateAssetPath;
 
-	[SetUp]
-	public override void Setup()
-	{
-		// this asset takes the place of InputManager.asset for the sake of testing, as we don't really want to go changing
-		// that asset in every test.
-		var testInputManager = ScriptableObject.CreateInstance<TestInputManager>();
-		AssetDatabase.CreateAsset(testInputManager, "Assets/TestInputManager.asset");
+    [SetUp]
+    public override void Setup()
+    {
+        // this asset takes the place of InputManager.asset for the sake of testing, as we don't really want to go changing
+        // that asset in every test.
+        var testInputManager = ScriptableObject.CreateInstance<TestInputManager>();
+        AssetDatabase.CreateAsset(testInputManager, "Assets/TestInputManager.asset");
 
-		// create a template input action asset from which the input action asset stuffed inside the InputManager will be created
-		var globalActions = ScriptableObject.CreateInstance<InputActionAsset>();
-		globalActions.AddActionMap("ActionMapOne").AddAction("ActionOne");
-		m_TemplateAssetPath = Path.Combine(Environment.CurrentDirectory, "Assets/TestGlobalActions.inputactions");
-		File.WriteAllText(m_TemplateAssetPath, globalActions.ToJson());
+        // create a template input action asset from which the input action asset stuffed inside the InputManager will be created
+        var globalActions = ScriptableObject.CreateInstance<InputActionAsset>();
+        globalActions.AddActionMap("ActionMapOne").AddAction("ActionOne");
+        m_TemplateAssetPath = Path.Combine(Environment.CurrentDirectory, "Assets/TestGlobalActions.inputactions");
+        File.WriteAllText(m_TemplateAssetPath, globalActions.ToJson());
 
-		InputSystem.SetGlobalActionAssetPaths(m_TemplateAssetPath, "Assets/TestInputManager.asset");
+        InputSystem.SetGlobalActionAssetPaths(m_TemplateAssetPath, "Assets/TestInputManager.asset");
 
-		base.Setup();
-	}
+        base.Setup();
+    }
 
-	[TearDown]
-	public override void TearDown()
-	{
-		if (File.Exists(m_TemplateAssetPath))
-			File.Delete(m_TemplateAssetPath);
+    [TearDown]
+    public override void TearDown()
+    {
+        if (File.Exists(m_TemplateAssetPath))
+            File.Delete(m_TemplateAssetPath);
 
-		AssetDatabase.DeleteAsset("Assets/TestInputManager.asset");
+        AssetDatabase.DeleteAsset("Assets/TestInputManager.asset");
 
-		base.TearDown();
-	}
+        base.TearDown();
+    }
 
-	[Test]
-	[Category("GlobalActions")]
-	public void GlobalActions_TemplateAssetIsInstalledOnFirstUse()
-	{
-		var asset = GlobalActionsAsset.GetOrCreateGlobalActionsAsset("Assets/TestInputManager.asset", m_TemplateAssetPath);
+    [Test]
+    [Category("GlobalActions")]
+    public void GlobalActions_TemplateAssetIsInstalledOnFirstUse()
+    {
+        var asset = GlobalActionsAsset.GetOrCreateGlobalActionsAsset("Assets/TestInputManager.asset", m_TemplateAssetPath);
 
-		Assert.That(asset, Is.Not.Null);
-		Assert.That(asset.actionMaps.Count, Is.EqualTo(1));
-		Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(1));
-	}
+        Assert.That(asset, Is.Not.Null);
+        Assert.That(asset.actionMaps.Count, Is.EqualTo(1));
+        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(1));
+    }
 
-	[Test]
-	[Category("GlobalActions")]
-	public void GlobalActions_CanQueryActionsByStringName()
-	{
-		var keyboard = InputSystem.AddDevice<Keyboard>();
+    [Test]
+    [Category("GlobalActions")]
+    public void GlobalActions_CanQueryActionsByStringName()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
 
-		Input.globalActions.FindAction("ActionOne").AddBinding("<keyboard>/w");
+        Input.globalActions.FindAction("ActionOne").AddBinding("<keyboard>/w");
 
-		Set(keyboard.wKey, 1);
+        Set(keyboard.wKey, 1);
 
-		Assert.That(Input.IsControlDown("ActionOne"), Is.True);
-		Assert.That(Input.IsControlPressed("ActionOne"), Is.True);
+        Assert.That(Input.IsControlDown("ActionOne"), Is.True);
+        Assert.That(Input.IsControlPressed("ActionOne"), Is.True);
 
-		Set(keyboard.wKey, 0);
+        Set(keyboard.wKey, 0);
 
-		Assert.That(Input.IsControlPressed("ActionOne"), Is.False);
-		Assert.That(Input.IsControlUp("ActionOne"), Is.True);
+        Assert.That(Input.IsControlPressed("ActionOne"), Is.False);
+        Assert.That(Input.IsControlUp("ActionOne"), Is.True);
 
-		InputSystem.Update();
+        InputSystem.Update();
 
-		Assert.That(Input.IsControlUp("ActionOne"), Is.False);
-	}
+        Assert.That(Input.IsControlUp("ActionOne"), Is.False);
+    }
 
-	public class TestInputManager : ScriptableObject
-	{
-	}
+    public class TestInputManager : ScriptableObject
+    {
+    }
 }

--- a/Assets/Tests/InputSystem/CoreTests_GlobalActions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_GlobalActions.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Editor;
+using Input = UnityEngine.InputSystem.HighLevel.Input;
+
+internal partial class CoreTests
+{
+	private string m_TemplateAssetPath;
+
+	[SetUp]
+	public override void Setup()
+	{
+		// this asset takes the place of InputManager.asset for the sake of testing, as we don't really want to go changing
+		// that asset in every test.
+		var testInputManager = ScriptableObject.CreateInstance<TestInputManager>();
+		AssetDatabase.CreateAsset(testInputManager, "Assets/TestInputManager.asset");
+
+		// create a template input action asset from which the input action asset stuffed inside the InputManager will be created
+		var globalActions = ScriptableObject.CreateInstance<InputActionAsset>();
+		globalActions.AddActionMap("ActionMapOne").AddAction("ActionOne");
+		m_TemplateAssetPath = Path.Combine(Environment.CurrentDirectory, "Assets/TestGlobalActions.inputactions");
+		File.WriteAllText(m_TemplateAssetPath, globalActions.ToJson());
+
+		InputSystem.SetGlobalActionAssetPaths(m_TemplateAssetPath, "Assets/TestInputManager.asset");
+
+		base.Setup();
+	}
+
+	[TearDown]
+	public override void TearDown()
+	{
+		if (File.Exists(m_TemplateAssetPath))
+			File.Delete(m_TemplateAssetPath);
+
+		AssetDatabase.DeleteAsset("Assets/TestInputManager.asset");
+
+		base.TearDown();
+	}
+
+	[Test]
+	[Category("GlobalActions")]
+	public void GlobalActions_TemplateAssetIsInstalledOnFirstUse()
+	{
+		var asset = GlobalActionsAsset.GetOrCreateGlobalActionsAsset("Assets/TestInputManager.asset", m_TemplateAssetPath);
+
+		Assert.That(asset, Is.Not.Null);
+		Assert.That(asset.actionMaps.Count, Is.EqualTo(1));
+		Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(1));
+	}
+
+	[Test]
+	[Category("GlobalActions")]
+	public void GlobalActions_CanQueryActionsByStringName()
+	{
+		var keyboard = InputSystem.AddDevice<Keyboard>();
+
+		Input.globalActions.FindAction("ActionOne").AddBinding("<keyboard>/w");
+
+		Set(keyboard.wKey, 1);
+
+		Assert.That(Input.IsControlDown("ActionOne"), Is.True);
+		Assert.That(Input.IsControlPressed("ActionOne"), Is.True);
+
+		Set(keyboard.wKey, 0);
+
+		Assert.That(Input.IsControlPressed("ActionOne"), Is.False);
+		Assert.That(Input.IsControlUp("ActionOne"), Is.True);
+
+		InputSystem.Update();
+
+		Assert.That(Input.IsControlUp("ActionOne"), Is.False);
+	}
+
+	public class TestInputManager : ScriptableObject
+	{
+	}
+}

--- a/Assets/Tests/InputSystem/CoreTests_GlobalActions.cs.meta
+++ b/Assets/Tests/InputSystem/CoreTests_GlobalActions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 611e85f74ae578548b3de6c64febcc73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/InputSystem/CoreTests_HighLevelAPI.cs
+++ b/Assets/Tests/InputSystem/CoreTests_HighLevelAPI.cs
@@ -390,18 +390,18 @@ internal partial class CoreTests
     [Category("HighLevelAPI")]
     public IEnumerator HighLevelAPI_DidAllGamepadsConnectOrDisconnectThisFrame()
     {
-	    for (var i = 0; i < Input.maxGamepadSlots; i++)
-	    {
-		    runtime.ReportNewInputDevice<Gamepad>();
-	    }
+        for (var i = 0; i < Input.maxGamepadSlots; i++)
+        {
+            runtime.ReportNewInputDevice<Gamepad>();
+        }
 
-	    yield return null;
+        yield return null;
 
         Assert.That(Input.DidGamepadConnectThisFrame(GamepadSlot.All), Is.True);
 
         foreach (var inputDevice in InputSystem.devices)
         {
-	        runtime.ReportInputDeviceRemoved(inputDevice);
+            runtime.ReportInputDeviceRemoved(inputDevice);
         }
 
         yield return null;
@@ -614,10 +614,10 @@ internal partial class CoreTests
     [Category("HighLevelAPI")]
     public void HighLevelAPI_IsGamepadConnectedReturnsTrueWhenAllIsSpecifiedAndAllSlotsAreFilled()
     {
-	    foreach (var gamepadSlotEnum in Input.gamepadSlotEnums)
-	    {
-		    InputSystem.AddDevice<Gamepad>();
-	    }
+        foreach (var gamepadSlotEnum in Input.gamepadSlotEnums)
+        {
+            InputSystem.AddDevice<Gamepad>();
+        }
 
         Assert.That(Input.IsGamepadConnected(GamepadSlot.All), Is.True);
 
@@ -631,45 +631,45 @@ internal partial class CoreTests
     public void HighLevelAPI_BasicAPIMethodsDoNotAllocate()
     {
         // Warm up all the methods so we don't log jitting and generic type generation as allocations
-	    ExerciseInputMethods();
+        ExerciseInputMethods();
 
         Assert.That(ExerciseInputMethods, Is.Not.AllocatingGCMemory());
     }
 
     private static void ExerciseInputMethods()
     {
-	    Input.IsControlDown(Inputs.Key_A);
-	    Input.IsControlDown(Inputs.Mouse_Left);
-	    Input.IsControlDown(Inputs.Gamepad_A);
-	    Input.IsControlDown(Inputs.Joystick_Trigger);
+        Input.IsControlDown(Inputs.Key_A);
+        Input.IsControlDown(Inputs.Mouse_Left);
+        Input.IsControlDown(Inputs.Gamepad_A);
+        Input.IsControlDown(Inputs.Joystick_Trigger);
 
-	    Input.IsControlUp(Inputs.Key_A);
-	    Input.IsControlUp(Inputs.Mouse_Left);
-	    Input.IsControlUp(Inputs.Gamepad_A);
-	    Input.IsControlUp(Inputs.Joystick_Trigger);
-	    
-	    Input.IsControlPressed(Inputs.Key_A);
-	    Input.IsControlPressed(Inputs.Mouse_Left);
-	    Input.IsControlPressed(Inputs.Gamepad_A);
-	    Input.IsControlPressed(Inputs.Joystick_Trigger);
+        Input.IsControlUp(Inputs.Key_A);
+        Input.IsControlUp(Inputs.Mouse_Left);
+        Input.IsControlUp(Inputs.Gamepad_A);
+        Input.IsControlUp(Inputs.Joystick_Trigger);
 
-	    Input.IsGamepadConnected(GamepadSlot.All);
-	    Input.IsGamepadConnected(GamepadSlot.Slot1);
-	    
-	    Input.DidGamepadConnectThisFrame(GamepadSlot.Slot1);
-	    Input.DidGamepadConnectThisFrame(GamepadSlot.All);
-	    Input.DidGamepadDisconnectThisFrame(GamepadSlot.Slot1);
-	    Input.DidGamepadDisconnectThisFrame(GamepadSlot.All);
-	    
-	    Input.GetAxis(GamepadAxis.LeftStick, GamepadSlot.All);
-	    Input.GetAxis(GamepadAxis.LeftStick, GamepadSlot.Slot1);
-	    
-	    Input.GetAxis(Inputs.Key_A);
-	    Input.GetAxis(Inputs.Mouse_Left);
-	    Input.GetAxis(Inputs.Gamepad_A);
-	    Input.GetAxis(Inputs.Joystick_Trigger);
-	    
-	    Input.GetAxis(JoystickSlot.All);
+        Input.IsControlPressed(Inputs.Key_A);
+        Input.IsControlPressed(Inputs.Mouse_Left);
+        Input.IsControlPressed(Inputs.Gamepad_A);
+        Input.IsControlPressed(Inputs.Joystick_Trigger);
+
+        Input.IsGamepadConnected(GamepadSlot.All);
+        Input.IsGamepadConnected(GamepadSlot.Slot1);
+
+        Input.DidGamepadConnectThisFrame(GamepadSlot.Slot1);
+        Input.DidGamepadConnectThisFrame(GamepadSlot.All);
+        Input.DidGamepadDisconnectThisFrame(GamepadSlot.Slot1);
+        Input.DidGamepadDisconnectThisFrame(GamepadSlot.All);
+
+        Input.GetAxis(GamepadAxis.LeftStick, GamepadSlot.All);
+        Input.GetAxis(GamepadAxis.LeftStick, GamepadSlot.Slot1);
+
+        Input.GetAxis(Inputs.Key_A);
+        Input.GetAxis(Inputs.Mouse_Left);
+        Input.GetAxis(Inputs.Gamepad_A);
+        Input.GetAxis(Inputs.Joystick_Trigger);
+
+        Input.GetAxis(JoystickSlot.All);
     }
 
     private Joystick AddHidJoystick()

--- a/Packages/com.unity.inputsystem/InputSystem/API/GlobalInputActions.inputactions
+++ b/Packages/com.unity.inputsystem/InputSystem/API/GlobalInputActions.inputactions
@@ -1,0 +1,3920 @@
+{
+    "name": "GlobalInputActions",
+    "maps": [
+        {
+            "name": "UI",
+            "id": "272f6d14-89ba-496f-b7ff-215263d3219f",
+            "actions": [
+                {
+                    "name": "Navigate",
+                    "type": "PassThrough",
+                    "id": "c95b2375-e6d9-4b88-9c4c-c5e76515df4b",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Submit",
+                    "type": "Button",
+                    "id": "7607c7b6-cd76-4816-beef-bd0341cfe950",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Cancel",
+                    "type": "Button",
+                    "id": "15cef263-9014-4fd5-94d9-4e4a6234a6ef",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Point",
+                    "type": "PassThrough",
+                    "id": "32b35790-4ed0-4e9a-aa41-69ac6d629449",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Click",
+                    "type": "PassThrough",
+                    "id": "3c7022bf-7922-4f7c-a998-c437916075ad",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "ScrollWheel",
+                    "type": "PassThrough",
+                    "id": "0489e84a-4833-4c40-bfae-cea84b696689",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "MiddleClick",
+                    "type": "PassThrough",
+                    "id": "dad70c86-b58c-4b17-88ad-f5e53adf419e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RightClick",
+                    "type": "PassThrough",
+                    "id": "44b200b1-1557-4083-816c-b22cbdf77ddf",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "TrackedDevicePosition",
+                    "type": "PassThrough",
+                    "id": "24908448-c609-4bc3-a128-ea258674378a",
+                    "expectedControlType": "Vector3",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "TrackedDeviceOrientation",
+                    "type": "PassThrough",
+                    "id": "9caa3d8a-6b2f-4e8e-8bad-6ede561bd9be",
+                    "expectedControlType": "Quaternion",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "Gamepad",
+                    "id": "809f371f-c5e2-4e7a-83a1-d867598f40dd",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "14a5d6e8-4aaf-4119-a9ef-34b8c2c548bf",
+                    "path": "<Gamepad>/leftStick/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "9144cbe6-05e1-4687-a6d7-24f99d23dd81",
+                    "path": "<Gamepad>/rightStick/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "2db08d65-c5fb-421b-983f-c71163608d67",
+                    "path": "<Gamepad>/leftStick/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "58748904-2ea9-4a80-8579-b500e6a76df8",
+                    "path": "<Gamepad>/rightStick/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "8ba04515-75aa-45de-966d-393d9bbd1c14",
+                    "path": "<Gamepad>/leftStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "712e721c-bdfb-4b23-a86c-a0d9fcfea921",
+                    "path": "<Gamepad>/rightStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "fcd248ae-a788-4676-a12e-f4d81205600b",
+                    "path": "<Gamepad>/leftStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "1f04d9bc-c50b-41a1-bfcc-afb75475ec20",
+                    "path": "<Gamepad>/rightStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "fb8277d4-c5cd-4663-9dc7-ee3f0b506d90",
+                    "path": "<Gamepad>/dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Joystick",
+                    "id": "e25d9774-381c-4a61-b47c-7b6b299ad9f9",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "3db53b26-6601-41be-9887-63ac74e79d19",
+                    "path": "<Joystick>/stick/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "0cb3e13e-3d90-4178-8ae6-d9c5501d653f",
+                    "path": "<Joystick>/stick/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "0392d399-f6dd-4c82-8062-c1e9c0d34835",
+                    "path": "<Joystick>/stick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "942a66d9-d42f-43d6-8d70-ecb4ba5363bc",
+                    "path": "<Joystick>/stick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "ff527021-f211-4c02-933e-5976594c46ed",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Navigate",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "563fbfdd-0f09-408d-aa75-8642c4f08ef0",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "eb480147-c587-4a33-85ed-eb0ab9942c43",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "2bf42165-60bc-42ca-8072-8c13ab40239b",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "85d264ad-e0a0-4565-b7ff-1a37edde51ac",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "74214943-c580-44e4-98eb-ad7eebe17902",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "cea9b045-a000-445b-95b8-0c171af70a3b",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "8607c725-d935-4808-84b1-8354e29bab63",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "4cda81dc-9edd-4e03-9d7c-a71a14345d0b",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Navigate",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "9e92bb26-7e3b-4ec4-b06b-3c8f8e498ddc",
+                    "path": "*/{Submit}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR",
+                    "action": "Submit",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "82627dcc-3b13-4ba9-841d-e4b746d6553e",
+                    "path": "*/{Cancel}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse;Gamepad;Touch;Joystick;XR",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c52c8e0b-8179-41d3-b8a1-d149033bbe86",
+                    "path": "<Mouse>/position",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Point",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e1394cbc-336e-44ce-9ea8-6007ed6193f7",
+                    "path": "<Pen>/position",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Point",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5693e57a-238a-46ed-b5ae-e64e6e574302",
+                    "path": "<Touchscreen>/touch*/position",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Touch",
+                    "action": "Point",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4faf7dc9-b979-4210-aa8c-e808e1ef89f5",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Click",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8d66d5ba-88d7-48e6-b1cd-198bbfef7ace",
+                    "path": "<Pen>/tip",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Click",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "47c2a644-3ebc-4dae-a106-589b7ca75b59",
+                    "path": "<Touchscreen>/touch*/press",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Touch",
+                    "action": "Click",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "bb9e6b34-44bf-4381-ac63-5aa15d19f677",
+                    "path": "<XRController>/trigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "Click",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "38c99815-14ea-4617-8627-164d27641299",
+                    "path": "<Mouse>/scroll",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "ScrollWheel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "24066f69-da47-44f3-a07e-0015fb02eb2e",
+                    "path": "<Mouse>/middleButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "MiddleClick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4c191405-5738-4d4b-a523-c6a301dbf754",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "RightClick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7236c0d9-6ca3-47cf-a6ee-a97f5b59ea77",
+                    "path": "<XRController>/devicePosition",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "TrackedDevicePosition",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "23e01e3a-f935-4948-8d8b-9bcac77714fb",
+                    "path": "<XRController>/deviceRotation",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "TrackedDeviceOrientation",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "FPS",
+            "id": "df70fa95-8a34-4494-b137-73ab6b9c7d37",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "351f2ccd-1f9f-44bf-9bec-d62ac5c5f408",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Look",
+                    "type": "Value",
+                    "id": "6b444451-8a00-4d00-a97e-f47457f736a8",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Fire",
+                    "type": "Button",
+                    "id": "6c2ab1b8-8984-453a-af3d-a3c78ae1679a",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "f1ba0d36-48eb-4cd5-b651-1c94a6531f70",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Interact",
+                    "type": "Button",
+                    "id": "852140f2-7766-474d-8707-702459ba45f3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Hold",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "NextWeapon",
+                    "type": "Value",
+                    "id": "b7230bb6-fc9b-4f52-8b25-f5e19cb2c2ba",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "PreviousWeapon",
+                    "type": "Value",
+                    "id": "2776c80d-3c14-4091-8c56-d04ced07a2b0",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Sprint",
+                    "type": "Button",
+                    "id": "641cd816-40e6-41b4-8c3d-04687c349290",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Melee",
+                    "type": "Button",
+                    "id": "27c5f898-bc57-4ee1-8800-db469aca5fe3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "978bfe49-cc26-4a3d-ab7b-7d7a29327403",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "WASD",
+                    "id": "00ca640b-d935-4593-8157-c05846ea39b3",
+                    "path": "Dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "e2062cb9-1b15-46a2-838c-2f8d72a0bdd9",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "8180e8bd-4097-4f4e-ab88-4523101a6ce9",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "320bffee-a40b-4347-ac70-c210eb8bc73a",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "1c5327b5-f71c-4f60-99c7-4e737386f1d1",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "d2581a9b-1d11-4566-b27d-b92aff5fabbc",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "2e46982e-44cc-431b-9f0b-c11910bf467a",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "fcfe95b8-67b9-4526-84b5-5d0bc98d6400",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "77bff152-3580-4b21-b6de-dcd0c7e41164",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "1635d3fe-58b6-4ba9-a4e2-f4b964f6b5c8",
+                    "path": "<XRController>/{Primary2DAxis}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3ea4d645-4504-4529-b061-ab81934c3752",
+                    "path": "<Joystick>/stick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8c8e490b-c610-4785-884f-f04217b23ca4",
+                    "path": "<Pointer>/delta",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse;Touch",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3e5f5442-8668-4b27-a940-df99bad7e831",
+                    "path": "<Joystick>/{Hatswitch}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "143bb1cd-cc10-4eca-a2f0-a3664166fe91",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "05f6913d-c316-48b2-a6bb-e225f14c7960",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Keyboard&Mouse",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "886e731e-7071-4ae4-95c0-e61739dad6fd",
+                    "path": "<Touchscreen>/primaryTouch/tap",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Touch",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ee3d0cd2-254e-47a7-a8cb-bc94d9658c54",
+                    "path": "<Joystick>/trigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8255d333-5683-4943-a58a-ccb207ff1dce",
+                    "path": "<XRController>/{PrimaryAction}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1c04ea5f-b012-41d1-a6f7-02e963b52893",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b3f66d0b-7751-423f-908b-a11c5bd95930",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "cbac6039-9c09-46a1-b5f2-4e5124ccb5ed",
+                    "path": "<Mouse>/scroll/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "NextWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e15ca19d-e649-4852-97d5-7fe8ccc44e94",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "NextWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1534dc16-a6aa-499d-9c3a-22b47347b52a",
+                    "path": "<Mouse>/scroll/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PreviousWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "25060bbd-a3a6-476e-8fba-45ae484aad05",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "PreviousWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f2e9ba44-c423-42a7-ad56-f20975884794",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Sprint",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "8cbb2f4b-a784-49cc-8d5e-c010b8c7f4e6",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Sprint",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "eb40bb66-4559-4dfa-9a2f-820438abb426",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "daba33a1-ad0c-4742-a909-43ad1cdfbeb6",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4f4649ac-64a8-4a73-af11-b3faef356a4d",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Melee",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "36e52cba-0905-478e-a818-f4bfcb9f3b9a",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Melee",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "Driving",
+            "id": "b5596ff9-f2e8-42a6-820b-2b03048144ea",
+            "actions": [
+                {
+                    "name": "Accelerate",
+                    "type": "Button",
+                    "id": "ad1f0bbc-d5bd-4823-8c5e-bfa3c577b32a",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Brake",
+                    "type": "Button",
+                    "id": "f5bae5a6-49b4-4983-83c9-cbb89dc37d77",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Clutch",
+                    "type": "Value",
+                    "id": "13798076-af8e-4d0f-8a1d-afb9a955c1f9",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Steer",
+                    "type": "Value",
+                    "id": "10a7f4cf-0bbb-49d9-b5a3-8b449c1e9479",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Horn",
+                    "type": "Button",
+                    "id": "00a51b46-b34a-44f4-9f19-18ce2d1c5d30",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Handbrake",
+                    "type": "Button",
+                    "id": "bbf6a57e-032e-443d-a506-0a3da48145af",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShiftUp",
+                    "type": "Button",
+                    "id": "13caa39e-071b-475d-a5ea-4f2ae8dd0a9b",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ShiftDown",
+                    "type": "Button",
+                    "id": "ef885a2e-393a-41a2-90b6-87e843eac924",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Headlights",
+                    "type": "Button",
+                    "id": "95151260-f86f-4fda-b1b2-d8295590859d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Wipers",
+                    "type": "Button",
+                    "id": "51b7d47e-514c-4434-a73c-091918cc27f1",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Ignition",
+                    "type": "Button",
+                    "id": "d8efbb55-27cf-4584-9c94-c0f83ccdad1c",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PitLimiter",
+                    "type": "Button",
+                    "id": "10e2a980-10a0-4579-a512-27c4bb1c5f03",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "DRS",
+                    "type": "Button",
+                    "id": "67af557a-b2a1-43be-9ead-38c000264a50",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleSteeringAssist",
+                    "type": "Button",
+                    "id": "97bc4365-4c4e-42c7-b1c1-e90e36342702",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleBrakingAssist",
+                    "type": "Button",
+                    "id": "d581b4fe-9940-49c4-998e-336c6e2b1c12",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleDamage",
+                    "type": "Button",
+                    "id": "e8a9991c-f4e6-45a1-900f-e55816088759",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleBrakeAssist",
+                    "type": "Button",
+                    "id": "519e6bb4-b53b-4fb5-988d-2682562616be",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ToggleTractionControl",
+                    "type": "Button",
+                    "id": "ddea3376-425d-4d60-90d1-2f02d743b6ec",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "TogglePitLaneAssist",
+                    "type": "Button",
+                    "id": "8823a2dc-1d5c-4ffb-969a-44b63febcf41",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "FreeLook",
+                    "type": "Value",
+                    "id": "2fef9730-44ed-4675-a2d1-5d2668ffad5b",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "LookLeft",
+                    "type": "Button",
+                    "id": "db1aa0e1-44ea-4b18-afd5-50bb71c462f5",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "LookRight",
+                    "type": "Button",
+                    "id": "18d2bd85-4010-4038-b1c3-1ca70e15abe7",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "LookUp",
+                    "type": "Button",
+                    "id": "1bbf0196-aa77-4fbd-9cb8-5a4f1dc5bd27",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "LookDown",
+                    "type": "Button",
+                    "id": "2f987804-f406-400a-976d-2a016f428baa",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "NextCamera",
+                    "type": "Button",
+                    "id": "1768cd4c-d7f8-4738-8776-00cb3a8b4fec",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PreviousCamera",
+                    "type": "Button",
+                    "id": "2fcdd05a-ed2b-497c-807b-112064e09ff8",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "f430c7eb-1e28-4691-8753-fc83287d04ee",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Accelerate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7d5cd8dc-076c-4215-a69e-a5a1fdd3be49",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Accelerate",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "bb0a1d2b-f3d6-4ac2-b0a1-0e9b2ca8dcf7",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Brake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "83eeee2f-39ee-456b-867d-f04abe4cd627",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Brake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "73b5f18c-a44e-4737-b5cc-216af1c7e97e",
+                    "path": "<Gamepad>/leftStick/x",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Steer",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Keyboard",
+                    "id": "4007ce78-9181-47b6-bec7-21394fd05b99",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Steer",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "5f835cf2-c1c9-4d24-8a88-64bd735dc57d",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Steer",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "6c3a8cf6-0e27-4f1b-8d0d-5e1f6cf23933",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Steer",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "d08c036a-b267-4909-bd19-acb420b5689c",
+                    "path": "<Keyboard>/h",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Horn",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "20ef1f3f-b50a-4e2a-8c93-8a08fc6466b6",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Horn",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e27d6642-bc32-46a2-b1a2-162955a9c8d9",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Handbrake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "70980a90-dcf6-4cbc-a60f-02ccb624fac9",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Handbrake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a5898e22-a6d6-4278-89cd-03615dd3baeb",
+                    "path": "<Keyboard>/r",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ShiftUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "04998f8f-8ecd-473a-97bf-6729444f8544",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ShiftUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9afb6b52-6148-4a80-8745-4bcf5f69961a",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ShiftDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0ea946e9-ed41-4af9-8005-d8ef33d66a47",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ShiftDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "50e01f08-b5b3-4fef-a2c8-f7a948fc0ada",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Clutch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "954713d3-6120-4546-921a-8e97a702a9a4",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Clutch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1597a1e-5d45-4cf3-a530-cad2f21dc598",
+                    "path": "<Keyboard>/l",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Headlights",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "85d141b0-a8b6-497c-b7f3-5a5cf18aeae3",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PitLimiter",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "851728f7-010f-4e8b-9a44-48f0408e8308",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ToggleSteeringAssist",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "aca0a8c7-c251-401e-afef-2f03c9581a0b",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ToggleBrakingAssist",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "119ba58a-a6de-40ef-aff4-0637b38fd93c",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ToggleDamage",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f808c9a6-8e9d-4b75-bc0b-7c1edcb7d53c",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ToggleBrakeAssist",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "eaeb56c5-e46f-4b30-bb8d-9d70e3bc8615",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "TogglePitLaneAssist",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "bdea19a1-6f07-40b6-a1db-c260ae8b6bab",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "FreeLook",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ed4088f1-87c9-4cbb-99a0-362a980b3513",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LookLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fad60b89-7b54-422a-a60e-64f3f294ff43",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LookRight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a818ecf1-269b-4aba-9e55-72f6b6173170",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LookUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "273b2fb0-2949-4fbc-a6ad-f39cd946507c",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "LookDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6f17a250-779c-44e2-ae37-d3577e5f0ccc",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Wipers",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e3e65fa5-03e3-4e9a-aa3c-785155d50cc3",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "NextCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e7959a20-e535-4104-bbf7-717b53a6c691",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PreviousCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fe8a6d4d-218c-42d7-8bb7-50710d94fd9e",
+                    "path": "<Keyboard>/i",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Ignition",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c991dab0-5466-4972-bb3e-6a7ca6ebdaa2",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ToggleTractionControl",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4a3dfd8d-3d8b-42fb-b97f-675e3575be82",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "DRS",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "2DPlatformer",
+            "id": "141b9ac5-d077-40a2-bff7-43890d286d6d",
+            "actions": [
+                {
+                    "name": "Left",
+                    "type": "Button",
+                    "id": "f80580e6-b8a7-457d-b114-4a54841d1cd7",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Right",
+                    "type": "Button",
+                    "id": "72952532-7898-4d05-a9a9-ea1136400f77",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "5d926db2-f470-4e95-802d-97a2f67ee747",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Sprint",
+                    "type": "Button",
+                    "id": "ef092183-55fb-4a58-9b5e-ac0b59021193",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Walk",
+                    "type": "Button",
+                    "id": "e26bb985-751d-49af-87bc-8eb706ff8c70",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Fire",
+                    "type": "Button",
+                    "id": "2c7f12a5-7c0d-44d0-aa37-6bb61d8822f2",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "62a58bda-1659-40cf-a25f-4e23fd721900",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Left",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6a1f164b-d824-4bef-a7a5-89ce7a1a2ef9",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Right",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b552a625-813b-4dc8-ba07-84df60be418e",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "346ff0d8-0012-49db-b904-660f5869321b",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Sprint",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6fe15839-277a-498b-a472-9d0317b57816",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Walk",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7510e361-4794-4bca-b2d0-cd6f9af1b052",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "610c3174-3d65-4114-98b0-630978f18549",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4693ab14-2ebd-4c0c-968d-8a871f4f7832",
+                    "path": "<Touchscreen>/primaryTouch/tap",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Touch",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "cde57944-726c-4c6e-b2b2-f9af75e9c9a3",
+                    "path": "<Joystick>/trigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "74f18e4e-7d2a-468f-add7-8cd9b83a3815",
+                    "path": "<XRController>/{PrimaryAction}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "ThirdPerson",
+            "id": "1272dfc9-7b10-4f6f-9924-2d9a11112a43",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "a54dc35e-6f0d-4d6d-a583-2786b726b7ea",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Look",
+                    "type": "Value",
+                    "id": "ada51d7b-60b5-49fc-8899-2a697f0b9076",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Fire",
+                    "type": "Button",
+                    "id": "628a92a1-58e8-4a4e-b4af-0ba2f8c7d347",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "53d335c5-d28e-4f53-8d87-ee9c76396de5",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Interact",
+                    "type": "Button",
+                    "id": "d0263211-5edf-4390-9203-f6630fdca07d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Hold",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "NextWeapon",
+                    "type": "Value",
+                    "id": "954dd260-b11c-479c-ab2c-737a2259958c",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "PreviousWeapon",
+                    "type": "Value",
+                    "id": "e3178203-1421-48ff-b00d-0805f9fad571",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Sprint",
+                    "type": "Button",
+                    "id": "8f4119bf-56e6-428a-b028-d2ba37c65fe3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Melee",
+                    "type": "Button",
+                    "id": "c2821eeb-6116-46fa-bc63-c0b88dfc1e24",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Walk",
+                    "type": "Button",
+                    "id": "cc364c96-0351-4d64-ac5a-bd0644875c47",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "c84b8f41-25cc-4f9c-8ead-343d86e6cf41",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "WASD",
+                    "id": "0c897c04-1ae6-4bf5-acc8-28636ceb1e4e",
+                    "path": "Dpad",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "ca4294b2-3a47-4516-9176-4d3dd466140a",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "up",
+                    "id": "b3a6bcc4-ca61-4b15-8320-7fbcdf1b5227",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "595ff5ec-b89d-4924-96ab-5ddaec11c670",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "6a036275-255d-45c0-b95c-81fe95187a95",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "b56b70ac-2377-457c-9211-25a89b6b690d",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "de514fbf-86ff-47dd-95aa-159d35a67500",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "8ac1dc6b-c1e8-434a-ba19-c145df25c9f9",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "e875f15f-66ab-45b3-93c6-b175979dcd41",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "d37e779e-9e52-49e7-a73b-4dbbe8c3673c",
+                    "path": "<XRController>/{Primary2DAxis}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "de66e4d3-a98f-4022-8b22-10bc7355bd5e",
+                    "path": "<Joystick>/stick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f80ddc1a-463b-4a14-94d2-0c7c7b9d670e",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a09f8752-f6af-4b14-9853-ecdf78726f74",
+                    "path": "<Pointer>/delta",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse;Touch",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6c3f73a0-b4e5-46ff-af6c-596d4cfbbe1a",
+                    "path": "<Joystick>/{Hatswitch}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Look",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6ac3cf98-7ad5-4cb2-9def-7b4bcf274962",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "39071773-d2f1-425b-a911-cd8eda4f7b05",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2fbf8bab-d61a-429a-9dfa-4aeb454bd404",
+                    "path": "<Touchscreen>/primaryTouch/tap",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Touch",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4502af7a-270e-43c3-9f51-b15b79058824",
+                    "path": "<Joystick>/trigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Joystick",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6a7869e3-29fe-4da3-8cdb-34f7457461df",
+                    "path": "<XRController>/{PrimaryAction}",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "XR",
+                    "action": "Fire",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1e50bc5f-ca99-46f8-9caf-b40b08743fb0",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c1adf17f-3884-46be-9819-ad19d6ba478c",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d8eb884d-20b1-4cee-8bdc-5448320226c3",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e46119fe-423c-42f7-b5e4-bd6ff616b4ff",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Interact",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "a6a8d5b9-ef00-4b3d-97ee-e22345da311a",
+                    "path": "<Mouse>/scroll/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "NextWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "cfbb6320-3f9b-46b1-8f54-28219cd47025",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "NextWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5120b6b8-57b8-4e49-b8fb-c5d270cc752e",
+                    "path": "<Mouse>/scroll/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PreviousWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "4bb148b1-f469-4e6b-b795-a7b86b2c002a",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "PreviousWeapon",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "25c39ff5-cd3c-4403-8768-381e8fc1f2d7",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Sprint",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5b3c0257-2926-431c-8b7d-802228e6edff",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Sprint",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9aa833e7-1f0a-491e-a19a-7fa30cd32cc2",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Melee",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "5d0d14e1-f30e-422d-8182-4964def8bc47",
+                    "path": "<Keyboard>/f",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Melee",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "25e35aca-9683-46f6-99b5-d91c5074047d",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Walk",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "2d16b7d1-6c8a-4779-bcbf-cfb5b9c3f138",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Walk",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "RTS",
+            "id": "824e4eea-b21b-40a7-8309-3065b7b752f7",
+            "actions": [
+                {
+                    "name": "Command",
+                    "type": "Button",
+                    "id": "d133b3fe-f0fd-4633-b277-c99ad92460dc",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Tap,MultiTap",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "AssignSelectedToGroup",
+                    "type": "Button",
+                    "id": "5273ae1b-974b-42f5-9e2c-08c1b2e6d48c",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "AddSelectedToGroup",
+                    "type": "Button",
+                    "id": "0dcb76f4-7637-48b7-b8f7-2afe18f6b52e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RemoveSelectedFromSelection",
+                    "type": "Button",
+                    "id": "2ca5e4a7-3238-42ef-a421-f16cc42199a8",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "SelectGroup",
+                    "type": "Button",
+                    "id": "ad79de4d-d5e8-471b-992f-9738bc547eae",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "CenterSelectedGroup",
+                    "type": "Button",
+                    "id": "37d37b1d-b031-4d81-9672-62ca945474d9",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "QueueOrders",
+                    "type": "Button",
+                    "id": "4dfcb496-8d93-4015-9522-32653b6308f4",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "PanCamera",
+                    "type": "Value",
+                    "id": "451e748d-f887-48f2-987d-65d5d17bb095",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "ZoomCamera",
+                    "type": "Value",
+                    "id": "25324818-b6d8-4cd4-9607-00baeaecd608",
+                    "expectedControlType": "Delta",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Move",
+                    "type": "Button",
+                    "id": "9dff20dd-d9b3-4434-9e9f-bbfdaecbd7ca",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Attack",
+                    "type": "Button",
+                    "id": "c9e3a587-3e14-40fb-b49a-b015198b2c7a",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Patrol",
+                    "type": "Button",
+                    "id": "aaeaaa10-df46-487d-b627-6dccc8210651",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Cancel",
+                    "type": "Button",
+                    "id": "20199cb4-9050-48b9-b928-e7edba322fad",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "62930542-fa77-480b-ac59-c7e3bb7457fe",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Command",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "1",
+                    "id": "9e358e70-995f-4a97-9cb8-4cf6ee84bd3a",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "9031201c-16e2-49e0-8d29-68242c1ace6a",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "0da744ce-1564-4bb9-9cef-3d94a6f2327c",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "2",
+                    "id": "97c4f9b4-b813-45c7-9a57-09c005d69de8",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "d22097e5-f155-4aa5-95de-489cc0606c9b",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "a7b55734-afaf-4ef7-b522-6815be1652e0",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "3",
+                    "id": "051b3f55-d3f3-40cf-a68a-f94e8706124f",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "39a6c29f-8b66-47cf-9ba8-ec2afecff685",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "e6f47fad-f599-4286-96e2-b09859aa48d8",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "4",
+                    "id": "3600f69b-e3f6-44d1-9319-fb2a590fb4bb",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "9b6c6433-66ab-40ca-81dd-aef25d7079df",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "532304b0-287b-4183-b4a3-d2f33db3f82e",
+                    "path": "<Keyboard>/4",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "5",
+                    "id": "21d3fa50-df3c-4c23-8e5a-36d5f681545b",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "5da3c0bf-4a54-4e21-958d-6877e8d8816d",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "861a55cb-d9eb-49db-b178-11e2f6e142ad",
+                    "path": "<Keyboard>/5",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "6",
+                    "id": "3c11c03b-acb5-404a-b03d-c0edff9168a4",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "a6ad39dc-70a3-437a-b2fe-3bdb7dcbb958",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "914b0263-46bd-4e4e-9f1e-2b9796fe3fee",
+                    "path": "<Keyboard>/6",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "7",
+                    "id": "ced5eea7-34c4-4805-ba6e-febb09fcb198",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "6fb98225-dedd-4607-975c-4f3f229a527c",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "1b3d0f5a-b555-4c3a-b86e-e4a449331cb4",
+                    "path": "<Keyboard>/7",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "8",
+                    "id": "fdcb1cba-c6e8-4e9b-9522-9fcea5689448",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "37f84f74-7edc-444c-9d74-7b628ed61af4",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "242bba90-5fee-46ca-b7a7-cdd668aade32",
+                    "path": "<Keyboard>/8",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "9",
+                    "id": "18e4fdf7-c838-47af-8864-b08d47a2dd11",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "538b9f8f-72c0-4a61-98d4-4a0486f5c0ce",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "76c1feeb-62b1-4830-a7c5-a905a17d0d71",
+                    "path": "<Keyboard>/9",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "10",
+                    "id": "c8747c05-0b13-4a1e-b1ab-17114ce99205",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "c0c937f0-1033-4247-a67f-21f9ea6505df",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "f65cdba8-fb77-4d96-96ad-fecae555e87d",
+                    "path": "<Keyboard>/0",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AssignSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "e16c9f09-9d97-4604-8e3c-3ec87ed7144e",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "22857e0a-75b8-42d1-9758-b315f9935ef8",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "36db72b8-b1fc-4e69-8d93-bd7c2dbe5994",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "94091f65-4cc5-48f4-a057-9f97dc1b034c",
+                    "path": "<Keyboard>/4",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "31f674e8-73ae-4977-b425-cdb8d08f5536",
+                    "path": "<Keyboard>/5",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ab5028d9-f2bc-41d1-bb3e-fecb29b46a4f",
+                    "path": "<Keyboard>/6",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e2747c8e-1733-464b-a164-765f96a75abd",
+                    "path": "<Keyboard>/7",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7d8b1141-756d-4550-b50d-f1a24270d003",
+                    "path": "<Keyboard>/8",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b87faa10-00e9-4a9b-8e4d-e383224d3307",
+                    "path": "<Keyboard>/9",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "be9d5a05-ee76-4a49-ba15-659f0a6824fc",
+                    "path": "<Keyboard>/0",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "SelectGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "1",
+                    "id": "f9cca42a-8415-4fac-8ef2-1c71df19ff8a",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "7655336f-67bc-4b9b-b521-b545f80caf8e",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "3052b8f7-7681-4d77-9254-834a1090fa78",
+                    "path": "<Keyboard>/1",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "2",
+                    "id": "5d6fe3e8-89a4-4f1f-88d6-d4378d9a347d",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "50a84161-0c86-4e33-809e-a8f869898a1b",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "8e3194f8-a5cc-41fc-afc5-cb60ab3538e5",
+                    "path": "<Keyboard>/2",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "3",
+                    "id": "c7fe3205-422c-41d9-ba8b-39e25cea8d6b",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "2de86f22-48ac-43b3-886f-defba06bae07",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "0c66a3f1-089b-4890-af34-302ec20a333a",
+                    "path": "<Keyboard>/3",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "4",
+                    "id": "f812267f-b077-450c-81c3-d3639fc40be6",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "06f596ee-6ac4-4d2b-8cdd-529b676a77e9",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "93dcfa5a-89b6-4e14-ab1b-88ef7b3b9f8d",
+                    "path": "<Keyboard>/4",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "5",
+                    "id": "915bf34a-3ddf-4f9c-bfe4-c750d28f4daf",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "cccf791f-6c65-4bbb-9c7d-4066b5a1ac2c",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "db4a5a45-ec43-4cef-9b25-d88befc8a3d2",
+                    "path": "<Keyboard>/5",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "6",
+                    "id": "191377a2-3830-4568-a17e-e5da524bd631",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "11a50844-074b-44d1-8b58-451b4ed5e46e",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "ddead542-a07f-442b-80db-47b174fc80eb",
+                    "path": "<Keyboard>/6",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "7",
+                    "id": "9033b69c-e7aa-426c-b806-ae497898a8af",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "01366a3e-ee33-4122-91ef-a840513b5b01",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "c051c96d-7425-47fe-8f7a-e709e1aea4f9",
+                    "path": "<Keyboard>/7",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "8",
+                    "id": "23ee7917-db52-4e6f-87b6-a4533fcda5b5",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "ce734e48-1fcb-4d68-83f5-5dd72992cdcd",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "f7e3bfd5-fb0c-49c3-a257-935f782d4c0a",
+                    "path": "<Keyboard>/8",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "9",
+                    "id": "473ba3d5-56cd-4fd3-a77a-21cd86d4f20c",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "ca5277dd-668a-420e-94b3-eef4ddf2f595",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "aaeb323d-b16c-436b-abbf-9f989d06d1d8",
+                    "path": "<Keyboard>/9",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "10",
+                    "id": "8f77b771-c516-47c7-bdb2-9ee7bf5d0f25",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "8ff3b08d-93a8-4119-b8d3-5e628ae35827",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "7c308619-13ca-400a-89a3-fcae139ddb9c",
+                    "path": "<Keyboard>/0",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "AddSelectedToGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Ctrl+C",
+                    "id": "8766b15d-b63c-49e3-9972-a952231221c6",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CenterSelectedGroup",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "f7714a1d-991a-4341-bfdf-1d7bd93db5c0",
+                    "path": "<Keyboard>/leftCtrl",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "CenterSelectedGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "60553da9-8cf8-404b-8d5e-4fd7480655cd",
+                    "path": "<Keyboard>/c",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "CenterSelectedGroup",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "7c8b655a-8bfd-44bc-84c3-b15279b009fb",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "QueueOrders",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "2D Vector",
+                    "id": "9378573c-98ec-478d-b050-979920f2e47c",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PanCamera",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "c000cceb-6e78-4503-b27a-5816c81c8c0a",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PanCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "c48d9bf7-3391-4a5f-85b5-50bd9544e86b",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PanCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "4223d814-6e18-4c95-80b5-078e7aef1ed8",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PanCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "a3f9a452-b61c-4e18-8d4e-936e443aa5ea",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PanCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Mouse",
+                    "id": "6d3da5ae-7eea-493e-a33b-6abf99e25047",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PanCamera",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "ab5ad376-d0a6-427e-bf30-eabe1d281b24",
+                    "path": "<Mouse>/middleButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "PanCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "0acc30bf-83b2-4175-aab0-e08e387cbd93",
+                    "path": "<Mouse>/position",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "PanCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "cbdb1ede-8751-407e-8063-336cb1fb57e2",
+                    "path": "<Mouse>/scroll",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ZoomCamera",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "One Modifier",
+                    "id": "2ac32aa7-4ab0-4397-abf7-32ea0e6de108",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RemoveSelectedFromSelection",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "5da1d3b6-8f5f-4a6b-8291-b54b87a8cbff",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RemoveSelectedFromSelection",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "9a960b93-6de1-4fc2-9924-ef149976fc2b",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RemoveSelectedFromSelection",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "1caa187d-c07c-4804-8125-17676c4cb949",
+                    "path": "<Keyboard>/m",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7d969ee6-2730-4251-8e89-26037d37f56f",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Attack",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b6096567-f9d1-475c-b25a-a838ce61c588",
+                    "path": "<Keyboard>/p",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Patrol",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9f5c8e82-a1dd-41a9-bf86-bf22373ca109",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0b15bb81-96a4-4959-aa22-f4968d589a3a",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Cancel",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "FlightSim",
+            "id": "938afe83-1003-4c20-8acf-527ab5ba1b11",
+            "actions": [
+                {
+                    "name": "ThrottleUp",
+                    "type": "Button",
+                    "id": "6c579a6d-77f5-4f08-8729-174faf49047f",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ThrottleDown",
+                    "type": "Button",
+                    "id": "c4dfcbf5-cf66-436d-b2f8-df52f6c9ddeb",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "ParkingBrake",
+                    "type": "Button",
+                    "id": "71645b37-0273-4b79-a605-095503b4c561",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "LandingGear",
+                    "type": "Button",
+                    "id": "a875a34b-85b5-434a-b286-c4599206d1b2",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "IncreaseFlaps",
+                    "type": "Button",
+                    "id": "a395964f-cb29-4958-a211-cf5183e31ce8",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "DecreaseFlaps",
+                    "type": "Button",
+                    "id": "9dfd8bcd-c17a-4ca5-8ad5-09fbc28ab5ba",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Ailerons",
+                    "type": "Value",
+                    "id": "9a940895-104f-4019-a5ab-4fa95a84486e",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "FreeLook",
+                    "type": "Value",
+                    "id": "01749430-be08-40ac-88f7-dbdf9ec9e7ea",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "ResetView",
+                    "type": "Button",
+                    "id": "b5caeed7-8b1b-4f22-aff8-ea2b15aa6e66",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "RudderLeft",
+                    "type": "Value",
+                    "id": "8d7ce01c-19e1-49ae-8550-542406b2abc2",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "RudderRight",
+                    "type": "Value",
+                    "id": "a3453bc2-eee4-49c2-a0bf-5ac1b0df1e59",
+                    "expectedControlType": "Axis",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "Brakes",
+                    "type": "Button",
+                    "id": "f4939b1d-0ad5-4364-bddd-26a3c76f4d6e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Autopilot",
+                    "type": "Button",
+                    "id": "c04d29fe-d293-4f8a-b05b-4275afb3667d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "b354b7dc-4d2b-48ee-ba8a-647ec9a01d13",
+                    "path": "<Keyboard>/numpadPlus",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ThrottleUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "ShiftPlus",
+                    "id": "9f3055e9-df54-48bb-922f-e144ad350fa6",
+                    "path": "OneModifier",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ThrottleUp",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "modifier",
+                    "id": "05dccac4-d8a4-4843-988d-a977169645c0",
+                    "path": "<Keyboard>/leftShift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ThrottleUp",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "binding",
+                    "id": "0a5187a0-2bf5-465c-b190-2d084fb5aed6",
+                    "path": "<Keyboard>/equals",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ThrottleUp",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "075e560e-c4d6-4bf3-9101-0b70e6f1e203",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ThrottleUp",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "468c5cde-eb2e-4556-87a9-6b62ef8878a8",
+                    "path": "<Keyboard>/numpadMinus",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ThrottleDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "f881196b-85f3-466b-84c9-2ddee44599d9",
+                    "path": "<Keyboard>/minus",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ThrottleDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d9041226-0a5b-457c-8fae-1d20a130a785",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ThrottleDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "910f00fc-5b33-4300-ad89-17748f56f90b",
+                    "path": "<Gamepad>/dpad/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "ParkingBrake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "df89393a-c4ab-4aa2-b45d-921673a182fb",
+                    "path": "<Keyboard>/leftArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "ParkingBrake",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "68bac0e6-0910-4d3f-b075-678972095b67",
+                    "path": "<Gamepad>/dpad/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "LandingGear",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ee620bab-9618-4cc8-8853-476e875731e8",
+                    "path": "<Keyboard>/rightArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "LandingGear",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "296be1e4-d74e-4573-aedd-9dac41335f38",
+                    "path": "<Keyboard>/upArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "IncreaseFlaps",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ea48010f-7510-4fe3-97d1-606c7c42cdc3",
+                    "path": "<Gamepad>/dpad/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "IncreaseFlaps",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "20bb0b67-28ea-4507-9505-b3698c723652",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "DecreaseFlaps",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ad42bb6a-9c1a-48fa-8f9a-2205bfd73da9",
+                    "path": "<Keyboard>/downArrow",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "DecreaseFlaps",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "718d0bf1-b3fe-4f86-85f4-da4ecf150edd",
+                    "path": "<Gamepad>/leftStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Ailerons",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "WASD",
+                    "id": "4d92a8f9-3300-4647-9d3b-10aba11eeef4",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Ailerons",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "c6c2a099-1631-44b8-95f5-a98e595b24cb",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Ailerons",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "7a81d55a-249b-465d-a2f7-4797be990821",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Ailerons",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "5349340c-b92b-4c2e-ae8a-680ebd25f096",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Ailerons",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "67f32e1b-b367-4355-bc39-c50b82859b55",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Ailerons",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "6bb76c7d-5b4b-4f07-9c1a-1d139e3d42eb",
+                    "path": "<Gamepad>/rightStick",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "FreeLook",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "44baa8dc-a73e-4704-b865-315f69fafb2d",
+                    "path": "<Gamepad>/rightStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ResetView",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "0c186eec-d298-42d8-8e46-814fdc7a8e4a",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "RudderLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "7586729b-b804-4176-889d-4e3ce6970567",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RudderLeft",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e1c6a5d9-9b32-4740-ad8a-0fd19a933a4d",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RudderRight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "21786c30-8bf4-4d5f-b87f-fd0165a2591b",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "RudderRight",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "fd1ba191-9e6f-40da-9ac3-0188cfc386a3",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Brakes",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "6e444333-4893-45f0-8e07-a26aca4be2e4",
+                    "path": "<Keyboard>/b",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Brakes",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "24a900ed-20ba-4d31-9d46-89ffc3d37c64",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Gamepad",
+                    "action": "Autopilot",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1502ebb7-8b07-4d00-a61f-8051f66584fc",
+                    "path": "<Keyboard>/x",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Autopilot",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "Keyboard&Mouse",
+            "bindingGroup": "Keyboard&Mouse",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                },
+                {
+                    "devicePath": "<Mouse>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Gamepad",
+            "bindingGroup": "Gamepad",
+            "devices": [
+                {
+                    "devicePath": "<Gamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Touch",
+            "bindingGroup": "Touch",
+            "devices": [
+                {
+                    "devicePath": "<Touchscreen>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Joystick",
+            "bindingGroup": "Joystick",
+            "devices": [
+                {
+                    "devicePath": "<Joystick>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "XR",
+            "bindingGroup": "XR",
+            "devices": [
+                {
+                    "devicePath": "<XRController>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/Packages/com.unity.inputsystem/InputSystem/API/GlobalInputActions.inputactions.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/API/GlobalInputActions.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: 7eb24c650c3fdaf4eaa4b56447c3e08d
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: UnityEngine.InputSystem

--- a/Packages/com.unity.inputsystem/InputSystem/API/Input.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/API/Input.cs
@@ -305,7 +305,7 @@ namespace UnityEngine.InputSystem.HighLevel
         All = Int32.MaxValue
     }
 
-    public static class Input
+    public static partial class Input
     {
         internal const float kDefaultJoystickDeadzone = 0.125f;
 
@@ -1637,7 +1637,16 @@ namespace UnityEngine.InputSystem.HighLevel
         internal struct InputSystemPlayerLoopHighLevelEndFrame{}
 #endif
 
-        internal static void Initialize()
+        /// <summary>
+        /// Initialize the API
+        /// </summary>
+        /// <param name="defaultGlobalActionsPath">The file path to read default global actions from.</param>
+        /// <param name="globalActionsAssetPath">The path to the asset in the asset database containing global actions.</param>
+        /// <remarks>
+        /// If this is the first time global actions have been initialized, a default set of actions is read from the inputactions
+        /// file located at 'defaultGlobalActionsPath' and saved into the asset located at 'globalActionsAssetPath' as sub assets.
+        /// </remarks>
+        internal static void Initialize(string defaultGlobalActionsPath, string globalActionsAssetPath)
         {
             for (var i = 0; i < maxGamepadSlots; i++)
             {
@@ -1696,6 +1705,8 @@ namespace UnityEngine.InputSystem.HighLevel
             s_ScrollAction.AddBinding("<Mouse>/scroll");
             s_ScrollAction.performed += OnMouseScrolled;
             s_ScrollAction.Enable();
+
+			InitializeGlobalActions(defaultGlobalActionsPath, globalActionsAssetPath);
         }
 
         internal static void Shutdown()
@@ -1715,7 +1726,9 @@ namespace UnityEngine.InputSystem.HighLevel
             }
 
             InputSystem.onDeviceChange -= OnDeviceChange;
-        }
+
+            ShutdownGlobalActions();
+		}
 
         private static void OnPointerMoved(InputAction.CallbackContext context)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/API/Input.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/API/Input.cs
@@ -7,6 +7,7 @@ using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.PlayerLoop;
 
+#if UNITY_2020_2_OR_NEWER
 // TODO rename HighLevel to something that makes sense
 namespace UnityEngine.InputSystem.HighLevel
 {
@@ -954,7 +955,7 @@ namespace UnityEngine.InputSystem.HighLevel
                         var gamepad = s_Gamepads[i];
                         if (gamepad == null) continue;
 
-                        if (GetGamepadButtonControl(gamepad, input).ReadValue() >= 
+                        if (GetGamepadButtonControl(gamepad, input).ReadValue() >=
                             GetGamepadTriggerPressPoint((GamepadSlot)i))
                             return true;
                     }
@@ -1298,16 +1299,16 @@ namespace UnityEngine.InputSystem.HighLevel
                 case InputDeviceType.Gamepad:
                     foreach (var gamepad in s_Gamepads)
                     {
-	                    if (gamepad == null) continue;
+                        if (gamepad == null) continue;
 
-	                    maxValue = Mathf.Max(maxValue,
+                        maxValue = Mathf.Max(maxValue,
                             Mathf.Clamp01(GetGamepadButtonControl(gamepad, input).ReadValue()));
                     }
                     break;
                 case InputDeviceType.Joystick:
                     foreach (var joystick in s_Joysticks)
                     {
-	                    if (joystick == null) continue;
+                        if (joystick == null) continue;
 
                         var control = GetJoystickButtonControl(joystick, input);
                         if (control == null) continue;
@@ -1461,15 +1462,15 @@ namespace UnityEngine.InputSystem.HighLevel
         /// <returns></returns>
         public static bool IsGamepadConnected(GamepadSlot slot)
         {
-	        if (slot != GamepadSlot.All) 
-		        return s_Gamepads[(int)slot] != null;
+            if (slot != GamepadSlot.All)
+                return s_Gamepads[(int)slot] != null;
 
-	        foreach (var g in s_Gamepads)
-	        {
-		        if (g == null) return false;
-	        }
+            foreach (var g in s_Gamepads)
+            {
+                if (g == null) return false;
+            }
 
-	        return true;
+            return true;
         }
 
         /// <summary>
@@ -1482,16 +1483,16 @@ namespace UnityEngine.InputSystem.HighLevel
         /// </remarks>
         public static bool DidGamepadConnectThisFrame(GamepadSlot slot)
         {
-	        if (slot != GamepadSlot.All) 
-		        return s_GamepadsConnectedFrames[(int)slot] == Time.frameCount;
+            if (slot != GamepadSlot.All)
+                return s_GamepadsConnectedFrames[(int)slot] == Time.frameCount;
 
-	        foreach (var frame in s_GamepadsConnectedFrames)
-	        {
-		        if (frame != Time.frameCount)
-			        return false;
-	        }
+            foreach (var frame in s_GamepadsConnectedFrames)
+            {
+                if (frame != Time.frameCount)
+                    return false;
+            }
 
-	        return true;
+            return true;
         }
 
         /// <summary>
@@ -1505,16 +1506,16 @@ namespace UnityEngine.InputSystem.HighLevel
         /// </remarks>
         public static bool DidGamepadDisconnectThisFrame(GamepadSlot slot)
         {
-	        if (slot != GamepadSlot.All) 
-		        return s_GamepadsDisconnectedFrames[(int)slot] == Time.frameCount;
+            if (slot != GamepadSlot.All)
+                return s_GamepadsDisconnectedFrames[(int)slot] == Time.frameCount;
 
-	        foreach (var frame in s_GamepadsDisconnectedFrames)
-	        {
-		        if (frame != Time.frameCount)
-			        return false;
-	        }
+            foreach (var frame in s_GamepadsDisconnectedFrames)
+            {
+                if (frame != Time.frameCount)
+                    return false;
+            }
 
-	        return true;
+            return true;
         }
 
         private static float GetGamepadTriggerPressPoint(GamepadSlot gamepadSlot)
@@ -1632,7 +1633,7 @@ namespace UnityEngine.InputSystem.HighLevel
             }
         }
 
-#if UNITY_EDITOR && UNITY_2020_2_OR_NEWER
+#if UNITY_EDITOR
         internal struct InputSystemPlayerLoopHighLevelTimeUpdate{}
         internal struct InputSystemPlayerLoopHighLevelEndFrame{}
 #endif
@@ -1640,13 +1641,11 @@ namespace UnityEngine.InputSystem.HighLevel
         /// <summary>
         /// Initialize the API
         /// </summary>
-        /// <param name="defaultGlobalActionsPath">The file path to read default global actions from.</param>
-        /// <param name="globalActionsAssetPath">The path to the asset in the asset database containing global actions.</param>
         /// <remarks>
         /// If this is the first time global actions have been initialized, a default set of actions is read from the inputactions
         /// file located at 'defaultGlobalActionsPath' and saved into the asset located at 'globalActionsAssetPath' as sub assets.
         /// </remarks>
-        internal static void Initialize(string defaultGlobalActionsPath, string globalActionsAssetPath)
+        internal static void Initialize()
         {
             for (var i = 0; i < maxGamepadSlots; i++)
             {
@@ -1676,7 +1675,7 @@ namespace UnityEngine.InputSystem.HighLevel
                 AddJoystickToFirstFreeSlot(joystick);
             }
 
-#if UNITY_EDITOR && UNITY_2020_2_OR_NEWER
+#if UNITY_EDITOR
             // To support DidGamepadConnectThisFrame and DidGamepadDisconnectThisFrame, we make use of Time.frameCount
             // to record what frame a device was connected or disconnected on. A problem with this is that in the editor,
             // device connected events can come from an editor update that happens before Time.frameCount has been
@@ -1705,8 +1704,6 @@ namespace UnityEngine.InputSystem.HighLevel
             s_ScrollAction.AddBinding("<Mouse>/scroll");
             s_ScrollAction.performed += OnMouseScrolled;
             s_ScrollAction.Enable();
-
-			InitializeGlobalActions(defaultGlobalActionsPath, globalActionsAssetPath);
         }
 
         internal static void Shutdown()
@@ -1728,7 +1725,7 @@ namespace UnityEngine.InputSystem.HighLevel
             InputSystem.onDeviceChange -= OnDeviceChange;
 
             ShutdownGlobalActions();
-		}
+        }
 
         private static void OnPointerMoved(InputAction.CallbackContext context)
         {
@@ -1763,7 +1760,7 @@ namespace UnityEngine.InputSystem.HighLevel
                 if (s_Gamepads[i] != null) continue;
 
                 var frameCount = Time.frameCount;
-#if UNITY_EDITOR && UNITY_2020_2_OR_NEWER
+#if UNITY_EDITOR
                 if (!s_TimeHasUpdatedThisFrame)
                     frameCount += 1;
 #endif
@@ -1782,7 +1779,7 @@ namespace UnityEngine.InputSystem.HighLevel
                 s_Gamepads[i] = null;
 
                 var frameCount = Time.frameCount;
-#if UNITY_EDITOR && UNITY_2020_2_OR_NEWER
+#if UNITY_EDITOR
                 if (!s_TimeHasUpdatedThisFrame)
                     frameCount += 1;
 #endif
@@ -1815,3 +1812,4 @@ namespace UnityEngine.InputSystem.HighLevel
         }
     }
 }
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/GlobalActions.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/GlobalActions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c27086ecfe4b4e34bb914c5559a20082
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/GlobalActions/GlobalActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/GlobalActions/GlobalActionsAsset.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEngine.InputSystem.Utilities;
+
+namespace UnityEngine.InputSystem.Editor
+{
+	internal static class GlobalActionsAsset
+	{
+		internal const string kDefaultGlobalActionsPath = "Packages/com.unity.inputsystem/InputSystem/API/GlobalInputActions.inputactions";
+		internal const string kGlobalActionsAssetPath = "ProjectSettings/InputManager.asset";
+		internal const string kGlobalActionsAssetName = "GlobalInputActions";
+
+		internal static InputActionAsset GetOrCreateGlobalActionsAsset(string assetPath = kGlobalActionsAssetPath, 
+			string templateAssetPath = kDefaultGlobalActionsPath)
+		{
+			var objects = AssetDatabase.LoadAllAssetsAtPath(assetPath);
+			if (objects == null)
+				throw new InvalidOperationException("Couldn't load global input system actions because the InputManager.asset file is missing or corrupt.");
+
+			var globalInputActionsAsset = objects.FirstOrDefault(o => o != null && o.name == kGlobalActionsAssetName) as InputActionAsset;
+			if (globalInputActionsAsset != null)
+				return globalInputActionsAsset;
+
+			var json = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, templateAssetPath));
+
+			var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+			asset.LoadFromJson(json);
+			asset.name = kGlobalActionsAssetName;
+
+			AssetDatabase.AddObjectToAsset(asset, assetPath);
+
+			// Make sure all the elements in the asset have GUIDs and that they are indeed unique.
+			var maps = asset.actionMaps;
+			foreach (var map in maps)
+			{
+				// Make sure action map has GUID.
+				if (string.IsNullOrEmpty(map.m_Id) || asset.actionMaps.Count(x => x.m_Id == map.m_Id) > 1)
+					map.GenerateId();
+
+				// Make sure all actions have GUIDs.
+				foreach (var action in map.actions)
+				{
+					var actionId = action.m_Id;
+					if (string.IsNullOrEmpty(actionId) || asset.actionMaps.Sum(m => m.actions.Count(a => a.m_Id == actionId)) > 1)
+						action.GenerateId();
+				}
+
+				// Make sure all bindings have GUIDs.
+				for (var i = 0; i < map.m_Bindings.LengthSafe(); ++i)
+				{
+					var bindingId = map.m_Bindings[i].m_Id;
+					if (string.IsNullOrEmpty(bindingId) || asset.actionMaps.Sum(m => m.bindings.Count(b => b.m_Id == bindingId)) > 1)
+						map.m_Bindings[i].GenerateId();
+				}
+			}
+
+			// Create sub-asset for each action. This is so that users can select individual input actions from the asset when they're
+			// trying to assign to a field that accepts only one action.
+			foreach (var map in maps)
+			{
+				foreach (var action in map.actions)
+				{
+					var actionReference = ScriptableObject.CreateInstance<InputActionReference>();
+					actionReference.Set(action);
+					AssetDatabase.AddObjectToAsset(actionReference, asset);
+				}
+			}
+
+			AssetDatabase.SaveAssets();
+			return asset;
+		}
+	}
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/GlobalActions/GlobalActionsAsset.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/GlobalActions/GlobalActionsAsset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3643093dd7fc8e6419c50fd217f5e71d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -661,11 +661,30 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// TODO:
+        /// Disable the high level API, including global actions.
         /// </summary>
-        public InputActionAsset globalInputActionsAsset { get; set; }
+        /// <remarks>
+        /// The high-level API (everything under the <see cref="UnityEngine.InputSystem.HighLevel.Input"/>
+        /// class) which includes the global actions functionality does take a very small amount of
+        /// processing time, so if it is not being used, turning it off can win back a small amount of
+        /// performance for free.
+        /// 
+        /// Note that setting this at runtime after the high-level API has already been initialized doesn't
+        /// cause the high-level API to initialize or shutdown. It must be set in the editor on a custom
+        /// <see cref="InputSettings"/> asset.
+        /// </remarks>
+        public bool disableHighLevelAPI
+        {
+	        get => m_DisableHighLevelApi;
+	        set
+	        {
+		        if (m_DisableHighLevelApi == value)
+			        return;
 
-        public bool disableGlobalInputActions { get; set; }
+		        m_DisableHighLevelApi = value;
+                OnChange();
+	        }
+        }
 
         /// <summary>
         /// Improves shortcut key support by making composite controls consume control input
@@ -760,9 +779,11 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
         [SerializeField] private bool m_DisableRedundantEventsMerging = false;
         [SerializeField] private bool m_ShortcutKeysConsumeInputs = false; // This is the shortcut support from v1.4. Temporarily moved here as an opt-in feature, while it's issues are investigated.
+        [SerializeField] private bool m_DisableHighLevelApi = false;
+        [SerializeField] private InputActionAsset m_GlobalInputActionsAsset;
 
         [NonSerialized] internal HashSet<string> m_FeatureFlags;
-
+        
         internal bool IsFeatureEnabled(string featureName)
         {
             return m_FeatureFlags != null && m_FeatureFlags.Contains(featureName.ToUpperInvariant());

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3388,7 +3388,7 @@ namespace UnityEngine.InputSystem
                     s_SystemObject.settings = JsonUtility.ToJson(settings);
                     s_SystemObject.exitEditModeTime = InputRuntime.s_Instance.currentTime;
                     s_SystemObject.enterPlayModeTime = 0;
-                    HighLevel.Input.Initialize();
+                    HighLevel.Input.Initialize(s_DefaultGlobalActionsPath, s_GlobalActionsAssetPath);
                     break;
 
                 case PlayModeStateChange.EnteredPlayMode:
@@ -3495,7 +3495,7 @@ namespace UnityEngine.InputSystem
             s_Manager.Initialize(runtime ?? NativeInputRuntime.instance, settings);
 
             // TODO: Processing for the high level API isn't free, so allow users to turn it off if they're not using it via input settings and check here.
-            HighLevel.Input.Initialize();
+            HighLevel.Input.Initialize(s_DefaultGlobalActionsPath, s_GlobalActionsAssetPath);
 
 #if !UNITY_DISABLE_DEFAULT_INPUT_PLUGIN_INITIALIZATION
             PerformDefaultPluginInitialization();
@@ -3510,7 +3510,7 @@ namespace UnityEngine.InputSystem
 
 #endif // UNITY_EDITOR
 
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void RunInitialUpdate()
         {
             // Request an initial Update so that user methods such as Start and Awake
@@ -3612,7 +3612,7 @@ namespace UnityEngine.InputSystem
             s_Manager = new InputManager();
             s_Manager.Initialize(runtime ?? NativeInputRuntime.instance, settings);
 
-            HighLevel.Input.Initialize();
+            HighLevel.Input.Initialize(s_DefaultGlobalActionsPath, s_GlobalActionsAssetPath); 
 
             s_Manager.m_Runtime.onPlayModeChanged = OnPlayModeChange;
             s_Manager.m_Runtime.onProjectChange = OnProjectChange;
@@ -3777,6 +3777,13 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        internal static void SetGlobalActionAssetPaths(string defaultAssetPath, string assetPath)
+        {
+	        s_DefaultGlobalActionsPath = defaultAssetPath;
+	        s_GlobalActionsAssetPath = assetPath;
+        }
 #endif
-    }
+	    private static string s_DefaultGlobalActionsPath = GlobalActionsAsset.kDefaultGlobalActionsPath;
+	    private static string s_GlobalActionsAssetPath = GlobalActionsAsset.kGlobalActionsAssetPath;
+	}
 }

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -90,6 +90,10 @@ namespace UnityEngine.InputSystem
 
                 runtime = new InputTestRuntime();
 
+                // we want to run most tests without the high level API being enabled because it interferes with
+                // global states. The specific high level tests will re-enable this flag
+                InputSystem.settings.disableHighLevelAPI = true;
+
                 // Push current input system state on stack.
                 InputSystem.SaveAndReset(enableRemoting: false, runtime: runtime);
 


### PR DESCRIPTION
Global actions are copied into the InputManager.asset file on startup if they do not already exist. 