### PR TITLE
InputForUI: Add repetition for Next/Previous navigation events

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -181,7 +181,7 @@ namespace InputSystem.Plugins.InputForUI
 
         private static int SortEvents(Event a, Event b)
         {
-            return Event.Compare(a, b);
+            return Event.CompareType(a, b);
         }
 
         public void OnFocusChanged(bool focus)


### PR DESCRIPTION
### Description

This PR allows dispatching repeated Next/Previous navigation events while a control is still pressed.

### Changes made

It removes the callbacks when the `_nextPreviousAction` is performed. 
The logic is now in `DirectionNavigation()` method running in every `Update()` call.

### Notes

⚠️ Depends on the latest commits from `trunk`
At the moment, it only detects Shift or Shift+Tab as Next/Previous bindings (same as #1667). A configuration to set up these bindings for the Input System is necessary. The Input Manager provides configuration for this.




