### PR TITLE
FIX: Broken "Listen" button in Input actions editor window with Unity dark skin (ISXB-536)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed UI clicks not registering when OS provides multiple input sources for the same event, e.g. on Samsung Dex (case ISX-1416, ISXB-342).
 - Fixed unstable integration test `Integration_CanSendAndReceiveEvents` by ignoring application focus on integration tests. (case ISX-1381)
+- Fixed broken "Listen" button in Input actions editor window with Unity dark skin (case ISXB-536).
 
 ## [1.6.1] - 2023-05-26
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem.Editor
     {
         private static class Styles
         {
-            public static readonly GUIStyle toolbarSearchField = "ToolbarSeachTextField";
+            public static readonly GUIStyle toolbarSearchField = "ToolbarSearchTextField";
             public static readonly GUIStyle itemStyle = new GUIStyle("PR Label")
                 .WithAlignment(TextAnchor.MiddleLeft)
                 .WithPadding(new RectOffset())


### PR DESCRIPTION
### Description

Fixes a bug that breaks viewing the "Listen" button in the input actions editor window when unity dark skin is applied. The original PR: [here](https://github.com/Unity-Technologies/InputSystem/pull/1692). Thanks to [thsbrown](https://github.com/thsbrown)!

### Changes made

Updated the style name from "ToolbarSeachTextField" (old style name with typo) to "ToolbarSearchTextField" (new corrected style name with no typo)

### Notes

The original PR can be viewed [here](https://github.com/Unity-Technologies/InputSystem/pull/1692).

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
