### PR TITLE
Release tests throws exceptions in InputSystem (ISXB-581)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed serialization migration in the Tracked Pose Driver component causing bindings to clear when prefabs are used in some cases ([case ISXB-512](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-512), [case ISXB-521](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-521)).
 - Fixed Tracked Pose Driver to use `Transform.SetLocalPositionAndRotation` when available to improve performance. Based on the user contribution from [DevDunk](https://forum.unity.com/members/devdunk.4432119/) in a [forum post](https://forum.unity.com/threads/more-performant-tracked-pose-driver-solution-included.1462691).
 - Fixed the `Clone` methods of `InputAction` and `InputActionMap` so it copies the Initial State Check flag (`InputAction.wantsInitialStateCheck`) of input actions.
+- Fixed the "Release tests throws exception in InputSystem" bug ([case ISXB-581](https://jira.unity3d.com/browse/ISXB-581)).
 
 ## [1.6.3] - 2023-07-11
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,7 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed serialization migration in the Tracked Pose Driver component causing bindings to clear when prefabs are used in some cases ([case ISXB-512](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-512), [case ISXB-521](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-521)).
 - Fixed Tracked Pose Driver to use `Transform.SetLocalPositionAndRotation` when available to improve performance. Based on the user contribution from [DevDunk](https://forum.unity.com/members/devdunk.4432119/) in a [forum post](https://forum.unity.com/threads/more-performant-tracked-pose-driver-solution-included.1462691).
 - Fixed the `Clone` methods of `InputAction` and `InputActionMap` so it copies the Initial State Check flag (`InputAction.wantsInitialStateCheck`) of input actions.
-- Fixed the "Release tests throws exception in InputSystem" bug ([case ISXB-581](https://jira.unity3d.com/browse/ISXB-581)).
+- Fixed the "Release tests throws exception in InputSystem" bug ([case ISXB-581](https://issuetracker.unity3d.com/issues/release-tests-fail-when-input-system-package-is-installed)).
 
 ## [1.6.3] - 2023-07-11
 

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -91,8 +91,9 @@ namespace UnityEngine.InputSystem
                 runtime = new InputTestRuntime();
 
                 // Push current input system state on stack.
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
                 InputSystem.SaveAndReset(enableRemoting: false, runtime: runtime);
-
+#endif
                 // Override the editor messing with logic like canRunInBackground and focus and
                 // make it behave like in the player.
                 #if UNITY_EDITOR
@@ -165,7 +166,9 @@ namespace UnityEngine.InputSystem
 
             try
             {
+#if DEVELOPMENT_BUILD || UNITY_EDITOR
                 InputSystem.Restore();
+#endif
                 runtime.Dispose();
 
                 // Unhook from play mode state changes.


### PR DESCRIPTION
### Description

fixed this [ticket](https://jira.unity3d.com/browse/ISXB-581) by surrounding code with conditional compilation if the methods are not accessible (due they should be only used in development mode or in editor)

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
