### PR TITLE
Expose the display index via the Touch object.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -234,6 +234,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         /// <seealso cref="InputSettings.defaultTapTime"/>
         /// <seealso cref="TouchControl.tap"/>
         public bool isTap => state.isTap;
+        
+        /// <summary>
+        /// The index of the display containing the touch.
+        /// </summary>
+        /// <value>A zero based number representing the display index containing the touch.</value>
+        /// <seealso cref="TouchControl.displayIndex"/>
+        /// <seealso cref="Display"/>
+        public int displayIndex => state.displayIndex;
 
         /// <summary>
         /// Whether the touch is currently in progress, i.e. has a <see cref="phase"/> of


### PR DESCRIPTION
### Description

Currently, the display index can only be retrieved from the primary touch which doesn't reflect the correct display index for each touch in case touches are triggered by two different touch devices.  With this change, the display index of each individual touch can be accurately retrieved.

### Changes made

Added a new field to the Touch struct to expose the index of the display that was touched.

### Notes

Currently, there is no way to accurately retrieve the index of the touched display from the Touch object. The primary touch does expose the display index but since this is set once upon the first touch, touching two displays at the same time will end up storing the index of the first display touched in the primary touch.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
