### PR TITLE
FIX: Fix breaking changes from ISBX-110

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1463,16 +1463,21 @@ namespace UnityEngine.InputSystem
             public string interactions;
             public string processors;
 
-            public static BindingOverrideJson FromBinding(InputBinding binding, InputAction bindingAction = null)
+            public static BindingOverrideJson FromBinding(InputBinding binding, string actionName)
             {
                 return new BindingOverrideJson
                 {
-                    action = bindingAction != null && !bindingAction.isSingletonAction ? $"{bindingAction.actionMap.name}/{bindingAction.name}" : "",
+                    action = actionName,
                     id = binding.id.ToString() ,
                     path = binding.overridePath ?? "null",
                     interactions = binding.overrideInteractions ?? "null",
                     processors = binding.overrideProcessors ?? "null"
                 };
+            }
+
+            public static BindingOverrideJson FromBinding(InputBinding binding)
+            {
+                return FromBinding(binding, binding.action);
             }
 
             public static InputBinding ToBinding(BindingOverrideJson bindingOverride)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionRebindingExtensions.cs
@@ -1143,7 +1143,8 @@ namespace UnityEngine.InputSystem
             if (action == null)
                 action = actions.FindAction(binding.action);
 
-            var @override = InputActionMap.BindingOverrideJson.FromBinding(binding, action);
+            string actionName = action != null && !action.isSingletonAction ? $"{action.actionMap.name}/{action.name}" : "";
+            var @override = InputActionMap.BindingOverrideJson.FromBinding(binding, actionName);
 
             list.Add(@override);
         }


### PR DESCRIPTION
### Description

Fixes breaking changes introduced by #1651 (thanks @andrew-oc for pointing it out!)

### Changes made

Adds a new overloading method for `FromBinding()`, keeping the old one to avoid breaking changes.



