### PR TITLE
CHANGE: Replaced XR layout builder logic to create Axis2D inputs as Stick controls

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -40,6 +40,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Changed define requirements of `Unity.InputSystem.TestFramework`, so that it can be used by other packages without setting the `com.unity.inputsystem` package to be testable in the project manifest.
+- Changed XR Layout build behavior to create Axis2D control devices with `StickControl` type instead of `Vector2Control`.
 
 ## [1.4.4] - 2022-11-01
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,9 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed InputAction.bindings.count not getting correctly updated after removing bindings with Erase().
 - Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-19480)).
 
+### Changed
+- Changed XR Layout build behavior to create Axis2D control devices with `StickControl` type instead of `Vector2Control`.
+
 ## [1.5.0] - 2023-01-24
 
 ### Added
@@ -40,7 +43,6 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Changed define requirements of `Unity.InputSystem.TestFramework`, so that it can be used by other packages without setting the `com.unity.inputsystem` package to be testable in the project manifest.
-- Changed XR Layout build behavior to create Axis2D control devices with `StickControl` type instead of `Vector2Control`.
 
 ## [1.4.4] - 2022-11-01
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
@@ -282,7 +282,7 @@ namespace UnityEngine.InputSystem.XR
                     case FeatureType.Axis2D:
                     {
                         builder.AddControl(featureName)
-                            .WithLayout("Vector2")
+                            .WithLayout("Stick")
                             .WithByteOffset(currentOffset)
                             .WithFormat(InputStateBlock.FormatVector2)
                             .WithUsages(currentUsages);


### PR DESCRIPTION
### Description

Modifies the XR layout builder logic to add inputs of type Axis2D as Stick controls, instead of Vector2 by default. This enhances functionality for XR controller with additional uses as D-pad, horizontal and vertical axes.

### Changes made

XRLayoutBuilder: When a XR Axis2D controller is added to the device layout, replaced layout type "Vector2" with "Stick".

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
