### PR TITLE
FIX: Allow InputSystem class to set runtime runInBackground field

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 - Added `InputSystem.customBindingPathValidators` interface to allow showing warnings in the `InputAsset` Editor for specific InputBindings and draw custom UI in the properties panel.
+- Added `InputSystem.runInBackground` to be used internally by specific platforms packages. Allows telling the input system that a specific platform runs in background. It allows fixing of [case UUM-6744](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744).
 
 ## [1.5.1] - 2023-03-15
 

--- a/Packages/com.unity.inputsystem/Documentation~/filter.yml
+++ b/Packages/com.unity.inputsystem/Documentation~/filter.yml
@@ -37,3 +37,6 @@ apiRules:
   - exclude:
       uidRegex: ^UnityEngine\.InputSystem\.Samples\..*$
       type: Namespace
+  - exclude:
+      uidRegex: ^UnityEngine\.InputSystem\.InputSystem\.runInBackground$
+      type: Member

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -170,7 +170,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// </summary>
         double currentTimeOffsetToRealtimeSinceStartup { get; }
 
-        bool runInBackground { get; }
+        bool runInBackground { get; set; }
 
         Vector2 screenSize { get; }
         ScreenOrientation screenOrientation { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.Haptics;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.Controls;
@@ -74,10 +75,12 @@ namespace UnityEngine.InputSystem
     /// be called on the main thread. However, select APIs like <see cref="QueueEvent"/> can be
     /// called from threads. Where this is the case, it is stated in the documentation.
     /// </remarks>
+
     [SuppressMessage("Microsoft.Naming", "CA1724:TypeNamesShouldNotMatchNamespaces", Justification = "Options for namespaces are limited due to the legacy input class. Agreed on this as the least bad solution.")]
 #if UNITY_EDITOR
     [InitializeOnLoad]
 #endif
+
     public static partial class InputSystem
     {
         #region Layouts
@@ -3280,7 +3283,7 @@ namespace UnityEngine.InputSystem
         public static Version version => new Version(kAssemblyVersion);
 
         /// <summary>
-        /// Allows setting the player to run in the background.
+        /// Property for internal use that allows setting the player to run in the background.
         /// </summary>
         /// <remarks>
         /// Some platforms don't care about <see cref="Application.runInBackground"/> and for those we need to

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3279,6 +3279,20 @@ namespace UnityEngine.InputSystem
         /// <value>Current version of the input system.</value>
         public static Version version => new Version(kAssemblyVersion);
 
+        /// <summary>
+        /// Allows setting the player to run in the background.
+        /// </summary>
+        /// <remarks>
+        /// Some platforms don't care about <see cref="Application.runInBackground"/> and for those we need to
+        /// enable it manually through this propriety.
+        /// </remarks>
+        /// <param name="value">The boolean value to set to <see cref="NativeInputRuntime.runInBackground"/></param>
+        public static bool runInBackground
+        {
+            get => s_Manager.m_Runtime.runInBackground;
+            set => s_Manager.m_Runtime.runInBackground = value;
+        }
+
         ////REVIEW: restrict metrics to editor and development builds?
         /// <summary>
         /// Get various up-to-date metrics about the input system.

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -227,11 +227,17 @@ namespace UnityEngine.InputSystem.LowLevel
         public double currentTimeOffsetToRealtimeSinceStartup => NativeInputSystem.currentTimeOffsetToRealtimeSinceStartup;
         public float unscaledGameTime => Time.unscaledTime;
 
-        public bool runInBackground => Application.runInBackground ||
-        // certain platforms ignore the runInBackground flag and always run. Make sure we're
-        // not running on one of those.
-        // TODO: Add more platforms here as they're discovered.
-        Application.platform == RuntimePlatform.PS5;
+        public bool runInBackground
+        {
+            get =>
+                Application.runInBackground ||
+                // certain platforms ignore the runInBackground flag and always run. Make sure we're
+                // not running on one of those and set the values when running on specific platforms.
+                m_RunInBackground;
+            set => m_RunInBackground = value;
+        }
+
+        bool m_RunInBackground;
 
         private Action m_ShutdownMethod;
         private InputUpdateDelegate m_OnUpdate;


### PR DESCRIPTION
### Description

Some platforms' background behavior isn't reflected in `Application.runInBackground`. This PR exposes `InputSystem.runInBackground` to be called by those particular platforms to tell the Input System that the platform runs in the background.

It should be considered for "internal use" only even though it is part of the public API.

Context: This is the alternative for the rejected PR #1648. Specific platforms can call this API as they wish, otherwise, we rely on `Application.runInBackground` set in the Editor settings for platforms that allow being run in the background.


- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
