### PR TITLE
FIX: Remove errors when using UITK Asset Editor (ISX-1531)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -182,6 +182,17 @@ namespace UnityEngine.InputSystem.Editor
             OnEnable();
         }
 
+#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+        /// <summary>
+        /// Default stub implementation of <see cref="InputParameterEditor.OnDrawVisualElements"/>.
+        /// Should be overridden to create the desired UI.
+        /// </summary>
+        public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
+        {
+        }
+
+#endif
+
         /// <summary>
         /// Helper for parameters that have defaults (usually from <see cref="InputSettings"/>).
         /// </summary>


### PR DESCRIPTION
### Description

[ISX-1531](https://jira.unity3d.com/browse/ISX-1531): This PR fixes errors for currently supported Unity versions that do not support UITK Asset Editor features we are using.

### Changes made

- Implemented a stub for the default implementation of `InputParameter<T>.OnDrawVisualElements` to avoid breaking the code of packages that have classes that derive from `InputParameter<T>`. Otherwise we would have a breaking change.

### Notes

Questions: 
- ~This doesn't fix problems for releasing. There are still issues for with XR Interaction Tool Kit. More comments in [ISX-1531](https://jira.unity3d.com/browse/ISX-1531) for the options we have. cc @lyndon-unity @jamesmcgill @ritamerkl~ It fixes it now :)
- Should UITK be enabled as well by default? Right now seems to be behind a [feature flag](https://github.com/Unity-Technologies/InputSystem/blob/132deb5acd63fa149a356c6f1199aa06a59a5f54/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs#L20) disabled by default.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
