### PR TITLE
[UUM-42538] Added GameRotationVector type to support devices that do not have RotationVector but have GameRotationVector

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
@@ -500,6 +500,7 @@ internal class AndroidTests : CoreTestsFixture
     [TestCase(typeof(AndroidRotationVector))]
     [TestCase(typeof(AndroidRelativeHumidity))]
     [TestCase(typeof(AndroidAmbientTemperature))]
+    [TestCase(typeof(AndroidGameRotationVector))]
     [TestCase(typeof(AndroidStepCounter))]
     public void Devices_CanCreateAndroidSensors(Type type)
     {
@@ -592,6 +593,7 @@ internal class AndroidTests : CoreTestsFixture
     [Test]
     [Category("Devices")]
     [TestCase("AndroidRotationVector", "attitude")]
+    [TestCase("AndroidGameRotationVector", "attitude")]
     public void Devices_SupportSensorsWithQuaternionControl(string layoutName, string controlName)
     {
         var device = InputSystem.AddDevice(layoutName);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
@@ -84,6 +84,7 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         // RotationVector - OK
         // RelativeHumidity - no alternative in old system
         // AmbientTemperature - no alternative in old system
+        // GameRotationVector - no alternative in old system
         // StepCounter - no alternative in old system
         // GeomagneticRotationVector - no alternative in old system
         // HeartRate - no alternative in old system
@@ -100,6 +101,7 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         [InputControl(name = "attitude", layout = "Quaternion", processors = "AndroidCompensateRotation", variants = "RotationVector")]
         [InputControl(name = "relativeHumidity", layout = "Axis", variants = "RelativeHumidity")]
         [InputControl(name = "ambientTemperature", layout = "Axis", variants = "AmbientTemperature")]
+        [InputControl(name = "attitude", layout = "Quaternion", processors = "AndroidCompensateRotation", variants = "GameRotationVector")]
         [InputControl(name = "stepCounter", layout = "Integer", variants = "StepCounter")]
         [InputControl(name = "rotation", layout = "Quaternion", processors = "AndroidCompensateRotation", variants = "GeomagneticRotationVector")]
         [InputControl(name = "rate", layout = "Axis", variants = "HeartRate")]
@@ -254,6 +256,15 @@ namespace UnityEngine.InputSystem.Android
     /// <seealso href="https://developer.android.com/reference/android/hardware/Sensor#TYPE_AMBIENT_TEMPERATURE"/>
     [InputControlLayout(stateType = typeof(AndroidSensorState), variants = "AmbientTemperature", hideInUI = true)]
     public class AndroidAmbientTemperature : AmbientTemperatureSensor
+    {
+    }
+
+    /// <summary>
+    /// Game rotation vector sensor device on Android.
+    /// </summary>
+    /// <seealso href="https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR"/>
+    [InputControlLayout(stateType = typeof(AndroidSensorState), variants = "GameRotationVector", hideInUI = true)]
+    public class AndroidGameRotationVector : AttitudeSensor
     {
     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
@@ -95,6 +95,11 @@ namespace UnityEngine.InputSystem.Android
                     .WithInterface(kAndroidInterface)
                     .WithDeviceClass("AndroidSensor")
                     .WithCapability("sensorType", AndroidSensorType.AmbientTemperature));
+            InputSystem.RegisterLayout<AndroidGameRotationVector>(
+                matches: new InputDeviceMatcher()
+                    .WithInterface(kAndroidInterface)
+                    .WithDeviceClass("AndroidSensor")
+                    .WithCapability("sensorType", AndroidSensorType.GameRotationVector));
             InputSystem.RegisterLayout<AndroidStepCounter>(
                 matches: new InputDeviceMatcher()
                     .WithInterface(kAndroidInterface)


### PR DESCRIPTION
### Description
**Jira Link:** https://jira.unity3d.com/browse/UUM-42538

**Issue:**
**Input.gyro.attitude** values ​​were not returned correctly on some tablet devices because they don't have [**Rotation vector**](https://source.android.com/docs/core/interaction/sensors/sensor-types#rotation_vector). However, I could find they have [**Game rotation vector**](https://source.android.com/docs/core/interaction/sensors/sensor-types#game_rotation_vector), which new Input System doesn't support. So added code to support **Game rotation vector**.

### Changes made
	modified:   Assets/Tests/InputSystem/Plugins/AndroidTests.cs
	modified:   Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
	modified:   Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs

Added two test cases and some code lines for AndroidGameRotationVector

### Notes

1. Ran Input System automated tests by selecting Window > General > Test Runner
2. Manual tests
   > 1. Opened the project attached to the ticket and installed InputSystem by selecting **Window** > **Package Manager** > **+** > **Install package from disk...** > and then select **package.json** from the source code repository
   >     <img width="232" alt="Screenshot 2023-08-16 at 15 09 43" src="https://github.com/Unity-Technologies/InputSystem/assets/44216949/6826eaa0-a07f-464e-b67f-e2231f0e147d">
   >     <img width="1000" alt="Screenshot 2023-08-22 at 17 14 10" src="https://github.com/Unity-Technologies/InputSystem/assets/44216949/1f3d2642-df4e-4bee-b239-c2614e4d5bb7">
   >     <img width="1000" alt="Screenshot 2023-08-22 at 17 20 31" src="https://github.com/Unity-Technologies/InputSystem/assets/44216949/8713a9e8-58c8-4b9e-b3ec-4c035a2b551f">
   > 2. Updated GyroCamera.cs file. Added some lines to enable AndroidRotationVector or AndroidGameRotationVector sensor. And updated **ApplyGyroRotation()** API to get attitude data
   >      
       ```
       private AttitudeSensor _attitudeSensor;
       private IEnumerator Start()
       {
           _attitudeSensor = InputSystem.GetDevice<AndroidRotationVector>();
           if (_attitudeSensor == null)
               _attitudeSensor = InputSystem.GetDevice<AndroidGameRotationVector>();

           if (_attitudeSensor != null)
                InputSystem.EnableDevice(_attitudeSensor);

           ...
       }
       ```

       ```
       private void ApplyGyroRotation()
       {
           //Quaternion gyroAttitude = Input.gyro.attitude;
           Quaternion gyroAttitude = Quaternion.identity;
           if (_attitudeSensor != null)
               gyroAttitude = _attitudeSensor.attitude.ReadValue();
           ...
       }
       ```
   > 3. Followed steps in the Jira ticket and to check if the view changes
   > Tested devices: VLNQA00524 - Galaxy S23+, VLNQA00488 - Galaxy Tab S6 Lite




### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
