### PR TITLE
[ISXB-551] Fix InputControls for precompiled layouts

### DIFF
--- a/Assets/Samples/CustomDevice/CustomDevice.cs
+++ b/Assets/Samples/CustomDevice/CustomDevice.cs
@@ -177,10 +177,10 @@ public class CustomDevice : InputDevice, IInputUpdateCallbackReceiver
     // for it a little bit. One thing we can do is expose the controls for our
     // device directly. While anyone can look up our controls using strings, exposing
     // the controls as properties makes it simpler to work with the device in script.
-    public ButtonControl firstButton { get; private set; }
-    public ButtonControl secondButton { get; private set; }
-    public ButtonControl thirdButton { get; private set; }
-    public StickControl stick { get; private set; }
+    public ButtonControl firstButton { get; protected set; }
+    public ButtonControl secondButton { get; protected set; }
+    public ButtonControl thirdButton { get; protected set; }
+    public StickControl stick { get; protected set; }
 
     // FinishSetup is where our device setup is finalized. Here we can look up
     // the controls that have been created.

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
 using Unity.Collections;
@@ -8,6 +10,7 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
@@ -1523,5 +1526,68 @@ partial class CoreTests
         Assert.That(mouse.position.x.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
         Assert.That(mouse.position.y.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatFloat));
         Assert.That(mouse.position.optimizedControlDataType, Is.EqualTo(InputStateBlock.FormatInvalid));
+    }
+    
+    [Test]
+    [Category("Controls")]
+    public void Controls_PrecompiledLayouts_AllChildControlPropertiesHaveSetters()
+    {
+        var inputDevice = typeof(InputDevice);
+        var inputControlType = typeof(InputControl);
+        var checkedTypes = new HashSet<Type>();
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            try
+            {
+                foreach (var type in assembly.GetTypes())
+                {
+                    // Skip base types
+                    if (type == inputControlType || type == inputDevice)
+                        continue;
+                    
+                    if (!inputControlType.IsAssignableFrom(type))
+                        continue;
+                    
+                    CheckChildControls(type, checkedTypes);
+                }
+            }
+            catch (ReflectionTypeLoadException)
+            {
+                // Suppress type load exceptions
+            }
+        }
+    }
+
+    static void CheckChildControls(Type type, HashSet<Type> checkedTypes)
+    {
+        if (!checkedTypes.Add(type))
+            return;
+
+        foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {   
+            if (!typeof(InputControl).IsAssignableFrom(property.PropertyType))
+                continue;
+
+            // Note: This will miss InputDevice controls that don't have an InputControlAttribute, but is necessary
+            // because not all InputControl properties are actually controls. We would need to build the device to know
+            // for sure if a given property is a control
+            if (!property.GetCustomAttributes<InputControlAttribute>().Any())
+                continue;
+
+            var setMethod = property.SetMethod;
+            if (typeof(InputDevice).IsAssignableFrom(type))
+            {
+                // Properties on an InputDevice can be protected, since the precompiled layout will be an inherited class
+                var inputDeviceMessage = $"A public or protected setter is required on {type.FullName}.{property.Name} in order to support precompiled layouts";
+                Assert.That(setMethod, Is.Not.Null, inputDeviceMessage);
+                Assert.That(setMethod.IsPrivate, Is.Not.True, inputDeviceMessage);
+                Assert.That(setMethod.IsAssembly, Is.Not.True, inputDeviceMessage);
+                continue;
+            }
+
+            var inputControlMessage = $"A public setter is required on {type.FullName}.{property.Name} in order to support precompiled layouts";
+            Assert.That(setMethod, Is.Not.Null, inputControlMessage);
+            Assert.That(setMethod.IsPublic, Is.True, inputControlMessage);
+        }
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -1041,7 +1041,7 @@ partial class CoreTests
     private class TestDeviceThatResetsStateInCallback : InputDevice, IInputStateCallbackReceiver
     {
         [InputControl(format = "FLT")]
-        public ButtonControl button { get; private set; }
+        public ButtonControl button { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -2029,7 +2029,7 @@ partial class CoreTests
     class DeviceWithCustomReset : InputDevice, ICustomDeviceReset
     {
         [InputControl]
-        public AxisControl axis { get; private set; }
+        public AxisControl axis { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -5630,8 +5630,8 @@ partial class CoreTests
 
         public Behavior behavior = Behavior.PreserveEventsAsIs;
 
-        public IntegerControl value1 { get; private set; }
-        public IntegerControl value2 { get; private set; }
+        public IntegerControl value1 { get; protected set; }
+        public IntegerControl value2 { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -2081,7 +2081,7 @@ partial class CoreTests
     [InputControlLayout(stateType = typeof(CustomDeviceState))]
     private class CustomDevice : InputDevice
     {
-        public AxisControl axis { get; private set; }
+        public AxisControl axis { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -2549,7 +2549,7 @@ partial class CoreTests
         }
 
         public bool throwExceptionOnState = true;
-        public AxisControl axis { get; private set; }
+        public AxisControl axis { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Assets/Tests/InputSystem/CoreTests_Remoting.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Remoting.cs
@@ -532,7 +532,7 @@ partial class CoreTests
 
     private class MyDevice : InputDevice
     {
-        public ButtonControl myControl { get; private set; }
+        public ButtonControl myControl { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -561,7 +561,7 @@ internal class OnScreenTests : CoreTestsFixture
     public class CustomDevice : InputDevice
     {
         [InputControl]
-        public ButtonControl button { get; private set; }
+        public ButtonControl button { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Assets/Tests/InputSystem/Plugins/SteamTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/SteamTests.cs
@@ -380,8 +380,8 @@ internal class SteamTests : CoreTestsFixture
     [InputControlLayout(stateType = typeof(TestControllerState))]
     class TestController : SteamController
     {
-        public ButtonControl fire { get; private set; }
-        public StickControl look { get; private set; }
+        public ButtonControl fire { get; protected set; }
+        public StickControl look { get; protected set; }
 
         public int updateCount;
         public int resolveActionsCount;

--- a/Assets/Tests/InputSystem/Plugins/XRTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XRTests.cs
@@ -333,11 +333,11 @@ internal class XRTests : CoreTestsFixture
     class TestHMD : UnityEngine.InputSystem.InputDevice
     {
         [InputControl]
-        public QuaternionControl rotation { get; private set; }
+        public QuaternionControl rotation { get; protected set; }
         [InputControl]
-        public Vector3Control position { get; private set; }
+        public Vector3Control position { get; protected set; }
         [InputControl]
-        public IntegerControl trackingState { get; private set; }
+        public IntegerControl trackingState { get; protected set; }
         protected override void FinishSetup()
         {
             base.FinishSetup();
@@ -351,9 +351,9 @@ internal class XRTests : CoreTestsFixture
     class TestHMDWithoutTrackingState : UnityEngine.InputSystem.InputDevice
     {
         [InputControl]
-        public QuaternionControl rotation { get; private set; }
+        public QuaternionControl rotation { get; protected set; }
         [InputControl]
-        public Vector3Control position { get; private set; }
+        public Vector3Control position { get; protected set; }
         protected override void FinishSetup()
         {
             base.FinishSetup();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed UI clicks not registering when OS provides multiple input sources for the same event, e.g. on Samsung Dex (case ISX-1416, ISXB-342).
 - Fixed unstable integration test `Integration_CanSendAndReceiveEvents` by ignoring application focus on integration tests. (case ISX-1381)
 - Fixed broken "Listen" button in Input actions editor window with Unity dark skin (case ISXB-536).
+- Fixed an issue where some controls like `QuaternionControl` could not be included in a Precompiled Layout because the generated code could not access a setter on child control properties.
 
 ## [1.6.1] - 2023-05-26
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/QuaternionControl.cs
@@ -22,28 +22,28 @@ namespace UnityEngine.InputSystem.Controls
         /// </summary>
         /// <value>Control representing the X component.</value>
         [InputControl(displayName = "X")]
-        public AxisControl x { get; private set; }
+        public AxisControl x { get; set; }
 
         /// <summary>
         /// The Y component of the quaternion.
         /// </summary>
         /// <value>Control representing the Y component.</value>
         [InputControl(displayName = "Y")]
-        public AxisControl y { get; private set; }
+        public AxisControl y { get; set; }
 
         /// <summary>
         /// The Z component of the quaternion.
         /// </summary>
         /// <value>Control representing the Z component.</value>
         [InputControl(displayName = "Z")]
-        public AxisControl z { get; private set; }
+        public AxisControl z { get; set; }
 
         /// <summary>
         /// The W component of the quaternion.
         /// </summary>
         /// <value>Control representing the W component.</value>
         [InputControl(displayName = "W")]
-        public AxisControl w { get; private set; }
+        public AxisControl w { get; set; }
 
         /// <summary>
         /// Default-initialize the control.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Sensor.cs
@@ -159,7 +159,7 @@ namespace UnityEngine.InputSystem
     [InputControlLayout(stateType = typeof(AccelerometerState))]
     public class Accelerometer : Sensor
     {
-        public Vector3Control acceleration { get; private set; }
+        public Vector3Control acceleration { get; protected set; }
 
         /// <summary>
         /// The accelerometer that was last added or had activity last.
@@ -199,7 +199,7 @@ namespace UnityEngine.InputSystem
     [InputControlLayout(stateType = typeof(GyroscopeState))]
     public class Gyroscope : Sensor
     {
-        public Vector3Control angularVelocity { get; private set; }
+        public Vector3Control angularVelocity { get; protected set; }
 
         /// <summary>
         /// The gyroscope that was last added or had activity last.
@@ -240,7 +240,7 @@ namespace UnityEngine.InputSystem
     [InputControlLayout(stateType = typeof(GravityState), displayName = "Gravity")]
     public class GravitySensor : Sensor
     {
-        public Vector3Control gravity { get; private set; }
+        public Vector3Control gravity { get; protected set; }
 
         /// <summary>
         /// The gravity sensor that was last added or had activity last.
@@ -282,7 +282,7 @@ namespace UnityEngine.InputSystem
     [InputControlLayout(stateType = typeof(AttitudeState), displayName = "Attitude")]
     public class AttitudeSensor : Sensor
     {
-        public QuaternionControl attitude { get; private set; }
+        public QuaternionControl attitude { get; protected set; }
 
         /// <summary>
         /// The attitude sensor that was last added or had activity last.
@@ -324,7 +324,7 @@ namespace UnityEngine.InputSystem
     [InputControlLayout(stateType = typeof(LinearAccelerationState), displayName = "Linear Acceleration")]
     public class LinearAccelerationSensor : Sensor
     {
-        public Vector3Control acceleration { get; private set; }
+        public Vector3Control acceleration { get; protected set; }
 
         /// <summary>
         /// The linear acceleration sensor that was last added or had activity last.
@@ -369,7 +369,7 @@ namespace UnityEngine.InputSystem
         /// Values are in micro-Tesla (uT) and measure the ambient magnetic field in the X, Y and Z axis.
         /// </remarks>
         [InputControl(displayName = "Magnetic Field", noisy = true)]
-        public Vector3Control magneticField { get; private set; }
+        public Vector3Control magneticField { get; protected set; }
 
         /// <summary>
         /// The linear acceleration sensor that was last added or had activity last.
@@ -410,7 +410,7 @@ namespace UnityEngine.InputSystem
         /// Light level in SI lux units.
         /// </summary>
         [InputControl(displayName = "Light Level", noisy = true)]
-        public AxisControl lightLevel { get; private set; }
+        public AxisControl lightLevel { get; protected set; }
 
         /// <summary>
         /// The light sensor that was last added or had activity last.
@@ -451,7 +451,7 @@ namespace UnityEngine.InputSystem
         /// Atmospheric pressure in hPa (millibar).
         /// </summary>
         [InputControl(displayName = "Atmospheric Pressure", noisy = true)]
-        public AxisControl atmosphericPressure { get; private set; }
+        public AxisControl atmosphericPressure { get; protected set; }
 
         /// <summary>
         /// The pressure sensor that was last added or had activity last.
@@ -495,7 +495,7 @@ namespace UnityEngine.InputSystem
         /// Proximity sensor distance measured in centimeters.
         /// </summary>
         [InputControl(displayName = "Distance", noisy = true)]
-        public AxisControl distance { get; private set; }
+        public AxisControl distance { get; protected set; }
 
         /// <summary>
         /// The proximity sensor that was last added or had activity last.
@@ -536,7 +536,7 @@ namespace UnityEngine.InputSystem
         /// Relative ambient air humidity in percent.
         /// </summary>
         [InputControl(displayName = "Relative Humidity", noisy = true)]
-        public AxisControl relativeHumidity { get; private set; }
+        public AxisControl relativeHumidity { get; protected set; }
 
         /// <summary>
         /// The humidity sensor that was last added or had activity last.
@@ -577,7 +577,7 @@ namespace UnityEngine.InputSystem
         /// Temperature in degree Celsius.
         /// </summary>
         [InputControl(displayName = "Ambient Temperature", noisy = true)]
-        public AxisControl ambientTemperature { get; private set; }
+        public AxisControl ambientTemperature { get; protected set; }
 
         /// <summary>
         /// The ambient temperature sensor that was last added or had activity last.
@@ -621,7 +621,7 @@ namespace UnityEngine.InputSystem
         /// The number of steps taken by the user since the last reboot while activated.
         /// </summary>
         [InputControl(displayName = "Step Counter", noisy = true)]
-        public IntegerControl stepCounter { get; private set; }
+        public IntegerControl stepCounter { get; protected set; }
 
         /// <summary>
         /// The step counter that was last added or had activity last.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/TrackedDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/TrackedDevice.cs
@@ -13,13 +13,13 @@ namespace UnityEngine.InputSystem
     public class TrackedDevice : InputDevice
     {
         [InputControl(synthetic = true)]
-        public IntegerControl trackingState { get; private set; }
+        public IntegerControl trackingState { get; protected set; }
         [InputControl(synthetic = true)]
-        public ButtonControl isTracked { get; private set; }
+        public ButtonControl isTracked { get; protected set; }
         [InputControl(noisy = true, dontReset = true)]
-        public Vector3Control devicePosition { get; private set; }
+        public Vector3Control devicePosition { get; protected set; }
         [InputControl(noisy = true, dontReset = true)]
-        public QuaternionControl deviceRotation { get; private set; }
+        public QuaternionControl deviceRotation { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -968,9 +968,9 @@ namespace UnityEngine.InputSystem.DualShock
     [InputControlLayout(stateType = typeof(DualShock3HIDInputReport), hideInUI = true, displayName = "PS3 Controller")]
     public class DualShock3GamepadHID : DualShockGamepad
     {
-        public ButtonControl leftTriggerButton { get; private set; }
-        public ButtonControl rightTriggerButton { get; private set; }
-        public ButtonControl playStationButton { get; private set; }
+        public ButtonControl leftTriggerButton { get; protected set; }
+        public ButtonControl rightTriggerButton { get; protected set; }
+        public ButtonControl playStationButton { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XInputController.cs
@@ -66,13 +66,13 @@ namespace UnityEngine.InputSystem.XInput
         // This follows Xbox One conventions; on Xbox 360, this is start=start and select=back.
         [InputControl(name = "start", displayName = "Menu", alias = "menu")]
         [InputControl(name = "select", displayName = "View", alias = "view")]
-        public ButtonControl menu { get; private set; }
+        public ButtonControl menu { get; protected set; }
 
         /// <summary>
         /// Same as <see cref="Gamepad.selectButton"/>
         /// </summary>
         /// <value>Same control as <see cref="Gamepad.selectButton"/>.</value>
-        public ButtonControl view { get; private set; }
+        public ButtonControl view { get; protected set; }
 
         /// <summary>
         /// What specific kind of XInput controller this is.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Controls/PoseControl.cs
@@ -132,7 +132,7 @@ namespace UnityEngine.InputSystem.XR
         /// </summary>
         /// <value>Control representing whether the pose is being fully tracked. Maps to the <see cref="PoseState.isTracked"/> value.</value>
         /// <seealso cref="PoseState.isTracked"/>
-        public ButtonControl isTracked { get; private set; }
+        public ButtonControl isTracked { get; set; }
 
         /// <summary>
         /// The other controls on this <see cref="PoseControl"/> that are currently reporting data.
@@ -142,7 +142,7 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
         /// <value>Control representing whether the pose is being fully tracked. Maps to the <see cref="PoseState.trackingState"/> value of the pose retrieved from this control.</value>
         /// <seealso cref="PoseState.trackingState"/>
-        public IntegerControl trackingState { get; private set; }
+        public IntegerControl trackingState { get; set; }
 
         /// <summary>
         /// The position, in meters, of this tracked pose relative to the tracking origin.
@@ -152,7 +152,7 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
         /// <value>Control representing whether the pose is being fully tracked. Maps to the <see cref="PoseState.position"/> value of the pose retrieved from this control.</value>
         /// <seealso cref="PoseState.position"/>
-        public Vector3Control position { get; private set; }
+        public Vector3Control position { get; set; }
 
         /// <summary>
         /// The rotation of this tracked pose relative to the tracking origin.
@@ -162,7 +162,7 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
         /// <value>Control representing whether the pose is being fully tracked. Maps to the <see cref="PoseState.rotation"/> value of the pose retrieved from this control.</value>
         /// <seealso cref="PoseState.rotation"/>
-        public QuaternionControl rotation { get; private set; }
+        public QuaternionControl rotation { get; set; }
 
         /// <summary>
         /// The velocity, in meters per second, of this tracked pose relative to the tracking origin.
@@ -172,7 +172,7 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
         /// <value>Control representing whether the pose is being fully tracked. Maps to the <see cref="PoseState.velocity"/> value of the pose retrieved from this control.</value>
         /// <seealso cref="PoseState.velocity"/>
-        public Vector3Control velocity { get; private set; }
+        public Vector3Control velocity { get; set; }
 
         /// <summary>
         /// The angular velocity of this tracked pose relative to the tracking origin.
@@ -182,7 +182,7 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
         /// <value>Control representing whether the pose is being fully tracked. Maps to the <see cref="PoseState.angularVelocity"/> value of the pose retrieved from this control.</value>
         /// <seealso cref="PoseState.angularVelocity"/>
-        public Vector3Control angularVelocity { get; private set; }
+        public Vector3Control angularVelocity { get; set; }
 
         /// <summary>
         /// Default-initialize the pose control.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/GoogleVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/GoogleVR.cs
@@ -22,27 +22,27 @@ namespace Unity.XR.GoogleVr
     public class DaydreamController : XRController
     {
         [InputControl]
-        public Vector2Control touchpad { get; private set; }
+        public Vector2Control touchpad { get; protected set; }
         [InputControl]
-        public ButtonControl volumeUp { get; private set; }
+        public ButtonControl volumeUp { get; protected set; }
         [InputControl]
-        public ButtonControl recentered { get; private set; }
+        public ButtonControl recentered { get; protected set; }
         [InputControl]
-        public ButtonControl volumeDown { get; private set; }
+        public ButtonControl volumeDown { get; protected set; }
         [InputControl]
-        public ButtonControl recentering { get; private set; }
+        public ButtonControl recentering { get; protected set; }
         [InputControl]
-        public ButtonControl app { get; private set; }
+        public ButtonControl app { get; protected set; }
         [InputControl]
-        public ButtonControl home { get; private set; }
+        public ButtonControl home { get; protected set; }
         [InputControl]
-        public ButtonControl touchpadClicked { get; private set; }
+        public ButtonControl touchpadClicked { get; protected set; }
         [InputControl]
-        public ButtonControl touchpadTouched { get; private set; }
+        public ButtonControl touchpadTouched { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAcceleration { get; private set; }
+        public Vector3Control deviceAcceleration { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/Oculus.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/Oculus.cs
@@ -17,31 +17,31 @@ namespace Unity.XR.Oculus.Input
         [InputControl]
         [InputControl(name = "trackingState", layout = "Integer", aliases = new[] { "devicetrackingstate" })]
         [InputControl(name = "isTracked", layout = "Button", aliases = new[] { "deviceistracked" })]
-        public ButtonControl userPresence { get; private set; }
+        public ButtonControl userPresence { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAcceleration { get; private set; }
+        public Vector3Control deviceAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularAcceleration { get; private set; }
+        public Vector3Control deviceAngularAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control leftEyeAngularVelocity { get; private set; }
+        public Vector3Control leftEyeAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control leftEyeAcceleration { get; private set; }
+        public Vector3Control leftEyeAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control leftEyeAngularAcceleration { get; private set; }
+        public Vector3Control leftEyeAngularAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control rightEyeAngularVelocity { get; private set; }
+        public Vector3Control rightEyeAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control rightEyeAcceleration { get; private set; }
+        public Vector3Control rightEyeAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control rightEyeAngularAcceleration { get; private set; }
+        public Vector3Control rightEyeAngularAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control centerEyeAngularVelocity { get; private set; }
+        public Vector3Control centerEyeAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control centerEyeAcceleration { get; private set; }
+        public Vector3Control centerEyeAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control centerEyeAngularAcceleration { get; private set; }
+        public Vector3Control centerEyeAngularAcceleration { get; protected set; }
 
 
         protected override void FinishSetup()
@@ -71,45 +71,45 @@ namespace Unity.XR.Oculus.Input
     public class OculusTouchController : XRControllerWithRumble
     {
         [InputControl(aliases = new[] { "Primary2DAxis", "Joystick" })]
-        public Vector2Control thumbstick { get; private set; }
+        public Vector2Control thumbstick { get; protected set; }
 
         [InputControl]
-        public AxisControl trigger { get; private set; }
+        public AxisControl trigger { get; protected set; }
         [InputControl]
-        public AxisControl grip { get; private set; }
+        public AxisControl grip { get; protected set; }
 
         [InputControl(aliases = new[] { "A", "X", "Alternate" })]
-        public ButtonControl primaryButton { get; private set; }
+        public ButtonControl primaryButton { get; protected set; }
         [InputControl(aliases = new[] { "B", "Y", "Primary" })]
-        public ButtonControl secondaryButton { get; private set; }
+        public ButtonControl secondaryButton { get; protected set; }
         [InputControl(aliases = new[] { "GripButton" })]
-        public ButtonControl gripPressed { get; private set; }
+        public ButtonControl gripPressed { get; protected set; }
         [InputControl]
-        public ButtonControl start { get; private set; }
+        public ButtonControl start { get; protected set; }
         [InputControl(aliases = new[] { "JoystickOrPadPressed", "thumbstickClick" })]
-        public ButtonControl thumbstickClicked { get; private set; }
+        public ButtonControl thumbstickClicked { get; protected set; }
         [InputControl(aliases = new[] { "ATouched", "XTouched", "ATouch", "XTouch" })]
-        public ButtonControl primaryTouched { get; private set; }
+        public ButtonControl primaryTouched { get; protected set; }
         [InputControl(aliases = new[] { "BTouched", "YTouched", "BTouch", "YTouch" })]
-        public ButtonControl secondaryTouched { get; private set; }
+        public ButtonControl secondaryTouched { get; protected set; }
         [InputControl(aliases = new[] { "indexTouch", "indexNearTouched" })]
-        public AxisControl triggerTouched { get; private set; }
+        public AxisControl triggerTouched { get; protected set; }
         [InputControl(aliases = new[] { "indexButton", "indexTouched" })]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
         [InputControl(aliases = new[] { "JoystickOrPadTouched", "thumbstickTouch" })]
         [InputControl(name = "trackingState", layout = "Integer", aliases = new[] { "controllerTrackingState" })]
         [InputControl(name = "isTracked", layout = "Button", aliases = new[] { "ControllerIsTracked" })]
         [InputControl(name = "devicePosition", layout = "Vector3", aliases = new[] { "controllerPosition" })]
         [InputControl(name = "deviceRotation", layout = "Quaternion", aliases = new[] { "controllerRotation" })]
-        public ButtonControl thumbstickTouched { get; private set; }
+        public ButtonControl thumbstickTouched { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "controllerVelocity" })]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "controllerAngularVelocity" })]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "controllerAcceleration" })]
-        public Vector3Control deviceAcceleration { get; private set; }
+        public Vector3Control deviceAcceleration { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "controllerAngularAcceleration" })]
-        public Vector3Control deviceAngularAcceleration { get; private set; }
+        public Vector3Control deviceAngularAcceleration { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -140,9 +140,9 @@ namespace Unity.XR.Oculus.Input
     public class OculusTrackingReference : TrackedDevice
     {
         [InputControl(aliases = new[] { "trackingReferenceTrackingState" })]
-        public new IntegerControl trackingState { get; private set; }
+        public new IntegerControl trackingState { get; protected set; }
         [InputControl(aliases = new[] { "trackingReferenceIsTracked" })]
-        public new ButtonControl isTracked { get; private set; }
+        public new ButtonControl isTracked { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -160,11 +160,11 @@ namespace Unity.XR.Oculus.Input
     public class OculusRemote : InputDevice
     {
         [InputControl]
-        public ButtonControl back { get; private set; }
+        public ButtonControl back { get; protected set; }
         [InputControl]
-        public ButtonControl start { get; private set; }
+        public ButtonControl start { get; protected set; }
         [InputControl]
-        public Vector2Control touchpad { get; private set; }
+        public Vector2Control touchpad { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -183,9 +183,9 @@ namespace Unity.XR.Oculus.Input
     public class OculusHMDExtended : OculusHMD
     {
         [InputControl]
-        public ButtonControl back { get; private set; }
+        public ButtonControl back { get; protected set; }
         [InputControl]
-        public Vector2Control touchpad { get; private set; }
+        public Vector2Control touchpad { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -203,23 +203,23 @@ namespace Unity.XR.Oculus.Input
     public class GearVRTrackedController : XRController
     {
         [InputControl]
-        public Vector2Control touchpad { get; private set; }
+        public Vector2Control touchpad { get; protected set; }
         [InputControl]
-        public AxisControl trigger { get; private set; }
+        public AxisControl trigger { get; protected set; }
         [InputControl]
-        public ButtonControl back { get; private set; }
+        public ButtonControl back { get; protected set; }
         [InputControl]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
         [InputControl]
-        public ButtonControl touchpadClicked { get; private set; }
+        public ButtonControl touchpadClicked { get; protected set; }
         [InputControl]
-        public ButtonControl touchpadTouched { get; private set; }
+        public ButtonControl touchpadTouched { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAcceleration { get; private set; }
+        public Vector3Control deviceAcceleration { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularAcceleration { get; private set; }
+        public Vector3Control deviceAngularAcceleration { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/OpenVR.cs
@@ -12,21 +12,21 @@ namespace Unity.XR.OpenVR
     public class OpenVRHMD : XRHMD
     {
         [InputControl(noisy = true)]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control leftEyeVelocity { get; private set; }
+        public Vector3Control leftEyeVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control leftEyeAngularVelocity { get; private set; }
+        public Vector3Control leftEyeAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control rightEyeVelocity { get; private set; }
+        public Vector3Control rightEyeVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control rightEyeAngularVelocity { get; private set; }
+        public Vector3Control rightEyeAngularVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control centerEyeVelocity { get; private set; }
+        public Vector3Control centerEyeVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control centerEyeAngularVelocity { get; private set; }
+        public Vector3Control centerEyeAngularVelocity { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -47,30 +47,30 @@ namespace Unity.XR.OpenVR
     public class OpenVRControllerWMR : XRController
     {
         [InputControl(noisy = true)]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
 
         [InputControl(aliases = new[] { "primary2DAxisClick", "joystickOrPadPressed" })]
-        public ButtonControl touchpadClick { get; private set; }
+        public ButtonControl touchpadClick { get; protected set; }
         [InputControl(aliases = new[] { "primary2DAxisTouch", "joystickOrPadTouched" })]
-        public ButtonControl touchpadTouch { get; private set; }
+        public ButtonControl touchpadTouch { get; protected set; }
         [InputControl]
-        public ButtonControl gripPressed { get; private set; }
+        public ButtonControl gripPressed { get; protected set; }
         [InputControl]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
         [InputControl(aliases = new[] { "primary" })]
-        public ButtonControl menu { get; private set; }
+        public ButtonControl menu { get; protected set; }
 
         [InputControl]
-        public AxisControl trigger { get; private set; }
+        public AxisControl trigger { get; protected set; }
         [InputControl]
-        public AxisControl grip { get; private set; }
+        public AxisControl grip { get; protected set; }
 
         [InputControl(aliases = new[] { "secondary2DAxis" })]
-        public Vector2Control touchpad { get; private set; }
+        public Vector2Control touchpad { get; protected set; }
         [InputControl(aliases = new[] { "primary2DAxis" })]
-        public Vector2Control joystick { get; private set; }
+        public Vector2Control joystick { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -100,26 +100,26 @@ namespace Unity.XR.OpenVR
     public class ViveWand : XRControllerWithRumble
     {
         [InputControl]
-        public AxisControl grip { get; private set; }
+        public AxisControl grip { get; protected set; }
         [InputControl]
-        public ButtonControl gripPressed { get; private set; }
+        public ButtonControl gripPressed { get; protected set; }
         [InputControl]
-        public ButtonControl primary { get; private set; }
+        public ButtonControl primary { get; protected set; }
         [InputControl(aliases = new[] { "primary2DAxisClick", "joystickOrPadPressed" })]
-        public ButtonControl trackpadPressed { get; private set; }
+        public ButtonControl trackpadPressed { get; protected set; }
         [InputControl(aliases = new[] { "primary2DAxisTouch", "joystickOrPadTouched" })]
-        public ButtonControl trackpadTouched { get; private set; }
+        public ButtonControl trackpadTouched { get; protected set; }
         [InputControl(aliases = new[] { "Primary2DAxis" })]
-        public Vector2Control trackpad { get; private set; }
+        public Vector2Control trackpad { get; protected set; }
         [InputControl]
-        public AxisControl trigger { get; private set; }
+        public AxisControl trigger { get; protected set; }
         [InputControl]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
 
         [InputControl(noisy = true)]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -154,9 +154,9 @@ namespace Unity.XR.OpenVR
     public class ViveTracker : TrackedDevice
     {
         [InputControl(noisy = true)]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -171,15 +171,15 @@ namespace Unity.XR.OpenVR
     public class HandedViveTracker : ViveTracker
     {
         [InputControl]
-        public AxisControl grip { get; private set; }
+        public AxisControl grip { get; protected set; }
         [InputControl]
-        public ButtonControl gripPressed { get; private set; }
+        public ButtonControl gripPressed { get; protected set; }
         [InputControl]
-        public ButtonControl primary { get; private set; }
+        public ButtonControl primary { get; protected set; }
         [InputControl(aliases = new[] { "JoystickOrPadPressed" })]
-        public ButtonControl trackpadPressed { get; private set; }
+        public ButtonControl trackpadPressed { get; protected set; }
         [InputControl]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -200,32 +200,32 @@ namespace Unity.XR.OpenVR
     public class OpenVROculusTouchController : XRControllerWithRumble
     {
         [InputControl]
-        public Vector2Control thumbstick { get; private set; }
+        public Vector2Control thumbstick { get; protected set; }
 
         [InputControl]
-        public AxisControl trigger { get; private set; }
+        public AxisControl trigger { get; protected set; }
         [InputControl]
-        public AxisControl grip { get; private set; }
+        public AxisControl grip { get; protected set; }
 
         // Primary & Secondary are switched in order to retain consistency with the Oculus SDK
         [InputControl(aliases = new[] { "Alternate" })]
-        public ButtonControl primaryButton { get; private set; }
+        public ButtonControl primaryButton { get; protected set; }
         [InputControl(aliases = new[] { "Primary" })]
-        public ButtonControl secondaryButton { get; private set; }
+        public ButtonControl secondaryButton { get; protected set; }
 
         [InputControl]
-        public ButtonControl gripPressed { get; private set; }
+        public ButtonControl gripPressed { get; protected set; }
         [InputControl]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
         [InputControl(aliases = new[] { "primary2DAxisClicked" })]
-        public ButtonControl thumbstickClicked { get; private set; }
+        public ButtonControl thumbstickClicked { get; protected set; }
         [InputControl(aliases = new[] { "primary2DAxisTouch" })]
-        public ButtonControl thumbstickTouched { get; private set; }
+        public ButtonControl thumbstickTouched { get; protected set; }
 
         [InputControl(noisy = true)]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/WindowsMR.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/Devices/WindowsMR.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.XR.WindowsMR.Input
         [InputControl]
         [InputControl(name = "devicePosition", layout = "Vector3", aliases = new[] { "HeadPosition" })]
         [InputControl(name = "deviceRotation", layout = "Quaternion", aliases = new[] { "HeadRotation" })]
-        public ButtonControl userPresence { get; private set; }
+        public ButtonControl userPresence { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -33,13 +33,13 @@ namespace UnityEngine.XR.WindowsMR.Input
     public class HololensHand : XRController
     {
         [InputControl(noisy = true, aliases = new[] { "gripVelocity" })]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(aliases = new[] { "triggerbutton" })]
-        public ButtonControl airTap { get; private set; }
+        public ButtonControl airTap { get; protected set; }
         [InputControl(noisy = true)]
-        public AxisControl sourceLossRisk { get; private set; }
+        public AxisControl sourceLossRisk { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control sourceLossMitigationDirection { get; private set; }
+        public Vector3Control sourceLossMitigationDirection { get; protected set; }
 
         protected override void FinishSetup()
         {
@@ -56,40 +56,40 @@ namespace UnityEngine.XR.WindowsMR.Input
     public class WMRSpatialController : XRControllerWithRumble
     {
         [InputControl(aliases = new[] { "Primary2DAxis", "thumbstickaxes" })]
-        public Vector2Control joystick { get; private set; }
+        public Vector2Control joystick { get; protected set; }
         [InputControl(aliases = new[] { "Secondary2DAxis", "touchpadaxes" })]
-        public Vector2Control touchpad { get; private set; }
+        public Vector2Control touchpad { get; protected set; }
         [InputControl(aliases = new[] { "gripaxis" })]
-        public AxisControl grip { get; private set; }
+        public AxisControl grip { get; protected set; }
         [InputControl(aliases = new[] { "gripbutton" })]
-        public ButtonControl gripPressed { get; private set; }
+        public ButtonControl gripPressed { get; protected set; }
         [InputControl(aliases = new[] { "Primary", "menubutton" })]
-        public ButtonControl menu { get; private set; }
+        public ButtonControl menu { get; protected set; }
         [InputControl(aliases = new[] { "triggeraxis" })]
-        public AxisControl trigger { get; private set; }
+        public AxisControl trigger { get; protected set; }
         [InputControl(aliases = new[] { "triggerbutton" })]
-        public ButtonControl triggerPressed { get; private set; }
+        public ButtonControl triggerPressed { get; protected set; }
         [InputControl(aliases = new[] { "thumbstickpressed" })]
-        public ButtonControl joystickClicked { get; private set; }
+        public ButtonControl joystickClicked { get; protected set; }
         [InputControl(aliases = new[] { "joystickorpadpressed", "touchpadpressed" })]
-        public ButtonControl touchpadClicked { get; private set; }
+        public ButtonControl touchpadClicked { get; protected set; }
         [InputControl(aliases = new[] { "joystickorpadtouched", "touchpadtouched" })]
-        public ButtonControl touchpadTouched { get; private set; }
+        public ButtonControl touchpadTouched { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "gripVelocity" })]
-        public Vector3Control deviceVelocity { get; private set; }
+        public Vector3Control deviceVelocity { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "gripAngularVelocity" })]
-        public Vector3Control deviceAngularVelocity { get; private set; }
+        public Vector3Control deviceAngularVelocity { get; protected set; }
 
         [InputControl(noisy = true)]
-        public AxisControl batteryLevel { get; private set; }
+        public AxisControl batteryLevel { get; protected set; }
         [InputControl(noisy = true)]
-        public AxisControl sourceLossRisk { get; private set; }
+        public AxisControl sourceLossRisk { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control sourceLossMitigationDirection { get; private set; }
+        public Vector3Control sourceLossMitigationDirection { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control pointerPosition { get; private set; }
+        public Vector3Control pointerPosition { get; protected set; }
         [InputControl(noisy = true, aliases = new[] { "PointerOrientation" })]
-        public QuaternionControl pointerRotation { get; private set; }
+        public QuaternionControl pointerRotation { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
@@ -35,17 +35,17 @@ namespace UnityEngine.InputSystem.XR
         /// </remarks>
 
         [InputControl(noisy = true)]
-        public Vector3Control leftEyePosition { get; private set; }
+        public Vector3Control leftEyePosition { get; protected set; }
         [InputControl(noisy = true)]
-        public QuaternionControl leftEyeRotation { get; private set; }
+        public QuaternionControl leftEyeRotation { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control rightEyePosition { get; private set; }
+        public Vector3Control rightEyePosition { get; protected set; }
         [InputControl(noisy = true)]
-        public QuaternionControl rightEyeRotation { get; private set; }
+        public QuaternionControl rightEyeRotation { get; protected set; }
         [InputControl(noisy = true)]
-        public Vector3Control centerEyePosition { get; private set; }
+        public Vector3Control centerEyePosition { get; protected set; }
         [InputControl(noisy = true)]
-        public QuaternionControl centerEyeRotation { get; private set; }
+        public QuaternionControl centerEyeRotation { get; protected set; }
 
         protected override void FinishSetup()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
@@ -283,11 +283,11 @@ namespace UnityEngine.InputSystem.XR
     public class BoneControl : InputControl<Bone>
     {
         [InputControl(offset = 0, displayName = "parentBoneIndex")]
-        public IntegerControl parentBoneIndex { get; private set; }
+        public IntegerControl parentBoneIndex { get; set; }
         [InputControl(offset = 4, displayName = "Position")]
-        public Vector3Control position { get; private set; }
+        public Vector3Control position { get; set; }
         [InputControl(offset = 16, displayName = "Rotation")]
-        public QuaternionControl rotation { get; private set; }
+        public QuaternionControl rotation { get; set; }
 
         protected override void FinishSetup()
         {
@@ -319,19 +319,19 @@ namespace UnityEngine.InputSystem.XR
     public class EyesControl : InputControl<Eyes>
     {
         [InputControl(offset = 0, displayName = "LeftEyePosition")]
-        public Vector3Control leftEyePosition { get; private set; }
+        public Vector3Control leftEyePosition { get; set; }
         [InputControl(offset = 12, displayName = "LeftEyeRotation")]
-        public QuaternionControl leftEyeRotation { get; private set; }
+        public QuaternionControl leftEyeRotation { get; set; }
         [InputControl(offset = 28, displayName = "RightEyePosition")]
-        public Vector3Control rightEyePosition { get; private set; }
+        public Vector3Control rightEyePosition { get; set; }
         [InputControl(offset = 40, displayName = "RightEyeRotation")]
-        public QuaternionControl rightEyeRotation { get; private set; }
+        public QuaternionControl rightEyeRotation { get; set; }
         [InputControl(offset = 56, displayName = "FixationPoint")]
-        public Vector3Control fixationPoint { get; private set; }
+        public Vector3Control fixationPoint { get; set; }
         [InputControl(offset = 68, displayName = "LeftEyeOpenAmount")]
-        public AxisControl leftEyeOpenAmount { get; private set; }
+        public AxisControl leftEyeOpenAmount { get; set; }
         [InputControl(offset = 72, displayName = "RightEyeOpenAmount")]
-        public AxisControl rightEyeOpenAmount { get; private set; }
+        public AxisControl rightEyeOpenAmount { get; set; }
 
         protected override void FinishSetup()
         {


### PR DESCRIPTION
### Description

If you try to create a precompiled layout for a device which uses `QuaternionControl` (for example, `XRController`), the generated code fails to compile because it tries to set values to the child controls. It seems like the code generally assumes these properties will have setters, but there's no check for that.

### Changes made

Added a test that checks all `InputDevice` and `InputControl` classes to ensure their control properties have setters. Also fixed up any instances that fail the test.

### Notes

The test isn't completely exhaustive. I noticed that the `CustomDevice` in the repo just declares public properties without using the `InputControlAttribute` to decorate them. They are still picked up by the layout generator, but I'm not entirely sure why. If I do the check on all public properties, I get some false positives for properties like `Keyboard.spaceKey`. I added a comment to the test to mention this, but I'd love to know if there's a better way to check which properties are actually controls. As far as I can tell, we'd have to actually build the layouts and get their controls that way, which seems like more trouble than it's worth for this test.

This is an "added API" and will require a minor version bump. It cannot be backported according to semver rules.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
