### PR TITLE
FIX: InputAction.bindings.count is not updated after calling Erase()

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -3609,6 +3609,40 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_CanRemoveBindingsFromActions()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var action = new InputAction();
+
+        action.AddBinding("<Gamepad>/leftStick");
+        action.AddBinding("<Gamepad>/rightStick");
+
+        action.AddCompositeBinding("OneModifier")
+            .With("Modifier", "<Keyboard>/Control")
+            .With("Button", "<Keyboard>/a");
+
+        // Total number of bindings should be 5: 2 normal bindings and 3 from the composite
+        // bindings
+        Assert.That(action.bindings, Has.Count.EqualTo(5));
+
+        // Since we have a composite bindings, all bindings will be removed at once
+        action.ChangeBinding(2).Erase();
+        Assert.That(action.bindings, Has.Count.EqualTo(2));
+
+        // Remove all remaining bindings
+        action.ChangeBinding(0).Erase();
+        action.ChangeBinding(0).Erase();
+        Assert.That(action.bindings, Has.Count.EqualTo(0));
+
+        // Add a binding to be removed
+        action.AddBinding("<Gamepad>/rightStick");
+        Assert.That(action.bindings, Has.Count.EqualTo(1));
+        action.ChangeBinding(0).Erase();
+        Assert.That(action.bindings, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_CanAddBindingsToActions_ToExistingComposite()
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,8 +11,8 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased]
 
 ### Fixed
-
 - Fixed unclosed profiler marker in `InvokeCallbacksSafe_AnyCallbackReturnsTrue` which would lead to eventually broken profiler traces in some cases like using `PlayerInput` (case ISXB-393).
+- Fixed InputAction.bindings.count not getting correctly updated after removing bindings with Erase().
 
 ## [1.5.0] - 2023-01-24
 
@@ -81,7 +81,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed DualSense low frequency motor speed being always set to min value.
 - Fixed an issue where `ReadUnprocessedValueFromState` in PoseControl always returning default values.
 - Fix Player 1's UI controls stop working after second player joins ([case ISXB-125](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-125)))
-
 
 ## [1.4.1] - 2022-05-30
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -803,7 +803,7 @@ namespace UnityEngine.InputSystem
             if (bindingIndexInMap == -1)
                 return default;
 
-            return new BindingSyntax(actionMap, bindingIndexInMap);
+            return new BindingSyntax(actionMap, bindingIndexInMap, action);
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs
@@ -1576,9 +1576,12 @@ namespace UnityEngine.InputSystem
                 if (isComposite)
                 {
                     while (m_BindingIndexInMap < m_ActionMap.m_Bindings.LengthSafe() && m_ActionMap.m_Bindings[m_BindingIndexInMap].isPartOfComposite)
+                    {
                         ArrayHelpers.EraseAt(ref m_ActionMap.m_Bindings, m_BindingIndexInMap);
+                    }
                 }
 
+                m_Action.m_BindingsCount = m_ActionMap.m_Bindings.LengthSafe();
                 m_ActionMap.OnBindingModified();
 
                 // We have switched to a different binding array. For singleton actions, we need to


### PR DESCRIPTION
### Description

This fixes `InputAction.bindings.count` not getting correctly updated after removing bindings with `Erase()`.

### Changes made

The [`Erase()`](https://github.com/Unity-Technologies/InputSystem/blob/3f0a6150fa13ee6d21a1220ebe68f5f21d666eef/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionSetupExtensions.cs#L1567-L1591) function didn't update `m_Action.m_BindingsCount` when a bindings were removed, and now it does.






