### PR TITLE
TrackedPoseDriver: Use SetlocalPositionAndRotation instead of 2 seperate calls to improve performance

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -581,18 +581,23 @@ namespace UnityEngine.InputSystem.XR
             var positionValid = m_IgnoreTrackingState || (m_CurrentTrackingState & TrackingStates.Position) != 0;
             var rotationValid = m_IgnoreTrackingState || (m_CurrentTrackingState & TrackingStates.Rotation) != 0;
 
-            if (rotationValid &&
-                (m_TrackingType == TrackingType.RotationAndPosition ||
-                 m_TrackingType == TrackingType.RotationOnly))
+            if (rotationValid && positionValid && m_TrackingType == TrackingType.RotationAndPosition)
             {
-                transform.localRotation = newRotation;
+                transform.SetLocalPositionAndRotation(newPosition, newRotation);
             }
-
-            if (positionValid &&
-                (m_TrackingType == TrackingType.RotationAndPosition ||
-                 m_TrackingType == TrackingType.PositionOnly))
+            else
             {
-                transform.localPosition = newPosition;
+                if (rotationValid &&
+                m_TrackingType == TrackingType.RotationOnly)
+                {
+                    transform.localRotation = newRotation;
+                }
+
+                if (positionValid &&
+                     m_TrackingType == TrackingType.PositionOnly)
+                {
+                    transform.localPosition = newPosition;
+                }
             }
         }
 


### PR DESCRIPTION
### DONT MERGE YET
This PR is open for feedback and to get this noticeable improvement to the team.

### Description

XR setups can involve a lot of game objects, especially when doing hand animation etc. Right now the tracked pose driver has 2 extern calls, which both calculate the position and rotation of all children. Combining these will help with performance, without changing any behavior.


### Changes made

Changed Track Pose Driver's SetLocalTransform() method to integrate SetLocalPositionAndRotation when tracking type is to rotation and position.

### Notes

This is supported in [2021.3.11+](https://unity.com/releases/editor/whats-new/2021.3.11) an 2022.3+
It is recommended to add conditionals to manually compile if the feature is supported.
Since you cannot use conditional compilation with the bugfix version in Unity using _OR_NEWER, the asmdef needs to add support.
This can easily be done with the following statements, or by implementing the conditionals for UNITY_2021_3_11_OR_NEWER
```
        {
            "name": "Unity",
            "expression": "[2021.3.11,2022.1)",
            "define": "HAS_POSITION_AND_ROTATION"
        },
        {
            "name": "Unity",
            "expression": "2022.3",
            "define": "HAS_POSITION_AND_ROTATION"
        }
```

```cs
#if HAS_POSITION_AND_ROTATION
//New code
#else
//Old code
#endif
```
