### PR TITLE
FIX: Allow setting background behavior UI regardless of Run In Background (UUM-21955)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where connecting a gamepad in the editor with certain settings will cause memory and performance to degrade ([case UUM-19480](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-19480)).
 - Fixed issue leading to a stack overflow crash during device initialization in `InsertControlBitRangeNode` (case ISXB-405).
 - Fixed the issue where saving and loading override bindings to JSON would set unassigned overrides (that were `null`) to assigned overrides (as an empty string `""`).
+- Allow Input Package settings menu to select Background Behavior regardless of the setting "Run in Background". This is useful for XR where the "Run in Background" isn't available ([case UUM-21955](https://issuetracker.unity3d.com/issues/quest-head-tracking-freezes-when-pausing-the-app)).
 
 ## [1.5.0] - 2023-01-24
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -98,11 +98,7 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUI.BeginChangeCheck();
 
                 EditorGUILayout.PropertyField(m_UpdateMode, m_UpdateModeContent);
-                var runInBackground = Application.runInBackground;
-                using (new EditorGUI.DisabledScope(!runInBackground))
-                    EditorGUILayout.PropertyField(m_BackgroundBehavior, m_BackgroundBehaviorContent);
-                if (!runInBackground)
-                    EditorGUILayout.HelpBox("Focus change behavior can only be changed if 'Run In Background' is enabled in Player Settings.", MessageType.Info);
+                EditorGUILayout.PropertyField(m_BackgroundBehavior, m_BackgroundBehaviorContent);
 
                 EditorGUILayout.Space();
                 EditorGUILayout.PropertyField(m_CompensateForScreenOrientation, m_CompensateForScreenOrientationContent);
@@ -293,7 +289,7 @@ namespace UnityEngine.InputSystem.Editor
                 + "'Reset And Disable All Devices' soft-resets and disables *all* devices while the application does not have focus. No device will receive input while the application "
                 + "is running in the background.\n"
                 + "'Ignore Focus' leaves all devices untouched when application focus changes. While running in the background, all input that is received is processed as if "
-                + "running in the foreground.");
+                + "running in the foreground.\n\n");
             m_EditorInputBehaviorInPlayModeContent = new GUIContent("Play Mode Input Behavior", "When in play mode, determines how focus of the Game View is handled with respect to input.\n\n"
                 + "'Pointers And Keyboards Respect Game View Focus' requires Game View focus only for pointers (mice, touch, etc.) and keyboards. Other devices will feed input to the game regardless "
                 + "of whether the Game View is focused or not. Note that this means that input on these devices is not visible in other EditorWindows.\n"


### PR DESCRIPTION
### Description

This makes sure that `IgnoreFocus` can be set to Background Behavior on the Input Package settings UI, without having to have "Run In Background" enabled in the Player settings.

It complements #1521 where we made sure `IgnoreFocus` could work around the fact that there is no way to enable "Run in Background" on Android's Player Settings. This has an impact on XR where the headset tracking freezes when the application goes out of focus (e.g., the application is paused).


### Changes made

Removed the guard to enable the selection of the Background Behavior dropdown menu.





