### PR TITLE
FIX: Integration tests CI instability on Integration_CanSendAndReceiveEvents 

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed UI clicks not registering when OS provides multiple input sources for the same event, e.g. on Samsung Dex (case ISX-1416, ISXB-342).
+- Fixed unstable integration test `Integration_CanSendAndReceiveEvents` by ignoring application focus on integration tests. (case ISX-1381)
 
 ## [1.6.1] - 2023-05-26
 

--- a/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
@@ -68,6 +68,22 @@ public class IntegrationTests
         var dummy = new System.ComponentModel.StringConverter();
     }
 
+    [SetUp]
+    public virtual void Setup()
+    {
+        // The standalone player can go out of focus when running tests. This makes the devices added during tests set
+        // as disabled. Which in turn makes the InputSystem update not process input state changes for devices.
+        // By ignoring focus, we can protect ourselves against this and always update the device state in the standalone
+        // test players
+        InputSystem.settings.backgroundBehavior = InputSettings.BackgroundBehavior.IgnoreFocus;
+    }
+
+    [TearDown]
+    public virtual void TearDown()
+    {
+        InputSystem.settings.backgroundBehavior = default;
+    }
+
     [Test]
     [Category("Integration")]
     public void Integration_CanSendAndReceiveEvents()


### PR DESCRIPTION
### Description

This PR fixes the CI instability reported in ISX-1381, where `Integration_CanSendAndReceiveEvents` would fail.

### Changes made

Locally, the test failed because sometimes the device state was not updated. This was because the device was seen as ["disabled"](https://github.com/Unity-Technologies/InputSystem/blob/ed762024987e355b04c64d3aaacf224fdab056c2/Packages/com.unity.inputsystem/InputSystem/InputManager.cs#L3119)), thus not updating its state. The reason why the device was disabled is that sometimes the test player didn't have "game focus" (see [[1]](https://github.com/Unity-Technologies/InputSystem/blob/ed762024987e355b04c64d3aaacf224fdab056c2/Packages/com.unity.inputsystem/InputSystem/InputManager.cs#L1184)  and [[2]](https://github.com/Unity-Technologies/InputSystem/blob/ed762024987e355b04c64d3aaacf224fdab056c2/Packages/com.unity.inputsystem/InputSystem/InputManager.cs#L314-L313).)

On macOS, I've seen this happening due to the "accept incoming connection" pop-up, and on Windows a similar pop-up appeared.
By setting the background behavior settings to InputSettings.BackgroundBehavior.IgnoreFocus, the test always passed locally.


### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
