### PR TITLE
Attempt to fix 'is marked as leaf input cacheable' build errors on IL…

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -16,16 +16,16 @@ upm_ci_install: npm install -g upm-ci-utils@stable --registry https://artifactor
 platforms_win:
   - name: win
     type: Unity::VM
-    image: package-ci/win10:default
+    image: package-ci/win10:v4.16.0
     flavor: b1.large
   - name: win_standalone
     type: Unity::VM
-    image: package-ci/win10:default
+    image: package-ci/win10:v4.16.0
     flavor: b1.large
     runtime: StandaloneWindows64
   - name: win_standalone_il2cpp
     type: Unity::VM
-    image: package-ci/win10:default
+    image: package-ci/win10:v4.16.0
     flavor: b1.large
     runtime: StandaloneWindows64
     scripting-backend: Il2Cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -154,7 +154,7 @@ build_android_{{ editor.version }}_{{ backend.name }}:
   name: Build Tests on {{ editor.version }} on android {{ backend.name }}
   agent:
       type: Unity::VM
-      image: package-ci/win10:default
+      image: package-ci/win10:v4.16.0
       flavor: b1.xlarge
   variables:
     BEE_CACHE_BEHAVIOUR: _
@@ -175,7 +175,7 @@ run_android_{{ editor.version }}_{{ backend.name }}:
   name: Run Tests on {{ editor.version }} on android {{ backend.name }}
   agent:
       type: Unity::mobile::shield
-      image: package-ci/win10:default
+      image: package-ci/win10:v4.16.0
       flavor: b1.medium
   # Skip repository cloning
   skip_checkout: true
@@ -238,7 +238,7 @@ publish{% cycle "", "_dryrun" %}:
   name: Publish to Internal Registry {% cycle "", "(Dry Run)" %}
   agent:
     type: Unity::VM
-    image: package-ci/win10:default
+    image: package-ci/win10:v4.16.0
     flavor: b1.large
   variables:
     UPMCI_ENABLE_PACKAGE_SIGNING: 1

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -44,6 +44,8 @@
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
+  variables:
+    BEE_CACHE_BEHAVIOUR: _
   commands:
     - {{ utr_install_nix }}
     - {{ upm_ci_install }}
@@ -154,6 +156,8 @@ build_android_{{ editor.version }}_{{ backend.name }}:
       type: Unity::VM
       image: package-ci/win10:default
       flavor: b1.xlarge
+  variables:
+    BEE_CACHE_BEHAVIOUR: _
   commands:
     - {{ utr_install_win }}
     - {{ unity_downloader_install }}


### PR DESCRIPTION
### Description

Temporarily disable BEE_CACHE_BEHAVIOUR on mac and android IL2CPP jobs in an attempt to fix the following Player build errors there:

`This node 'Lib_Mac_x64 Library/Bee/artifacts/MacStandalonePlayerBuildProgram/8ahfr/il2cpp.a' is marked as leaf input cacheable.`
and
`This node 'Lib_Android_arm32 Library/Bee/artifacts/Android/tapai/il2cpp.a' is marked as leaf input cacheable.`

### Changes made

BEE_CACHE_BEHAVIOUR disabled in yamato config for mac standalone and android

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
