### PR TITLE
Add dispatch of navigation events for InputForUI

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -94,8 +94,9 @@ namespace InputSystem.Plugins.InputForUI
         {
             if (ctx.control.device is Keyboard)
             {
+                //TODO repeat rate
                 var keyboard = ctx.control.device as Keyboard;
-                EventProvider.Dispatch(Event.From(new NavigationEvent
+                DispatchFromCallback(Event.From(new NavigationEvent
                 {
                     type = NavigationEvent.Type.Move,
                     direction = keyboard.shiftKey.isPressed ? NavigationEvent.Direction.Previous : NavigationEvent.Direction.Next,
@@ -365,7 +366,6 @@ namespace InputSystem.Plugins.InputForUI
 
         private void OnSubmitPerformed(InputAction.CallbackContext ctx)
         {
-            // TODO repeat rate
             DispatchFromCallback(Event.From(new NavigationEvent
             {
                 type = NavigationEvent.Type.Submit,
@@ -379,7 +379,6 @@ namespace InputSystem.Plugins.InputForUI
 
         private void OnCancelPerformed(InputAction.CallbackContext ctx)
         {
-            // TODO repeat rate
             DispatchFromCallback(Event.From(new NavigationEvent
             {
                 type = NavigationEvent.Type.Cancel,


### PR DESCRIPTION
### Description

Dispatches `NavigationEvents` such as `Left`, `Right`, `Up`, `Down` for both Mouse and Keyboard, as they are part of the `_moveAction` setup by the default input actions asset.
`Next` and `Previous` currently are only setup for Keyboard, as there is not default action that has `tab` bindings. A new action was created for this.

### Notes

If this approach works and is good enough for now, I'll refactor the code a bit to avoid having less repetition for `NavigationEvents` in both `InputManagerProvider` (not part of this repository) and `InputSystemProvider`.


