### PR TITLE
CHANGE: Add automated testing setup for InputForUI

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -2,11 +2,17 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.InputForUI;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Plugins.InputForUI;
 using Event = UnityEngine.InputForUI.Event;
 using EventProvider = UnityEngine.InputForUI.EventProvider;
 
+// These tests are not meant to test the InputForUI module itself, but rather the integration between the InputForUI
+// module and the InputSystem package.
+// Be aware that these tests don't account for events dispatched by the InputEventPartialProvider. Those events are
+// already tested in the Input Manager provider.
+// Also, the internals to test InputEventPartialProvider are not exposed publicly, so we can't test them here.
 public class InputForUITests : InputTestFixture
 {
     readonly List<Event> m_InputForUIEvents = new List<Event>();
@@ -53,7 +59,72 @@ public class InputForUITests : InputTestFixture
 
         Assert.IsTrue(m_InputForUIEvents.Count == 2);
         Assert.That(m_InputForUIEvents[0].type, Is.EqualTo(Event.Type.PointerEvent));
+        Assert.That(m_InputForUIEvents[0].asPointerEvent.type, Is.EqualTo(PointerEvent.Type.ButtonPressed));
         Assert.That(m_InputForUIEvents[1].type, Is.EqualTo(Event.Type.PointerEvent));
+        Assert.That(m_InputForUIEvents[1].asPointerEvent.type, Is.EqualTo(PointerEvent.Type.ButtonReleased));
+    }
+
+    [Test]
+    [Category("InputForUI")]
+    // Checks that mouse events are ignored when a touch is active.
+    // This is to workaround the issue ISXB-269 on Windows.
+    public void TouchIsPressedAndMouseEventsAreIgnored()
+    {
+        var touch = InputSystem.AddDevice<Touchscreen>();
+        var mouse = InputSystem.AddDevice<Mouse>();
+        // Set initial mouse position to (0.5, 0.5) so that we get a delta when the mouse is moved, to dispatch
+        // a pointer move event
+        Set(mouse.position, new Vector2(0.5f, 0.5f));
+        Update();
+
+        // Start touch and move mouse to the same position to replicate the issue of duplicated Mouse events for
+        // Touch events on Windows.
+        BeginTouch(1, new Vector2(100f, 0.5f));
+        Move(mouse.position, new Vector2(100f, 0.5f));
+        Update();
+
+        Assert.IsTrue(m_InputForUIEvents.Count == 1);
+        Assert.That(m_InputForUIEvents[0] is Event
+        {
+            type: Event.Type.PointerEvent,
+            asPointerEvent: { type: PointerEvent.Type.ButtonPressed,
+                              eventSource: EventSource.Touch }
+        });
+    }
+
+    [Test]
+    [Category("InputForUI")]
+    // Presses a gamepad left stick left and verifies that a navigation move event is dispatched
+    public void NavigationMoveWorks()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        Update();
+        Press(gamepad.leftStick.left);
+        Update();
+        Release(gamepad.leftStick.left);
+        Update();
+
+        Assert.IsTrue(m_InputForUIEvents.Count == 1);
+        Assert.That(m_InputForUIEvents[0] is Event
+        {
+            type: Event.Type.NavigationEvent,
+            asNavigationEvent: { type: NavigationEvent.Type.Move,
+                                 direction: NavigationEvent.Direction.Left,
+                                 eventSource: EventSource.Gamepad}
+        });
+    }
+
+    [Test]
+    [Category("InputForUI")]
+    public void SendWheelEvent()
+    {
+        var kScrollUGUIScaleFactor = 40f; // See InputSystemProvider OnScrollWheelPerformed() callback
+        var mouse = InputSystem.AddDevice<Mouse>();
+        Update();
+        Set(mouse.scroll.y, -1f * kScrollUGUIScaleFactor);
+        Update();
+        Assert.IsTrue(m_InputForUIEvents.Count == 1);
+        Assert.That(m_InputForUIEvents[0].asPointerEvent.scroll, Is.EqualTo(new Vector2(0, 1)));
     }
 
     static void Update()

--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -1,0 +1,65 @@
+#if UNITY_2023_2_OR_NEWER // UnityEngine.InputForUI Module unavailable in earlier releases
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Plugins.InputForUI;
+using Event = UnityEngine.InputForUI.Event;
+using EventProvider = UnityEngine.InputForUI.EventProvider;
+
+public class InputForUITests : InputTestFixture
+{
+    readonly List<Event> m_InputForUIEvents = new List<Event>();
+    InputSystemProvider m_InputSystemProvider;
+
+    [SetUp]
+    public void SetUp()
+    {
+        base.Setup();
+
+        var defaultActions = new DefaultInputActions();
+        defaultActions.Enable();
+
+        m_InputSystemProvider = new InputSystemProvider();
+        EventProvider.SetMockProvider(m_InputSystemProvider);
+        // Register at least one consumer so the mock update gets invoked
+        EventProvider.Subscribe(InputForUIOnEvent);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        EventProvider.Unsubscribe(InputForUIOnEvent);
+        EventProvider.ClearMockProvider();
+        m_InputForUIEvents.Clear();
+    }
+
+    private bool InputForUIOnEvent(in Event ev)
+    {
+        m_InputForUIEvents.Add(ev);
+        return true;
+    }
+
+    [Test]
+    [Category("InputForUI")]
+    public void PointerEventsAreDispatchedFromMouse()
+    {
+        var mouse = InputSystem.AddDevice<Mouse>();
+        Update();
+
+        PressAndRelease(mouse.leftButton);
+
+        Update();
+
+        Assert.IsTrue(m_InputForUIEvents.Count == 2);
+        Assert.That(m_InputForUIEvents[0].type, Is.EqualTo(Event.Type.PointerEvent));
+        Assert.That(m_InputForUIEvents[1].type, Is.EqualTo(Event.Type.PointerEvent));
+    }
+
+    static void Update()
+    {
+        EventProvider.NotifyUpdate();
+        InputSystem.Update();
+    }
+}
+#endif

--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs.meta
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cd326e953b134d419a86c3638e51c644
+timeCreated: 1684329046

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -9,7 +9,8 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "Unity.PerformanceTesting",
-        "Unity.Coding.Editor"
+        "Unity.Coding.Editor",
+        "Unity.InputSystem.ForUI"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/AssemblyInfo.cs
@@ -2,4 +2,5 @@ using System.Runtime.CompilerServices;
 using UnityEngine.Scripting;
 
 [assembly: InternalsVisibleTo("UnityEngine.InputForUIVisualizer")]
+[assembly: InternalsVisibleTo("Unity.InputSystem.Tests")]
 [assembly: AlwaysLinkAssembly]


### PR DESCRIPTION
### Description

Adds the test setup for the InputSystemProvider that is used on the 2023.2+ InputForUI module.

### Changes made

Sets up the Unity project to test the InputForUI module with the InputSystemProvider implementation.
Adds a basic test with a mouse to validate that the test setup is working and that events are being dispatched.

### Notes

**This depends on #1679 and should not be merged before** 

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests : 'Plugins/InputForUITests.cs`


During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
