### PR TITLE
Fix for TrackedPoseDriver's BeforeRender update not being invoked

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed UI clicks not registering when OS provides multiple input sources for the same event, e.g. on Samsung Dex (case ISX-1416, ISXB-342).
+- Fixed drift lag in `TrackedPoseDriver` due to `InputUpdateType.BeforeRender` not being invoked anywhere.
 
 ## [1.6.1] - 2023-05-26
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -422,6 +422,7 @@ namespace UnityEngine.InputSystem.XR
         /// </summary>
         protected void OnEnable()
         {
+            Application.onBeforeRender += PerformInputSystemUpdateBeforeRender;
             InputSystem.onAfterUpdate += UpdateCallback;
             BindActions();
 
@@ -437,6 +438,7 @@ namespace UnityEngine.InputSystem.XR
         {
             UnbindActions();
             InputSystem.onAfterUpdate -= UpdateCallback;
+            Application.onBeforeRender -= PerformInputSystemUpdateBeforeRender;
         }
 
         /// <summary>
@@ -451,6 +453,8 @@ namespace UnityEngine.InputSystem.XR
             }
 #endif
         }
+
+        void PerformInputSystemUpdateBeforeRender() => InputSystem.Update(InputUpdateType.BeforeRender);
 
         /// <summary>
         /// The callback method called after the Input System has completed an update and processed all pending events.


### PR DESCRIPTION
### Description

This fixes the drift lag issue with `TrackedPoseDriver` that made it less usable than the deprecated `ARPoseDriver`

#### Issue Links
- https://github.com/Unity-Technologies/arfoundation-samples/issues/1063

### Changes made

`TrackedPoseDriver` now hooks into `Application.onBeforeRender` and invokes `InputSystem.Update(InputUpdateType.BeforeRender)`. `TrackedPoseDriver` expects that update type, yet it's not actually invoked from anywhere. Since `TrackedPoseDriver` requires OnBeforeRender input updates to be called to work properly, we simply have `TrackedPoseDriver` manage invoking the update.

### Notes

- Should we have the `OnBeforeRender` input update called from elsewhere, or is it acceptable for `TrackedPoseDriver` to manage it?
- XR `TrackedPoseDriver` Tests already covers BeforeRender update.
- No doc changes, as no API surface changes.
