### PR TITLE
Fix device disconnects being missed on console platforms while running in the background

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed unclosed profiler marker in `InvokeCallbacksSafe_AnyCallbackReturnsTrue` which would lead to eventually broken profiler traces in some cases like using `PlayerInput` (case ISXB-393).
 - Fixed InputAction.bindings.count not getting correctly updated after removing bindings with Erase().
 - Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-19480)).
+- Fixed run in background issue on multiple consoles where device disconnect events were being missed by the input system while the app was in the background. This would result in multiple devices being added to the input system for the same physical device([case UUM-6744](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744)).
 
 ## [1.5.0] - 2023-01-24
 

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -228,10 +228,15 @@ namespace UnityEngine.InputSystem.LowLevel
         public float unscaledGameTime => Time.unscaledTime;
 
         public bool runInBackground => Application.runInBackground ||
-        // certain platforms ignore the runInBackground flag and always run. Make sure we're
-        // not running on one of those.
+        // certain platforms ignore the runInBackground flag and pump updates even if it is set to false. If we're
+        // running on one of those, just force the runInBackground flag to true. If we ever add a native flag like
+        // ignoresRunInBackground or something similar, we can check that here and remove the specific platform checks.
+        // https://issuetracker.unity3d.com/issues/ps5-inputsystem-devices-are-not-removed-properly-when-pad-turned-off-with-application-in-background
         // TODO: Add more platforms here as they're discovered.
-        Application.platform == RuntimePlatform.PS5;
+        Application.platform == RuntimePlatform.PS5 ||
+        Application.platform == RuntimePlatform.PS4 ||
+        Application.platform == RuntimePlatform.GameCoreXboxOne ||
+        Application.platform == RuntimePlatform.GameCoreXboxSeries;
 
         private Action m_ShutdownMethod;
         private InputUpdateDelegate m_OnUpdate;


### PR DESCRIPTION
### Description

Certain platforms ignore the runInBackground flag. If a device disconnect event occurs while the app is in the background on one of those platforms, the input system will discard the event, and the device instance will stay in memory.

### Changes made

Forced the input system to ignore the runInBackground flag in managed code on the troublesome platforms.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
