### PR TITLE
Add uids to markdown documents

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/ActionAssets.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionAssets.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-action-assets
+---
 # Input Action Assets
 
 * [Creating Action Assets](#creating-input-action-assets)

--- a/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/ActionBindings.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-action-bindings
+---
 # Input Bindings
 
 * [Composite Bindings](#composite-bindings)

--- a/Packages/com.unity.inputsystem/Documentation~/Actions.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Actions.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-actions
+---
 # Actions
 
 - [Actions](#actions)

--- a/Packages/com.unity.inputsystem/Documentation~/Architecture.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Architecture.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-architecture
+---
 # Architecture
 
 The Input System has a layered architecture that consists of a low-level layer and a high-level layer.

--- a/Packages/com.unity.inputsystem/Documentation~/Concepts.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Concepts.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-concepts
+---
 # Input System Concepts
 
 This page introduces the concepts that relate to working with the Input System.

--- a/Packages/com.unity.inputsystem/Documentation~/Contributing.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Contributing.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-contributing
+---
 # Contributing
 
 The [full source code](https://github.com/Unity-Technologies/InputSystem) for the Input System is available on GitHub. This is also where most of the Input System's development happens.

--- a/Packages/com.unity.inputsystem/Documentation~/Controls.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Controls.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-controls
+---
 # Controls
 
 * [Hierarchies](#control-hierarchies)

--- a/Packages/com.unity.inputsystem/Documentation~/Debugging.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Debugging.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-debugging
+---
 # Debugging
 
 - [Debugging](#debugging)

--- a/Packages/com.unity.inputsystem/Documentation~/Devices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Devices.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-devices
+---
 # Devices
 
 - [Devices](#devices)

--- a/Packages/com.unity.inputsystem/Documentation~/EditorFeatures.md
+++ b/Packages/com.unity.inputsystem/Documentation~/EditorFeatures.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-editor-features
+---
 # Input System Editor Features
 
 This section describes how the Input System integrates with the Unity Editor, which allows you to read input in edit mode, debug input values, and set up automated input tests.

--- a/Packages/com.unity.inputsystem/Documentation~/Events.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Events.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-events
+---
 # Input events
 
 * [Types of events](#types-of-events)

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-gamepad
+---
 # Gamepad Support
 
 - [Gamepad Support](#gamepad-support)

--- a/Packages/com.unity.inputsystem/Documentation~/HID.md
+++ b/Packages/com.unity.inputsystem/Documentation~/HID.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-hid
+---
 # HID Support
 
 Human Interface Device (HID) is a [specification](https://www.usb.org/hid) to describe peripheral user input devices connected to computers via USB or Bluetooth. HID is commonly used to implement devices such as gamepads, joysticks, or racing wheels.

--- a/Packages/com.unity.inputsystem/Documentation~/HowDoI.md
+++ b/Packages/com.unity.inputsystem/Documentation~/HowDoI.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-how-do-i
+---
 # How do I…?
 
 A collection of frequently asked questions, and where to find their answers in the documentation.

--- a/Packages/com.unity.inputsystem/Documentation~/Installation.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Installation.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-installation
+---
 # Installation guide
 
 * [Installing the package](#installing-the-package)

--- a/Packages/com.unity.inputsystem/Documentation~/Interactions.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Interactions.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-interactions
+---
 # Interactions
 
 - [Interactions](#interactions)

--- a/Packages/com.unity.inputsystem/Documentation~/Joystick.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Joystick.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-joystick
+---
 # Joystick support
 
 The Input System currently has limited support for joysticks as generic [HIDs](HID.md) only. The system attempts to identify Controls based on the information provided in the HID descriptor of the Device, but it might not always be accurate. These Devices often work best when you allow the user to [manually remap the Controls](../api/UnityEngine.InputSystem.InputActionRebindingExtensions.html).

--- a/Packages/com.unity.inputsystem/Documentation~/Keyboard.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Keyboard.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-keyboard
+---
 # Keyboard support
 
 The [`Keyboard`](../api/UnityEngine.InputSystem.Keyboard.html) class defines a [Device](Devices.md) with a set of key Controls defined by the [`Key`](../api/UnityEngine.InputSystem.Key.html) enumeration.

--- a/Packages/com.unity.inputsystem/Documentation~/KnownLimitations.md
+++ b/Packages/com.unity.inputsystem/Documentation~/KnownLimitations.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-known-limitations
+---
 # Known Limitations
 
 The following is a list of known limitations that the Input System currently has.

--- a/Packages/com.unity.inputsystem/Documentation~/Layouts.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Layouts.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-layouts
+---
 # Layouts
 
 * [Layout formats](#layout-formats)

--- a/Packages/com.unity.inputsystem/Documentation~/Migration.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Migration.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-migration
+---
 # Migrating from the old input system
 
 This guide provides a list of APIs in `UnityEngine.Input` (and other related APIs in `UnityEngine`) and their corresponding APIs in the new Input System. Not all APIs have a corresponding version in the new API yet.

--- a/Packages/com.unity.inputsystem/Documentation~/Mouse.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Mouse.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-mouse
+---
 # Mouse support
 
 The Input System represents mouse input with the [`Mouse`](../api/UnityEngine.InputSystem.Mouse.html) Device layout that the [`Mouse`](../api/UnityEngine.InputSystem.Mouse.html) class implements. Mice are based on the [`Pointer`](Pointers.md) layout.

--- a/Packages/com.unity.inputsystem/Documentation~/OnScreen.md
+++ b/Packages/com.unity.inputsystem/Documentation~/OnScreen.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-on-screen
+---
 # On-screen Controls
 
 You can use on-screen Controls to simulate Input Devices with UI widgets that the user interacts with on the screen. The most prominent example is the use of stick and button widgets on touchscreens to emulate a joystick or gamepad.

--- a/Packages/com.unity.inputsystem/Documentation~/Pen.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Pen.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-pen
+---
 # Pen, tablet, and stylus support
 
 Pen support comprises both tablets on desktops (such as the various tablets produced by Wacom), and styluses on mobile devices (such as the stylus on the Samsung Note, the Apple Pencil on iOS, or the Surface Pen on the Microsoft Surface line of notebooks).

--- a/Packages/com.unity.inputsystem/Documentation~/PlayerInput.md
+++ b/Packages/com.unity.inputsystem/Documentation~/PlayerInput.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-player-input
+---
 # The PlayerInput component
 
 The Input System provides two related components that simplify how you set up and work with input: the **Player Input** component and the [**Player Input Manager**](PlayerInputManager.md) component.

--- a/Packages/com.unity.inputsystem/Documentation~/PlayerInputManager.md
+++ b/Packages/com.unity.inputsystem/Documentation~/PlayerInputManager.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-player-input-manager
+---
 # The Player Input Manager component
 
 >NOTE: The Input System package comes with a sample called `Simple Multiplayer` which you can install from the package manager UI in the Unity editor. The sample demonstrates how to use [`PlayerInputManager`](../api/UnityEngine.InputSystem.PlayerInputManager.html) to set up a simple local multiplayer scenario.

--- a/Packages/com.unity.inputsystem/Documentation~/Pointers.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Pointers.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-pointers
+---
 # Pointers
 
 [`Pointer`](../api/UnityEngine.InputSystem.Pointer.html) Devices are defined as [`InputDevices`](../api/UnityEngine.InputSystem.InputDevice.html) that track positions on a 2D surface. The Input System supports three types of pointers:

--- a/Packages/com.unity.inputsystem/Documentation~/Processors.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Processors.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-processors
+---
 # Processors
 
 An Input Processor takes a value and returns a processed result for it. The received value and result value must be of the same type. For example, you can use a [clamp](#clamp) Processor to clamp values from a control to a certain range.

--- a/Packages/com.unity.inputsystem/Documentation~/Sensors.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Sensors.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-sensors
+---
 # Sensor support
 
 * [Sampling Frequency](#sampling-frequency)

--- a/Packages/com.unity.inputsystem/Documentation~/Settings.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Settings.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-settings
+---
 # Input settings
 
 * [Update Mode](#update-mode)

--- a/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
+++ b/Packages/com.unity.inputsystem/Documentation~/SupportedDevices.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-supported-devices
+---
 # Supported Input Devices
 
 This page lists Input Device types and products that the Input System package supports, and the platforms they're supported on.

--- a/Packages/com.unity.inputsystem/Documentation~/Testing.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Testing.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-testing
+---
 # Input testing
 
 The Input System has built-in support for writing automated input tests. You can drive input entirely from code, without any dependencies on platform backends and physical hardware devices. The automated input tests you write consider the generated input to be the same as input generated at runtime by actual platform code.

--- a/Packages/com.unity.inputsystem/Documentation~/Touch.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Touch.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-touch
+---
 # Touch support
 
 - [Touch support](#touch-support)

--- a/Packages/com.unity.inputsystem/Documentation~/UISupport.md
+++ b/Packages/com.unity.inputsystem/Documentation~/UISupport.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-ui-support
+---
 # UI support
 
 * [Setting up UI Input](#setting-up-ui-input)

--- a/Packages/com.unity.inputsystem/Documentation~/UseInEditor.md
+++ b/Packages/com.unity.inputsystem/Documentation~/UseInEditor.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-use-in-editor
+---
 # Using Input in the Editor
 
 Unlike Unity's old Input Manager, you can use the new Input System from within `EditorWindow` code as well. For example, you can gain access to pen pressure information like this:

--- a/Packages/com.unity.inputsystem/Documentation~/UserManagement.md
+++ b/Packages/com.unity.inputsystem/Documentation~/UserManagement.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-user-management
+---
 # User Management
 
 The Input System supports multi-user management through the [`InputUser`](../api/UnityEngine.InputSystem.Users.InputUser.html) class. This comprises both user account management features on platforms that have these capabilities built into them (such as Xbox and PS4), as well as features to manage Device allocations to one or more local users.

--- a/Packages/com.unity.inputsystem/Documentation~/Workflow-ActionsAsset.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Workflow-ActionsAsset.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-workflow-actions-asset
+---
 # Workflow Overview - Using an Actions Asset
 
 ![image alt text](./Images/Workflow-ActionsAsset.svg)

--- a/Packages/com.unity.inputsystem/Documentation~/Workflow-Direct.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Workflow-Direct.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-workflow-direct
+---
 # Workflow Overview - Directly Reading Device States
 
 ![image alt text](./Images/Workflow-Direct.svg)

--- a/Packages/com.unity.inputsystem/Documentation~/Workflow-Embedded.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Workflow-Embedded.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-workflow-embedded
+---
 # Workflow Overview - Using Embedded Actions
 
 ![image alt text](./Images/Workflow-Embedded.svg)

--- a/Packages/com.unity.inputsystem/Documentation~/Workflow-PlayerInput.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Workflow-PlayerInput.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-workflow-player-input
+---
 # Workflow Overview - Using an Actions Asset and PlayerInput Component
 
 ![image alt text](./Images/Workflow-PlayerInput.svg)

--- a/Packages/com.unity.inputsystem/Documentation~/Workflows.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Workflows.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-workflows
+---
 
 # Input System Workflows
 

--- a/Packages/com.unity.inputsystem/Documentation~/index.md
+++ b/Packages/com.unity.inputsystem/Documentation~/index.md
@@ -1,3 +1,6 @@
+---
+uid: input-system-index
+---
 # Input System
 
 The **Input System** allows your users to control your game or app using a device, touch, or gestures.


### PR DESCRIPTION
### Description

This allows dependent packages to link to the correct version.

The PMDT (Package Manager Doc Tool) supports using a special link format to link to other package docs by uid. While this is automatic for API types, UIDs must be assigned manually to the pages of the manual. This system allows a package that is dependent on the Input System (in this case) to resolve such links to the version which that package depends on without needing to specify the version explicitly in the link. (If you set the version in the link, then someone needs to update that version in every instance when the dependent version changes.)
 
### Changes made

Adds a uid header to every markdown file in Documentation~.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
