### PR TITLE
NEW: Expose displayIndex via the Touch object

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added `InputSystem.customBindingPathValidators` interface to allow showing warnings in the `InputAsset` Editor for specific InputBindings and draw custom UI in the properties panel.
 - Added `InputSystem.runInBackground` to be used internally by specific platforms packages. Allows telling the input system that a specific platform runs in background. It allows fixing of [case UUM-6744](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-6744).
 - Added new UIToolkit version of the `InputActionsAsset` editor. Currently this is incomplete (view-only) and the existing editor is still used by default.
+- Added `displayIndex` field to the Touch struct to expose the index of the display that was touched.
 
 ### Changed
 - Changed XR Layout build behavior to create Axis2D control devices with `StickControl` type instead of `Vector2Control`.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/EnhancedTouch/Touch.cs
@@ -236,6 +236,14 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         public bool isTap => state.isTap;
 
         /// <summary>
+        /// The index of the display containing the touch.
+        /// </summary>
+        /// <value>A zero based number representing the display index containing the touch.</value>
+        /// <seealso cref="TouchControl.displayIndex"/>
+        /// <seealso cref="Display"/>
+        public int displayIndex => state.displayIndex;
+
+        /// <summary>
         /// Whether the touch is currently in progress, i.e. has a <see cref="phase"/> of
         /// <see cref="TouchPhase.Began"/>, <see cref="TouchPhase.Moved"/>, or <see cref="TouchPhase.Stationary"/>.
         /// </summary>


### PR DESCRIPTION
### Description

Currently, the display index can only be retrieved from the primary touch which doesn't reflect the correct display index for each touch in case touches are triggered by two different touch devices. With this change, the display index of each individual touch can be accurately retrieved.

Recreating https://github.com/Unity-Technologies/InputSystem/pull/1673 for reasons. All praise goes to https://github.com/TonyAbouHaidar

### Changes made

Added a new field to the Touch struct to expose the index of the display that was touched.

### Notes

Currently, there is no way to accurately retrieve the index of the touched display from the Touch object. The primary touch does expose the display index but since this is set once upon the first touch, touching two displays at the same time will end up storing the index of the first display touched in the primary touch.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
