### PR TITLE
bump version to 1.8.0-pre.2

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,7 +10,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
-## [1.8.0-pre.1] - 2023-08-14
+## [1.8.0-pre.1] - 2023-09-04
 
 ### Added
 - Initial version of Project Wide Actions for pre-release (`InputSystem.actions`). This feature is available only on Unity Editor versions 2022.3 and above and can be modified in the Project Settings.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 Due to package verification, the latest version below is the unpublished version and the date is meaningless.
 however, it has to be formatted properly to pass verification tests.
 
+## [Unreleased]
+
 ## [1.8.0-pre.1] - 2023-08-14
 
 ### Added

--- a/Packages/com.unity.inputsystem/ValidationExceptions.json
+++ b/Packages/com.unity.inputsystem/ValidationExceptions.json
@@ -1,4 +1,9 @@
 {
-    "ErrorExceptions": [],
+    "ErrorExceptions": [
+		{
+             "ValidationTest": "API Updater Configuration Validation",
+             "PackageVersion": "1.8.0-pre.2"
+        }
+	],
     "WarningExceptions": []
 }

--- a/Packages/com.unity.inputsystem/ValidationExceptions.json
+++ b/Packages/com.unity.inputsystem/ValidationExceptions.json
@@ -1,9 +1,4 @@
 {
-    "ErrorExceptions": [
-		{
-             "ValidationTest": "API Updater Configuration Validation",
-             "PackageVersion": "1.8.0-pre.2"
-        }
-	],
+    "ErrorExceptions": [],
     "WarningExceptions": []
 }

--- a/Packages/com.unity.inputsystem/package.json
+++ b/Packages/com.unity.inputsystem/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "com.unity.inputsystem",
 	"displayName": "Input System",
-	"version": "1.8.0-pre.1",
+	"version": "1.8.0-pre.2",
 	"unity": "2019.4",
 	"description": "A new input system which can be used as a more extensible and customizable alternative to Unity's classic input system in UnityEngine.Input.",
 	"keywords": [


### PR DESCRIPTION
### Description

Version bump, assembly files and C# generation not part of this, since these don't handle "-pre.x" version changes

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
