### PR TITLE
Adding generalized support for controller usages with the binding path dropdown. Added optional info blurb on the binding paths covered

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Layouts.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Layouts.cs
@@ -2548,6 +2548,43 @@ partial class CoreTests
 
     [Test]
     [Category("Layouts")]
+    public void Layouts_CanMatchControlPath()
+    {
+        const string jsonBase = @"
+            {
+                ""name"" : ""BaseLayout"",
+                ""extend"" : ""DeviceWithLayoutVariantA"",
+                ""controls"" : [
+                    { ""name"" : ""ControlFromBase"", ""layout"" : ""Button"" },
+                    { ""name"" : ""OtherControlFromBase"", ""layout"" : ""Axis"" },
+                    { ""name"" : ""ControlWithExplicitDefaultVariant"", ""layout"" : ""Axis"", ""variants"" : ""default"" },
+                    { ""name"" : ""StickControl"", ""layout"" : ""Stick"" },
+                    { ""name"" : ""StickControl/x"", ""offset"" : 14, ""variants"" : ""A"" }
+                ]
+            }
+        ";
+        const string jsonDerived = @"
+            {
+                ""name"" : ""DerivedLayout"",
+                ""extend"" : ""BaseLayout"",
+                ""controls"" : [
+                    { ""name"" : ""ControlFromBase"", ""variants"" : ""A"", ""offset"" : 20 }
+                ]
+            }
+        ";
+
+        InputSystem.RegisterLayout<DeviceWithLayoutVariantA>();
+        InputSystem.RegisterLayout(jsonBase);
+        InputSystem.RegisterLayout(jsonDerived);
+
+        var layout = InputSystem.LoadLayout("DerivedLayout");
+        var parsedPath = InputControlPath.Parse("<BaseLayout>/ControlWithExplicitDefaultVariant").ToArray()[1];
+
+        Assert.That(layout.m_Controls.Any(x => InputControlPath.MatchControlComponent(ref parsedPath, ref x)), Is.True);
+    }
+
+    [Test]
+    [Category("Layouts")]
     [Ignore("TODO")]
     public void TODO_Layouts_CurrentPlatformIsImplicitLayoutVariant()
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -720,6 +720,42 @@ namespace UnityEngine.InputSystem
             return MatchesRecursive(ref parser, control);
         }
 
+        internal static bool Matches(IEnumerable<string> usages, string name, ref InputControlLayout.ControlItem controlItem)
+        {
+            if (usages.Count() > 0)
+            {
+                // All of usages should match to the one of usage in the control
+                foreach (var usage in usages)
+                {
+                    if (usage.Length > 0)
+                    {
+                        var usageCount = controlItem.usages.Count;
+                        var anyUsageMatches = false;
+                        for (var i = 0; i < usageCount; ++i)
+                        {
+                            if (StringMatches(usage, controlItem.usages[i]))
+                            {
+                                anyUsageMatches = true;
+                                break;
+                            }
+                        }
+
+                        if (!anyUsageMatches)
+                            return false;
+                    }
+                }
+            }
+
+            // Match name.
+            if (name.Length > 0)
+            {
+                if (!StringMatches(name, controlItem.name))
+                    return false;
+            }
+
+            return true;
+        }
+
         /// <summary>
         /// Check whether the given path matches <paramref name="control"/> or any of its parents.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -720,36 +720,33 @@ namespace UnityEngine.InputSystem
             return MatchesRecursive(ref parser, control);
         }
 
-        internal static bool Matches(IEnumerable<string> usages, string name, ref InputControlLayout.ControlItem controlItem)
+        internal static bool MatchControlComponent(ref ParsedPathComponent expectedControlComponent, ref InputControlLayout.ControlItem controlItem)
         {
-            if (usages.Count() > 0)
+            // All of usages should match to the one of usage in the control
+            foreach (var usage in expectedControlComponent.m_Usages)
             {
-                // All of usages should match to the one of usage in the control
-                foreach (var usage in usages)
+                if (!usage.isEmpty)
                 {
-                    if (usage.Length > 0)
+                    var usageCount = controlItem.usages.Count;
+                    var anyUsageMatches = false;
+                    for (var i = 0; i < usageCount; ++i)
                     {
-                        var usageCount = controlItem.usages.Count;
-                        var anyUsageMatches = false;
-                        for (var i = 0; i < usageCount; ++i)
+                        if (StringMatches(usage, controlItem.usages[i]))
                         {
-                            if (StringMatches(usage, controlItem.usages[i]))
-                            {
-                                anyUsageMatches = true;
-                                break;
-                            }
+                            anyUsageMatches = true;
+                            break;
                         }
-
-                        if (!anyUsageMatches)
-                            return false;
                     }
+
+                    if (!anyUsageMatches)
+                        return false;
                 }
             }
 
             // Match name.
-            if (name.Length > 0)
+            if (!expectedControlComponent.m_Name.isEmpty)
             {
-                if (!StringMatches(name, controlItem.name))
+                if (!StringMatches(expectedControlComponent.m_Name, controlItem.name))
                     return false;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -104,7 +104,7 @@ namespace UnityEngine.InputSystem.Editor
                     }
                 }
 
-                showPaths = EditorGUILayout.Toggle("Show all matched control paths", showPaths);
+                showPaths = EditorGUILayout.Toggle("Show Matching Paths", showPaths);
                 // Show the specific layouts that implement the control on this path
                 if (showPaths)
                 {
@@ -128,17 +128,21 @@ namespace UnityEngine.InputSystem.Editor
             if(parsedPath.Length == 2)
             {
                 EditorGUILayout.BeginVertical();
-                DrawMatchingControlPathsForLayout(new InternedString(layout), ref parsedPath[1]);
+                if(!DrawMatchingControlPathsForLayout(new InternedString(layout), ref parsedPath[1]))
+                {
+                    EditorGUILayout.LabelField("No registered control paths match this current binding");
+                }
                 EditorGUILayout.EndVertical();
             }
         }
 
         /// <summary>
         /// Finds all registered control paths implemented by concrete classes under a given device layout which match the current binding path and renders it.
+        /// Return true if there exist matching registered control paths, false otherwise.
         /// </summary>
         /// <param name="deviceLayout">The device layout to draw control paths for</param>
         /// <param name="pathControlComponent">The parsed path component containing details of the Input Controls that can be matched</param>
-        private void DrawMatchingControlPathsForLayout(InternedString deviceLayout, ref InputControlPath.ParsedPathComponent pathControlComponent)
+        private bool DrawMatchingControlPathsForLayout(InternedString deviceLayout, ref InputControlPath.ParsedPathComponent pathControlComponent)
         {
             var path = m_ControlPathEditor.pathProperty.stringValue;
             var matchedChildLayouts = EditorInputControlLayoutCache.allLayouts
@@ -150,6 +154,8 @@ namespace UnityEngine.InputSystem.Editor
                    .Where(x => x.isDeviceLayout && !x.isOverride && !x.hideInUI && x.isGenericTypeOfDevice).OrderBy(x => x.displayName);
             }
 
+            bool matchExists = false;
+
             if (matchedChildLayouts.Count() > 0)
             {
                 foreach (var childLayout in matchedChildLayouts)
@@ -159,15 +165,18 @@ namespace UnityEngine.InputSystem.Editor
                         if (InputControlPath.MatchControlComponent(ref pathControlComponent, ref childLayout.m_Controls[i]))
                         {
                             EditorGUILayout.LabelField(childLayout.displayName + "/" + childLayout.m_Controls[i].displayName);
+                            matchExists = true;
                             continue;
                         }
                     }
 
                     EditorGUI.indentLevel++;
-                    DrawMatchingControlPathsForLayout(childLayout.name, ref pathControlComponent);
+                    matchExists |= DrawMatchingControlPathsForLayout(childLayout.name, ref pathControlComponent);
                     EditorGUI.indentLevel--;
                 }
             }
+
+            return matchExists;
         }
 
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
@@ -72,10 +72,9 @@ namespace UnityEngine.InputSystem.Editor
 
     internal sealed class UsageDropdownItem : InputControlDropdownItem
     {
-        public override string controlPathWithDevice => string.IsNullOrEmpty(m_Device) ? $"*/{{{m_ControlPath}}}" 
-                                                        : $"<{m_Device}>/{{{m_ControlPath}}}";
+        public override string controlPathWithDevice => string.IsNullOrEmpty(m_Device) ? $"*/{{{m_ControlPath}}}" : $"<{m_Device}>/{{{m_ControlPath}}}";
 
-        public UsageDropdownItem(string usage, string device)
+        public UsageDropdownItem(string device, string usage)
             : base(usage)
         {
             m_Device = device;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
@@ -72,12 +72,13 @@ namespace UnityEngine.InputSystem.Editor
 
     internal sealed class UsageDropdownItem : InputControlDropdownItem
     {
-        public override string controlPathWithDevice => $"{m_Device}/{{{m_ControlPath}}}";
+        public override string controlPathWithDevice => string.IsNullOrEmpty(m_Device) ? $"*/{{{m_ControlPath}}}" 
+                                                        : $"<{m_Device}>/{{{m_ControlPath}}}";
 
-        public UsageDropdownItem(string usage)
+        public UsageDropdownItem(string usage, string device)
             : base(usage)
         {
-            m_Device = "*";
+            m_Device = device;
             m_ControlPath = usage;
             id = controlPathWithDevice.GetHashCode();
             m_Searchable = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
@@ -91,7 +91,7 @@ namespace UnityEngine.InputSystem.Editor
         public ControlUsageDropdownItem(string device, string usage, string controlUsage)
             : base(usage)
         {
-            m_Device = device;
+            m_Device = string.IsNullOrEmpty(device) ? "*" : device;
             m_Usage = usage;
             m_ControlPath = $"{{{ controlUsage }}}";
             name = controlUsage;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlDropdownItem.cs
@@ -70,15 +70,31 @@ namespace UnityEngine.InputSystem.Editor
         }
     }
 
-    internal sealed class UsageDropdownItem : InputControlDropdownItem
+    internal sealed class ControlUsageDropdownItem : InputControlDropdownItem
     {
-        public override string controlPathWithDevice => string.IsNullOrEmpty(m_Device) ? $"*/{{{m_ControlPath}}}" : $"<{m_Device}>/{{{m_ControlPath}}}";
+        public override string controlPathWithDevice => BuildControlPath();
+        private string BuildControlPath()
+        {
+            if (m_Device == "*")
+            {
+                var path = new StringBuilder(m_Device);
+                if (!string.IsNullOrEmpty(m_Usage))
+                    path.Append($"{{{m_Usage}}}");
+                if (!string.IsNullOrEmpty(m_ControlPath))
+                    path.Append($"/{m_ControlPath}");
+                return path.ToString();
+            }
+            else
+                return base.controlPathWithDevice;
+        }
 
-        public UsageDropdownItem(string device, string usage)
+        public ControlUsageDropdownItem(string device, string usage, string controlUsage)
             : base(usage)
         {
             m_Device = device;
-            m_ControlPath = usage;
+            m_Usage = usage;
+            m_ControlPath = $"{{{ controlUsage }}}";
+            name = controlUsage;
             id = controlPathWithDevice.GetHashCode();
             m_Searchable = true;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -81,7 +81,7 @@ namespace UnityEngine.InputSystem.Editor
             // Usages.
             if (m_Mode != InputControlPicker.Mode.PickDevice)
             {
-                var usages = BuildTreeForUsages();
+                var usages = BuildTreeForControlUsages();
                 if (usages.children.Any())
                 {
                     root.AddChild(usages);
@@ -124,14 +124,14 @@ namespace UnityEngine.InputSystem.Editor
             m_OnPickCallback(path);
         }
 
-        private AdvancedDropdownItem BuildTreeForUsages()
+        private AdvancedDropdownItem BuildTreeForControlUsages(string device = "")
         {
             var usageRoot = new AdvancedDropdownItem("Usages");
             foreach (var usageAndLayouts in EditorInputControlLayoutCache.allUsages)
             {
                 if (usageAndLayouts.Item2.Any(LayoutMatchesExpectedControlLayoutFilter))
                 {
-                    var child = new UsageDropdownItem(usageAndLayouts.Item1);
+                    var child = new UsageDropdownItem(usageAndLayouts.Item1, device);
                     usageRoot.AddChild(child);
                 }
             }
@@ -183,12 +183,29 @@ namespace UnityEngine.InputSystem.Editor
 
             var defaultControlPickerLayout = new DefaultInputControlPickerLayout();
 
-            // Add common usage variants.
+            // Add control usages for the device
+            var deviceControlUsages = BuildTreeForControlUsages(layout.name);
+            if (deviceControlUsages.children.Any())
+            {
+                deviceItem.AddChild(deviceControlUsages);
+                deviceItem.AddSeparator();
+            }
+
+            // Add common device usage variants.
             if (layout.commonUsages.Count > 0)
             {
                 foreach (var usage in layout.commonUsages)
                 {
                     var usageItem = new DeviceDropdownItem(layout, usage);
+
+                    // Add control usages for the device sub-variant
+                    var deviceVariantControlUsages = BuildTreeForControlUsages(usageItem.name);
+                    if (deviceVariantControlUsages.children.Any())
+                    {
+                        usageItem.AddChild(deviceVariantControlUsages);
+                        usageItem.AddSeparator();
+                    }
+
                     if (m_Mode == InputControlPicker.Mode.PickControl)
                         AddControlTreeItemsRecursive(defaultControlPickerLayout, layout, usageItem, layout.name, usage, searchable);
                     deviceItem.AddChild(usageItem);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -131,7 +131,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 if (usageAndLayouts.Item2.Any(LayoutMatchesExpectedControlLayoutFilter))
                 {
-                    var child = new UsageDropdownItem(usageAndLayouts.Item1, device);
+                    var child = new UsageDropdownItem(device, usageAndLayouts.Item1);
                     usageRoot.AddChild(child);
                 }
             }
@@ -183,22 +183,14 @@ namespace UnityEngine.InputSystem.Editor
 
             var defaultControlPickerLayout = new DefaultInputControlPickerLayout();
 
-            // Add control usages for the device
-            var deviceControlUsages = BuildTreeForControlUsages(layout.name);
-            if (deviceControlUsages.children.Any())
-            {
-                deviceItem.AddChild(deviceControlUsages);
-                deviceItem.AddSeparator();
-            }
-
-            // Add common device usage variants.
+            // Add common usage variants of the device
             if (layout.commonUsages.Count > 0)
             {
                 foreach (var usage in layout.commonUsages)
                 {
                     var usageItem = new DeviceDropdownItem(layout, usage);
 
-                    // Add control usages for the device sub-variant
+                    // Add control usages to the device variants
                     var deviceVariantControlUsages = BuildTreeForControlUsages(usageItem.name);
                     if (deviceVariantControlUsages.children.Any())
                     {
@@ -210,6 +202,14 @@ namespace UnityEngine.InputSystem.Editor
                         AddControlTreeItemsRecursive(defaultControlPickerLayout, layout, usageItem, layout.name, usage, searchable);
                     deviceItem.AddChild(usageItem);
                 }
+                deviceItem.AddSeparator();
+            }
+
+            // Add control usages
+            var deviceControlUsages = BuildTreeForControlUsages(layout.name);
+            if (deviceControlUsages.children.Any())
+            {
+                deviceItem.AddChild(deviceControlUsages);
                 deviceItem.AddSeparator();
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -124,14 +124,14 @@ namespace UnityEngine.InputSystem.Editor
             m_OnPickCallback(path);
         }
 
-        private AdvancedDropdownItem BuildTreeForControlUsages(string device = "")
+        private AdvancedDropdownItem BuildTreeForControlUsages(string device = "", string usage = "")
         {
             var usageRoot = new AdvancedDropdownItem("Usages");
             foreach (var usageAndLayouts in EditorInputControlLayoutCache.allUsages)
             {
                 if (usageAndLayouts.Item2.Any(LayoutMatchesExpectedControlLayoutFilter))
                 {
-                    var child = new UsageDropdownItem(device, usageAndLayouts.Item1);
+                    var child = new ControlUsageDropdownItem(device, usage, usageAndLayouts.Item1);
                     usageRoot.AddChild(child);
                 }
             }
@@ -191,7 +191,7 @@ namespace UnityEngine.InputSystem.Editor
                     var usageItem = new DeviceDropdownItem(layout, usage);
 
                     // Add control usages to the device variants
-                    var deviceVariantControlUsages = BuildTreeForControlUsages(usageItem.name);
+                    var deviceVariantControlUsages = BuildTreeForControlUsages(layout.name, usage);
                     if (deviceVariantControlUsages.children.Any())
                     {
                         usageItem.AddChild(deviceVariantControlUsages);


### PR DESCRIPTION
### Description

This PR augments the binding path dropdown, allowing users to add control usages for specific devices.

This PR also adds a "Show Matching Paths" checkbox, which shows the users exactly which specific registered layout paths their current binding path will match with.

The goal of this PR is to address some grievances found in this thread: https://forum.unity.com/threads/openxr-primary2daxisclick-not-working.1120864/

https://user-images.githubusercontent.com/39840334/232162490-588f48e2-d521-4215-ab6a-3a8fa93b4554.mp4

https://user-images.githubusercontent.com/39840334/232162498-4089680c-bd06-4be6-a643-5c1bae0b7b29.mp4


### Changes made
Updated the InputControlPickerDropdown to allow for control usages to be selected and added to the paths in after specifying a desired device.

Augmented the UsageDropdown to be usable in more contexts.

Added unit tests for the new InputControlPath function.

Added new option to the InputBindingsPropertiesView.

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
