### PR TITLE
check through Profiler.BeginSample markers for early returns (uum-49019)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -33,6 +33,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case [ISXB-580](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-580) (UI Submit / Cancel not working with Switch Pro controller) by adding "Submit" & "Cancel" usages to the Switch Pro controller input controls.
 - Fixed an issue where undoing deletion of Action Maps did not restore Actions correctly.
 - Fixed case [ISXB-628](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-628) (OnIMECompositionChange does not return an empty string on accept when using Microsoft IME) by clarifying expectations and intended usage for the IME composition change event.
+- Fixed case [ISX-1668] (The Profiler shows incorrect data and spams the console with "Missing Profiler.EndSample" errors when there is an Input System Component in Scene).
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -836,7 +836,10 @@ namespace UnityEngine.InputSystem.LowLevel
                         newBufferSize = m_MaxEventBufferSize;
 
                     if (newBufferSize < bytesNeeded)
+                    {
+                        Profiler.EndSample();
                         return;
+                    }
 
                     Resize(newBufferSize);
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -845,13 +845,14 @@ namespace UnityEngine.InputSystem
         ////FIXME: allowing the description to be modified as part of this is surprising; find a better way
         public InternedString TryFindMatchingControlLayout(ref InputDeviceDescription deviceDescription, int deviceId = InputDevice.InvalidDeviceId)
         {
+            string layoutName = string.Empty;
             try
             {
                 Profiler.BeginSample("InputSystem.TryFindMatchingControlLayout");
                 ////TODO: this will want to take overrides into account
 
                 // See if we can match by description.
-                var layoutName = m_Layouts.TryFindMatchingLayout(deviceDescription);
+                layoutName = m_Layouts.TryFindMatchingLayout(deviceDescription);
                 if (layoutName.IsEmpty())
                 {
                     // No, so try to match by device class. If we have a "Gamepad" layout,

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -845,7 +845,7 @@ namespace UnityEngine.InputSystem
         ////FIXME: allowing the description to be modified as part of this is surprising; find a better way
         public InternedString TryFindMatchingControlLayout(ref InputDeviceDescription deviceDescription, int deviceId = InputDevice.InvalidDeviceId)
         {
-            string layoutName = string.Empty;
+            InternedString layoutName = new InternedString(string.Empty);
             try
             {
                 Profiler.BeginSample("InputSystem.TryFindMatchingControlLayout");

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -879,6 +879,7 @@ namespace UnityEngine.InputSystem
                     m_DeviceFindExecuteCommandDelegate =
                         (ref InputDeviceCommand commandRef) =>
                     {
+                        Profiler.EndSample();
                         if (m_DeviceFindExecuteCommandDeviceId == InputDevice.InvalidDeviceId)
                             return InputDeviceCommand.GenericFailure;
                         return m_Runtime.DeviceCommand(m_DeviceFindExecuteCommandDeviceId, ref commandRef);
@@ -1259,7 +1260,10 @@ namespace UnityEngine.InputSystem
             if (layout.IsEmpty())
             {
                 if (throwIfNoLayoutFound)
+                {
+                    Profiler.EndSample();
                     throw new ArgumentException($"Cannot find layout matching device description '{description}'", nameof(description));
+                }
 
                 // If it's a device coming from the runtime, disable it.
                 if (deviceId != InputDevice.InvalidDeviceId)
@@ -2844,7 +2848,10 @@ namespace UnityEngine.InputSystem
             Profiler.BeginSample("InputUpdate");
 
             if (m_InputEventStream.isOpen)
+            {
+                Profiler.EndSample();
                 throw new InvalidOperationException("Already have an event buffer set! Was OnUpdate() called recursively?");
+            }
 
             // Restore devices before checking update mask. See InputSystem.RunInitialUpdate().
             RestoreDevicesAfterDomainReloadIfNecessary();
@@ -3205,7 +3212,10 @@ namespace UnityEngine.InputSystem
                         var shouldProcess = ((IEventPreProcessor)device).PreProcessEvent(currentEventReadPtr);
 #if UNITY_EDITOR
                         if (currentEventReadPtr->sizeInBytes > eventSizeBeforePreProcessor)
+                        {
+                            Profiler.EndSample();
                             throw new AccessViolationException($"'{device}'.PreProcessEvent tries to grow an event from {eventSizeBeforePreProcessor} bytes to {currentEventReadPtr->sizeInBytes} bytes, this will potentially corrupt events after the current event and/or cause out-of-bounds memory access.");
+                        }
 #endif
                         if (!shouldProcess)
                         {
@@ -3386,6 +3396,7 @@ namespace UnityEngine.InputSystem
             {
                 // We need to restore m_InputEventStream to a sound state
                 // to avoid failing recursive OnUpdate check next frame.
+                Profiler.EndSample();
                 m_InputEventStream.CleanUpAfterException();
                 throw;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Users/InputUser.cs
@@ -1658,7 +1658,10 @@ namespace UnityEngine.InputSystem.Users
             // we early out and ignore the event entirely.
             if (!DelegateHelpers.InvokeCallbacksSafe_AnyCallbackReturnsTrue(
                 ref s_GlobalState.onPreFilterUnpairedDeviceUsed, device, eventPtr, "InputUser.onPreFilterUnpairedDeviceActivity"))
+            {
+                Profiler.EndSample();
                 return;
+            }
 
             // Go through the changed controls in the event and look for ones actuated
             // above a magnitude of a little above zero.


### PR DESCRIPTION
### Description

While looking into https://jira.unity3d.com/browse/UUM-49019 ("The Profiler shows incorrect data and spams the console with "Missing Profiler.EndSample" errors when there is an Input System Component in Scene and switching to profiling in Deep Mode") I noticed several other BeginSample calls that might be missing EndSample calls.

### Changes made

Ran through all the BeginSample calls looking for returns without a matching EndSample and fixed them up.

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [N/A] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [N/A] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
