### PR TITLE
pin older bokken image version to unblock CI

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -34,16 +34,16 @@ platforms_win:
 platforms_nix:
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-13:default
+    image: package-ci/macos-13:4.9.0
     flavor: m1.mac
   - name: mac_standalone
     type: Unity::VM::osx
-    image: package-ci/macos-13:default
+    image: package-ci/macos-13:4.9.0
     flavor: m1.mac
     runtime: StandaloneOSX
   - name: mac_standalone_il2cpp
     type: Unity::VM::osx
-    image: package-ci/macos-13:default
+    image: package-ci/macos-13:4.9.0
     flavor: m1.mac
     runtime: StandaloneOSX
     scripting-backend: Il2Cpp

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -34,16 +34,16 @@ platforms_win:
 platforms_nix:
   - name: mac
     type: Unity::VM::osx
-    image: package-ci/macos-13:4.9.0
+    image: package-ci/macos-13:default
     flavor: m1.mac
   - name: mac_standalone
     type: Unity::VM::osx
-    image: package-ci/macos-13:4.9.0
+    image: package-ci/macos-13:default
     flavor: m1.mac
     runtime: StandaloneOSX
   - name: mac_standalone_il2cpp
     type: Unity::VM::osx
-    image: package-ci/macos-13:4.9.0
+    image: package-ci/macos-13:default
     flavor: m1.mac
     runtime: StandaloneOSX
     scripting-backend: Il2Cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -115,7 +115,7 @@ build_tvos_{{ editor.version }}:
   name: Build Tests on {{ editor.version }} on tvos
   agent:
     type: Unity::VM::osx
-    image: package-ci/macos-12:v4.20.0
+    image: package-ci/macos-12:v4.19.0
     flavor: b1.large
   commands:
     - {{ utr_install_nix }}
@@ -134,7 +134,7 @@ run_tvos_{{ editor.version }}:
   name: Run Tests on {{ editor.version }} on tvos
   agent:
       type: Unity::mobile::appletv
-      image: package-ci/macos-12:v4.20.0
+      image: package-ci/macos-12:v4.19.0
       flavor: b1.medium
   skip_checkout: true
   dependencies:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -115,7 +115,7 @@ build_tvos_{{ editor.version }}:
   name: Build Tests on {{ editor.version }} on tvos
   agent:
     type: Unity::VM::osx
-    image: package-ci/macos-12:default
+    image: package-ci/macos-12:4.20.0
     flavor: b1.large
   commands:
     - {{ utr_install_nix }}
@@ -134,7 +134,7 @@ run_tvos_{{ editor.version }}:
   name: Run Tests on {{ editor.version }} on tvos
   agent:
       type: Unity::mobile::appletv
-      image: package-ci/macos-12:default
+      image: package-ci/macos-12:4.20.0
       flavor: b1.medium
   skip_checkout: true
   dependencies:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -115,7 +115,7 @@ build_tvos_{{ editor.version }}:
   name: Build Tests on {{ editor.version }} on tvos
   agent:
     type: Unity::VM::osx
-    image: package-ci/macos-12:4.20.0
+    image: package-ci/macos-12:v4.20.0
     flavor: b1.large
   commands:
     - {{ utr_install_nix }}
@@ -134,7 +134,7 @@ run_tvos_{{ editor.version }}:
   name: Run Tests on {{ editor.version }} on tvos
   agent:
       type: Unity::mobile::appletv
-      image: package-ci/macos-12:4.20.0
+      image: package-ci/macos-12:v4.20.0
       flavor: b1.medium
   skip_checkout: true
   dependencies:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -78,7 +78,7 @@ build_ios_{{ editor.version }}:
   name: Build Tests on {{ editor.version }} on ios
   agent:
     type: Unity::VM::osx
-    image: package-ci/macos-12:default
+    image: package-ci/macos-12:v4.19.0
     flavor: b1.large
   commands:
     - {{ utr_install_nix }}
@@ -97,7 +97,7 @@ run_ios_{{ editor.version }}:
   name: Run Tests on {{ editor.version }} on ios
   agent:
       type: Unity::mobile::iPhone
-      image: package-ci/macos-12:default
+      image: package-ci/macos-12:v4.19.0
       model: SE
       flavor: b1.medium
   skip_checkout: true


### PR DESCRIPTION
### Description

Internal: Latest CI image for iOS and tvOS fail with xcode error. Using last week's version fixes this for us.

### Changes made

Pin image v.4.19.0 for iOS and tvOS tests.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
