### PR TITLE
Fix CI by resolving package dependency errors

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -12,7 +12,8 @@
   commands:
     - {{ utr_install_win }}
     - {{ upm_ci_install }}
-    # Get version 2.3.0-preview of doctools package (if fails for 3.0.0). Automatically makes the documentation tests in APIVerification go live.
+    # Get version 2.3.0-preview of doctools package (it currently fails for 3.0.0-preview).
+    # Automatically makes the documentation tests in APIVerification go live.
     - '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
     - git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
     # We keep the samples in Assets/ as they otherwise won't get imported and you can't
@@ -47,7 +48,7 @@
   commands:
     - {{ utr_install_nix }}
     - {{ upm_ci_install }}
-    # Get version 2.3.0-preview of doctools package (if fails for 3.0.0).
+    # Get version 2.3.0-preview of doctools package (it currently fails for 3.0.0-preview).
     # Automatically makes the documentation tests in APIVerification go live.
     - git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
     # We keep the samples in Assets/ as they otherwise won't get imported and you can't

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -12,9 +12,9 @@
   commands:
     - {{ utr_install_win }}
     - {{ upm_ci_install }}
-    # Get latest version of doctools package. Automatically makes the documentation tests in APIVerification go live.
+    # Get version 2.3.0-preview of doctools package (if fails for 3.0.0). Automatically makes the documentation tests in APIVerification go live.
     - '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-    - git clone git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+    - git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
     # We keep the samples in Assets/ as they otherwise won't get imported and you can't
     # really work with them. Move them into the package for when we run upm-ci here.
     - move /Y .\Assets\Samples .\Packages\com.unity.inputsystem
@@ -47,8 +47,9 @@
   commands:
     - {{ utr_install_nix }}
     - {{ upm_ci_install }}
-    # Get latest version of doctools package. Automatically makes the documentation tests in APIVerification go live.
-    - git clone git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+    # Get version 2.3.0-preview of doctools package (if fails for 3.0.0).
+    # Automatically makes the documentation tests in APIVerification go live.
+    - git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
     # We keep the samples in Assets/ as they otherwise won't get imported and you can't
     # really work with them. Move them into the package for when we run upm-ci here.
     - mv ./Assets/Samples ./Packages/com.unity.inputsystem

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.settings-manager": "1.0.3",
     "com.unity.test-framework": "1.1.33",
     "com.unity.test-framework.build": "0.0.1-preview.12",
-    "com.unity.test-framework.performance": "3.0.2",
+    "com.unity.test-framework.performance": "3.0.0",
     "com.unity.test-framework.utp-reporter": "1.1.0-preview",
     "com.unity.textmeshpro": "2.1.4",
     "com.unity.ugui": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.settings-manager": "1.0.3",
     "com.unity.test-framework": "1.1.33",
     "com.unity.test-framework.build": "0.0.1-preview.12",
-    "com.unity.test-framework.performance": "3.0.0-pre.2",
+    "com.unity.test-framework.performance": "3.0.2",
     "com.unity.test-framework.utp-reporter": "1.1.0-preview",
     "com.unity.textmeshpro": "2.1.4",
     "com.unity.ugui": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.unity.settings-manager": "1.0.3",
     "com.unity.test-framework": "1.1.33",
     "com.unity.test-framework.build": "0.0.1-preview.12",
-    "com.unity.test-framework.performance": "3.0.0",
+    "com.unity.test-framework.performance": "3.0.2",
     "com.unity.test-framework.utp-reporter": "1.1.0-preview",
     "com.unity.textmeshpro": "2.1.4",
     "com.unity.ugui": "1.0.0",
@@ -45,8 +45,5 @@
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
     "com.unity.modules.xr": "1.0.0"
-  },
-  "testables": [
-    "com.unity.test-framework.performance"
-  ]
+  }
 }


### PR DESCRIPTION
### Description

Makes CI green again 🟢

### Changes made

- Updates [performance testing framework package](https://github.cds.internal.unity3d.com/unity/com.unity.test-framework.performance) to a stable version. Remove `"testables"` as they are no longer working properly.
- Pin [`doctools` package](https://github.cds.internal.unity3d.com/unity/com.unity.package-manager-doctools) version to `2.3.0-preview` until we resolve the issues of the latest `3.0.0-preview` version. I opened a [ticket](https://jira.unity3d.com/browse/ISX-1649) for that.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
