### PR TITLE
Remove 2022.1 from CI tests

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -2,7 +2,7 @@ editors:
   - version: 2020.3
     disable_tvos_run: true
   - version: 2021.3
-  - version: 2022.2
+  - version: 2022.3
   - version: 2023.1
   - version: trunk
     disable_tvos_run: true

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -2,7 +2,6 @@ editors:
   - version: 2020.3
     disable_tvos_run: true
   - version: 2021.3
-  - version: 2022.1
   - version: 2022.2
   - version: 2023.1
   - version: trunk


### PR DESCRIPTION
Remove 2022.1 from CI tests as they are no longer passing and the version is no longer supported anyway.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
