### PR TITLE
FIX: Broken "Listen" button in Input actions editor window on Unity 2022.3.1f1 with Unity dark skin

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem.Editor
     {
         private static class Styles
         {
-            public static readonly GUIStyle toolbarSearchField = "ToolbarSeachTextField";
+            public static readonly GUIStyle toolbarSearchField = "ToolbarSearchTextField";
             public static readonly GUIStyle itemStyle = new GUIStyle("PR Label")
                 .WithAlignment(TextAnchor.MiddleLeft)
                 .WithPadding(new RectOffset())


### PR DESCRIPTION
### Description
Fixes a bug in **Unity 2022.3f1** that breaks viewing the "Listen" button in the input actions editor window when unity dark skin is applied.

## Before
![Snag_a50c385](https://github.com/Unity-Technologies/InputSystem/assets/2967721/4fcb4ad1-f3a1-4f74-a9c7-c0669ee3332c)
![Snag_a50d037](https://github.com/Unity-Technologies/InputSystem/assets/2967721/de4996b3-7b3c-4a7b-9a6e-c913b9bfd4bd)
## After
![image](https://github.com/Unity-Technologies/InputSystem/assets/2967721/f230fadf-63c2-410f-b26c-8188900726e7)


### Changes made

* Updated the style name from "ToolbarSeachTextField" (old style name with typo) to "ToolbarSearchTextField" (new corrected style name with no typo)

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
