### PR TITLE
[UUM-42538] Added GameRotationVector type to support devices that do not have RotationVector but have GameRotationVector

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/AndroidTests.cs
@@ -500,6 +500,7 @@ internal class AndroidTests : CoreTestsFixture
     [TestCase(typeof(AndroidRotationVector))]
     [TestCase(typeof(AndroidRelativeHumidity))]
     [TestCase(typeof(AndroidAmbientTemperature))]
+    [TestCase(typeof(AndroidGameRotationVector))]
     [TestCase(typeof(AndroidStepCounter))]
     public void Devices_CanCreateAndroidSensors(Type type)
     {
@@ -592,6 +593,7 @@ internal class AndroidTests : CoreTestsFixture
     [Test]
     [Category("Devices")]
     [TestCase("AndroidRotationVector", "attitude")]
+    [TestCase("AndroidGameRotationVector", "attitude")]
     public void Devices_SupportSensorsWithQuaternionControl(string layoutName, string controlName)
     {
         var device = InputSystem.AddDevice(layoutName);

--- a/Docs/Presentation/InputSystem-TheGrandTour.html
+++ b/Docs/Presentation/InputSystem-TheGrandTour.html
@@ -36,7 +36,7 @@
       .footnote {
         position: absolute;
         bottom: 3em;
-		font-size: 0.4em;
+        font-size: 0.4em;
       }
     </style>
   </head>
@@ -273,19 +273,19 @@ https://www.youtube.com/playlist?list=PLXbAKDQVwzta4J2Sbmjio2rTD6uO-phbR
 * Establish __input__ channel from 1+ controls to an action
 * Can be grouped into control schemes
 * Controls are addressed using a "path language":
-	```
-	<XRController>{LeftHand}/trigger
-	```
+    ```
+    <XRController>{LeftHand}/trigger
+    ```
 * Can apply processor stack to incoming values
-	```
-	"invert,scale(factor=2)"
-	```
+    ```
+    "invert,scale(factor=2)"
+    ```
 * Can apply "interactions"
-	```
-	"multitap(tapCount=3)"
-	```
+    ```
+    "multitap(tapCount=3)"
+    ```
 * Can use "composites" to source several bindings into one
-	.center[![BindingComposite](BindingComposite.png)]
+    .center[![BindingComposite](BindingComposite.png)]
 
 ]
 
@@ -518,7 +518,7 @@ https://www.youtube.com/playlist?list=PLXbAKDQVwzta4J2Sbmjio2rTD6uO-phbR
     <script src="https://remarkjs.com/downloads/remark-latest.min.js">
     </script>
     <script>
-		var slideshow = remark.create();
+        var slideshow = remark.create();
     </script>
   </body>
 </html>

--- a/ExternalSampleProjects/TouchSamples/Assets/ControlMaps/GamepadControls.cs
+++ b/ExternalSampleProjects/TouchSamples/Assets/ControlMaps/GamepadControls.cs
@@ -17,7 +17,7 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace InputSamples.Controls
 {
-    public partial class @GamepadControls : IInputActionCollection2, IDisposable
+    public partial class @GamepadControls: IInputActionCollection2, IDisposable
     {
         public InputActionAsset asset { get; }
         public @GamepadControls()
@@ -231,12 +231,14 @@ namespace InputSamples.Controls
         {
             asset.Disable();
         }
+
         public IEnumerable<InputBinding> bindings => asset.bindings;
 
         public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
         {
             return asset.FindAction(actionNameOrId, throwIfNotFound);
         }
+
         public int FindBinding(InputBinding bindingMask, out InputAction action)
         {
             return asset.FindBinding(bindingMask, out action);

--- a/ExternalSampleProjects/TouchSamples/Assets/ControlMaps/PointerControls.cs
+++ b/ExternalSampleProjects/TouchSamples/Assets/ControlMaps/PointerControls.cs
@@ -17,7 +17,7 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace InputSamples.Controls
 {
-    public partial class @PointerControls : IInputActionCollection2, IDisposable
+    public partial class @PointerControls: IInputActionCollection2, IDisposable
     {
         public InputActionAsset asset { get; }
         public @PointerControls()
@@ -544,12 +544,14 @@ namespace InputSamples.Controls
         {
             asset.Disable();
         }
+
         public IEnumerable<InputBinding> bindings => asset.bindings;
 
         public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
         {
             return asset.FindAction(actionNameOrId, throwIfNotFound);
         }
+
         public int FindBinding(InputBinding bindingMask, out InputAction action)
         {
             return asset.FindBinding(bindingMask, out action);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,7 +23,8 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 - Preliminary support for visionOS.
 - Show a list of `Derived Bindings` underneath the Binding Path editor to show all controls that matched.
-
+- Support for Game rotation vector on Android
+  
 ### Changed
 - Changed the `InputAction` constructors so it generates an ID for the action and the optional binding parameter. This is intended to improve the serialization of input actions on behaviors when created through API when the property drawer in the Inspector window does not have a chance to generate an ID.
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 - Initial version of Project Wide Actions for pre-release (`InputSystem.actions`). This feature is available only on Unity Editor versions 2022.3 and above and can be modified in the Project Settings.
+- Support for [Game rotation vector](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR) sensor on Android
 
 ### Fixed
 - Fixed device selection menu not responding to mouse clicks when trying to add a device in a Control Scheme ([case ISXB-622](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-622)).
@@ -23,8 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 - Preliminary support for visionOS.
 - Show a list of `Derived Bindings` underneath the Binding Path editor to show all controls that matched.
-- Support for Game rotation vector on Android
-  
+
 ### Changed
 - Changed the `InputAction` constructors so it generates an ID for the action and the optional binding parameter. This is intended to improve the serialization of input actions on behaviors when created through API when the property drawer in the Inspector window does not have a chance to generate an ID.
 

--- a/Packages/com.unity.inputsystem/Documentation~/Sensors.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Sensors.md
@@ -96,7 +96,8 @@ Use the gravity sensor to determine the direction of the gravity vector relative
 
 Use the attitude sensor to determine the orientation of a device. This is useful to control content by rotating a device. Values are affected by the [__Compensate Orientation__](Settings.md#compensate-orientation) setting.
 
-**Android**: Has two types of Attitude sensors - [**RotationVector**](https://developer.android.com/reference/android/hardware/Sensor#TYPE_ROTATION_VECTOR) and [**GameRotationVector**](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR), **RotationVector** is not always available, thus you should implement a fallback mechanism in your code.
+**Note**: On Android devices, there are two types of attitude sensors: [**RotationVector**](https://developer.android.com/reference/android/hardware/Sensor#TYPE_ROTATION_VECTOR) and [**GameRotationVector**](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR). Some Android devices have both types of sensor, while other devices may only have one or the other type available. These two types of attitude sensor behave slightly differently to each other. You can [read about the differences between them here](https://developer.android.com/guide/topics/sensors/sensors_position#sensors-pos-gamerot). Because of this variety in what type of rotation sensors are available across devices, when you require input from a rotation sensor on Android devices, you should include code that checks for your preferred type of rotation sensor with a fallback to the alternative type of rotation sensor if it is not present. For example:
+
 ```CSharp
 AttitudeSensor attitudeSensor = InputSystem.GetDevice<AndroidRotationVector>();
 if (attitudeSensor == null)

--- a/Packages/com.unity.inputsystem/Documentation~/Sensors.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Sensors.md
@@ -96,6 +96,20 @@ Use the gravity sensor to determine the direction of the gravity vector relative
 
 Use the attitude sensor to determine the orientation of a device. This is useful to control content by rotating a device. Values are affected by the [__Compensate Orientation__](Settings.md#compensate-orientation) setting.
 
+**Android**: Has two types of Attitude sensors - [**RotationVector**](https://developer.android.com/reference/android/hardware/Sensor#TYPE_ROTATION_VECTOR) and [**GameRotationVector**](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR), **RotationVector** is not always available, thus you should implement a fallback mechanism in your code.
+```CSharp
+AttitudeSensor attitudeSensor = InputSystem.GetDevice<AndroidRotationVector>();
+if (attitudeSensor == null)
+{
+    attitudeSensor = InputSystem.GetDevice<AndroidGameRotationVector>();
+    if (attitudeSensor == null)
+       Debug.LogError("AttitudeSensor is not available");
+}
+
+if (attitudeSensor != null)
+    InputSystem.EnableDevice(attitudeSensor);
+```
+
 ## <a name="linearaccelerationsensor"></a>[`LinearAccelerationSensor`](../api/UnityEngine.InputSystem.LinearAccelerationSensor.html)
 
 Use the accelerometer to measure the acceleration of a device. This is useful to control content by moving a device around. Linear acceleration is the acceleration of a device unaffected by gravity. This is usually derived from a hardware `Accelerometer`, by subtracting the effect of gravity (see `GravitySensor`). Values are affected by the [__Compensate Orientation__](Settings.md#compensate-orientation) setting.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
@@ -84,6 +84,7 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         // RotationVector - OK
         // RelativeHumidity - no alternative in old system
         // AmbientTemperature - no alternative in old system
+        // GameRotationVector - no alternative in old system
         // StepCounter - no alternative in old system
         // GeomagneticRotationVector - no alternative in old system
         // HeartRate - no alternative in old system
@@ -100,6 +101,7 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         [InputControl(name = "attitude", layout = "Quaternion", processors = "AndroidCompensateRotation", variants = "RotationVector")]
         [InputControl(name = "relativeHumidity", layout = "Axis", variants = "RelativeHumidity")]
         [InputControl(name = "ambientTemperature", layout = "Axis", variants = "AmbientTemperature")]
+        [InputControl(name = "attitude", layout = "Quaternion", processors = "AndroidCompensateRotation", variants = "GameRotationVector")]
         [InputControl(name = "stepCounter", layout = "Integer", variants = "StepCounter")]
         [InputControl(name = "rotation", layout = "Quaternion", processors = "AndroidCompensateRotation", variants = "GeomagneticRotationVector")]
         [InputControl(name = "rate", layout = "Axis", variants = "HeartRate")]
@@ -254,6 +256,15 @@ namespace UnityEngine.InputSystem.Android
     /// <seealso href="https://developer.android.com/reference/android/hardware/Sensor#TYPE_AMBIENT_TEMPERATURE"/>
     [InputControlLayout(stateType = typeof(AndroidSensorState), variants = "AmbientTemperature", hideInUI = true)]
     public class AndroidAmbientTemperature : AmbientTemperatureSensor
+    {
+    }
+
+    /// <summary>
+    /// Game rotation vector sensor device on Android.
+    /// </summary>
+    /// <seealso href="https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR"/>
+    [InputControlLayout(stateType = typeof(AndroidSensorState), variants = "GameRotationVector", hideInUI = true)]
+    public class AndroidGameRotationVector : AttitudeSensor
     {
     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs
@@ -95,6 +95,11 @@ namespace UnityEngine.InputSystem.Android
                     .WithInterface(kAndroidInterface)
                     .WithDeviceClass("AndroidSensor")
                     .WithCapability("sensorType", AndroidSensorType.AmbientTemperature));
+            InputSystem.RegisterLayout<AndroidGameRotationVector>(
+                matches: new InputDeviceMatcher()
+                    .WithInterface(kAndroidInterface)
+                    .WithDeviceClass("AndroidSensor")
+                    .WithCapability("sensorType", AndroidSensorType.GameRotationVector));
             InputSystem.RegisterLayout<AndroidStepCounter>(
                 matches: new InputDeviceMatcher()
                     .WithInterface(kAndroidInterface)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Tutorials on how to use the Input System are available as part of:
     - [Simple Demo](Assets/Samples/SimpleDemo) - Shows how to set up a simple character controller using actions, action asset as well as using the `PlayerInput` component.
     - [Simple Multiplayer](Assets/Samples/SimpleMultiplayer) - Demonstrates a basic split-screen local multiplayer setup where players can join by pressing buttons on the supported devices to join the game.
     - [UI vs Game Input](Assets/Samples/UIvsGameInput) - Illustrates how to handle input and resolve ambiguities that arise when overlaying UI elements in the game-view.
-    - [Visualizers](Assets/Samples/Visualizers) - Provides various input data visualizations for common devices. 
+    - [Visualizers](Assets/Samples/Visualizers) - Provides various input data visualizations for common devices.
 
 ## How to use a released versions of the package within a Unity project
 
@@ -38,21 +38,20 @@ To test out the latest (unreleased) changes:
 1. Clone [develop](https://github.com/Unity-Technologies/InputSystem/tree/develop). The intention is to always keep the `develop` branch in a releasable state, but it reflects current development and may contain bugs or unexpected behavior that was not present in the latest released version.
 2. Add the local package to your project by following the steps described in [Unity Manual - Installing a package from a local folder](https://docs.unity3d.com/Manual/upm-ui-local.html) and select `Packages/com.unity.inputsystem/package.json`.
 
-## Recommended way of developing the Input System 
+## Recommended way of developing the Input System
 
-1. Clone [develop](https://github.com/Unity-Technologies/InputSystem/tree/develop) or the desired branch or release tag. 
+1. Clone [develop](https://github.com/Unity-Technologies/InputSystem/tree/develop) or the desired branch or release tag.
 2. Open the root folder of the repository in the Unity Editor. This way you have access to tests and samples that are excluded when importing only the package into another Unity project.
 
-During development, run Input System automated tests by selecting `Window > General > Test Runner` to access the Test Runner and select `Run All` for `PlayMode` or `EditMode` tests. 
+During development, run Input System automated tests by selecting `Window > General > Test Runner` to access the Test Runner and select `Run All` for `PlayMode` or `EditMode` tests.
 
 ## Contribution & Feedback
-This project is developed by Unity Technologies but welcomes user contributions and feedback. 
+This project is developed by Unity Technologies but welcomes user contributions and feedback.
 
-If you have any feedback or questions about Unity's Input System, you are invited to join us on the [Unity Forums](https://forum.unity.com/forums/new-input-system.103/). 
+If you have any feedback or questions about Unity's Input System, you are invited to join us on the [Unity Forums](https://forum.unity.com/forums/new-input-system.103/).
 
 If you want to contribute to the development of the Input System see [CONTRIBUTIONS.md](https://github.com/Unity-Technologies/InputSystem/blob/develop/CONTRIBUTIONS.md) for additional information.
 
 ## License
 
 This package is distributed under the [Unity Companion License for Unity-dependent projects](LICENSE.md) license with addition of [third party licenses](Third%20Party%20Notices.md) which applies to the [Assets/Samples/RebindingUI](Assets/Samples/RebindingUI) example project specifically.
-


### PR DESCRIPTION
### Description
**Jira Link:** https://jira.unity3d.com/browse/UUM-42538

**Issue:**
**Input.gyro.attitude** values ​​were not returned correctly on some tablet devices because they don't have [**Rotation vector**](https://source.android.com/docs/core/interaction/sensors/sensor-types#rotation_vector). However, I could find they have [**Game rotation vector**](https://source.android.com/docs/core/interaction/sensors/sensor-types#game_rotation_vector), which new Input System doesn't support. So added code to support **Game rotation vector**.

### Changes made
	modified:   Assets/Tests/InputSystem/Plugins/AndroidTests.cs
	modified:   Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSensors.cs
	modified:   Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidSupport.cs

Added [Android Game rotation vector](https://source.android.com/docs/core/interaction/sensors/sensor-types#game_rotation_vector) and added two test cases for it.

### Notes

1. Ran Input System automated tests by selecting Window > General > Test Runner
2. Manual tests
   > 1. Opened the project attached to the ticket and installed InputSystem by selecting **Window** > **Package Manager** > **+** > **Install package from disk...** > and then select **package.json** from the source code repository
   >     <img width="232" alt="Screenshot 2023-08-16 at 15 09 43" src="https://github.com/Unity-Technologies/InputSystem/assets/44216949/6826eaa0-a07f-464e-b67f-e2231f0e147d">
   >     <img width="1000" alt="Screenshot 2023-08-22 at 17 14 10" src="https://github.com/Unity-Technologies/InputSystem/assets/44216949/1f3d2642-df4e-4bee-b239-c2614e4d5bb7">
   >     <img width="1000" alt="Screenshot 2023-08-22 at 17 20 31" src="https://github.com/Unity-Technologies/InputSystem/assets/44216949/8713a9e8-58c8-4b9e-b3ec-4c035a2b551f">
   > 2. Updated GyroCamera.cs file. Added some lines to enable AndroidRotationVector or AndroidGameRotationVector sensor. And updated **ApplyGyroRotation()** API to get attitude data
   >      
       ```
       private AttitudeSensor _attitudeSensor;
       private IEnumerator Start()
       {
           _attitudeSensor = InputSystem.GetDevice<AndroidRotationVector>();
           if (_attitudeSensor == null)
               _attitudeSensor = InputSystem.GetDevice<AndroidGameRotationVector>();

           if (_attitudeSensor != null)
                InputSystem.EnableDevice(_attitudeSensor);

           ...
       }
       ```

       ```
       private void ApplyGyroRotation()
       {
           //Quaternion gyroAttitude = Input.gyro.attitude;
           Quaternion gyroAttitude = Quaternion.identity;
           if (_attitudeSensor != null)
               gyroAttitude = _attitudeSensor.attitude.ReadValue();
           ...
       }
       ```
   > 3. Followed steps in the Jira ticket and to check if the view changes


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
