### PR TITLE
NEW: Focus on selected action when opening UITK Asset Editor (ISX-1131)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -61,11 +61,11 @@ namespace UnityEngine.InputSystem.Editor
             if (asset == null)
             {
                 var actionReference = obj as InputActionReference;
-                if (actionReference != null)
+                if (actionReference != null && actionReference.asset != null)
                 {
                     asset = actionReference.asset;
-                    actionMapToSelect = actionReference.action.actionMap.name;
-                    actionToSelect = actionReference.action.name;
+                    actionMapToSelect = actionReference.action.actionMap?.name;
+                    actionToSelect = actionReference.action?.name;
                 }
                 else
                 {
@@ -82,9 +82,8 @@ namespace UnityEngine.InputSystem.Editor
             window.m_IsDirty = false;
             window.m_AssetId = instanceId;
             window.titleContent = new GUIContent("Input Actions Editor");
-            window.SetAsset(asset, actionToSelect, actionMapToSelect);
             window.minSize = k_MinWindowSize;
-            window.SetAsset(asset);
+            window.SetAsset(asset, actionToSelect, actionMapToSelect);
             window.Show();
 
             return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -179,8 +179,11 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionsTreeView.SetRootItems(viewState.treeViewData);
             m_ActionsTreeView.Rebuild();
             if (viewState.newElementID != -1)
+            {
                 m_ActionsTreeView.SetSelectionById(viewState.newElementID);
-            RenameNewAction(viewState.newElementID);
+                m_ActionsTreeView.ScrollToItemById(viewState.newElementID);
+            }
+            RenameNewAction(viewState.newElementID);;
             addActionButton.SetEnabled(viewState.actionMapCount > 0);
         }
 


### PR DESCRIPTION
### Description

This PR adds functionality to focus on selected action when editor is opened and an input action from the Asset folder is selected: https://jira.unity3d.com/browse/ISX-1131

### Changes made

- Change the view state to select the action and actionMap  selected in the Editor window
- Focus on the tree view item that corresponds to the action selected. Scrolling to the element ID on the tree view is needed because the action might not be visible in case there are a lot of tree view elements (a lot of actions and bindings for example).

### Notes

📣  **Should only be merged after the release process of `1.8.0-pre.1` is done.**


