### PR TITLE
FIX: exiting rename field of actionMaps, actions and composites (ISX-1480)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Partially fixed case ISX-1357 (Investigate performance regressing over time).  A sample showed that leaving an InputActionMap enabled could lead to an internal list of listeners growing.  This leads to slow-down, so we now warn if we think this is happening.
 - UI fix for input fields in interactions: they are wider now and the width is fixed.
+- Fixed exiting empty input fields for actions, action maps and composites in the input action asset editor.
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
@@ -118,7 +118,7 @@ namespace UnityEngine.InputSystem.Editor
                 return;
             lastSingleClick = 0;
             delegatesFocus = false;
-            
+
             renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
             label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
             m_IsEditing = false;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
@@ -118,23 +118,19 @@ namespace UnityEngine.InputSystem.Editor
                 return;
             lastSingleClick = 0;
             delegatesFocus = false;
+            
+            renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            m_IsEditing = false;
 
             var text = renameTextfield.text?.Trim();
             if (string.IsNullOrEmpty(text))
             {
-                renameTextfield.schedule.Execute(() =>
-                {
-                    FocusOnRenameTextField();
-                    renameTextfield.SetValueWithoutNotify(text);
-                });
+                renameTextfield.schedule.Execute(() => renameTextfield.SetValueWithoutNotify(text));
                 return;
             }
 
-            renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
-            label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
-
             EditTextFinished?.Invoke(text);
-            m_IsEditing = false;
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -119,22 +119,17 @@ namespace UnityEngine.InputSystem.Editor
             lastSingleClick = 0;
             delegatesFocus = false;
 
+            renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            m_IsEditing = false;
+
             var text = renameTextfield.text?.Trim();
             if (string.IsNullOrEmpty(text))
             {
-                renameTextfield.schedule.Execute(() =>
-                {
-                    FocusOnRenameTextField();
-                    renameTextfield.SetValueWithoutNotify(text);
-                });
+                renameTextfield.schedule.Execute(() => renameTextfield.SetValueWithoutNotify(text));
                 return;
             }
-
-            renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
-            label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
-
             EditTextFinished?.Invoke(text);
-            m_IsEditing = false;
         }
     }
 }


### PR DESCRIPTION
### Description

Reordering the OnEditTextFinished function fixed the issue exiting the renaming text field when it was blank. Find the ticket [here](https://jira.unity3d.com/browse/ISX-1480).

### Changes made

Fixed: 
- exiting blank rename text field for actionMaps, actions and composites

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
