### PR TITLE
FIX: Fix for the event buffer growing unbounded in Editor when a cont…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed unclosed profiler marker in `InvokeCallbacksSafe_AnyCallbackReturnsTrue` which would lead to eventually broken profiler traces in some cases like using `PlayerInput` (case ISXB-393).
+- Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://jira.unity3d.com/browse/UUM-19480)).
 
 ## [1.5.0] - 2023-01-24
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,7 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed unclosed profiler marker in `InvokeCallbacksSafe_AnyCallbackReturnsTrue` which would lead to eventually broken profiler traces in some cases like using `PlayerInput` (case ISXB-393).
-- Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://jira.unity3d.com/browse/UUM-19480)).
+- Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-19480)).
 
 ## [1.5.0] - 2023-01-24
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2882,16 +2882,16 @@ namespace UnityEngine.InputSystem
                 );
 
 
-	    bool dropStatusEvents = false;
+            bool dropStatusEvents = false;
 
 #if UNITY_EDITOR
-	    if (!gameIsPlaying && gameShouldGetInputRegardlessOfFocus && (eventBuffer.sizeInBytes > (100*1024)))
-	    {
-		// If the game is not playing but we're sending all input events to the game, the buffer can just grow unbounded.
-		// So, in that case, set a flag to say we'd like to drop status events, and do not early out.
-		canEarlyOut = false;
-		dropStatusEvents = true;
-	    }
+            if (!gameIsPlaying && gameShouldGetInputRegardlessOfFocus && (eventBuffer.sizeInBytes > (100 * 1024)))
+            {
+                // If the game is not playing but we're sending all input events to the game, the buffer can just grow unbounded.
+                // So, in that case, set a flag to say we'd like to drop status events, and do not early out.
+                canEarlyOut = false;
+                dropStatusEvents = true;
+            }
 #endif
 
             if (canEarlyOut)
@@ -2966,16 +2966,16 @@ namespace UnityEngine.InputSystem
                     var currentEventType = currentEventReadPtr->type;
 
 #if UNITY_EDITOR
-		    if (dropStatusEvents)
-		    {
-			// If the type here is a status event, ask advance not to leave the event in the buffer.  Otherwise, leave it there.
-			if (currentEventType == StateEvent.Type || currentEventType == DeltaStateEvent.Type || currentEventType == IMECompositionEvent.Type)
-				m_InputEventStream.Advance(false);
-			else
-				m_InputEventStream.Advance(true);
+                    if (dropStatusEvents)
+                    {
+                        // If the type here is a status event, ask advance not to leave the event in the buffer.  Otherwise, leave it there.
+                        if (currentEventType == StateEvent.Type || currentEventType == DeltaStateEvent.Type || currentEventType == IMECompositionEvent.Type)
+                            m_InputEventStream.Advance(false);
+                        else
+                            m_InputEventStream.Advance(true);
 
-			continue;
-		    }
+                        continue;
+                    }
 #endif
 
                     // In the editor, we discard all input events that occur in-between exiting edit mode and having


### PR DESCRIPTION
…roller is connected and certain options are set.

### Description

Fix for bug https://jira.unity3d.com/browse/UUM-19480 - PS4 Controller causes large CPU lag spikes when connected under certain settings.

The status events received by the Editor are just being kept in the buffer used to pass events into managed code.  As more status events come in, the buffer grows, reallocating and copying the existing events into the new buffer (which is slow as the buffer reaches 50+MB after a few minutes).

### Changes made

When the buffer containing events is passed into managed code, if the settings are causing the buffer to grow (“Background Behaviour” is set to “Ignore Focus” and “Play Mode Input Behaviour” is set to “All Device Input Always Goes To Game View”) then we check the buffer size.  Usually the managed code update would early out and leave events in the buffer at this point, but now when the buffer is larger than 100kB (slightly arbitrary, chosen based on a suggestion that the buffer should not be getting this big) then we will run through the buffer and drop any status events.

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [X] ~~Tests added/changed, if applicable.~~
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [X] ~~Docs for new/changed API's.~~
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
