### PR TITLE
Save / Auto save now disabled only for project wide settings, but enabled for input assets (ISX-1556)

### DIFF
--- a/Assets/Samples/UnityRemote/UnityRemoteTestScript.cs
+++ b/Assets/Samples/UnityRemote/UnityRemoteTestScript.cs
@@ -7,7 +7,7 @@ using Touch = UnityEngine.InputSystem.EnhancedTouch.Touch;
 
 public class UnityRemoteTestScript : MonoBehaviour
 {
-    public Camera camera;
+    public new Camera camera;
 
     public Text accelerometerInputText;
     public Text touchInputText;

--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -19,7 +19,7 @@ public class InputForUITests : InputTestFixture
     InputSystemProvider m_InputSystemProvider;
 
     [SetUp]
-    public void SetUp()
+    public override void Setup()
     {
         base.Setup();
 
@@ -33,11 +33,13 @@ public class InputForUITests : InputTestFixture
     }
 
     [TearDown]
-    public void TearDown()
+    public override void TearDown()
     {
         EventProvider.Unsubscribe(InputForUIOnEvent);
         EventProvider.ClearMockProvider();
         m_InputForUIEvents.Clear();
+
+        base.TearDown();
     }
 
     private bool InputForUIOnEvent(in Event ev)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,9 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 - Support for [Game rotation vector](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR) sensor on Android
 
+### Changed
+- Input asset editor now switched to use UI Toolkit which matches the project wide input actions editor interface.
+
 ## [1.8.0-pre.1] - 2023-09-04
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -38,7 +38,7 @@ namespace UnityEngine.InputSystem.Editor
         public static bool OnOpenAsset(int instanceId, int line)
         {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-            if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseUIToolkitEditorForAllAssets))
+            if (!InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
                 return false;
 #endif
             var path = AssetDatabase.GetAssetPath(instanceId);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -41,7 +41,7 @@ namespace UnityEngine.InputSystem.Editor
                         InputActionsEditorWindow.OpenEditor(inputActionAsset);
                     else
 #endif
-                        InputActionEditorWindow.OpenEditor(inputActionAsset);
+                    InputActionEditorWindow.OpenEditor(inputActionAsset);
                 }
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -35,7 +35,14 @@ namespace UnityEngine.InputSystem.Editor
             using (new EditorGUI.DisabledScope(inputActionAsset == null))
             {
                 if (GUILayout.Button("Edit asset"))
-                    InputActionEditorWindow.OpenEditor(inputActionAsset);
+                {
+#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+                    if (!InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
+                        InputActionsEditorWindow.OpenEditor(inputActionAsset);
+                    else
+#endif
+                        InputActionEditorWindow.OpenEditor(inputActionAsset);
+                }
             }
 
             EditorGUILayout.Space();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -16,8 +16,8 @@ namespace UnityEngine.InputSystem.Editor
             return GetOrCreateViewData(property).TreeView.totalHeight;
         }
 
-#if !UNITY_2023_2_OR_NEWER 
-        [Obsolete("CanCacheInspectorGUI has been deprecated and is no longer used.", false)]
+#if UNITY_2023_2_OR_NEWER 
+        [System.Obsolete("CanCacheInspectorGUI has been deprecated and is no longer used.", false)]
 #endif
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -16,6 +16,9 @@ namespace UnityEngine.InputSystem.Editor
             return GetOrCreateViewData(property).TreeView.totalHeight;
         }
 
+#if !UNITY_2023_2_OR_NEWER 
+        [Obsolete("CanCacheInspectorGUI has been deprecated and is no longer used.", false)]
+#endif
         public override bool CanCacheInspectorGUI(SerializedProperty property)
         {
             return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionDrawerBase.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.InputSystem.Editor
             return GetOrCreateViewData(property).TreeView.totalHeight;
         }
 
-#if UNITY_2023_2_OR_NEWER 
+#if UNITY_2023_2_OR_NEWER
         [System.Obsolete("CanCacheInspectorGUI has been deprecated and is no longer used.", false)]
 #endif
         public override bool CanCacheInspectorGUI(SerializedProperty property)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -299,16 +299,17 @@ namespace UnityEngine.InputSystem.Editor
             };
         }
 
-        public static Command SaveAsset()
+        public static Command SaveAsset(Action postSaveAction)
         {
             return (in InputActionsEditorState state) =>
             {
                 InputActionsEditorWindowUtils.SaveAsset(state.serializedObject);
+                postSaveAction?.Invoke();
                 return state;
             };
         }
 
-        public static Command ToggleAutoSave(bool newValue)
+        public static Command ToggleAutoSave(bool newValue, Action postSaveAction)
         {
             return (in InputActionsEditorState state) =>
             {
@@ -316,7 +317,10 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     // If it changed from disabled to enabled, perform an initial save.
                     if (newValue)
+                    {
                         InputActionsEditorWindowUtils.SaveAsset(state.serializedObject);
+                        postSaveAction?.Invoke();
+                    }
 
                     InputEditorUserSettings.autoSaveInputActionAssets = newValue;
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -29,8 +29,8 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnStateChanged(InputActionsEditorState newState)
         {
-            if (InputEditorUserSettings.autoSaveInputActionAssets)
-                InputActionsEditorWindowUtils.SaveAsset(m_State.serializedObject);
+            // Project wide input actions always auto save - don't check the asset auto save status
+            InputActionsEditorWindowUtils.SaveAsset(m_State.serializedObject);
         }
 
         private void BuildUI()
@@ -38,10 +38,11 @@ namespace UnityEngine.InputSystem.Editor
             m_StateContainer = new StateContainer(m_RootVisualElement, m_State);
             m_StateContainer.StateChanged += OnStateChanged;
             m_RootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            new InputActionsEditorView(m_RootVisualElement, m_StateContainer);
+            new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null);
             m_StateContainer.Initialize();
 
             // Hide the save / auto save buttons in the project wide input actions
+            // Project wide input actions always auto save
             var element = m_RootVisualElement.Q("save-asset-toolbar-container");
             if (element != null)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -40,6 +40,14 @@ namespace UnityEngine.InputSystem.Editor
             m_RootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
             new InputActionsEditorView(m_RootVisualElement, m_StateContainer);
             m_StateContainer.Initialize();
+
+            // Hide the save / auto save buttons in the project wide input actions
+            var element = m_RootVisualElement.Q("save-asset-toolbar-container");
+            if (element != null)
+            {
+                element.style.visibility = Visibility.Hidden;
+                element.style.display = DisplayStyle.None;
+            }
         }
 
         [SettingsProvider]

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -67,11 +67,23 @@ namespace UnityEngine.InputSystem.Editor
                 }
             }
 
+            OpenWindow(asset, actionMapToSelect, actionToSelect);
+            return true;
+        }
+
+        private static InputActionsEditorWindow OpenWindow(InputActionAsset asset, string actionMapToSelect = null, string actionToSelect = null)
+        {
+            int instanceId = asset.GetInstanceID();
+
+            ////REVIEW: It'd be great if the window got docked by default but the public EditorWindow API doesn't allow that
+            ////        to be done for windows that aren't singletons (GetWindow<T>() will only create one window and it's the
+            ////        only way to get programmatic docking with the current API).
+            // See if we have an existing editor window that has the asset open.
             var window = GetOrCreateWindow(instanceId, out var isAlreadyOpened);
             if (isAlreadyOpened)
             {
                 window.Focus();
-                return true;
+                return window;
             }
             window.m_IsDirty = false;
             window.m_AssetId = instanceId;
@@ -80,7 +92,18 @@ namespace UnityEngine.InputSystem.Editor
             window.SetAsset(asset, actionToSelect, actionMapToSelect);
             window.Show();
 
-            return true;
+            return window;
+        }
+
+        /// <summary>
+        /// Open the specified <paramref name="asset"/> in an editor window. Used when someone hits the "Edit Asset" button in the
+        /// importer inspector.
+        /// </summary>
+        /// <param name="asset">The InputActionAsset to open.</param>
+        /// <returns>The editor window.</returns>
+        public static InputActionsEditorWindow OpenEditor(InputActionAsset asset)
+        {
+            return OpenWindow(asset, null, null);
         }
 
         private static InputActionsEditorWindow GetOrCreateWindow(int id, out bool isAlreadyOpened)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -122,13 +122,17 @@ namespace UnityEngine.InputSystem.Editor
             var stateContainer = new StateContainer(rootVisualElement, m_State);
             stateContainer.StateChanged += OnStateChanged;
 
-            var theme = EditorGUIUtility.isProSkin
-                ? AssetDatabase.LoadAssetAtPath<StyleSheet>(InputActionsEditorConstants.PackagePath + InputActionsEditorConstants.ResourcesPath + "/InputAssetEditorDark.uss")
-                : AssetDatabase.LoadAssetAtPath<StyleSheet>(InputActionsEditorConstants.PackagePath + InputActionsEditorConstants.ResourcesPath + "/InputAssetEditorLight.uss");
-
-            rootVisualElement.styleSheets.Add(theme);
+            rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
             var view = new InputActionsEditorView(rootVisualElement, stateContainer);
             stateContainer.Initialize();
+
+            // Hide the save / auto save buttons in the project wide input actions
+            var element = rootVisualElement.Q("save-asset-toolbar-container");
+            if (element != null)
+            {
+                element.style.visibility = Visibility.Hidden;
+                element.style.display = DisplayStyle.None;
+            }
         }
 
         private void OnStateChanged(InputActionsEditorState newState)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -21,7 +21,7 @@ namespace UnityEngine.InputSystem.Editor
             // At the moment, the UITK Asset Editor doesn't have feature parity with the IMGUI version.
             // This is set to false to show the IMGUI version of the InputActionAsset Editor instead.
             // UITK Editor is always be used for the Project Settings Editor regardless of this setting.
-            InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseUIToolkitEditorForAllAssets, false);
+            InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseUIToolkitEditorForAllAssets, true);
         }
     }
 
@@ -125,14 +125,6 @@ namespace UnityEngine.InputSystem.Editor
             rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
             var view = new InputActionsEditorView(rootVisualElement, stateContainer);
             stateContainer.Initialize();
-
-            // Hide the save / auto save buttons in the project wide input actions
-            var element = rootVisualElement.Q("save-asset-toolbar-container");
-            if (element != null)
-            {
-                element.style.visibility = Visibility.Hidden;
-                element.style.display = DisplayStyle.None;
-            }
         }
 
         private void OnStateChanged(InputActionsEditorState newState)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -16,12 +16,6 @@ namespace UnityEngine.InputSystem.Editor
     {
         static EnableUITKEditor()
         {
-            // Controls whether the UITK version of the InputActionAsset Editor is enabled or not for
-            // editing standalone user Input Action assets.
-            // At the moment, the UITK Asset Editor doesn't have feature parity with the IMGUI version.
-            // This is set to false to show the IMGUI version of the InputActionAsset Editor instead.
-            // UITK Editor is always be used for the Project Settings Editor regardless of this setting.
-            InputSystem.settings.SetInternalFeatureFlag(InputFeatureNames.kUseUIToolkitEditorForAllAssets, true);
         }
     }
 
@@ -40,7 +34,7 @@ namespace UnityEngine.InputSystem.Editor
         [OnOpenAsset]
         public static bool OpenAsset(int instanceId, int line)
         {
-            if (!InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseUIToolkitEditorForAllAssets))
+            if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
                 return false;
 
             var path = AssetDatabase.GetAssetPath(instanceId);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
@@ -169,13 +169,6 @@
     width: 190px;
 }
 
-#save-asset-toolbar-container
-{
-    /* hide while always autosaving in project wide settings */
-    display: none;
-}
-
-
 .unity-two-pane-split-view__dragline-anchor {
     background-color: rgb(25, 25, 25);
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -13,10 +13,13 @@ namespace UnityEngine.InputSystem.Editor
         private const string saveButtonId = "save-asset-toolbar-button";
         private const string autoSaveToggleId = "auto-save-toolbar-toggle";
 
-        public InputActionsEditorView(VisualElement root, StateContainer stateContainer)
+        Action m_PostSaveAction;
+
+        public InputActionsEditorView(VisualElement root, StateContainer stateContainer, Action mpostSaveAction)
             : base(stateContainer)
         {
             m_Root = root;
+            m_PostSaveAction = mpostSaveAction;
             BuildUI();
         }
 
@@ -64,12 +67,12 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnSaveButton()
         {
-            Dispatch(Commands.SaveAsset());
+            Dispatch(Commands.SaveAsset(m_PostSaveAction));
         }
 
         private void OnAutoSaveToggle(ChangeEvent<bool> evt)
         {
-            Dispatch(Commands.ToggleAutoSave(evt.newValue));
+            Dispatch(Commands.ToggleAutoSave(evt.newValue, m_PostSaveAction));
         }
 
         public override void RedrawUI(ViewState viewState)

--- a/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputFeatureNames.cs
@@ -10,7 +10,7 @@ namespace UnityEngine.InputSystem
         public const string kParanoidReadValueCachingChecks = "PARANOID_READ_VALUE_CACHING_CHECKS";
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-        public const string kUseUIToolkitEditorForAllAssets = "USE_UITOOLKIT_EDITOR";
+        public const string kUseIMGUIEditorForAssets = "USE_IMGUI_EDITOR_FOR_ASSETS";
 #endif
     }
 }


### PR DESCRIPTION
### Description

Save / Auto save now disabled only for project wide settings, but enabled for input assets ([ISX-1556](https://jira.unity3d.com/browse/ISX-1556))

![image](https://github.com/Unity-Technologies/InputSystem/assets/33493311/9b9e161b-d90b-4c54-9ed0-81c85655db79)
![image](https://github.com/Unity-Technologies/InputSystem/assets/33493311/4237912b-7e38-4a6f-8858-b46656fed4cb)


### Changes made

Added explicit code to find save container and hide it (rather than being in the USS style sheet file) This is in the settings window code and not in the asset dialog code, so only effects project wide input actions.

UI TK editor now enabled for input assets as well as project wide input actions

Also removed some duplicate code for accessing stylesheets
And fixed some tests:

- a missing teardown call in InputUI tests
- a warning on an obsolete API (from 2023.2 onward)
- a camera override warning

### Notes

### Checklist

Before review:

- Changelog entry not added as this is not a user facing change from what they already see
- Tests changed, if applicable.
    - Functional tests - those listed above
- Docs for new/changed API's. - no API's changed

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
