### PR TITLE
Add UNITY_VISIONOS ifdefs where appropriate

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,8 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Added
+- Preliminary support for visionOS.
 
 ## [1.6.3] - 2023-07-11
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3625,11 +3625,11 @@ namespace UnityEngine.InputSystem
         {
             UISupport.Initialize();
 
-            #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS
+            #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_WSA || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS
             XInputSupport.Initialize();
             #endif
 
-            #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_PS4 || UNITY_PS5 || UNITY_WSA || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS
+            #if UNITY_EDITOR || UNITY_STANDALONE || UNITY_PS4 || UNITY_PS5 || UNITY_WSA || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS
             DualShockSupport.Initialize();
             #endif
 
@@ -3641,7 +3641,7 @@ namespace UnityEngine.InputSystem
             Android.AndroidSupport.Initialize();
             #endif
 
-            #if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS
+            #if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS
             iOS.iOSSupport.Initialize();
             #endif
 
@@ -3665,7 +3665,7 @@ namespace UnityEngine.InputSystem
             Linux.LinuxSupport.Initialize();
             #endif
 
-            #if UNITY_EDITOR || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_WSA
+            #if UNITY_EDITOR || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_WSA || UNITY_VISIONOS
             OnScreen.OnScreenSupport.Initialize();
             #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenSupport.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_WSA
+#if UNITY_EDITOR || UNITY_ANDROID || UNITY_IOS || UNITY_TVOS || UNITY_WSA || UNITY_VISIONOS
 namespace UnityEngine.InputSystem.OnScreen
 {
     /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/IOSGameController.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS || PACKAGE_DOCS_GENERATION
+#if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS || PACKAGE_DOCS_GENERATION
 using System.Runtime.InteropServices;
 using UnityEngine.InputSystem.DualShock;
 using UnityEngine.InputSystem.Layouts;
@@ -135,4 +135,4 @@ namespace UnityEngine.InputSystem.iOS
     {
     }
 }
-#endif // UNITY_EDITOR || UNITY_IOS || UNITY_TVOS
+#endif // UNITY_EDITOR || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/iOSSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/iOS/iOSSupport.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS
+#if UNITY_EDITOR || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS
 using UnityEngine.InputSystem.iOS.LowLevel;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
@@ -62,4 +62,4 @@ namespace UnityEngine.InputSystem.iOS
         }
     }
 }
-#endif // UNITY_EDITOR || UNITY_IOS || UNITY_TVOS
+#endif // UNITY_EDITOR || UNITY_IOS || UNITY_TVOS || UNITY_VISIONOS


### PR DESCRIPTION
### Description

Add visionOS ifdefs to necessary places to support input devices on visionOS

### Changes made

Added visionOS to some ifdefs alonside IOS. Explicitly did _not_ add them to the CoreMotion ones; CoreMotion is available, but pedometer is not. If we need CoreMotion bits without pedometer we can do that in a future PR.

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
- [x] No tests added.
- [x] No docs added.