### PR TITLE
NEW: Add InputSystemProvider for InputForUI

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -61,7 +61,7 @@ namespace UnityEngine.InputSystem.Editor
                 return;
 
             FocusOnRenameTextField();
-            e.PreventDefault();
+            e.StopPropagation();
         }
 
         private void OnMouseDownEventForRename(MouseDownEvent e)
@@ -70,7 +70,6 @@ namespace UnityEngine.InputSystem.Editor
                 return;
 
             FocusOnRenameTextField();
-
             e.StopPropagation();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 96500a17645c67442a0ccdca007e6d28
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs
@@ -1,3 +1,5 @@
 using System.Runtime.CompilerServices;
+using UnityEngine.Scripting;
 
 [assembly: InternalsVisibleTo("UnityEngine.InputForUIVisualizer")]
+[assembly: AlwaysLinkAssembly]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("UnityEngine.InputForUIVisualizer")]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65c861c7ef9bee2479c728694e87ea45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemForUI.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemForUI.asmdef
@@ -1,0 +1,15 @@
+{
+    "name": "Unity.InputSystem.ForUI",
+    "references": [
+        "Unity.InputSystem"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemForUI.asmdef.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemForUI.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 09dcc9c0126b6b34ab2a877b8f2277f5
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -1,14 +1,14 @@
-using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using Unity.IntegerTime;
-using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputForUI;
 using UnityEngine.InputSystem;
 using Event = UnityEngine.InputForUI.Event;
 using EventModifiers = UnityEngine.InputForUI.EventModifiers;
 using EventProvider = UnityEngine.InputForUI.EventProvider;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace InputSystem.Plugins.InputForUI
 {
@@ -21,13 +21,23 @@ namespace InputSystem.Plugins.InputForUI
 
         private Configuration _cfg;
 
+        private InputActionAsset _inputActionAsset;
+        private InputActionReference _pointAction;
+        private InputActionReference _moveAction;
+        private InputActionReference _submitAction;
+        private InputActionReference _cancelAction;
+        private InputActionReference _leftClickAction;
+        private InputActionReference _middleClickAction;
+        private InputActionReference _rightClickAction;
+        private InputActionReference _scrollWheelAction;
+
         private List<Event> _events = new List<Event>();
 
         static InputSystemProvider()
         {
             // TODO check if input system is enabled before doing this
             // enable me to test!
-            // EventProvider.SetInputSystemProvider(new InputSystemProvider());
+            EventProvider.SetInputSystemProvider(new InputSystemProvider());
         }
 
         [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
@@ -173,6 +183,21 @@ namespace InputSystem.Plugins.InputForUI
         
         private void OnLeftClickPerformed(InputAction.CallbackContext ctx)
         {
+            
+//             var index = GetPointerStateIndexFor(ref context);
+//             if (index == -1)
+//                 return;
+//
+//             ref var state = ref GetPointerStateForIndex(index);
+//             bool wasPressed = state.leftButton.isPressed;
+//             state.leftButton.isPressed = context.ReadValueAsButton();
+//             state.changedThisFrame = true;
+//             if (IgnoreNextClick(ref context, wasPressed))
+//                 state.leftButton.ignoreNextClick = true;
+// #if UNITY_2023_1_OR_NEWER
+//             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
+// #endif
+//             
         }
 
         private void OnMiddleClickPerformed(InputAction.CallbackContext ctx)
@@ -215,103 +240,121 @@ namespace InputSystem.Plugins.InputForUI
 
         private void RegisterActions(Configuration cfg)
         {
-            if (cfg.PointAction.action != null)
-                cfg.PointAction.action.performed += OnPointerPerformed;
+            _inputActionAsset = InputActionAsset.FromJson(cfg.InputActionAssetAsJson);
 
-            if (cfg.MoveAction.action != null)
-                cfg.MoveAction.action.performed += OnMovePerformed;
+            _pointAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.PointAction));
+            _moveAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.MoveAction));
+            _submitAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.SubmitAction));
+            _cancelAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.CancelAction));
+            _leftClickAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.LeftClickAction));
+            _middleClickAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.MiddleClickAction));
+            _rightClickAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.RightClickAction));
+            _scrollWheelAction = InputActionReference.Create(_inputActionAsset.FindAction(_cfg.ScrollWheelAction));
+
+            if (_pointAction.action != null)
+                _pointAction.action.performed += OnPointerPerformed;
+
+            if (_moveAction.action != null)
+                _moveAction.action.performed += OnMovePerformed;
             
-            if (cfg.SubmitAction.action != null)
-                cfg.SubmitAction.action.performed += OnSubmitPerformed;
+            if (_submitAction.action != null)
+                _submitAction.action.performed += OnSubmitPerformed;
 
-            if (cfg.CancelAction.action != null)
-                cfg.CancelAction.action.performed += OnCancelPerformed;
+            if (_cancelAction.action != null)
+                _cancelAction.action.performed += OnCancelPerformed;
 
-            if (cfg.LeftClickAction.action != null)
-                cfg.LeftClickAction.action.performed += OnLeftClickPerformed;
+            if (_leftClickAction.action != null)
+                _leftClickAction.action.performed += OnLeftClickPerformed;
 
-            if (cfg.MiddleClickAction.action != null)
-                cfg.MiddleClickAction.action.performed += OnMiddleClickPerformed;
+            if (_middleClickAction.action != null)
+                _middleClickAction.action.performed += OnMiddleClickPerformed;
 
-            if (cfg.RightClickAction.action != null)
-                cfg.RightClickAction.action.performed += OnRightClickPerformed;
+            if (_rightClickAction.action != null)
+                _rightClickAction.action.performed += OnRightClickPerformed;
 
-            if (cfg.ScrollWheelAction.action != null)
-                cfg.ScrollWheelAction.action.performed += OnScrollWheelPerformed;
+            if (_scrollWheelAction.action != null)
+                _scrollWheelAction.action.performed += OnScrollWheelPerformed;
             
             // When adding new one's don't forget to add them to UnregisterActions 
 
-            cfg.InputActionAsset.Enable();
+            _inputActionAsset.Enable();
         }
 
         private void UnregisterActions(Configuration cfg)
         {
-            if (cfg.PointAction.action != null)
-                cfg.PointAction.action.performed -= OnPointerPerformed;
+            if (_pointAction.action != null)
+                _pointAction.action.performed -= OnPointerPerformed;
             
-            if (cfg.MoveAction.action != null)
-                cfg.MoveAction.action.performed -= OnMovePerformed;
+            if (_moveAction.action != null)
+                _moveAction.action.performed -= OnMovePerformed;
             
-            if (cfg.SubmitAction.action != null)
-                cfg.SubmitAction.action.performed -= OnSubmitPerformed;
+            if (_submitAction.action != null)
+                _submitAction.action.performed -= OnSubmitPerformed;
 
-            if (cfg.CancelAction.action != null)
-                cfg.CancelAction.action.performed -= OnCancelPerformed;
+            if (_cancelAction.action != null)
+                _cancelAction.action.performed -= OnCancelPerformed;
 
-            if (cfg.LeftClickAction.action != null)
-                cfg.LeftClickAction.action.performed -= OnLeftClickPerformed;
+            if (_leftClickAction.action != null)
+                _leftClickAction.action.performed -= OnLeftClickPerformed;
 
-            if (cfg.MiddleClickAction.action != null)
-                cfg.MiddleClickAction.action.performed -= OnMiddleClickPerformed;
+            if (_middleClickAction.action != null)
+                _middleClickAction.action.performed -= OnMiddleClickPerformed;
 
-            if (cfg.RightClickAction.action != null)
-                cfg.RightClickAction.action.performed -= OnRightClickPerformed;
+            if (_rightClickAction.action != null)
+                _rightClickAction.action.performed -= OnRightClickPerformed;
 
-            if (cfg.ScrollWheelAction.action != null)
-                cfg.ScrollWheelAction.action.performed -= OnScrollWheelPerformed;
+            if (_scrollWheelAction.action != null)
+                _scrollWheelAction.action.performed -= OnScrollWheelPerformed;
+            
+            _pointAction = null;
+            _moveAction = null;
+            _submitAction = null;
+            _cancelAction = null;
+            _leftClickAction = null;
+            _middleClickAction = null;
+            _rightClickAction = null;
+            _scrollWheelAction = null;
 
-            cfg.InputActionAsset.Disable();
+            _inputActionAsset.Disable();
+            UnityEngine.Object.Destroy(_inputActionAsset); // TODO check if this is ok
         }
 
         public struct Configuration
         {
-            public InputActionAsset InputActionAsset;
-            public InputActionReference PointAction;
-            public InputActionReference MoveAction;
-            public InputActionReference SubmitAction;
-            public InputActionReference CancelAction;
-            public InputActionReference LeftClickAction;
-            public InputActionReference MiddleClickAction;
-            public InputActionReference RightClickAction;
-            public InputActionReference ScrollWheelAction;
-            //public InputActionReference TrackedDevicePositionAction;
-            //public InputActionReference TrackedDeviceOrientationAction;
+            public string InputActionAssetAsJson;
+            public string PointAction;
+            public string MoveAction;
+            public string SubmitAction;
+            public string CancelAction;
+            public string LeftClickAction;
+            public string MiddleClickAction;
+            public string RightClickAction;
+            public string ScrollWheelAction;
+            //public string TrackedDevicePositionAction;
+            //public string TrackedDeviceOrientationAction;
 
             // public float InputActionsPerSecond;
             // public float RepeatDelay;
 
-            public IEnumerable<InputActionReference> InputActionReferences()
-            {
-                yield return PointAction;
-            }
-
             public static Configuration GetDefaultConfiguration()
             {
-                // TODO doesn't work in player builds
-                //var asset = (InputActionAsset)AssetDatabase.LoadAssetAtPath("Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions", typeof(InputActionAsset));
-                var asset = new DefaultInputActions().asset;
+                // TODO this is a weird way of doing that, is there an easier way?
+                var asset = new DefaultInputActions();
+                var json = asset.asset.ToJson();
+                UnityEngine.Object.DestroyImmediate(asset.asset); // TODO just Dispose doesn't work in edit mode
+                // asset.Dispose();
                 
                 return new Configuration
                 {
-                    InputActionAsset = asset,
-                    PointAction = InputActionReference.Create(asset.FindAction("UI/Point")),
-                    MoveAction = InputActionReference.Create(asset.FindAction("UI/Navigate")),
-                    SubmitAction = InputActionReference.Create(asset.FindAction("UI/Submit")),
-                    CancelAction = InputActionReference.Create(asset.FindAction("UI/Cancel")),
-                    LeftClickAction = InputActionReference.Create(asset.FindAction("UI/Click")),
-                    MiddleClickAction = InputActionReference.Create(asset.FindAction("UI/MiddleClick")),
-                    RightClickAction = InputActionReference.Create(asset.FindAction("UI/RightClick")),
-                    ScrollWheelAction = InputActionReference.Create(asset.FindAction("UI/ScrollWheel")),
+                    InputActionAssetAsJson = json,
+                    PointAction = "UI/Point",
+                    MoveAction = "UI/Navigate",
+                    SubmitAction = "UI/Submit",
+                    CancelAction = "UI/Cancel",
+                    LeftClickAction = "UI/Click",
+                    MiddleClickAction = "UI/MiddleClick",
+                    RightClickAction = "UI/RightClick",
+                    ScrollWheelAction = "UI/ScrollWheel",
                     // InputActionsPerSecond = 10,
                     // RepeatDelay = 0.5f,
                 };

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -1,0 +1,65 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputForUI;
+using Event = UnityEngine.InputForUI.Event;
+using EventProvider = UnityEngine.InputForUI.EventProvider;
+
+namespace InputSystem.Plugins.InputForUI
+{
+#if UNITY_EDITOR
+    [InitializeOnLoad]
+#endif
+    internal class InputSystemProvider : IEventProviderImpl
+    {
+        private InputEventPartialProvider _inputEventPartialProvider;
+
+        static InputSystemProvider()
+        {
+            // disable for now
+            EventProvider.SetInputSystemProvider(new InputSystemProvider());
+        }
+
+        [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void Bootstrap()
+        {
+            // will invoke static class constructor
+        }
+
+        public void Initialize()
+        {
+            _inputEventPartialProvider ??= new InputEventPartialProvider();
+            _inputEventPartialProvider.Initialize();
+        }
+
+        public void Shutdown()
+        {
+        }
+
+        public void Update()
+        {
+            _inputEventPartialProvider.Update();
+
+            // TODO implement action mapping to axes
+        }
+
+        public void OnFocusChanged(bool focus)
+        {
+            _inputEventPartialProvider.OnFocusChanged(focus);
+        }
+
+        public bool RequestCurrentState(Event.Type type)
+        {
+            if (_inputEventPartialProvider.RequestCurrentState(type))
+                return true;
+
+            switch (type)
+            {
+                // TODO
+                default:
+                    return false;
+            }
+        }
+
+        public uint playerCount => 1; // TODO
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -1,7 +1,13 @@
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Unity.IntegerTime;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputForUI;
+using UnityEngine.InputSystem;
 using Event = UnityEngine.InputForUI.Event;
+using EventModifiers = UnityEngine.InputForUI.EventModifiers;
 using EventProvider = UnityEngine.InputForUI.EventProvider;
 
 namespace InputSystem.Plugins.InputForUI
@@ -13,10 +19,15 @@ namespace InputSystem.Plugins.InputForUI
     {
         private InputEventPartialProvider _inputEventPartialProvider;
 
+        private Configuration _cfg;
+
+        private List<Event> _events = new List<Event>();
+
         static InputSystemProvider()
         {
-            // disable for now
-            EventProvider.SetInputSystemProvider(new InputSystemProvider());
+            // TODO check if input system is enabled before doing this
+            // enable me to test!
+            // EventProvider.SetInputSystemProvider(new InputSystemProvider());
         }
 
         [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
@@ -25,21 +36,37 @@ namespace InputSystem.Plugins.InputForUI
             // will invoke static class constructor
         }
 
+        private EventModifiers _eventModifiers => _inputEventPartialProvider._eventModifiers;
+
+        private DiscreteTime _currentTime => (DiscreteTime)Time.timeAsRational;
+        
+        private const uint kDefaultPlayerId = 0u;
+
         public void Initialize()
         {
             _inputEventPartialProvider ??= new InputEventPartialProvider();
             _inputEventPartialProvider.Initialize();
+            
+            // TODO should UITK somehow override this?
+            _cfg = Configuration.GetDefaultConfiguration();
+            RegisterActions(_cfg);
         }
 
         public void Shutdown()
         {
+            UnregisterActions(_cfg);
+
+            _inputEventPartialProvider.Shutdown();
+            _inputEventPartialProvider = null;
         }
 
         public void Update()
         {
             _inputEventPartialProvider.Update();
 
-            // TODO implement action mapping to axes
+            foreach (var ev in _events) // TODO sort them
+                EventProvider.Dispatch(ev);
+            _events.Clear();
         }
 
         public void OnFocusChanged(bool focus)
@@ -61,5 +88,166 @@ namespace InputSystem.Plugins.InputForUI
         }
 
         public uint playerCount => 1; // TODO
+        
+        private void DispatchFromCallback(in Event ev)
+        {
+            _events.Add(ev);
+        }
+
+        private void OnPointerPerformed(InputAction.CallbackContext ctx)
+        {
+            // Debug.Log($"Pointer performed {ctx.control.name}");
+
+            var position = ctx.ReadValue<Vector2>();
+            var delta = Vector2.zero;
+            var targetDisplay = 0;
+
+            DispatchFromCallback(Event.From(new PointerEvent
+            {
+                type = PointerEvent.Type.PointerMoved,
+                pointerIndex = 0,
+                position = position,
+                deltaPosition = delta,
+                scroll = Vector2.zero,
+                displayIndex = targetDisplay,
+                tilt = Vector2.zero,
+                twist = 0.0f,
+                pressure = 0.0f,
+                isInverted = false,
+                button = 0,
+                //buttonsState = _mouseState.ButtonsState,
+                clickCount = 0,
+                timestamp = _currentTime,
+                eventSource = EventSource.Mouse,
+                playerId = kDefaultPlayerId,
+                eventModifiers = _eventModifiers
+            }));
+        }
+
+        private void OnMovePerformed(InputAction.CallbackContext ctx)
+        {
+            var direction = NavigationEvent.DetermineMoveDirection(ctx.ReadValue<Vector2>());
+            if (direction == NavigationEvent.Direction.None)
+                return;
+            //     _navigationEventRepeatHelper.Reset();
+
+            // TODO repeat rate
+            DispatchFromCallback(Event.From(new NavigationEvent
+            {
+                type = NavigationEvent.Type.Move,
+                direction = direction,
+                timestamp = _currentTime,
+                eventSource = EventSource.Unspecified, // TODO
+                playerId = kDefaultPlayerId,
+                eventModifiers = _eventModifiers
+            }));
+        }
+
+        private void OnSubmitPerformed(InputAction.CallbackContext ctx)
+        {
+            // TODO repeat rate
+            DispatchFromCallback(Event.From(new NavigationEvent
+            {
+                type = NavigationEvent.Type.Submit,
+                direction = NavigationEvent.Direction.None,
+                timestamp = _currentTime,
+                eventSource = EventSource.Unspecified, // TODO
+                playerId = kDefaultPlayerId,
+                eventModifiers = _eventModifiers
+            }));
+        }
+
+        private void OnCancelPerformed(InputAction.CallbackContext ctx)
+        {
+            // TODO repeat rate
+            DispatchFromCallback(Event.From(new NavigationEvent
+            {
+                type = NavigationEvent.Type.Cancel,
+                direction = NavigationEvent.Direction.None,
+                timestamp = _currentTime,
+                eventSource = EventSource.Unspecified, // TODO
+                playerId = kDefaultPlayerId,
+                eventModifiers = _eventModifiers
+            }));
+        }
+
+        private void RegisterActions(Configuration cfg)
+        {
+            if (cfg.PointAction.action != null)
+                cfg.PointAction.action.performed += OnPointerPerformed;
+
+            if (cfg.MoveAction.action != null)
+                cfg.MoveAction.action.performed += OnMovePerformed;
+            
+            if (cfg.SubmitAction.action != null)
+                cfg.SubmitAction.action.performed += OnSubmitPerformed;
+
+            if (cfg.CancelAction.action != null)
+                cfg.CancelAction.action.performed += OnCancelPerformed;
+
+            cfg.InputActionAsset.Enable();
+        }
+
+        private void UnregisterActions(Configuration cfg)
+        {
+            if (cfg.PointAction.action != null)
+                cfg.PointAction.action.performed -= OnPointerPerformed;
+            
+            if (cfg.MoveAction.action != null)
+                cfg.MoveAction.action.performed -= OnMovePerformed;
+            
+            if (cfg.SubmitAction.action != null)
+                cfg.SubmitAction.action.performed -= OnSubmitPerformed;
+
+            if (cfg.CancelAction.action != null)
+                cfg.CancelAction.action.performed -= OnCancelPerformed;
+            
+            cfg.InputActionAsset.Disable();
+        }
+
+        public struct Configuration
+        {
+            public InputActionAsset InputActionAsset;
+            public InputActionReference PointAction;
+            public InputActionReference MoveAction;
+            public InputActionReference SubmitAction;
+            public InputActionReference CancelAction;
+            public InputActionReference LeftClickAction;
+            public InputActionReference MiddleClickAction;
+            public InputActionReference RightClickAction;
+            public InputActionReference ScrollWheelAction;
+            //public InputActionReference TrackedDevicePositionAction;
+            //public InputActionReference TrackedDeviceOrientationAction;
+
+            // public float InputActionsPerSecond;
+            // public float RepeatDelay;
+
+            public IEnumerable<InputActionReference> InputActionReferences()
+            {
+                yield return PointAction;
+            }
+
+            public static Configuration GetDefaultConfiguration()
+            {
+                // TODO doesn't work in player builds
+                //var asset = (InputActionAsset)AssetDatabase.LoadAssetAtPath("Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/DefaultInputActions.inputactions", typeof(InputActionAsset));
+                var asset = new DefaultInputActions().asset;
+                
+                return new Configuration
+                {
+                    InputActionAsset = asset,
+                    PointAction = InputActionReference.Create(asset.FindAction("UI/Point")),
+                    MoveAction = InputActionReference.Create(asset.FindAction("UI/Navigate")),
+                    SubmitAction = InputActionReference.Create(asset.FindAction("UI/Submit")),
+                    CancelAction = InputActionReference.Create(asset.FindAction("UI/Cancel")),
+                    LeftClickAction = InputActionReference.Create(asset.FindAction("UI/Click")),
+                    MiddleClickAction = InputActionReference.Create(asset.FindAction("UI/MiddleClick")),
+                    RightClickAction = InputActionReference.Create(asset.FindAction("UI/RightClick")),
+                    ScrollWheelAction = InputActionReference.Create(asset.FindAction("UI/ScrollWheel")),
+                    // InputActionsPerSecond = 10,
+                    // RepeatDelay = 0.5f,
+                };
+            }
+        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -129,6 +129,10 @@ namespace InputSystem.Plugins.InputForUI
                 _aliveTouchesCount = 0;
                 _touchFingerIdToFingerIndex.Clear();
             }
+            
+            _seenTouchEvents = false;
+            _seenPenEvents = false;
+            _seenMouseEvents = false;
         }
 
         private static int SortEvents(Event a, Event b)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -1,19 +1,17 @@
-using System;
 using System.Collections.Generic;
 using Unity.IntegerTime;
-using UnityEngine;
-using UnityEngine.InputForUI;
-using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
-using Event = UnityEngine.InputForUI.Event;
-using EventModifiers = UnityEngine.InputForUI.EventModifiers;
-using EventProvider = UnityEngine.InputForUI.EventProvider;
+using UnityEngine.InputForUI;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 
-namespace InputSystem.Plugins.InputForUI
+namespace UnityEngine.InputSystem.Plugins.InputForUI
 {
+    using Event = UnityEngine.InputForUI.Event;
+    using EventModifiers = UnityEngine.InputForUI.EventModifiers;
+    using EventProvider = UnityEngine.InputForUI.EventProvider;
+
 #if UNITY_EDITOR
     [InitializeOnLoad]
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -170,6 +170,48 @@ namespace InputSystem.Plugins.InputForUI
                 eventModifiers = _eventModifiers
             }));
         }
+        
+        private void OnLeftClickPerformed(InputAction.CallbackContext ctx)
+        {
+        }
+
+        private void OnMiddleClickPerformed(InputAction.CallbackContext ctx)
+        {
+        }
+
+        private void OnRightClickPerformed(InputAction.CallbackContext ctx)
+        {
+        }
+
+        private void OnScrollWheelPerformed(InputAction.CallbackContext ctx)
+        {
+            // TODO
+            var position = Vector2.zero;
+            var delta = Vector2.zero;
+            var scroll = ctx.ReadValue<Vector2>();
+            var targetDisplay = 0;
+
+            DispatchFromCallback(Event.From(new PointerEvent
+            {
+                type = PointerEvent.Type.Scroll,
+                pointerIndex = 0,
+                position = position,
+                deltaPosition = delta,
+                scroll = scroll,
+                displayIndex = targetDisplay,
+                tilt = Vector2.zero,
+                twist = 0.0f,
+                pressure = 0.0f,
+                isInverted = false,
+                button = 0,
+                //buttonsState = _mouseState.ButtonsState,
+                clickCount = 0,
+                timestamp = _currentTime,
+                eventSource = EventSource.Mouse,
+                playerId = kDefaultPlayerId,
+                eventModifiers = _eventModifiers
+            }));
+        }
 
         private void RegisterActions(Configuration cfg)
         {
@@ -184,6 +226,20 @@ namespace InputSystem.Plugins.InputForUI
 
             if (cfg.CancelAction.action != null)
                 cfg.CancelAction.action.performed += OnCancelPerformed;
+
+            if (cfg.LeftClickAction.action != null)
+                cfg.LeftClickAction.action.performed += OnLeftClickPerformed;
+
+            if (cfg.MiddleClickAction.action != null)
+                cfg.MiddleClickAction.action.performed += OnMiddleClickPerformed;
+
+            if (cfg.RightClickAction.action != null)
+                cfg.RightClickAction.action.performed += OnRightClickPerformed;
+
+            if (cfg.ScrollWheelAction.action != null)
+                cfg.ScrollWheelAction.action.performed += OnScrollWheelPerformed;
+            
+            // When adding new one's don't forget to add them to UnregisterActions 
 
             cfg.InputActionAsset.Enable();
         }
@@ -201,7 +257,19 @@ namespace InputSystem.Plugins.InputForUI
 
             if (cfg.CancelAction.action != null)
                 cfg.CancelAction.action.performed -= OnCancelPerformed;
-            
+
+            if (cfg.LeftClickAction.action != null)
+                cfg.LeftClickAction.action.performed -= OnLeftClickPerformed;
+
+            if (cfg.MiddleClickAction.action != null)
+                cfg.MiddleClickAction.action.performed -= OnMiddleClickPerformed;
+
+            if (cfg.RightClickAction.action != null)
+                cfg.RightClickAction.action.performed -= OnRightClickPerformed;
+
+            if (cfg.ScrollWheelAction.action != null)
+                cfg.ScrollWheelAction.action.performed -= OnScrollWheelPerformed;
+
             cfg.InputActionAsset.Disable();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -3,9 +3,6 @@ using System.Collections.Generic;
 using Unity.IntegerTime;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputForUI;
-#if UNITY_EDITOR
-using UnityEditor;
-#endif
 
 namespace UnityEngine.InputSystem.Plugins.InputForUI
 {
@@ -13,9 +10,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
     using EventModifiers = UnityEngine.InputForUI.EventModifiers;
     using EventProvider = UnityEngine.InputForUI.EventProvider;
 
-#if UNITY_EDITOR
-    [InitializeOnLoad]
-#endif
     internal class InputSystemProvider : IEventProviderImpl
     {
         private InputEventPartialProvider _inputEventPartialProvider;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -390,19 +390,9 @@ namespace InputSystem.Plugins.InputForUI
             }));
         }
 
-        private void OnClickCancelled(InputAction.CallbackContext ctx, EventSource eventSource, PointerEvent.Button button)
-        {
-        }
-
         private void OnLeftClickPerformed(InputAction.CallbackContext ctx) => OnClickPerformed(ctx, GetEventSourceForCallback(ctx), PointerEvent.Button.MouseLeft);
-        
-        private void OnLeftClickCancelled(InputAction.CallbackContext ctx) => OnClickCancelled(ctx, GetEventSourceForCallback(ctx), PointerEvent.Button.MouseLeft);
-
         private void OnMiddleClickPerformed(InputAction.CallbackContext ctx) => OnClickPerformed(ctx, GetEventSourceForCallback(ctx), PointerEvent.Button.MouseMiddle);
-        private void OnMiddleClickCancelled(InputAction.CallbackContext ctx) => OnClickCancelled(ctx, GetEventSourceForCallback(ctx), PointerEvent.Button.MouseLeft);
-
         private void OnRightClickPerformed(InputAction.CallbackContext ctx) => OnClickPerformed(ctx, GetEventSourceForCallback(ctx), PointerEvent.Button.MouseRight);
-        private void OnRightClickCancelled(InputAction.CallbackContext ctx) => OnClickCancelled(ctx, GetEventSourceForCallback(ctx), PointerEvent.Button.MouseLeft);
 
         private void OnScrollWheelPerformed(InputAction.CallbackContext ctx)
         {
@@ -480,22 +470,13 @@ namespace InputSystem.Plugins.InputForUI
                 _cancelAction.action.performed += OnCancelPerformed;
 
             if (_leftClickAction.action != null)
-            {
                 _leftClickAction.action.performed += OnLeftClickPerformed;
-                _leftClickAction.action.canceled += OnLeftClickCancelled;
-            }
 
             if (_middleClickAction.action != null)
-            {
                 _middleClickAction.action.performed += OnMiddleClickPerformed;
-                _middleClickAction.action.canceled += OnMiddleClickCancelled;
-            }
 
             if (_rightClickAction.action != null)
-            {
                 _rightClickAction.action.performed += OnRightClickPerformed;
-                _rightClickAction.action.canceled += OnRightClickCancelled;
-            }
 
             if (_scrollWheelAction.action != null)
                 _scrollWheelAction.action.performed += OnScrollWheelPerformed;
@@ -520,22 +501,13 @@ namespace InputSystem.Plugins.InputForUI
                 _cancelAction.action.performed -= OnCancelPerformed;
 
             if (_leftClickAction.action != null)
-            {
                 _leftClickAction.action.performed -= OnLeftClickPerformed;
-                _leftClickAction.action.canceled -= OnLeftClickCancelled;
-            }
 
             if (_middleClickAction.action != null)
-            {
                 _middleClickAction.action.performed -= OnMiddleClickPerformed;
-                _middleClickAction.action.canceled -= OnMiddleClickCancelled;
-            }
 
             if (_rightClickAction.action != null)
-            {
                 _rightClickAction.action.performed -= OnRightClickPerformed;
-                _rightClickAction.action.canceled -= OnRightClickCancelled;
-            }
 
             if (_scrollWheelAction.action != null)
                 _scrollWheelAction.action.performed -= OnScrollWheelPerformed;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -1,3 +1,4 @@
+#if UNITY_2023_2_OR_NEWER // UnityEngine.InputForUI Module unavailable in earlier releases
 using System.Collections.Generic;
 using Unity.IntegerTime;
 using UnityEngine.InputSystem.Controls;
@@ -663,3 +664,4 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         }
     }
 }
+#endif // UNITY_2023_2_OR_NEWER

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -340,7 +340,7 @@ namespace InputSystem.Plugins.InputForUI
             var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
             var pointerIndex = FindPointerIndex(asTouchscreenDevice, asTouchControl);
 
-            if (asTouchControl != null)
+            if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;
             else if (asPenDevice != null)
                 _seenPenEvents = true;
@@ -436,6 +436,11 @@ namespace InputSystem.Plugins.InputForUI
             var asTouchscreenDevice = ctx.control.device is Touchscreen ? (Touchscreen)ctx.control.device : null;
             var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
             var pointerIndex = FindPointerIndex(asTouchscreenDevice, asTouchControl);
+            
+            if (asTouchControl != null || asTouchscreenDevice != null)
+                _seenTouchEvents = true;
+            else
+                _seenMouseEvents = true;
 
             var wasPressed = state.ButtonsState.Get(button);
             var isPressed = ctx.ReadValueAsButton();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -91,6 +91,14 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         public void Update()
         {
+#if UNITY_EDITOR
+            // Ensure we are in a good (initialized) state before running updates.
+            // This could be in a bad state for a duration while the build pipeline is running
+            // when building tests to run in the Standalone Player.
+            if (m_InputActionAsset == null)
+                return;
+#endif
+
             m_InputEventPartialProvider.Update();
 
             m_Events.Sort(SortEvents);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -31,7 +31,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         List<Event> _events = new List<Event>();
 
         private PointerState _mouseState;
-        private bool _seenMouseEvents;
 
         private PointerState _penState;
         private bool _seenPenEvents;
@@ -70,7 +69,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             _events.Clear();
 
             _mouseState.Reset();
-            _seenMouseEvents = false;
 
             _penState.Reset();
             _seenPenEvents = false;
@@ -132,7 +130,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         {
             _seenTouchEvents = false;
             _seenPenEvents = false;
-            _seenMouseEvents = false;
         }
 
         //TODO: Refactor as there is no need for having almost the same implementation in the IM and ISX?
@@ -343,7 +340,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             if (touchscreen == null)
                 return 0;
 
-			// Finds the index of the matching control type in the Touchscreen device lost of touch controls (touches)
+            // Finds the index of the matching control type in the Touchscreen device lost of touch controls (touches)
             for (var i = 0; i < touchscreen.touches.Count; ++i)
             {
                 if (asVector2Control != null && asVector2Control == touchscreen.touches[i].position)
@@ -374,8 +371,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
                 _seenTouchEvents = true;
             else if (asPenDevice != null)
                 _seenPenEvents = true;
-            else
-                _seenMouseEvents = true;
 
             var positionISX = ctx.ReadValue<Vector2>();
             var targetDisplay = asPointerDevice != null ? asPointerDevice.displayIndex.ReadValue() : (asTouchscreenDevice != null ? asTouchscreenDevice.displayIndex.ReadValue() : 0);
@@ -458,8 +453,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             _resetSeenEventsOnUpdate = true;
             if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;
-            else
-                _seenMouseEvents = true;
 
             var wasPressed = state.ButtonsState.Get(button);
             var isPressed = ctx.ReadValueAsButton();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -90,22 +90,6 @@ namespace InputSystem.Plugins.InputForUI
             RegisterActions(_cfg);
         }
 
-        private void OnNextPreviousPerformed(InputAction.CallbackContext ctx)
-        {
-            if (ctx.control.device is Keyboard)
-            {
-                //TODO repeat rate
-                var keyboard = ctx.control.device as Keyboard;
-                DispatchFromCallback(Event.From(new NavigationEvent
-                {
-                    type = NavigationEvent.Type.Move,
-                    direction = keyboard.shiftKey.isPressed ? NavigationEvent.Direction.Previous : NavigationEvent.Direction.Next,
-                    timestamp = _currentTime,
-                    eventSource = EventSource.Keyboard,
-                }));
-            }
-        }
-
         public void Shutdown()
         {
             UnregisterActions(_cfg);
@@ -143,12 +127,18 @@ namespace InputSystem.Plugins.InputForUI
             _seenMouseEvents = false;
         }
 
+        //TODO: Refactor as there is no need for having almost the same implementation in the IM and ISX?
         private void DirectionNavigation(DiscreteTime currentTime)
         {
-            //TODO: Refactor as there is no need for having almost the same implementation in the IM and ISX?
             var(move, axesButtonWerePressed) = ReadCurrentNavigationMoveVector();
-
             var direction = NavigationEvent.DetermineMoveDirection(move);
+
+            // Checks for next/previous directions if no movement was detected
+            if (direction == NavigationEvent.Direction.None)
+            {
+                direction = ReadNextPreviousDirection();
+                axesButtonWerePressed = _nextPreviousAction.WasPressedThisFrame();
+            }
 
             if (direction == NavigationEvent.Direction.None)
             {
@@ -163,11 +153,29 @@ namespace InputSystem.Plugins.InputForUI
                         type = NavigationEvent.Type.Move,
                         direction = direction,
                         timestamp = currentTime,
-                        eventSource = GetEventSource(_moveAction.action.activeControl.device),
+                        eventSource = GetEventSource(GetActiveDeviceFromDirection(direction)),
                         playerId = kDefaultPlayerId,
                         eventModifiers = _eventModifiers
                     }));
                 }
+            }
+        }
+
+        private InputDevice GetActiveDeviceFromDirection(NavigationEvent.Direction direction)
+        {
+            switch (direction)
+            {
+                case NavigationEvent.Direction.Left:
+                case NavigationEvent.Direction.Up:
+                case NavigationEvent.Direction.Right:
+                case NavigationEvent.Direction.Down:
+                    return _moveAction.action.activeControl.device;
+                case NavigationEvent.Direction.Next:
+                case NavigationEvent.Direction.Previous:
+                    return _nextPreviousAction.activeControl.device;
+                case NavigationEvent.Direction.None:
+                default:
+                    return Keyboard.current;
             }
         }
 
@@ -179,9 +187,28 @@ namespace InputSystem.Plugins.InputForUI
             return (move, axisWasPressed);
         }
 
+        private NavigationEvent.Direction ReadNextPreviousDirection()
+        {
+            if (_nextPreviousAction.IsPressed())
+            {
+                //TODO: For now it only deals with Keyboard, needs to deal with other devices if we can add bindings
+                //      for Gamepad, etc
+                //TODO: An alternative could be to have an action for next and for previous since shortcut support does
+                //      not work properly
+                if (_nextPreviousAction.activeControl.device is Keyboard)
+                {
+                    var keyboard = _nextPreviousAction.activeControl.device as Keyboard;
+                    // Return direction based on whether shift is pressed or not
+                    return keyboard.shiftKey.isPressed ? NavigationEvent.Direction.Previous : NavigationEvent.Direction.Next;
+                }
+            }
+
+            return NavigationEvent.Direction.None;
+        }
+
         private static int SortEvents(Event a, Event b)
         {
-            return Event.Compare(a, b);
+            return Event.CompareType(a, b);
         }
 
         public void OnFocusChanged(bool focus)
@@ -492,12 +519,9 @@ namespace InputSystem.Plugins.InputForUI
 
         private void RegisterNextPreviousAction()
         {
-            _nextPreviousAction = new InputAction(name: "nextPreviousAction");
+            _nextPreviousAction = new InputAction(name: "nextPreviousAction", type: InputActionType.Button);
             // TODO add more default bindings, or make them configurable
             _nextPreviousAction.AddBinding("<Keyboard>/tab");
-            if (_nextPreviousAction != null)
-                _nextPreviousAction.performed += OnNextPreviousPerformed;
-
             _nextPreviousAction.Enable();
         }
 
@@ -505,7 +529,6 @@ namespace InputSystem.Plugins.InputForUI
         {
             if (_nextPreviousAction != null)
             {
-                _nextPreviousAction.performed -= OnNextPreviousPerformed;
                 _nextPreviousAction.Disable();
                 _nextPreviousAction = null;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -105,7 +105,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
                 // this is mostly used to filter out simulated input, e.g. when pen is active it also generates mouse input
                 if (_seenTouchEvents && ev.type == Event.Type.PointerEvent && ev.eventSource == EventSource.Pen)
                     _penState.Reset();
-                else if ((_seenTouchEvents || _seenPenEvents) && 
+                else if ((_seenTouchEvents || _seenPenEvents) &&
                          ev.type == Event.Type.PointerEvent && (ev.eventSource == EventSource.Mouse || ev.eventSource == EventSource.Unspecified))
                     _mouseState.Reset();
                 else
@@ -121,9 +121,8 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
                 ResetSeenEvents();
                 _resetSeenEventsOnUpdate = false;
             }
-            
-            _events.Clear();
 
+            _events.Clear();
         }
 
         private void ResetSeenEvents()
@@ -449,7 +448,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             var asTouchscreenDevice = ctx.control.device is Touchscreen ? (Touchscreen)ctx.control.device : null;
             var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
             var pointerIndex = FindTouchFingerIndex(asTouchscreenDevice, ctx);
-            
+
             _resetSeenEventsOnUpdate = true;
             if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -335,6 +335,27 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             _events.Add(ev);
         }
 
+        private static int FindTouchFingerIndex(Touchscreen touchscreen, InputAction.CallbackContext ctx)
+        {
+            var asVector2Control = ctx.control is Vector2Control ? (Vector2Control)ctx.control : null;
+            var asTouchPressControl = ctx.control is TouchPressControl ? (TouchPressControl)ctx.control : null;
+            var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
+            if (touchscreen == null)
+                return 0;
+
+			// Finds the index of the matching control type in the Touchscreen device lost of touch controls (touches)
+            for (var i = 0; i < touchscreen.touches.Count; ++i)
+            {
+                if (asVector2Control != null && asVector2Control == touchscreen.touches[i].position)
+                    return i;
+                if (asTouchPressControl != null && asTouchPressControl == touchscreen.touches[i].press)
+                    return i;
+                if (asTouchControl != null && asTouchControl == touchscreen.touches[i])
+                    return i;
+            }
+            return 0;
+        }
+
         private void OnPointerPerformed(InputAction.CallbackContext ctx)
         {
             var eventSource = GetEventSource(ctx);
@@ -346,9 +367,8 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             var asPenDevice = ctx.control.device is Pen ? (Pen)ctx.control.device : null;
             var asTouchscreenDevice = ctx.control.device is Touchscreen ? (Touchscreen)ctx.control.device : null;
             var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
-            var pointerIndex = FindPointerIndex(asTouchscreenDevice, asTouchControl);
+            var pointerIndex = FindTouchFingerIndex(asTouchscreenDevice, ctx);
 
-            
             _resetSeenEventsOnUpdate = false;
             if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;
@@ -427,26 +447,14 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             }));
         }
 
-        private int FindPointerIndex(Touchscreen touchscreen, TouchControl touchControl)
-        {
-            if (touchscreen == null || touchControl == null)
-                return 0;
-
-            for (var i = 0; i < touchscreen.touches.Count; ++i)
-                if (touchscreen.touches[i] == touchControl)
-                    return i;
-
-            return 0;
-        }
-
         private void OnClickPerformed(InputAction.CallbackContext ctx, EventSource eventSource, PointerEvent.Button button)
         {
             ref var state = ref GetPointerStateForSource(eventSource);
 
             var asTouchscreenDevice = ctx.control.device is Touchscreen ? (Touchscreen)ctx.control.device : null;
             var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
-            var pointerIndex = FindPointerIndex(asTouchscreenDevice, asTouchControl);
-
+            var pointerIndex = FindTouchFingerIndex(asTouchscreenDevice, ctx);
+            
             _resetSeenEventsOnUpdate = true;
             if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         private const float kSmallestReportedMovementSqrDist = 0.01f;
 
         private NavigationEventRepeatHelper repeatHelper = new();
-        private bool _doNotResetSeenEventsOnUpdate;
+        private bool _resetSeenEventsOnUpdate;
 
         static InputSystemProvider()
         {
@@ -122,10 +122,10 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             // To avoid dispatching them, the seen event flags aren't reset in between calls to OnPointerPerformed.
             // Essentially, if we're moving with Touch or Pen, lower priority events aren't dispatch as well.
             // Once OnClickPerformed is called, the seen flags are reset
-            if (!_doNotResetSeenEventsOnUpdate)
+            if (_resetSeenEventsOnUpdate)
             {
                 ResetSeenEvents();
-                _doNotResetSeenEventsOnUpdate = false;
+                _resetSeenEventsOnUpdate = false;
             }
             
             _events.Clear();
@@ -353,7 +353,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             var pointerIndex = FindPointerIndex(asTouchscreenDevice, asTouchControl);
 
             
-            _doNotResetSeenEventsOnUpdate = true;
+            _resetSeenEventsOnUpdate = false;
             if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;
             else if (asPenDevice != null)
@@ -451,7 +451,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             var asTouchControl = ctx.control is TouchControl ? (TouchControl)ctx.control : null;
             var pointerIndex = FindPointerIndex(asTouchscreenDevice, asTouchControl);
 
-            _doNotResetSeenEventsOnUpdate = false;
+            _resetSeenEventsOnUpdate = true;
             if (asTouchControl != null || asTouchscreenDevice != null)
                 _seenTouchEvents = true;
             else

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -51,16 +51,15 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         static InputSystemProvider()
         {
-            // TODO check if input system is enabled before doing this
-            // enable me to test!
+            // Only if InputSystem is enabled in the PlayerSettings do we set it as the provider.
+            // This includes situations where both InputManager and InputSystem are enabled.
+#if ENABLE_INPUT_SYSTEM
             EventProvider.SetInputSystemProvider(new InputSystemProvider());
+#endif
         }
 
         [RuntimeInitializeOnLoadMethod(loadType: RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void Bootstrap()
-        {
-            // will invoke static class constructor
-        }
+        private static void Bootstrap() {} // Empty function. Exists only to invoke the static class constructor in Runtime Players
 
         private EventModifiers _eventModifiers => _inputEventPartialProvider._eventModifiers;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -111,11 +111,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
                          ev.type == Event.Type.PointerEvent && (ev.eventSource == EventSource.Mouse || ev.eventSource == EventSource.Unspecified))
                     _mouseState.Reset();
                 else
-                {
-                   if(ev.eventSource == EventSource.Mouse) 
-                       Debug.Log("Mouse event triggered");
                     EventProvider.Dispatch(ev);
-                }
             }
 
             // Sometimes single lower priority events can be received when using Touch or Pen, on a different frame.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6965b068653ebe45986cb10b38854d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -15,6 +15,7 @@
 		"xr"
 	],
 	"dependencies" : {
-		"com.unity.modules.uielements": "1.0.0"
+		"com.unity.modules.uielements": "1.0.0",
+		"com.unity.inputsystem.forui": "1.0.0"
 	}
 }

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -15,7 +15,6 @@
 		"xr"
 	],
 	"dependencies" : {
-		"com.unity.modules.uielements": "1.0.0",
-		"com.unity.inputsystem.forui": "1.0.0"
+		"com.unity.modules.uielements": "1.0.0"
 	}
 }


### PR DESCRIPTION
### Description

This adds the `InputSystemProvider` implementation for the InputForUI module.
The InputForUI module was added to newer Unity Engine versions (2023.2 and above) to better abstract UI components (i.e. UI Toolkit) from the Input implementation.
This is purely an internal api artifact and should not result in any behaviour changes for users.

`InputSystemProvider` is responsible for providing input to UI frameworks when InputSystem is installed and enables.

### Changes made

Added the `InputSystemProvider` class which sits in it's own Assembly. 


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
