### PR TITLE
Removed icons on Action Maps

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,10 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Changed
+- Removed icons from action map list as these were always the same and the icon was placeholder
+
+
 ## [1.8.0-pre.1] - 2023-09-04
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorConstants.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorConstants.cs
@@ -13,6 +13,7 @@ namespace UnityEngine.InputSystem.Editor
         public const string CompositeBindingPropertiesViewUxml = "/CompositeBindingPropertiesEditor.uxml";
         public const string CompositePartBindingPropertiesViewUxml = "/CompositePartBindingPropertiesEditor.uxml";
         public const string ControlSchemeEditorViewUxml = "/ControlSchemeEditor.uxml";
+        public const string InputActionMapsTreeViewItemUxml = "/InputActionMapsTreeViewItem.uxml";
         public const string InputActionsTreeViewItemUxml = "/InputActionsTreeViewItem.uxml";
 
         /// Classes

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionMapsTreeViewItem.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionMapsTreeViewItem.uxml
@@ -1,0 +1,10 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
+    <ui:VisualElement name="item-row" class="unity-list-view__item" style="flex-direction: row; flex-grow: 1; justify-content: space-between; margin-left: 4px; flex-shrink: 0;">
+        <ui:VisualElement name="row" style="flex-direction: row; border-left-width: 0; border-left-color: rgb(89, 89, 89); justify-content: flex-start; align-items: center;">
+            <ui:TextField picking-mode="Ignore" name="rename-text-field" is-delayed="true" focusable="true" class="unity-input-actions-editor-hidden" style="visibility: visible; flex-shrink: 1;" />
+            <ui:Label text="binding-name" display-tooltip-when-elided="true" name="name" style="flex-grow: 1; justify-content: center; align-items: stretch; margin-left: 4px; -unity-font-style: normal;" />
+        </ui:VisualElement>
+        <ui:Button text="+" display-tooltip-when-elided="true" enable-rich-text="false" name="add-new-binding-button" style="opacity: 1; background-color: rgba(255, 255, 255, 0); border-left-color: rgba(255, 255, 255, 0); border-right-color: rgba(255, 255, 255, 0); border-top-color: rgba(255, 255, 255, 0); border-bottom-color: rgba(255, 255, 255, 0); display: none; align-items: flex-end; align-self: auto; flex-direction: row-reverse;" />
+    </ui:VisualElement>
+</ui:UXML>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionMapsTreeViewItem.uxml.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionMapsTreeViewItem.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 3fa44185ed614414ebab354dfe5a06b6
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -22,7 +22,7 @@ namespace UnityEngine.InputSystem.Editor
 
             m_ListView.bindItem = (element, i) =>
             {
-                var treeViewItem = (InputActionsTreeViewItem)element;
+                var treeViewItem = (InputActionMapsTreeViewItem)element;
                 treeViewItem.label.text = (string)m_ListView.itemsSource[i];
                 treeViewItem.EditTextFinishedCallback = newName => ChangeActionMapName(i, newName);
                 treeViewItem.EditTextFinished += treeViewItem.EditTextFinishedCallback;
@@ -33,10 +33,10 @@ namespace UnityEngine.InputSystem.Editor
 
                 ContextMenu.GetContextMenuForActionMapItem(treeViewItem);
             };
-            m_ListView.makeItem = () => new InputActionsTreeViewItem();
+            m_ListView.makeItem = () => new InputActionMapsTreeViewItem();
             m_ListView.unbindItem = (element, i) =>
             {
-                var treeViewElement = (InputActionsTreeViewItem)element;
+                var treeViewElement = (InputActionMapsTreeViewItem)element;
                 treeViewElement.Reset();
                 treeViewElement.OnDeleteItem -= treeViewElement.DeleteCallback;
                 treeViewElement.OnDuplicateItem -= treeViewElement.DuplicateCallback;
@@ -45,7 +45,7 @@ namespace UnityEngine.InputSystem.Editor
 
             m_ListView.itemsChosen += objects =>
             {
-                var item = m_ListView.GetRootElementForIndex(m_ListView.selectedIndex).Q<InputActionsTreeViewItem>();
+                var item = m_ListView.GetRootElementForIndex(m_ListView.selectedIndex).Q<InputActionMapsTreeViewItem>();
                 item.FocusOnRenameTextField();
             };
 
@@ -82,7 +82,7 @@ namespace UnityEngine.InputSystem.Editor
                 return;
             m_ListView.ScrollToItem(m_ListView.selectedIndex);
             var element = m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
-            ((InputActionsTreeViewItem)element).FocusOnRenameTextField();
+            ((InputActionMapsTreeViewItem)element).FocusOnRenameTextField();
             m_EnterRenamingMode = false;
         }
 
@@ -122,13 +122,13 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnKeyDownEventForRename()
         {
-            var item = (InputActionsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
+            var item = (InputActionMapsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
             item.FocusOnRenameTextField();
         }
 
         private void OnKeyDownEventForDelete()
         {
-            var item = (InputActionsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
+            var item = (InputActionMapsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
             item.DeleteItem();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -14,15 +14,15 @@ namespace UnityEngine.InputSystem.Editor
         private static readonly string add_positiveNegative_Binding_String = "Add Positive\\Negative Binding";
         private static readonly string add_oneModifier_Binding_String = "Add Binding With One Modifier";
         private static readonly string add_twoModifier_Binding_String = "Add Binding With Two Modifiers";
-        public static void GetContextMenuForActionMapItem(InputActionsTreeViewItem treeViewItem)
+        public static void GetContextMenuForActionMapItem(InputActionMapsTreeViewItem treeViewItem)
         {
             var _ = new ContextualMenuManipulator(menuEvent =>
             {
-                menuEvent.menu.AppendAction(add_Action_String, _ => InputActionViewsControlsHolder.CreateAction.Invoke(treeViewItem));
+                menuEvent.menu.AppendAction(add_Action_String, _ => InputActionViewsControlsHolder.CreateActionMap.Invoke(treeViewItem));
                 menuEvent.menu.AppendSeparator();
                 menuEvent.menu.AppendAction(rename_String, _ => InputActionViewsControlsHolder.RenameActionMap.Invoke(treeViewItem));
-                AppendDuplicateAction(menuEvent, treeViewItem);
-                AppendDeleteAction(menuEvent, treeViewItem);
+                AppendDuplicateActionMap(menuEvent, treeViewItem);
+                AppendDeleteActionMap(menuEvent, treeViewItem);
             }) { target = treeViewItem };
         }
 
@@ -58,6 +58,16 @@ namespace UnityEngine.InputSystem.Editor
                 AppendDuplicateAction(menuEvent, treeViewItem);
                 AppendDeleteAction(menuEvent, treeViewItem);
             }) { target = treeViewItem };
+        }
+
+        private static void AppendDeleteActionMap(ContextualMenuPopulateEvent menuEvent, InputActionMapsTreeViewItem treeViewItem)
+        {
+            menuEvent.menu.AppendAction(delete_String, _ => { InputActionViewsControlsHolder.DeleteActionMap.Invoke(treeViewItem); });
+        }
+
+        private static void AppendDuplicateActionMap(ContextualMenuPopulateEvent menuEvent, InputActionMapsTreeViewItem treeViewItem)
+        {
+            menuEvent.menu.AppendAction(duplicate_String, _ => { InputActionViewsControlsHolder.DuplicateActionMap.Invoke(treeViewItem); });
         }
 
         private static void AppendDeleteAction(ContextualMenuPopulateEvent menuEvent, InputActionsTreeViewItem treeViewItem)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
@@ -1,0 +1,141 @@
+// UITK TreeView is not supported in earlier versions
+// Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
+#if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+using System.Threading.Tasks;
+using UnityEditor;
+using UnityEngine.InputSystem.Editor;
+using UnityEngine.UIElements;
+
+namespace UnityEngine.InputSystem.Editor
+{
+    /// <summary>
+    /// A visual element that supports renaming of items.
+    /// </summary>
+    internal class InputActionMapsTreeViewItem : VisualElement
+    {
+        public EventCallback<string> EditTextFinishedCallback;
+        public EventCallback<int> DeleteCallback;
+        public EventCallback<int> DuplicateCallback;
+
+        private const string kRenameTextField = "rename-text-field";
+        public event EventCallback<string> EditTextFinished;
+        public event EventCallback<int> OnDeleteItem;
+        public event EventCallback<int> OnDuplicateItem;
+
+        private bool m_IsEditing;
+
+        public InputActionMapsTreeViewItem()
+        {
+            var template = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(
+                InputActionsEditorConstants.PackagePath +
+                InputActionsEditorConstants.ResourcesPath +
+                InputActionsEditorConstants.InputActionMapsTreeViewItemUxml);
+            template.CloneTree(this);
+
+            focusable = true;
+            delegatesFocus = false;
+
+            renameTextfield.selectAllOnFocus = true;
+            renameTextfield.selectAllOnMouseUp = false;
+
+            RegisterCallback<MouseDownEvent>(OnMouseDownEventForRename);
+            renameTextfield.RegisterCallback<FocusOutEvent>(e => OnEditTextFinished());
+        }
+
+        public Label label => this.Q<Label>();
+        private TextField renameTextfield => this.Q<TextField>(kRenameTextField);
+
+
+        public void UnregisterInputField()
+        {
+            renameTextfield.SetEnabled(false);
+            renameTextfield.selectAllOnFocus = false;
+            UnregisterCallback<MouseDownEvent>(OnMouseDownEventForRename);
+            renameTextfield.UnregisterCallback<FocusOutEvent>(e => OnEditTextFinished());
+        }
+
+        private float lastSingleClick;
+        private static InputActionMapsTreeViewItem selected;
+
+        private void OnMouseDownEventForRename(MouseDownEvent e)
+        {
+            if (e.clickCount != 1 || e.button != (int)MouseButton.LeftMouse || e.target == null)
+                return;
+
+            if (selected == this && Time.time - lastSingleClick < 3f)
+            {
+                FocusOnRenameTextField();
+                e.StopImmediatePropagation();
+                lastSingleClick = 0;
+            }
+            lastSingleClick = Time.time;
+            selected = this;
+        }
+
+        public void Reset()
+        {
+            EditTextFinished = null;
+            m_IsEditing = false;
+        }
+
+        public void FocusOnRenameTextField()
+        {
+            if (m_IsEditing)
+                return;
+            delegatesFocus = true;
+
+            renameTextfield.SetValueWithoutNotify(label.text);
+            renameTextfield.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            label?.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
+
+            //a bit hacky - e.StopImmediatePropagation() for events does not work like expected on ListViewItems or TreeViewItems because
+            //the listView/treeView reclaims the focus - this is a workaround with less overhead than rewriting the events
+            DelayCall();
+            renameTextfield.SelectAll();
+
+            m_IsEditing = true;
+        }
+
+        async void DelayCall()
+        {
+            await Task.Delay(120);
+            renameTextfield.Q<TextField>().Focus();
+        }
+
+        public void DeleteItem()
+        {
+            OnDeleteItem?.Invoke(0);
+        }
+
+        public void DuplicateItem()
+        {
+            OnDuplicateItem?.Invoke(0);
+        }
+
+        private void OnEditTextFinished()
+        {
+            if (!m_IsEditing)
+                return;
+            lastSingleClick = 0;
+            delegatesFocus = false;
+
+            var text = renameTextfield.text?.Trim();
+            if (string.IsNullOrEmpty(text))
+            {
+                renameTextfield.schedule.Execute(() =>
+                {
+                    FocusOnRenameTextField();
+                    renameTextfield.SetValueWithoutNotify(text);
+                });
+                return;
+            }
+
+            renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
+
+            EditTextFinished?.Invoke(text);
+            m_IsEditing = false;
+        }
+    }
+}
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8b82aecdbfbdd1b49b90eb0d509b4166

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionViewsControlsHolder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionViewsControlsHolder.cs
@@ -100,6 +100,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             inputActionsTreeViewItem.DuplicateItem();
         }
+
         private static void DuplicateActionItem(InputActionsTreeViewItem inputActionsTreeViewItem)
         {
             inputActionsTreeViewItem.DuplicateItem();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionViewsControlsHolder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionViewsControlsHolder.cs
@@ -10,14 +10,17 @@ namespace UnityEngine.InputSystem.Editor
         private static ActionsTreeView m_ActionsTreeView;
         private static ListView m_ListView;
         internal static Action<int, InputActionsTreeViewItem> RenameAction => RenameActionItem;
-        internal static Action<InputActionsTreeViewItem> RenameActionMap => RenameActionMapItem;
-        internal static Action<InputActionsTreeViewItem> DeleteAction => Delete;
+        internal static Action<InputActionMapsTreeViewItem> RenameActionMap => RenameActionMapItem;
+        internal static Action<InputActionsTreeViewItem> DeleteAction => DeleteActionItem;
+        internal static Action<InputActionMapsTreeViewItem> DeleteActionMap => DeleteActionMapItem;
         internal static Action<InputActionsTreeViewItem> AddBinding => AddNewBinding;
         internal static Action<InputActionsTreeViewItem> AddCompositePositivNegativModifier => AddNewPositiveNegativeComposite;
         internal static Action<InputActionsTreeViewItem> AddCompositeOneModifier => AddNewOneModifierComposite;
         internal static Action<InputActionsTreeViewItem> AddCompositeTwoModifier => AddNewTwoModifierComposite;
+        internal static Action<InputActionMapsTreeViewItem> CreateActionMap => CreateNewActionMap;
         internal static Action<InputActionsTreeViewItem> CreateAction => CreateNewAction;
-        internal static Action<InputActionsTreeViewItem> DuplicateAction => Duplicate;
+        internal static Action<InputActionsTreeViewItem> DuplicateAction => DuplicateActionItem;
+        internal static Action<InputActionMapsTreeViewItem> DuplicateActionMap => DuplicateActionMapItem;
 
         internal static void Initialize(VisualElement root, ActionsTreeView actionsTreeView)
         {
@@ -32,7 +35,7 @@ namespace UnityEngine.InputSystem.Editor
             treeViewItem.FocusOnRenameTextField();
         }
 
-        private static void RenameActionMapItem(InputActionsTreeViewItem treeViewItem)
+        private static void RenameActionMapItem(InputActionMapsTreeViewItem treeViewItem)
         {
             var index = m_ListView.itemsSource.IndexOf(treeViewItem.label.text);
             if (index < 0 || index >= m_ListView.itemsSource.Count)
@@ -41,9 +44,23 @@ namespace UnityEngine.InputSystem.Editor
             treeViewItem.FocusOnRenameTextField();
         }
 
-        private static void Delete(InputActionsTreeViewItem treeViewItem)
+        private static void DeleteActionItem(InputActionsTreeViewItem treeViewItem)
         {
             treeViewItem.DeleteItem();
+        }
+
+        private static void DeleteActionMapItem(InputActionMapsTreeViewItem treeViewItem)
+        {
+            treeViewItem.DeleteItem();
+        }
+
+        private static void CreateNewActionMap(InputActionMapsTreeViewItem item)
+        {
+            var index = m_ListView.itemsSource.IndexOf(item.label.text);
+            if (index < 0 || index >= m_ListView.itemsSource.Count)
+                return;
+            m_ListView.SetSelection(index);
+            m_ActionsTreeView.AddAction();
         }
 
         private static void CreateNewAction(InputActionsTreeViewItem item)
@@ -79,7 +96,11 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionsTreeView.AddComposite(action, "TwoModifiers");
         }
 
-        private static void Duplicate(InputActionsTreeViewItem inputActionsTreeViewItem)
+        private static void DuplicateActionMapItem(InputActionMapsTreeViewItem inputActionsTreeViewItem)
+        {
+            inputActionsTreeViewItem.DuplicateItem();
+        }
+        private static void DuplicateActionItem(InputActionsTreeViewItem inputActionsTreeViewItem)
         {
             inputActionsTreeViewItem.DuplicateItem();
         }


### PR DESCRIPTION
### Description

Removed Icons on actions maps ([ISX-1555](https://jira.unity3d.com/browse/ISX-1555))

![image](https://github.com/Unity-Technologies/InputSystem/assets/33493311/4b5dbbf5-4d65-45b1-94d1-fbf1b56f94d9)


### Changes made

Split action map UXML off to InputActionMapsTreeViewItem so we can have a different style for those with no icons

### Notes

### Checklist

Before review:

- [X] Changelog entry added.
- [ ] Tests added/changed, if applicable.
    - Not applicable
- [ ] Docs for new/changed API's.
    - Not applicable
    -  
During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
