### PR TITLE
FIX: Potential NullReferenceException in UnregisterCallbacks()

### DIFF
--- a/Assets/Samples/InGameHints/InGameHintsActions.cs
+++ b/Assets/Samples/InGameHints/InGameHintsActions.cs
@@ -373,6 +373,7 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
 
             private void UnregisterCallbacks(IGameplayActions instance)
             {
+                if (instance == null) return;
                 @Move.started -= instance.OnMove;
                 @Move.performed -= instance.OnMove;
                 @Move.canceled -= instance.OnMove;

--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -258,6 +258,7 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
 
         private void UnregisterCallbacks(IGameplayActions instance)
         {
+            if (instance == null) return;
             @fire.started -= instance.OnFire;
             @fire.performed -= instance.OnFire;
             @fire.canceled -= instance.OnFire;

--- a/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
+++ b/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
@@ -166,6 +166,7 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
 
         private void UnregisterCallbacks(IGameplayActions instance)
         {
+            if (instance == null) return;
             @action1.started -= instance.OnAction1;
             @action1.performed -= instance.OnAction1;
             @action1.canceled -= instance.OnAction1;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,9 @@ however, it has to be formatted properly to pass verification tests.
 - Added `InputSystem.customBindingPathValidators` interface to allow showing warnings in the `InputAsset` Editor for specific InputBindings and draw custom UI in the properties panel.
 - Added `InputSystem.runInBackground` to be used internally by specific platforms packages. Allows telling the input system that a specific platform runs in background. It allows fixing of [case UUM-6744](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744).
 
+### Fixed
+- Fixed potential `NullReferenceException` when setting callbacks from the generated `InputActions` C# file.
+
 ## [1.5.1] - 2023-03-15
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -260,6 +260,8 @@ namespace UnityEngine.InputSystem.Editor
                 // UnregisterCallbacks method.
                 writer.WriteLine($"private void UnregisterCallbacks(I{mapTypeName} instance)");
                 writer.BeginBlock();
+
+                writer.WriteLine($"if (instance == null) return;");
                 foreach (var action in map.actions)
                 {
                     var actionName = CSharpCodeHelpers.MakeIdentifier(action.name);


### PR DESCRIPTION
### Description

A callback interface can get destroyed and lead to a missing reference within the `InputActions` callbacks list. If `SetCallbacks()` is called afterwards, it can attempt to unregister null entries within the list, leading to a `NullReferenceException`.

### Changes made

Added a null check at the top of `UnregisterCallbacks()`.
Ran unit tests and updated auto-generated code in the Unity project.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
