### PR TITLE
CHANGE: Re-enable temporarily disabled tests due to ProjectWide actions (ISX-1455)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -5073,12 +5073,6 @@ partial class CoreTests
     [Category("Actions")]
     public void Actions_WhenControlsUpdate_InProgressActionsKeepGoing()
     {
-#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-        // @TODO: This should not need disabled for this test (https://jira.unity3d.com/browse/ISX-1455)
-        // Causes: "[Assert] Could not find active control after binding resolution"
-        // when RemoveDevice() called
-        InputSystem.actions.Disable();
-#endif
         currentTime = 0;
         var gamepad = InputSystem.AddDevice<Gamepad>();
 

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -529,7 +529,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -2102,7 +2102,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -2356,7 +2356,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -2648,7 +2648,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var keyboard = InputSystem.AddDevice<Keyboard>();
@@ -3173,7 +3173,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -3621,7 +3621,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Remove from `ListEnabledActions`
 #endif
 
         var action = new InputAction(binding: "<Gamepad>/leftStick");
@@ -3869,7 +3869,7 @@ partial class CoreTests
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
         InputSystem.actions?.Disable();
-        InputActionState.DestroyAllActionMapStates(); // Also remove controls so the changed control count is accurate
+        InputActionState.DestroyAllActionMapStates(); // Required for `onActionChange` to report correct number of changes
 #endif
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -4761,7 +4761,7 @@ partial class CoreTests
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
         InputSystem.actions?.Disable();
-        InputActionState.DestroyAllActionMapStates(); // Also remove controls so the changed control count is accurate
+        InputActionState.DestroyAllActionMapStates(); // Required for `onActionChange` to report correct number of changes
 #endif
 
         var gamepad = InputSystem.AddDevice<Gamepad>();
@@ -4909,8 +4909,8 @@ partial class CoreTests
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
         InputSystem.actions?.Disable();
-        InputActionState.DestroyAllActionMapStates(); // Also remove controls so the changed control count is accurate
-#endif
+        InputActionState.DestroyAllActionMapStates(); // Required for `onActionChange` to report correct number of changes
+ #endif
 
         var enabledAction = new InputAction("enabledAction", binding: "<Gamepad>/leftTrigger");
 
@@ -4971,7 +4971,7 @@ partial class CoreTests
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
         InputSystem.actions?.Disable();
-        InputActionState.DestroyAllActionMapStates(); // Also remove controls so the changed control count is accurate
+        InputActionState.DestroyAllActionMapStates(); // Required for `onActionChange` to report correct number of changes
 #endif
 
         var actionMap = new InputActionMap("map");
@@ -5002,8 +5002,8 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();  // Worked in Standalone
-        InputActionState.DestroyAllActionMapStates(); // Also remove controls so the changed control count is accurate
+        InputSystem.actions?.Disable();
+        InputActionState.DestroyAllActionMapStates(); // Required for `onActionChange` to report correct number of changes
 #endif
 
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -5192,7 +5192,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Remove from `ListEnabledActions`
 #endif
 
         var action1 = new InputAction(name: "a");
@@ -9836,7 +9836,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var touchscreen = InputSystem.AddDevice<Touchscreen>();
@@ -9911,7 +9911,7 @@ partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions?.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         // Give us known parameters for tap detection.

--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -753,7 +753,7 @@ internal partial class CoreTests
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
-        InputSystem.actions.Disable();
+        InputSystem.actions?.Disable(); // Prevent these actions appearing in the `InputActionTrace`
 #endif
 
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -485,7 +485,7 @@ partial class CoreTests
         // and invalidate the cache (make it stale), immediately afterwards we
         // call NotifyControlStateChanged for each of the actions which _may_ cause a Read()
         // on the control and make it immediately cached (non-stale) again.
-        InputSystem.actions.Disable();
+        InputSystem.actions?.Disable();
 #endif
 
         var keyboard = InputSystem.AddDevice<Keyboard>();

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -478,9 +478,13 @@ partial class CoreTests
     [Category("Controls")]
     public void Controls_ValueCachingWorksAcrossEntireDeviceMemoryRange()
     {
-        // @TODO: This should not need disabled for this test (https://jira.unity3d.com/browse/ISX-1455)
-        // Somehow the presence of action controls prevents those controls being marked as stale
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+        // Exclude project-wide actions from this test
+        // The presence of any enabled actions means we have installed StateChangeMonitors
+        // which interferes with this test. Essentially when we update the device state
+        // and invalidate the cache (make it stale), immediately afterwards we
+        // call NotifyControlStateChanged for each of the actions which _may_ cause a Read()
+        // on the control and make it immediately cached (non-stale) again.
         InputSystem.actions.Disable();
 #endif
 

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4390,12 +4390,6 @@ partial class CoreTests
     [TestCase(false, InputSettings.BackgroundBehavior.ResetAndDisableNonBackgroundDevices, InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView)]
     public unsafe void Devices_CanHandleFocusChanges(bool appRunInBackground, InputSettings.BackgroundBehavior backgroundBehavior, InputSettings.EditorInputBehaviorInPlayMode editorInputBehaviorInPlayMode)
     {
-#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-        // @TODO: This should not need disabled for this test (https://jira.unity3d.com/browse/ISX-1455)
-        // Causes: "[Assert] Could not find active control after binding resolution"
-        // due to: mouse3 = InputSystem.AddDevice<Mouse>();
-        InputSystem.actions.Disable();
-#endif
         // The constant leads to "Unreachable code detected" warnings.
         #pragma warning disable CS0162
 
@@ -5363,16 +5357,6 @@ partial class CoreTests
     [Category("Devices")]
     public void Devices_RemovingDevice_MakesNextDeviceOfTypeCurrent()
     {
-#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-        // @TODO: This should not need disabled for this test (https://jira.unity3d.com/browse/ISX-1455)
-        // Causes: "[Assert] Could not find active control after binding resolution"
-        // during  point where Pointer is removed
-        // - InputActionState.OnDeviceChange(device, InputDeviceChange.Removed);
-        // - LazyResolveBindings(bool fullResolve)
-        // - ResolveBindings()
-        // - RestoreActionStatesAfterReResolvingBindings(UnmanagedMemory oldState, InputControlList<InputControl> activeControls, bool isFullResolve)
-        InputSystem.actions.Disable();
-#endif
         var mouse = InputSystem.AddDevice<Mouse>();
         Press(mouse.leftButton);
         Assert.That(Pointer.current, Is.EqualTo(mouse));

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -4100,7 +4100,7 @@ partial class CoreTests
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // Exclude project-wide actions from this test
         // Prevent GC Allocations happening later in test
-        InputSystem.actions.Disable();
+        InputSystem.actions?.Disable();
         InputActionState.DestroyAllActionMapStates();
 #endif
 

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2838,10 +2838,11 @@ partial class CoreTests
     public void Editor_LeavingPlayMode_DestroysAllActionStates()
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-        // With Project-wide Actions `InputSystem.actions`, we begin with some initial ActionState
         // Exclude project-wide actions from this test
+        // With Project-wide Actions `InputSystem.actions`, we begin with some initial ActionState
+        // Disabling Project-wide actions so that we begin from zero.
         Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(1));
-        InputSystem.actions.Disable();
+        InputSystem.actions?.Disable();
         InputActionState.DestroyAllActionMapStates();
 #endif
 

--- a/Assets/Tests/InputSystem/CoreTests_ProjectWideActions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ProjectWideActions.cs
@@ -163,7 +163,7 @@ internal partial class CoreTests
         Assert.That(enabledActions, Has.Exactly(1).SameAs(action));
 
         // Disabling works
-        InputSystem.actions.Disable();
+        InputSystem.actions?.Disable();
         enabledActions = InputSystem.ListEnabledActions();
         Assert.That(enabledActions, Has.Count.EqualTo(1));
         Assert.That(enabledActions, Has.Exactly(1).SameAs(action));

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3231,8 +3231,6 @@ internal class UITests : CoreTestsFixture
         Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.leftGameObject));
     }
 
-// @TODO: This should not need disabled for this test (https://jira.unity3d.com/browse/ISX-1455)
-#if !UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS || UNITY_EDITOR
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_WhenBindingsAreReResolved_PointerStatesAreKeptInSync()
@@ -3282,8 +3280,6 @@ internal class UITests : CoreTestsFixture
 
         Assert.That(EventSystem.current.IsPointerOverGameObject(), Is.True);
     }
-
-#endif
 
     ////REVIEW: While `deselectOnBackgroundClick` does solve the problem of breaking keyboard and gamepad navigation, the question
     ////        IMO is whether navigation should even be affected that way by not having a current selection. Seems to me that the
@@ -3800,8 +3796,6 @@ internal class UITests : CoreTestsFixture
         Assert.That(clicked, Is.True);
     }
 
-// @TODO: This should not need disabled for this test (https://jira.unity3d.com/browse/ISX-1455)
-#if !UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS || UNITY_EDITOR
     [UnityTest]
     [Category("UI")]
     public IEnumerator UI_WhenCursorIsLockedToScreenCenter_PointerEnterAndExitEventsFire()
@@ -3833,8 +3827,6 @@ internal class UITests : CoreTestsFixture
         yield return null;
         Assert.That(callbackReceiver.events.Any(e => e.type == EventType.PointerExit), Is.True);
     }
-
-#endif
 
     #region Multi Display Tests
 #if UNITY_2022_3_OR_NEWER // displayIndex is only available from 2022.3 onwards

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -551,6 +551,7 @@ namespace UnityEngine.InputSystem
                 newActionState.pressedInUpdate = oldActionState.pressedInUpdate;
                 newActionState.releasedInUpdate = oldActionState.releasedInUpdate;
                 newActionState.startTime = oldActionState.startTime;
+                newActionState.bindingIndex = oldActionState.bindingIndex;
 
                 if (oldActionState.phase != InputActionPhase.Disabled)
                 {
@@ -628,6 +629,7 @@ namespace UnityEngine.InputSystem
                     // so we can simply look on the binding for where the control is now.
                     var newControlIndex = FindControlIndexOnBinding(bindingIndex, control);
 
+                    // This assert is used by test: Actions_ActiveBindingsHaveCorrectBindingIndicesAfterBindingResolution
                     Debug.Assert(newControlIndex != kInvalidIndex, "Could not find active control after binding resolution");
                     if (newControlIndex != kInvalidIndex)
                     {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsBuildProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsBuildProvider.cs
@@ -19,14 +19,12 @@ namespace UnityEngine.InputSystem.Editor
             var preloadedAssets = PlayerSettings.GetPreloadedAssets();
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-            EditorBuildSettings.TryGetConfigObject(InputSettingsProvider.kEditorBuildSettingsActionsConfigKey,
-                out m_ProjectWideActions);
-
+            m_ProjectWideActions = Editor.ProjectWideActionsAsset.GetOrCreate();
             if (m_ProjectWideActions != null)
             {
-                if (!preloadedAssets.Contains(InputSystem.actions))
+                if (!preloadedAssets.Contains(m_ProjectWideActions))
                 {
-                    ArrayHelpers.Append(ref preloadedAssets, InputSystem.actions);
+                    ArrayHelpers.Append(ref preloadedAssets, m_ProjectWideActions);
                     PlayerSettings.SetPreloadedAssets(preloadedAssets);
                 }
             }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3032,13 +3032,7 @@ namespace UnityEngine.InputSystem
                     return s_projectWideActions;
 
                 #if UNITY_EDITOR
-                // Load the InputActionsAsset and store it in EditorBuildSettings so it can be packed in Player builds
                 s_projectWideActions = Editor.ProjectWideActionsAsset.GetOrCreate();
-                if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(s_projectWideActions)))
-                {
-                    EditorBuildSettings.AddConfigObject(InputSettingsProvider.kEditorBuildSettingsActionsConfigKey,
-                        s_projectWideActions, true);
-                }
                 #else
                 s_projectWideActions = Resources.FindObjectsOfTypeAll<InputActionAsset>().FirstOrDefault(o => o != null && o.name == kProjectWideActionsAssetName);
                 #endif
@@ -3055,14 +3049,6 @@ namespace UnityEngine.InputSystem
 
                 if (s_projectWideActions == value)
                     return;
-
-                #if UNITY_EDITOR
-                if (!string.IsNullOrEmpty(AssetDatabase.GetAssetPath(value)))
-                {
-                    EditorBuildSettings.AddConfigObject(InputSettingsProvider.kEditorBuildSettingsActionsConfigKey,
-                        value, true);
-                }
-                #endif
 
                 s_projectWideActions?.Disable();
                 s_projectWideActions = value;

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -120,8 +120,6 @@ PlayerSettings:
     Others: 1
   bundleVersion: 1.0
   preloadedAssets:
-  - {fileID: 0}
-  - {fileID: 0}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
### Description

When Project wide actions landed a number of tests were disabled due to last minute bugs being found.
This PR fixes those issues and re-enables all tests.
Some tests still have project wide actions disabled. Each of those have been reviewed and accepted as having a genuine reason to disable the actions for the test. An explanation comment has been provided to each one in this PR too.

### Changes made

- Fix for the nasty binding resolution assert with a test.
- Document reasons on tests where project wide actions are disabled
- Stop using EditorBuildSettings as it was unnecessary. AssetDatabase is sufficient.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
