### PR TITLE
Updated TrackedPoseDriver to make use of Transform.SetLocalPositionAndRotation

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed missing prefab errors in InputDeviceTester project ([case ISXB-420](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-420)).
 - Fixed serialization migration in the Tracked Pose Driver component causing bindings to clear when prefabs are used in some cases ([case ISXB-512](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-512), [case ISXB-521](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-521)).
+- Fixed Tracked Pose Driver to use `Transform.SetLocalPositionAndRotation` when available to improve performance. Based on the user contribution from [DevDunk](https://forum.unity.com/members/devdunk.4432119/) in a [forum post](https://forum.unity.com/threads/more-performant-tracked-pose-driver-solution-included.1462691).
 - Fixed the `Clone` methods of `InputAction` and `InputActionMap` so it copies the Initial State Check flag (`InputAction.wantsInitialStateCheck`) of input actions.
 
 ## [1.6.3] - 2023-07-11

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -1,3 +1,15 @@
+// Transform.SetLocalPositionAndRotation API added in:
+
+// 2022.3.0f1 or newer
+#if UNITY_2022_3_OR_NEWER
+#define HAS_SET_LOCAL_POSITION_AND_ROTATION
+#endif
+
+// 2021.3.11f1 or newer
+#if UNITY_2021_3 && !(UNITY_2021_3_0 || UNITY_2021_3_1 || UNITY_2021_3_2 || UNITY_2021_3_3 || UNITY_2021_3_4 || UNITY_2021_3_5 || UNITY_2021_3_6 || UNITY_2021_3_7 || UNITY_2021_3_8 || UNITY_2021_3_9 || UNITY_2021_3_10)
+#define HAS_SET_LOCAL_POSITION_AND_ROTATION
+#endif
+
 using System;
 using UnityEngine.InputSystem.LowLevel;
 
@@ -578,6 +590,14 @@ namespace UnityEngine.InputSystem.XR
         {
             var positionValid = m_IgnoreTrackingState || (m_CurrentTrackingState & TrackingStates.Position) != 0;
             var rotationValid = m_IgnoreTrackingState || (m_CurrentTrackingState & TrackingStates.Rotation) != 0;
+
+#if HAS_SET_LOCAL_POSITION_AND_ROTATION
+            if (m_TrackingType == TrackingType.RotationAndPosition && rotationValid && positionValid)
+            {
+                transform.SetLocalPositionAndRotation(newPosition, newRotation);
+                return;
+            }
+#endif
 
             if (rotationValid &&
                 (m_TrackingType == TrackingType.RotationAndPosition ||

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -1,15 +1,3 @@
-// Transform.SetLocalPositionAndRotation API added in:
-
-// 2022.3.0f1 or newer
-#if UNITY_2022_3_OR_NEWER
-#define HAS_SET_LOCAL_POSITION_AND_ROTATION
-#endif
-
-// 2021.3.11f1 or newer
-#if UNITY_2021_3 && !(UNITY_2021_3_0 || UNITY_2021_3_1 || UNITY_2021_3_2 || UNITY_2021_3_3 || UNITY_2021_3_4 || UNITY_2021_3_5 || UNITY_2021_3_6 || UNITY_2021_3_7 || UNITY_2021_3_8 || UNITY_2021_3_9 || UNITY_2021_3_10)
-#define HAS_SET_LOCAL_POSITION_AND_ROTATION
-#endif
-
 using System;
 using UnityEngine.InputSystem.LowLevel;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -63,7 +63,12 @@
         },
         {
             "name": "Unity",
-            "expression": "2022.3",
+            "expression": "[2022.1.19,2022.2)",
+            "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
+        },
+        {
+            "name": "Unity",
+            "expression": "2022.2",
             "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
         }
     ],

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -10,8 +10,8 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [     
-         {
+    "versionDefines": [
+        {
             "name": "com.unity.xr.oculus",
             "expression": "1.0.3",
             "define": "DISABLE_BUILTIN_INPUT_SYSTEM_OCULUS"
@@ -55,6 +55,16 @@
             "name": "com.unity.ugui",
             "expression": "1.0.0",
             "define": "UNITY_INPUT_SYSTEM_ENABLE_UI"
+        },
+        {
+            "name": "Unity",
+            "expression": "[2021.3.11,2022.1)",
+            "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
+        },
+        {
+            "name": "Unity",
+            "expression": "2022.3",
+            "define": "HAS_SET_LOCAL_POSITION_AND_ROTATION"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
### Description

Updated `TrackedPoseDriver` to make use of [`Transform.SetLocalPositionAndRotation`](https://docs.unity3d.com/Documentation/ScriptReference/Transform.SetLocalPositionAndRotation.html) which was added with:

- Unity [2021.3.11f1](https://unity.com/releases/editor/whats-new/2021.3.11)
- Unity [2022.1.19f1](https://unity.com/releases/editor/whats-new/2022.1.19)
- Unity [2022.2.0f1](https://unity.com/releases/editor/whats-new/2022.2.0)

### Changes made

Updated method in `TrackedPoseDriver` and an `.asmdef` scoped `#define`.

### Notes

Note that the code from the [forum post](https://forum.unity.com/threads/more-performant-tracked-pose-driver-solution-included.1462691) wasn't quite right. The position or rotation should still be applied to the Transform if either is valid when the tracking type is set to `RotationAndPosition` (i.e. if rotation is valid but not position, the rotation should still be applied when the tracking type is both).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
