### PR TITLE
Modified `onIMECompositionChange` documentation to bring clarity to intended usage

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -30,6 +30,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case [ISXB-251](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-251) (Action only calls started & performed callbacks when control type is set to Vector3Composite). `EvaluateMagnitude` wasn't overridden for Vector3Composite, also made some minor changes to Vector3Composite and Vector2Composite for consistency.
 - Fixed case [ISXB-580](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-580) (UI Submit / Cancel not working with Switch Pro controller) by adding "Submit" & "Cancel" usages to the Switch Pro controller input controls.
 - Fixed an issue where undoing deletion of Action Maps did not restore Actions correctly.
+- Fixed case [ISXB-628](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-628) (OnIMECompositionChange does not return an empty string on accept when using Microsoft IME) by clarifying expectations and intended usage for the IME composition change event.
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Keyboard.cs
@@ -959,12 +959,16 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// An event that is fired to get IME composition strings.  Fired once for every change,
-        /// sends the entire string to date, and sends a blank string whenever a composition is submitted or reset.
+        /// An event that is fired to get IME composition strings.  Fired once for every change containing the entire string to date.
+        /// When using an IME, this event can be used to display the composition string while it is being edited. When a composition
+        /// string is submitted, one or many <see cref="Keyboard.OnTextInput"/> events will fire with the submitted characters.
         /// </summary>
         /// <remarks>
         /// Some languages use complex input methods which involve opening windows to insert characters.
         /// Typically, this is not desirable while playing a game, as games may just interpret key strokes as game input, not as text.
+        ///
+        /// Many IMEs cause this event to fire with a blank string when the composition is submitted or reset, however it is best
+        /// not to rely on this behaviour since it is IME dependent.
         ///
         /// See <see cref="Keyboard.SetIMEEnabled"/> for turning IME on/off
         /// </remarks>


### PR DESCRIPTION
### Description

When investigating a user's issue with the `onIMECompositionChange` event with a specific IME on Windows 10 (Korean), we noticed that there are cases where the blank event is not fired to signify the submission or resetting of the composition. The more consistent way to use this events is to use the IME Composition Change event to display the text that is currently being edited and rely on the `onTextInput` event for submission (resetting can be handled by listening for a new composition event and updating the displayed text accordingly).

The specific line that likely caused the user to *expect* (and therefore rely on) the empty string event is as follows:
> Fired once for every change, sends the entire string to date, and sends a blank string whenever a composition is submitted or reset.

### Changes made

- Modified the `onIMECompositionChange` event documentation to better point users to intended usage

### Notes

This is a work in progress PR with the intention of iterating on the documentation wording.
