### PR TITLE
ISX-1551 Make Project-Wide Actions and UITK editor available from 2022.3+

### DIFF
--- a/Assets/Samples/ProjectWideActionsTest/ProjectWideActionsTest.cs
+++ b/Assets/Samples/ProjectWideActionsTest/ProjectWideActionsTest.cs
@@ -1,4 +1,4 @@
-#if UNITY_2020_2_OR_NEWER
+#if UNITY_INPUT_SYSTEM_ENABLE_GLOBAL_ACTIONS_API
 using System;
 using UnityEngine;
 using UnityEngine.InputSystem;

--- a/Assets/Samples/ProjectWideActionsTest/Unity.InputSystem.ProjectWideActionsTest.asmdef
+++ b/Assets/Samples/ProjectWideActionsTest/Unity.InputSystem.ProjectWideActionsTest.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "InputSystem.Samples",
+    "rootNamespace": "",
+    "references": [
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [
+        {
+            "name": "Unity",
+            "expression": "2022.3",
+            "define": "UNITY_INPUT_SYSTEM_ENABLE_GLOBAL_ACTIONS_API"
+        }
+    ],
+    "noEngineReferences": false
+}

--- a/Assets/Samples/ProjectWideActionsTest/Unity.InputSystem.ProjectWideActionsTest.asmdef.meta
+++ b/Assets/Samples/ProjectWideActionsTest/Unity.InputSystem.ProjectWideActionsTest.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e3314781e7f294f22897363049b6dac9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
@@ -1,4 +1,4 @@
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
 using NUnit.Framework;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Editor;

--- a/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
+++ b/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
@@ -1,6 +1,6 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;

--- a/Assets/Tests/InputSystem.Editor/TestData.cs
+++ b/Assets/Tests/InputSystem.Editor/TestData.cs
@@ -1,4 +1,4 @@
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;

--- a/Assets/Tests/InputSystem.Editor/TestDataGenerators.cs
+++ b/Assets/Tests/InputSystem.Editor/TestDataGenerators.cs
@@ -1,4 +1,4 @@
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
 using System.Collections.Generic;
 using UnityEngine.InputSystem;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -204,7 +204,7 @@ namespace UnityEngine.InputSystem.Composites
             target.mode = (Vector2Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField("Mode", target.mode)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -177,7 +177,7 @@ namespace UnityEngine.InputSystem.Composites
             target.mode = (Vector2Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField("Mode", target.mode)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputControlScheme.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputControlScheme.cs
@@ -112,7 +112,7 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+        #if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
         internal InputControlScheme(SerializedProperty sp)
         {
             var requirements = new List<DeviceRequirement>();

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -128,7 +128,7 @@ namespace UnityEngine.InputSystem.Interactions
             m_DurationSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -202,7 +202,7 @@ namespace UnityEngine.InputSystem.Interactions
             m_PressPointSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var tapCountField = new IntegerField(m_TapCountLabel.text) { value = target.tapCount };

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -218,7 +218,7 @@ namespace UnityEngine.InputSystem.Interactions
             m_PressPointSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             root.Add(new HelpBox(s_HelpBoxText.text, HelpBoxMessageType.None));

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
@@ -92,7 +92,7 @@ namespace UnityEngine.InputSystem.Interactions
             m_PressPointSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -106,7 +106,7 @@ namespace UnityEngine.InputSystem.Interactions
             m_PressPointSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -97,7 +97,7 @@ namespace UnityEngine.InputSystem.Processors
             m_MaxSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_MinSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -86,7 +86,7 @@ namespace UnityEngine.InputSystem.Processors
             m_MaxSetting.OnGUI();
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_MinSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -37,7 +37,7 @@ namespace UnityEngine.InputSystem.Editor
         [OnOpenAsset]
         public static bool OnOpenAsset(int instanceId, int line)
         {
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
             if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseUIToolkitEditor))
                 return false;
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -247,7 +247,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
             m_ParameterEditor = null;
         }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public void OnDrawVisualElements(VisualElement root)
         {
             if (m_ParameterEditor != null)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem.Editor
         /// </summary>
         public abstract void OnGUI();
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         /// <summary>
         /// Add visual elements for this parameter editor to a root VisualElement.
         /// </summary>
@@ -212,7 +212,7 @@ namespace UnityEngine.InputSystem.Editor
                         $"Uses \"{defaultName}\" set in project-wide input settings.");
             }
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
             public void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
             {
                 var value = m_GetValue();
@@ -373,7 +373,7 @@ namespace UnityEngine.InputSystem.Editor
             private FloatField m_FloatField;
             private Button m_OpenInputSettingsButton;
             private Toggle m_DefaultToggle;
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
             private HelpBox m_HelpBox;
 #endif
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR // We use some UITK controls that are only available in 2022.2 or later (MultiColumnListView for example)
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER // We use some UITK controls that are only available in 2022.2 or later (MultiColumnListView for example)
 using System;
 using System.Collections.Generic;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -1,6 +1,6 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.IO;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindowUtils.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindowUtils.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using UnityEditor;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Linq;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Linq.Expressions;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.InputSystem.Utilities;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -1,6 +1,6 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/BindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/BindingPropertiesView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System.Linq;
 using UnityEditor;
 using UnityEngine.UIElements;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositeBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositeBindingPropertiesView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositePartBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositePartBindingPropertiesView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -1,6 +1,6 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/PropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/PropertiesView.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Linq;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using System.Collections.Generic;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/VisualElementExtensions.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/VisualElementExtensions.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_EDITOR && UNITY_2022_3_OR_NEWER
 using System;
 using UnityEngine.UIElements;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
@@ -9,7 +9,7 @@ namespace UnityEngine.InputSystem
         public const string kUseReadValueCaching = "USE_READ_VALUE_CACHING";
         public const string kParanoidReadValueCachingChecks = "PARANOID_READ_VALUE_CACHING_CHECKS";
 
-#if UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR
+#if UNITY_2022_3_OR_NEWER
         public const string kUseUIToolkitEditor = "USE_UITOOLKIT_EDITOR";
 #endif
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -58,13 +58,8 @@
         },
         {
             "name": "Unity",
-            "expression": "2020.2",
+            "expression": "2022.3",
             "define": "UNITY_INPUT_SYSTEM_ENABLE_GLOBAL_ACTIONS_API"
-        },
-        {
-            "name": "Unity",
-            "expression": "2020.2",
-            "define": "UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
### Description

This PR makes the Project-Wide Actions and UITK available from 2022.3+. More in the notes below.
**🔔  It targets the current WIP project wide actions branch #1720**

### Changes made

It removes `UNITY_INPUT_SYSTEM_UI_TK_ASSET_EDITOR` and replaces it with `UNITY_2022_3_OR_NEWER` since UITK functionality is only available from 2022.3 forward. 
- The main reason is that we use the element `TreeView` which is only available from 2022.2 but we still get some errors due to the features we're using that are only stable in 2022.3. So it's more reasonable to enable it for 2022.3.

For `UNITY_INPUT_SYSTEM_ENABLE_GLOBAL_ACTIONS_API` I did not do the same. Rather I updated the `.asmdef` to make Project Wide Actions available from 2022.3 to match UI TK Asset Editor.  
- However, It might be possible to remove the definition altogether and not restrict it to only 2022.3 or any other version. For example, the device-only API doesn't have to depend on UI TK. 
- But before doing that, I'd like to have a stable branch so that I can run automated testing against it. At the moment, a lot of tests are still failing in `api/global-actions-source-generators`.

I also didn't remove the feature flags yet. We could do that once we do a stable `1.8.0`  when both these features available have been tested and used more and are stable enough.

### Notes

Also, a decision will need to be made about having Project Wide Actions without UI TK support, since it is only available for 2022.3. 
There's no point in having Project Wide Actions if the users cannot see them in the Project Settings. And at the moment there is no easy way to just use the IMGUI implementation of the Asset Editor and embed it in the Project Settings editor AFAIK.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
