### PR TITLE
Test against staging editor branches to get CI unblocking fix (ISX-1571)

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,7 +1,7 @@
 editors:
-  - version: 2021.3/staging
-  - version: 2022.3/staging
-  - version: 2023.1/staging
+  - version: 2021.3
+  - version: 2022.3
+  - version: 2023.1
   - version: 2023.2/staging
   - version: trunk
     disable_tvos_run: true

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,8 +1,8 @@
 editors:
-  - version: 2021.3
-  - version: 2022.3
-  - version: 2023.1
-  - version: 2023.2
+  - version: 2021.3/staging
+  - version: 2022.3/staging
+  - version: 2023.1/staging
+  - version: 2023.2/staging
   - version: trunk
     disable_tvos_run: true
 


### PR DESCRIPTION
### Description

Our yamato is still blocked. Apparently we are waiting on the next 2023.2 beta release (b10) due to the way our CI is setup.
This change should give us the latest revisions from 2023.2/staging branches which includes the build system fix we are waiting on.

Notes:
I had intended do this for all versions but I ended up only doing this for 2023.2 because now the older branches have the build problem. I.e. the backports containing the bug have now started to land in the older staging branches but the fixes have not arrived yet. This means this will likely have to change again in the future.

Also, if we do this we would need to modify the `required` jobs in github as you'll notice 2023.2 is not running now (2023/staging is additional).

This will all temporary and should be put back in a week or so (or whenever b10 arrives)


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
