### PR TITLE
FIX: JSON Binding overrides are set to empty string when null

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed InputAction.bindings.count not getting correctly updated after removing bindings with Erase().
 - Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-19480)).
 - Fixed issue leading to a stack overflow crash during device initialization in `InsertControlBitRangeNode` (case ISXB-405).
+- Fixed the issue where saving and loading override bindings to JSON would set unassigned overrides (that were `null`) to assigned overrides (as an empty string `""`).
 
 ## [1.5.0] - 2023-01-24
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1463,15 +1463,25 @@ namespace UnityEngine.InputSystem
             public string interactions;
             public string processors;
 
-            public static BindingOverrideJson FromBinding(InputBinding binding)
+            public static BindingOverrideJson FromBinding(InputBinding binding, InputAction bindingAction = null)
             {
                 return new BindingOverrideJson
                 {
-                    action = binding.action,
-                    id = binding.m_Id,
-                    path = binding.overridePath,
-                    interactions = binding.overrideInteractions,
-                    processors = binding.overrideProcessors,
+                    action = bindingAction != null && !bindingAction.isSingletonAction ? $"{bindingAction.actionMap.name}/{bindingAction.name}" : "",
+                    id = binding.id.ToString() ,
+                    path = binding.overridePath ?? "null",
+                    interactions = binding.overrideInteractions ?? "null",
+                    processors = binding.overrideProcessors ?? "null"
+                };
+            }
+
+            public static InputBinding ToBinding(BindingOverrideJson bindingOverride)
+            {
+                return new InputBinding
+                {
+                    overridePath = bindingOverride.path != "null" ? bindingOverride.path : null,
+                    overrideInteractions = bindingOverride.interactions != "null" ? bindingOverride.interactions : null,
+                    overrideProcessors = bindingOverride.processors != "null" ? bindingOverride.processors : null,
                 };
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -891,7 +891,6 @@ namespace UnityEngine.InputSystem
             if (overrides == null)
                 throw new ArgumentNullException(nameof(overrides));
 
-
             foreach (var binding in overrides)
                 ApplyBindingOverride(actionMap, binding);
         }
@@ -902,7 +901,6 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentNullException(nameof(actionMap));
             if (overrides == null)
                 throw new ArgumentNullException(nameof(overrides));
-
 
             foreach (var binding in overrides)
                 RemoveBindingOverride(actionMap, binding);
@@ -1145,14 +1143,7 @@ namespace UnityEngine.InputSystem
             if (action == null)
                 action = actions.FindAction(binding.action);
 
-            var @override = new InputActionMap.BindingOverrideJson
-            {
-                action = action != null && !action.isSingletonAction ? $"{action.actionMap.name}/{action.name}" : null,
-                id = binding.id.ToString(),
-                path = binding.overridePath,
-                interactions = binding.overrideInteractions,
-                processors = binding.overrideProcessors
-            };
+            var @override = InputActionMap.BindingOverrideJson.FromBinding(binding, action);
 
             list.Add(@override);
         }
@@ -1262,16 +1253,10 @@ namespace UnityEngine.InputSystem
                     var bindingIndex = actions.FindBinding(new InputBinding { m_Id = entry.id }, out var action);
                     if (bindingIndex != -1)
                     {
-                        action.ApplyBindingOverride(bindingIndex, new InputBinding
-                        {
-                            overridePath = entry.path,
-                            overrideInteractions = entry.interactions,
-                            overrideProcessors = entry.processors,
-                        });
+                        action.ApplyBindingOverride(bindingIndex, InputActionMap.BindingOverrideJson.ToBinding(entry));
                         continue;
                     }
                 }
-
                 Debug.LogWarning("Could not override binding as no existing binding was found with the id: " + entry.id);
             }
         }


### PR DESCRIPTION
### Description

When saving unsigned binding overrides (with `null` value) they were being set as empty strings "" when loading from JSON. The JsonUtility class seems to set `null` overrides to an empty string `""` when loading JSON data.

### Changes made

`BindingOverrideJson` now serializes `null` overrides with "null" strings when saving, and assignes `null` for "null" strings when loading.
An alternative would be to add `bool` values for all the override values to check if the values were set on not. However, it felt that we could use the existing fields to disambiguate the data without adding flags to the JSON structure. Happy to discuss if there are downsides to my approach.





