### PR TITLE
WIP CHANGE: Auto-save project wide actions when editor out-of-focus 

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -27,19 +27,38 @@ namespace UnityEngine.InputSystem.Editor
             BuildUI();
         }
 
+        public override void OnDeactivate()
+        {
+            // Debug.Log("Project settings Editor destroyed, trying to save asset");
+            TrySaveAsset();
+        }
+
         private void OnStateChanged(InputActionsEditorState newState)
         {
             // Project wide input actions always auto save - don't check the asset auto save status
             InputActionsEditorWindowUtils.SaveAsset(m_State.serializedObject);
         }
 
+        private void TrySaveAsset()
+        {
+            if (m_State.serializedObject != null)
+            {
+                InputActionsEditorWindowUtils.SaveAsset(m_State.serializedObject);
+            }
+        }
+
         private void BuildUI()
         {
             m_StateContainer = new StateContainer(m_RootVisualElement, m_State);
-            m_StateContainer.StateChanged += OnStateChanged;
+            //TODO: remove this
+            // m_StateContainer.StateChanged += OnStateChanged;
             m_RootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
             new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null);
             m_StateContainer.Initialize();
+
+            var mainElement = m_RootVisualElement.Q("actions-split-view");
+            mainElement.focusable = true;
+            mainElement.RegisterCallback<FocusOutEvent>(OnFocusLost);
 
             // Hide the save / auto save buttons in the project wide input actions
             // Project wide input actions always auto save
@@ -48,6 +67,21 @@ namespace UnityEngine.InputSystem.Editor
             {
                 element.style.visibility = Visibility.Hidden;
                 element.style.display = DisplayStyle.None;
+            }
+        }
+
+        void OnFocusLost(FocusOutEvent evt)
+        {
+            // Workaround to find if the "main window" is out of focus.
+            // `relatedTarget` contains the element that gains focus, which seems to be null if we select
+            // elements outside of project settings Editor Window.
+            var element = (VisualElement)evt.relatedTarget;
+            if (element == null)
+            {
+                // Debug.Log("Focus lost, saving asset");
+                //TODO Validate if something else needs to happen
+                //TODO I think the state is not in a good condition if we just save here
+                TrySaveAsset();
             }
         }
 


### PR DESCRIPTION
### Description


Implements https://jira.unity3d.com/browse/ISX-1556 while dealing with https://jira.unity3d.com/browse/ISX-1636
### Changes made

🚧 This branches of #1751 , but not the latest commits.

Saves project-wide actions asset changes when the project settings editor window goes out of focus, or the "Input Actions" settings provider view is disabled.

📣 I'd like the reviewers to validate this is the right auto-save workflow:
- Edit the asset in Project Settings/Input Actions
- Go out of focus or close the project settings window
- Recompilation/Domain reload should happen.

Result:
![Kapture 2023-09-27 at 17 03 23](https://github.com/Unity-Technologies/InputSystem/assets/123556071/4c19ecbb-74ea-408a-b2fd-db6827af97a1)



Also, I'm not sure just saving the asset is enough, there might be some other updates necessary to be done to the serializedObject but I'm not sure yet.

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
