### PR TITLE
[2022.3] Change #ifdef to allow for displayIndex (multi-display) in Unity 2022.3

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3829,7 +3829,7 @@ internal class UITests : CoreTestsFixture
     }
 
     #region Multi Display Tests
-#if UNITY_2023_1_OR_NEWER // displayIndex is only available from 2023.1 onwards
+#if UNITY_2022_3_OR_NEWER // displayIndex is only available from 2022.3 onwards
 
     [UnityTest]
 #if UNITY_TVOS
@@ -4377,7 +4377,7 @@ internal class UITests : CoreTestsFixture
                 radius = eventData.radius,
                 radiusVariance = eventData.radiusVariance,
 #endif
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
                 displayIndex = eventData.displayIndex,
 #endif
             };

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Added
+- Enabled `displayIndex` support for Unity 2022.3.
+
 ### Fixed
 - Fixed UI clicks not registering when OS provides multiple input sources for the same event, e.g. on Samsung Dex (case ISX-1416, ISXB-342).
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
@@ -96,7 +96,7 @@ namespace UnityEngine.InputSystem.UI
             stringBuilder.AppendLine("altitudeAngle: " + altitudeAngle);
             stringBuilder.AppendLine("twist: " + twist);
             #endif
-            #if UNITY_2023_1_OR_NEWER
+            #if UNITY_2022_3_OR_NEWER
             stringBuilder.AppendLine("displayIndex: " + displayIndex);
             #endif
             return stringBuilder.ToString();
@@ -142,7 +142,7 @@ namespace UnityEngine.InputSystem.UI
                 altitudeAngle = (pen.tilt.value.y + 1) * Mathf.PI / 2;
                 twist = pen.twist.value * Mathf.PI * 2;
                 #endif
-                #if UNITY_2023_1_OR_NEWER
+                #if UNITY_2022_3_OR_NEWER
                 displayIndex = pen.displayIndex.ReadValue();
                 #endif
             }
@@ -153,7 +153,7 @@ namespace UnityEngine.InputSystem.UI
                 pressure = touchControl.pressure.magnitude;
                 radius = touchControl.radius.value;
                 #endif
-                #if UNITY_2023_1_OR_NEWER
+                #if UNITY_2022_3_OR_NEWER
                 displayIndex = touchControl.displayIndex.ReadValue();
                 #endif
             }
@@ -164,7 +164,7 @@ namespace UnityEngine.InputSystem.UI
                 pressure = touchscreen.pressure.magnitude;
                 radius = touchscreen.radius.value;
                 #endif
-                #if UNITY_2023_1_OR_NEWER
+                #if UNITY_2022_3_OR_NEWER
                 displayIndex = touchscreen.displayIndex.ReadValue();
                 #endif
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1737,7 +1737,7 @@ namespace UnityEngine.InputSystem.UI
                     eventData.pointerType = pointerType;
                     eventData.pointerId = pointerId;
                     eventData.touchId = touchId;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
                     eventData.displayIndex = displayIndex;
 #endif
 
@@ -1833,7 +1833,7 @@ namespace UnityEngine.InputSystem.UI
                 eventData = new ExtendedPointerEventData(eventSystem);
 
             eventData.pointerId = pointerId;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             eventData.displayIndex = displayIndex;
 #endif
             eventData.touchId = touchId;
@@ -1959,7 +1959,7 @@ namespace UnityEngine.InputSystem.UI
 
             ref var state = ref GetPointerStateForIndex(index);
             state.screenPosition = context.ReadValue<Vector2>();
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }
@@ -1990,7 +1990,7 @@ namespace UnityEngine.InputSystem.UI
             state.changedThisFrame = true;
             if (IgnoreNextClick(ref context, wasPressed))
                 state.leftButton.ignoreNextClick = true;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }
@@ -2007,7 +2007,7 @@ namespace UnityEngine.InputSystem.UI
             state.changedThisFrame = true;
             if (IgnoreNextClick(ref context, wasPressed))
                 state.rightButton.ignoreNextClick = true;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }
@@ -2024,7 +2024,7 @@ namespace UnityEngine.InputSystem.UI
             state.changedThisFrame = true;
             if (IgnoreNextClick(ref context, wasPressed))
                 state.middleButton.ignoreNextClick = true;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }
@@ -2055,7 +2055,7 @@ namespace UnityEngine.InputSystem.UI
             // The old input system reported scroll deltas in lines, we report pixels.
             // Need to scale as the UI system expects lines.
             state.scrollDelta = context.ReadValue<Vector2>() * (1 / kPixelPerLine);
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }
@@ -2074,7 +2074,7 @@ namespace UnityEngine.InputSystem.UI
 
             ref var state = ref GetPointerStateForIndex(index);
             state.worldOrientation = context.ReadValue<Quaternion>();
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }
@@ -2087,7 +2087,7 @@ namespace UnityEngine.InputSystem.UI
 
             ref var state = ref GetPointerStateForIndex(index);
             state.worldPosition = context.ReadValue<Vector3>();
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif
         }


### PR DESCRIPTION
### Description

Alters the #ifdef's that protect the displayIndex work to match supported Unity editor versions. It actually landed in late 2022.2 as well, but it was safer to use the UNITY_2022_3_OR_NEWER condition.

### Changes made

`#if UNITY_2023_1_OR_NEWER` is now `#if UNITY_2022_3_OR_NEWER` for displayIndex code
