### PR TITLE
FIX: Global Actions UI flickers when user expands actions (ISX-1547)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -145,21 +145,22 @@ namespace UnityEngine.InputSystem.Editor
             return id;
         }
 
-        private int GetComponentOrBindingID(List<TreeViewItemData<ActionOrBindingData>> treeList, int selectedBindingIndex)
+        private int GetComponentOrBindingID(List<TreeViewItemData<ActionOrBindingData>> treeItemList, int selectedBindingIndex)
         {
-            var currentBindingIndex = -1;
-            foreach (var action in treeList)
+            foreach (var actionItem in treeItemList)
             {
-                foreach (var bindingOrComponent in action.children)
+                // Look for the element ID by checking if the selected binding index matches the binding index of
+                // the ActionOrBindingData of the item. Deals with composite bindings as well.
+                foreach (var bindingOrComponentItem in actionItem.children)
                 {
-                    currentBindingIndex++;
-                    if (currentBindingIndex == selectedBindingIndex) return bindingOrComponent.id;
-                    if (bindingOrComponent.hasChildren)
+                    if (bindingOrComponentItem.data.bindingIndex == selectedBindingIndex)
+                        return bindingOrComponentItem.id;
+                    if (bindingOrComponentItem.hasChildren)
                     {
-                        foreach (var binding in bindingOrComponent.children)
+                        foreach (var bindingItem in bindingOrComponentItem.children)
                         {
-                            currentBindingIndex++;
-                            if (currentBindingIndex == selectedBindingIndex) return binding.id;
+                            if (bindingOrComponentItem.data.bindingIndex == selectedBindingIndex)
+                                return bindingItem.id;
                         }
                     }
                 }


### PR DESCRIPTION
### Description

Fixes https://jira.unity3d.com/browse/ISX-1547
Opening some bindings was causing some UI flickering in the UITK Asset Editor

### Changes made

The method `ActionsTreeView.GetComponentOrBindingID` was returning the wrong tree view item ID of the selected binding index. It assumed all the bindings were ordered according to the tree items which might not always be the case. This change makes sure we get the matching tree view item ID for the selected binding index.

📣 Originally this bug was reported against #1720. But I tested and did the changes against the new #1735 Project Wide Actions Phase 1 branch.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
