### PR TITLE
FIX: exception on renaming control scheme (ISX-1544)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -31,7 +31,7 @@ namespace UnityEngine.InputSystem.Editor
                     state.selectedControlScheme.deviceRequirements.Where((r, i) => i != selectedDeviceIndex)));
             };
         }
-
+        
         public static Command SaveControlScheme(string oldName = "", bool updateExisting = false)
         {
             return (in InputActionsEditorState state) =>
@@ -39,6 +39,7 @@ namespace UnityEngine.InputSystem.Editor
                 var controlSchemeName = state.selectedControlScheme.name;
 
                 var controlSchemesArray = state.serializedObject.FindProperty(nameof(InputActionAsset.m_ControlSchemes));
+                //use the old name to find the control scheme in the array
                 var controlScheme = controlSchemesArray
                     .FirstOrDefault(sp => sp.FindPropertyRelative(nameof(InputControlScheme.m_Name)).stringValue == (string.IsNullOrEmpty(oldName) ? controlSchemeName : oldName));
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -31,7 +31,7 @@ namespace UnityEngine.InputSystem.Editor
                     state.selectedControlScheme.deviceRequirements.Where((r, i) => i != selectedDeviceIndex)));
             };
         }
-        
+
         public static Command SaveControlScheme(string oldName = "", bool updateExisting = false)
         {
             return (in InputActionsEditorState state) =>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -39,7 +39,6 @@ namespace UnityEngine.InputSystem.Editor
                 var controlSchemeName = state.selectedControlScheme.name;
 
                 var controlSchemesArray = state.serializedObject.FindProperty(nameof(InputActionAsset.m_ControlSchemes));
-                //use the old name to find the control scheme in the array
                 var controlScheme = controlSchemesArray
                     .FirstOrDefault(sp => sp.FindPropertyRelative(nameof(InputControlScheme.m_Name)).stringValue == controlSchemeName);
 
@@ -72,10 +71,7 @@ namespace UnityEngine.InputSystem.Editor
                 }
 
                 state.serializedObject.ApplyModifiedProperties();
-
-                if (!string.IsNullOrEmpty(newName))
-                    return state.With(selectedControlScheme: new InputControlScheme(controlScheme));
-                return state.With(selectedControlSchemeIndex: controlSchemesArray.arraySize - 1);
+                return state.With(selectedControlScheme: new InputControlScheme(controlScheme));
             };
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -9,6 +9,7 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class ControlSchemesView : ViewBase<InputControlScheme>
     {
+        private string m_OldName;
         public ControlSchemesView(VisualElement root, StateContainer stateContainer, bool updateExisting = false)
             : base(stateContainer)
         {
@@ -27,6 +28,8 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Dispatch(ControlSchemeCommands.ChangeSelectedControlSchemeName(((TextField)evt.currentTarget).value));
             });
+
+            OnClosing += (d) => m_OldName = "";
 
             m_ModalWindow = new VisualElement
             {
@@ -63,7 +66,12 @@ namespace UnityEngine.InputSystem.Editor
             m_ListView.itemsSource = new List<string>();
 
             CreateSelector(s => s.selectedControlScheme,
-                (_, s) => s.selectedControlScheme);
+                (_, s) =>
+                {
+                    if (string.IsNullOrEmpty(m_OldName))
+                        m_OldName = s.selectedControlScheme.name;
+                    return s.selectedControlScheme;
+                });
         }
 
         private void AddDeviceRequirement()
@@ -102,7 +110,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void SaveAndClose()
         {
-            Dispatch(ControlSchemeCommands.SaveControlScheme(m_UpdateExisting));
+            Dispatch(ControlSchemeCommands.SaveControlScheme(m_OldName, m_UpdateExisting));
             Close();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -9,6 +9,7 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class ControlSchemesView : ViewBase<InputControlScheme>
     {
+        //is used to save the original name of the control scheme when renaming
         private string m_OldName;
         public ControlSchemesView(VisualElement root, StateContainer stateContainer, bool updateExisting = false)
             : base(stateContainer)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -18,8 +18,6 @@ namespace UnityEngine.InputSystem.Editor
 
     internal abstract class ViewBase<TViewState> : IView
     {
-        public event Action<ViewBase<TViewState>> OnClosing;
-
         protected ViewBase(StateContainer stateContainer)
         {
             this.stateContainer = stateContainer;
@@ -54,11 +52,6 @@ namespace UnityEngine.InputSystem.Editor
         {
             m_ChildViews.Add(view);
             return view;
-        }
-
-        public void Close()
-        {
-            OnClosing?.Invoke(this);
         }
 
         public void DestroyChildView<TView>(TView view) where TView : IView


### PR DESCRIPTION
### Description

This PR fixes the exception captured in this [ticket](https://jira.unity3d.com/browse/ISX-1544).

### Changes made

provided old name to compare control scheme with serialized properties

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
