### PR TITLE
[ISXB-552] Fix Precompiled Layouts for types with no namespace

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed UI clicks not registering when OS provides multiple input sources for the same event, e.g. on Samsung Dex (case ISX-1416, ISXB-342).
 - Fixed unstable integration test `Integration_CanSendAndReceiveEvents` by ignoring application focus on integration tests. (case ISX-1381)
 - Fixed broken "Listen" button in Input actions editor window with Unity dark skin (case ISXB-536).
+- Fixed issues with generating Precompiled Layouts for devices which are not defined in a namespace
 
 ## [1.6.1] - 2023-05-26
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputLayoutCodeGenerator.cs
@@ -110,11 +110,17 @@ namespace UnityEngine.InputSystem.Editor
             writer.WriteLine("// that we don't end up using.");
             writer.WriteLine("#pragma warning disable CS0219");
             writer.WriteLine("");
-            if (@namespace != "")
+            if (!string.IsNullOrEmpty(@namespace))
+            {
                 writer.WriteLine("namespace " + @namespace);
-            writer.BeginBlock();
+                writer.BeginBlock();
+            }
 
-            writer.WriteLine($"{visibility} partial class {namePrefix}{baseTypeName} : {baseTypeNamespace}.{baseTypeName}");
+            if (string.IsNullOrEmpty(baseTypeNamespace))
+                writer.WriteLine($"{visibility} partial class {namePrefix}{baseTypeName} : {baseTypeName}");
+            else
+                writer.WriteLine($"{visibility} partial class {namePrefix}{baseTypeName} : {baseTypeNamespace}.{baseTypeName}");
+            
             writer.BeginBlock();
 
             // "Metadata". ATM this is simply a flat, semicolon-separated list of names for layouts and processors that
@@ -304,7 +310,9 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             writer.EndBlock();
-            writer.EndBlock();
+            
+            if (!string.IsNullOrEmpty(@namespace))
+                writer.EndBlock();
 
             if (defines != null)
                 writer.WriteLine($"#endif // {defines}");


### PR DESCRIPTION
### Description

There is some logic in `GenerateCodeForDeviceLayout` for deciding which namespace to use, but the actual codegen logic did not properly account for the case where this namespace was null or empty.

### Changes made

Added cases for null/empty namespace, both for the new type and base type.

### Notes

I can see an argument for falling back to some default namespace, rather than just skipping the namespace block entirely. I figure skipping the namespace if none are specified is safer/easier.

I haven't added tests, but I think that's out of scope for this fix. Precompiled layout generation isn't very well covered to begin with, so I think a future PR/task would be good for covering the feature more holistically. In fact, I have a [WIP branch](https://github.com/mtschoen-unity/InputSystem/tree/fix-all-precompiled-layouts) where I'm playing around with such a test. Basically I have the following script:
```
using System;
using System.IO;
using UnityEngine;
using UnityEngine.InputSystem.Editor;

namespace UnityEditor.InputSystem
{
    public static class GenerateAllPrecompiledLayouts
    {
        [MenuItem("Assets/Generate precompiled layouts for all devices")]
        static void GenerateLayouts()
        {
            const string folder = "Assets/PrecompiledLayouts";
            Directory.CreateDirectory(folder);
            
            var count = 0;
            foreach (var layout in UnityEngine.InputSystem.InputSystem.ListLayouts())
            {
                try
                {
                    var loadedLayout = UnityEngine.InputSystem.InputSystem.LoadLayout(layout);
                    if (loadedLayout.isControlLayout)
                        continue;

                    var fileName = $"{folder}/{layout}_{count++}.cs";
                    var code = InputLayoutCodeGenerator.GenerateCodeFileForDeviceLayout(layout, fileName, prefix: "Fast");
                    File.WriteAllText(fileName, code);
                }
                catch (Exception e)
                {
                    Debug.LogException(e);
                }
            }
            
            AssetDatabase.Refresh();
        }
    }
}
```

And what it generates has a bunch of errors that I started tracking down. I'll take this a little further but I may need some help actually resolving everything.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
