### PR TITLE
FIX: NullReferenceError on adding actions with no existing action maps (ISXB-497)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -85,7 +85,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private static InputActionsEditorState SelectPrevActionMap(InputActionsEditorState state)
         {
-            var count = Selectors.GetActionMapCount(state.serializedObject);
+            var count = Selectors.GetActionMapCount(state);
             int index = -1;
             if (count != null && count.Value > 0)
                 index = Math.Max(state.selectedActionMapIndex - 1, 0);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -112,13 +112,14 @@ namespace UnityEngine.InputSystem.Editor
 
             m_ActionsTreeView.RegisterCallback<KeyDownEvent>(OnKeyDownEvent);
 
-            CreateSelector(Selectors.GetActionsForSelectedActionMap,
-                (_, state) =>
+            CreateSelector(Selectors.GetActionsForSelectedActionMap, Selectors.GetActionMapCount,
+                (_, count, state) =>
                 {
                     var treeData = Selectors.GetActionsAsTreeViewData(state);
                     return new ViewState
                     {
                         treeViewData = treeData,
+                        actionMapCount = count ?? 0,
                         newElementID = GetSelectedElementId(state, treeData)
                     };
                 });
@@ -174,6 +175,7 @@ namespace UnityEngine.InputSystem.Editor
             if (viewState.newElementID != -1)
                 m_ActionsTreeView.SetSelectionById(viewState.newElementID);
             RenameNewAction(viewState.newElementID);
+            addActionButton.SetEnabled(viewState.actionMapCount > 0);
         }
 
         private void RenameNewAction(int id)
@@ -242,6 +244,7 @@ namespace UnityEngine.InputSystem.Editor
         internal class ViewState
         {
             public List<TreeViewItemData<ActionOrBindingData>> treeViewData;
+            public int actionMapCount;
             public int newElementID;
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -56,9 +56,9 @@ namespace UnityEngine.InputSystem.Editor
             return actionMap?.FindPropertyRelative(nameof(InputActionMap.m_Actions))?.arraySize;
         }
 
-        public static int? GetActionMapCount(SerializedObject serializedObject)
+        public static int? GetActionMapCount(InputActionsEditorState state)
         {
-            return serializedObject?.FindProperty(nameof(InputActionAsset.m_ActionMaps))?.arraySize;
+            return state.serializedObject?.FindProperty(nameof(InputActionAsset.m_ActionMaps))?.arraySize;
         }
 
         public static SerializedInputAction GetActionInMap(InputActionsEditorState state, int mapIndex, string name)


### PR DESCRIPTION
### Description

The fix for [this](https://jira.unity3d.com/browse/ISXB-497) ticket. Before: a error appeared when the add-button was pressed on trying to add a action without an existing action map. 

### Changes made

The add-button for actions is only enabled now, if there are action maps in the action maps list view.

### Notes


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
