### PR TITLE
NEW: add maps, actions and bindings via '+' button (ISX-1040)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,7 +14,6 @@ however, it has to be formatted properly to pass verification tests.
 - Added `InputSystem.customBindingPathValidators` interface to allow showing warnings in the `InputAsset` Editor for specific InputBindings and draw custom UI in the properties panel.
 - Added `InputSystem.runInBackground` to be used internally by specific platforms packages. Allows telling the input system that a specific platform runs in background. It allows fixing of [case UUM-6744](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744).
 - Added new UIToolkit version of the `InputActionsAsset` editor. Currently this is incomplete (view-only) and the existing editor is still used by default.
-  - add functionality for actions, maps and bindings
 
 ### Changed
 - Changed XR Layout build behavior to create Axis2D control devices with `StickControl` type instead of `Vector2Control`.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added `InputSystem.customBindingPathValidators` interface to allow showing warnings in the `InputAsset` Editor for specific InputBindings and draw custom UI in the properties panel.
 - Added `InputSystem.runInBackground` to be used internally by specific platforms packages. Allows telling the input system that a specific platform runs in background. It allows fixing of [case UUM-6744](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744).
 - Added new UIToolkit version of the `InputActionsAsset` editor. Currently this is incomplete (view-only) and the existing editor is still used by default.
+  - add functionality for actions, maps and bindings
 
 ### Changed
 - Changed XR Layout build behavior to create Axis2D control devices with `StickControl` type instead of `Vector2Control`.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -29,7 +29,7 @@ namespace UnityEngine.InputSystem.Editor
                 var actionProperty = InputActionSerializationHelpers.AddAction(newMap);
                 InputActionSerializationHelpers.AddBinding(actionProperty, newMap);
                 state.serializedObject.ApplyModifiedProperties();
-                return state.SelectActionMap(newMap.FindPropertyRelative(nameof(InputActionMap.m_Name)).stringValue);
+                return state.SelectActionMap(newMap);
             };
         }
 
@@ -41,7 +41,7 @@ namespace UnityEngine.InputSystem.Editor
                 var newAction = InputActionSerializationHelpers.AddAction(actionMap);
                 InputActionSerializationHelpers.AddBinding(newAction, actionMap);
                 state.serializedObject.ApplyModifiedProperties();
-                return state.SelectAction(newAction.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue);
+                return state.SelectAction(newAction);
             };
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -21,6 +21,43 @@ namespace UnityEngine.InputSystem.Editor
             return (in InputActionsEditorState state) => state.SelectActionMap(actionMapName);
         }
 
+        public static Command AddActionMap()
+        {
+            return (in InputActionsEditorState state) =>
+            {
+                var newMap = InputActionSerializationHelpers.AddActionMap(state.serializedObject);
+                var actionProperty = InputActionSerializationHelpers.AddAction(newMap);
+                InputActionSerializationHelpers.AddBinding(actionProperty, newMap);
+                state.serializedObject.ApplyModifiedProperties();
+                return state.SelectActionMap(newMap.FindPropertyRelative(nameof(InputActionMap.m_Name)).stringValue);
+            };
+        }
+
+        public static Command AddAction()
+        {
+            return (in InputActionsEditorState state) =>
+            {
+                var actionMap = Selectors.GetSelectedActionMap(state).wrappedProperty;
+                var newAction = InputActionSerializationHelpers.AddAction(actionMap);
+                InputActionSerializationHelpers.AddBinding(newAction, actionMap);
+                state.serializedObject.ApplyModifiedProperties();
+                return state.SelectAction(newAction.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue);
+            };
+        }
+
+        public static Command AddBinding()
+        {
+            return (in InputActionsEditorState state) =>
+            {
+                var action = Selectors.GetSelectedAction(state).wrappedProperty;
+                var map = Selectors.GetSelectedActionMap(state).wrappedProperty;
+                var binding = InputActionSerializationHelpers.AddBinding(action, map);
+                var bindingIndex = new SerializedInputBinding(binding).indexOfBinding;
+                state.serializedObject.ApplyModifiedProperties();
+                return state.With(selectedBindingIndex: bindingIndex, selectionType: SelectionType.Binding);
+            };
+        }
+
         public static Command ExpandCompositeBinding(SerializedInputBinding binding)
         {
             return (in InputActionsEditorState state) => state.ExpandCompositeBinding(binding);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -152,6 +152,18 @@ namespace UnityEngine.InputSystem.Editor
             throw new InvalidOperationException($"Couldn't find an action map with name '{actionName}'.");
         }
 
+        public InputActionsEditorState SelectAction(SerializedProperty state)
+        {
+            var index = state.GetIndexOfArrayElement();
+            return With(selectedActionIndex: index, selectionType: SelectionType.Action);
+        }
+
+        public InputActionsEditorState SelectActionMap(SerializedProperty state)
+        {
+            var index = state.GetIndexOfArrayElement();
+            return With(selectedBindingIndex: 0, selectedActionMapIndex: index, selectedActionIndex: 0);
+        }
+
         public InputActionsEditorState SelectActionMap(string actionMapName)
         {
             var actionMap = GetActionMapByName(actionMapName);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -160,6 +160,11 @@ namespace UnityEngine.InputSystem.Editor
                 selectedActionIndex: 0);
         }
 
+        public InputActionsEditorState SelectBinding(int index)
+        {
+            return With(selectedBindingIndex: index);
+        }
+
         public ReadOnlyCollection<int> GetOrCreateExpandedState()
         {
             return new ReadOnlyCollection<int>(GetOrCreateExpandedStateInternal().ToList());

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -32,8 +32,9 @@
             </ui:VisualElement>
             <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="400" style="height: auto;">
                 <ui:VisualElement name="actions-container" class="body-panel-container">
-                    <ui:VisualElement name="header" class="body-panel-header">
+                    <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between;">
                         <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" />
+                        <ui:Button text="+" display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;" />
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
                         <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
@@ -29,6 +29,11 @@
     border-width: 0;
 }
 
+#add-new-action-button {
+    background-color: transparent;
+    border-width: 0;
+}
+
 #bindings-container {
     min-width: 225px;
     border-left-width: 0;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsTreeViewItem.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsTreeViewItem.uxml
@@ -1,10 +1,11 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
-    <ui:VisualElement name="item-row" class="unity-list-view__item" style="flex-direction: row; flex-grow: 1; justify-content: flex-start; margin-left: 4px; flex-shrink: 0;">
+    <ui:VisualElement name="item-row" class="unity-list-view__item" style="flex-direction: row; flex-grow: 1; justify-content: space-between; margin-left: 4px; flex-shrink: 0;">
         <ui:VisualElement name="row" style="flex-direction: row; border-left-width: 0; border-left-color: rgb(89, 89, 89); justify-content: flex-start; align-items: center;">
             <ui:VisualElement name="icon" style="justify-content: center; background-image: url(&apos;project://database/Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_InputControl.png?fileID=2800000&amp;guid=399cd90f4e31041e692a7d3a8b1aa4d0&amp;type=3#d_InputControl&apos;); width: 16px; height: 16px;" />
             <ui:TextField picking-mode="Ignore" name="rename-text-field" is-delayed="true" focusable="true" class="unity-input-actions-editor-hidden" style="visibility: visible; flex-shrink: 1;" />
             <ui:Label text="binding-name" display-tooltip-when-elided="true" name="name" style="flex-grow: 1; justify-content: center; align-items: stretch; margin-left: 4px; -unity-font-style: normal;" />
         </ui:VisualElement>
+        <ui:Button text="+" display-tooltip-when-elided="true" enable-rich-text="false" name="add-new-binding-button" style="opacity: 1; background-color: rgba(255, 255, 255, 0); border-left-color: rgba(255, 255, 255, 0); border-right-color: rgba(255, 255, 255, 0); border-top-color: rgba(255, 255, 255, 0); border-bottom-color: rgba(255, 255, 255, 0); display: none; align-items: flex-end; align-self: auto; flex-direction: row-reverse;" />
     </ui:VisualElement>
 </ui:UXML>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR && UNITY_2022_1_OR_NEWER
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine.InputSystem.Utilities;
 using UnityEngine.UIElements;
 
 namespace UnityEngine.InputSystem.Editor
@@ -33,25 +34,23 @@ namespace UnityEngine.InputSystem.Editor
 
             CreateSelector(s => new ViewStateCollection<string>(Selectors.GetActionMapNames(s)),
                 (actionMapNames, state) => new ViewState(Selectors.GetSelectedActionMap(state), actionMapNames));
+
+            addActionMapButton.clicked += AddActionMap;
         }
 
         private Button addActionMapButton => m_Root?.Q<Button>("add-new-action-map-button");
 
         public override void RedrawUI(ViewState viewState)
         {
-            m_ListView.bindItem = (element, i) =>
-            {
-                var treeViewItem = (InputActionsTreeViewItem)element;
-                treeViewItem.label.text = (string)m_ListView.itemsSource[i];
-            };
-            m_ListView.makeItem = () => new InputActionsTreeViewItem();
             m_ListView.itemsSource = viewState.actionMapNames?.ToList() ?? new List<string>();
-            addActionMapButton.clicked += ShowAddActionMapWindow;
+            var indexOf = viewState.actionMapNames.IndexOf(viewState.selectedActionMap.name);
+            m_ListView.SetSelection(indexOf);
+            m_ListView.Rebuild();
         }
 
         public override void DestroyView()
         {
-            addActionMapButton.clicked -= ShowAddActionMapWindow;
+            addActionMapButton.clicked -= AddActionMap;
         }
 
         private void ChangeActionMapName(string newName)
@@ -64,8 +63,9 @@ namespace UnityEngine.InputSystem.Editor
             Dispatch(Commands.SelectActionMap((string)m_ListView.selectedItem));
         }
 
-        private void ShowAddActionMapWindow()
+        private void AddActionMap()
         {
+            Dispatch(Commands.AddActionMap());
         }
 
         private readonly VisualElement m_Root;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -73,19 +73,19 @@ namespace UnityEngine.InputSystem.Editor
 
         private int GetComponentOrBindingID(List<TreeViewItemData<ActionOrBindingData>> treeList, int selectedBindingIndex)
         {
-            var i = -1;
+            var currentBindingIndex = -1;
             foreach (var action in treeList)
             {
                 foreach (var bindingOrComponent in action.children)
                 {
-                    i++;
-                    if (i == selectedBindingIndex) return bindingOrComponent.id;
+                    currentBindingIndex++;
+                    if (currentBindingIndex == selectedBindingIndex) return bindingOrComponent.id;
                     if (bindingOrComponent.hasChildren)
                     {
                         foreach (var binding in bindingOrComponent.children)
                         {
-                            i++;
-                            if (i == selectedBindingIndex) return binding.id;
+                            currentBindingIndex++;
+                            if (currentBindingIndex == selectedBindingIndex) return binding.id;
                         }
                     }
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -193,7 +193,7 @@ namespace UnityEngine.InputSystem.Editor
                         i--;
                         bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(id++,
                             new ActionOrBindingData(false, serializedInputBinding.name, action.expectedControlType, serializedInputBinding.indexOfBinding),
-                            compositeItems));
+                            compositeItems.Count > 0 ? compositeItems : null));
                     }
                     else
                     {
@@ -202,9 +202,8 @@ namespace UnityEngine.InputSystem.Editor
                                 GetControlLayout(serializedInputBinding.path), serializedInputBinding.indexOfBinding)));
                     }
                 }
-
                 actionItems.Add(new TreeViewItemData<ActionOrBindingData>(id++,
-                    new ActionOrBindingData(true, action.name, action.expectedControlType), bindingItems));
+                    new ActionOrBindingData(true, action.name, action.expectedControlType), bindingItems.Count > 0 ? bindingItems : null));
             }
             return actionItems;
         }


### PR DESCRIPTION
### Description

Added '+' button on top of Map-View for adding new action maps. Also added a '+' button on top of the action view to add new action items. Added a '+' button for each action element to add new bindings. 
Implemented UI and fuctionality.
Link to the ticket: [ISX-1040](https://jira.unity3d.com/browse/ISX-1040)

### Changes made

Added: add maps, actions and bindings via the '+' buttons on the UI 

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
