### PR TITLE
Listen button fix for older unity versions (ISXB-535)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem.Editor
     {
         private static class Styles
         {
-#if UNITY_2023_2_OR_NEWER || UNITY_2021_3_28 || UNITY_2022_3_1 || UNITY_2023_1
+#if UNITY_2023_2_OR_NEWER || UNITY_2021_3_28 || UNITY_2022_3_1
             public static readonly GUIStyle toolbarSearchField = "ToolbarSearchTextField";
 #else
             public static readonly GUIStyle toolbarSearchField = "ToolbarSeachTextField";

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownGUI.cs
@@ -10,7 +10,11 @@ namespace UnityEngine.InputSystem.Editor
     {
         private static class Styles
         {
+#if UNITY_2023_2_OR_NEWER || UNITY_2021_3_28 || UNITY_2022_3_1 || UNITY_2023_1
             public static readonly GUIStyle toolbarSearchField = "ToolbarSearchTextField";
+#else
+            public static readonly GUIStyle toolbarSearchField = "ToolbarSeachTextField";
+#endif
             public static readonly GUIStyle itemStyle = new GUIStyle("PR Label")
                 .WithAlignment(TextAnchor.MiddleLeft)
                 .WithPadding(new RectOffset())


### PR DESCRIPTION
### Description

added conditional compilation for line to avoid older unity versions to throw a warning. 


Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
