### PR TITLE
FIX: TreeView tracking of collapse/expanded states (ISX-1626)

### DIFF
--- a/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
+++ b/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
@@ -1,6 +1,8 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
@@ -22,7 +24,7 @@ internal class SelectorsTests
         var actionTwo = actionMap.AddAction("Action2", binding: "<Keyboard>/d");
 
 
-        var treeViewData = Selectors.GetActionsAsTreeViewData(TestData.EditorStateWithAsset(asset).Generate());
+        var treeViewData = Selectors.GetActionsAsTreeViewData(TestData.EditorStateWithAsset(asset).Generate(), new Dictionary<Guid, int>());
 
 
         Assert.That(treeViewData.Count, Is.EqualTo(2));

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -33,6 +33,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case [ISXB-580](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-580) (UI Submit / Cancel not working with Switch Pro controller) by adding "Submit" & "Cancel" usages to the Switch Pro controller input controls.
 - Fixed an issue where undoing deletion of Action Maps did not restore Actions correctly.
 - Fixed case [ISXB-628](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-628) (OnIMECompositionChange does not return an empty string on accept when using Microsoft IME) by clarifying expectations and intended usage for the IME composition change event.
+- Fixed case [ISX-1626](https://jira.unity3d.com/browse/ISX-1626) where the expanded/collapsed state of items in the input action editor was not properly saved between rebuilds of the UI.
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
@@ -12,6 +12,7 @@ namespace UnityEngine.InputSystem.Editor
             // serialized fields and make sure they're present?
             wrappedProperty = serializedProperty ?? throw new ArgumentNullException(nameof(serializedProperty));
 
+            id = serializedProperty.FindPropertyRelative(nameof(InputAction.m_Id)).stringValue;
             name = serializedProperty.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue;
             expectedControlType = ReadExpectedControlType(serializedProperty);
             type = (InputActionType)serializedProperty.FindPropertyRelative(nameof(InputAction.m_Type)).intValue;
@@ -22,6 +23,7 @@ namespace UnityEngine.InputSystem.Editor
             expectedControlTypeTooltip = serializedProperty.FindPropertyRelative(nameof(InputAction.m_ExpectedControlType)).GetTooltip();
         }
 
+        public string id { get; }
         public string name { get; }
         public string expectedControlType { get; }
         public InputActionType type { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             wrappedProperty = serializedProperty ?? throw new ArgumentNullException(nameof(serializedProperty));
 
+            id = serializedProperty.FindPropertyRelative("m_Id").stringValue;
             name = serializedProperty.FindPropertyRelative("m_Name").stringValue;
             path = serializedProperty.FindPropertyRelative("m_Path").stringValue;
             interactions = serializedProperty.FindPropertyRelative("m_Interactions").stringValue;
@@ -38,6 +39,7 @@ namespace UnityEngine.InputSystem.Editor
         }
 
         public string name { get; }
+        public string id { get; }
         public string path { get; }
         public string interactions { get; }
         public string processors { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -22,12 +22,18 @@ namespace UnityEngine.InputSystem.Editor
         private bool m_RenameOnActionAdded;
         private readonly CollectionViewSelectionChangeFilter m_ActionsTreeViewSelectionChangeFilter;
 
+        //save TreeView element id's of individual input actions and bindings to ensure saving of expanded state
+        private Dictionary<Guid, int> m_GuidToTreeViewId;
+
         public ActionsTreeView(VisualElement root, StateContainer stateContainer)
             : base(stateContainer)
         {
             m_Root = root;
 
             m_ActionsTreeView = m_Root.Q<TreeView>("actions-tree-view");
+            //assign unique viewDataKey to store treeView states like expanded/collapsed items - make it unique to avoid conflicts with other TreeViews
+            m_ActionsTreeView.viewDataKey = "InputActionTreeView " + stateContainer.GetState().serializedObject.targetObject.GetInstanceID();
+            m_GuidToTreeViewId = new Dictionary<Guid, int>();
             m_ActionsTreeView.selectionType = UIElements.SelectionType.Single;
             m_ActionsTreeView.makeItem = () => new InputActionsTreeViewItem();
             m_ActionsTreeView.bindItem = (e, i) =>
@@ -127,7 +133,7 @@ namespace UnityEngine.InputSystem.Editor
             CreateSelector(Selectors.GetActionsForSelectedActionMap, Selectors.GetActionMapCount,
                 (_, count, state) =>
                 {
-                    var treeData = Selectors.GetActionsAsTreeViewData(state);
+                    var treeData = Selectors.GetActionsAsTreeViewData(state, m_GuidToTreeViewId);
                     return new ViewState
                     {
                         treeViewData = treeData,
@@ -305,7 +311,7 @@ namespace UnityEngine.InputSystem.Editor
 
     internal static partial class Selectors
     {
-        public static List<TreeViewItemData<ActionOrBindingData>> GetActionsAsTreeViewData(InputActionsEditorState state)
+        public static List<TreeViewItemData<ActionOrBindingData>> GetActionsAsTreeViewData(InputActionsEditorState state, Dictionary<Guid, int> idDictionary)
         {
             var actionMapIndex = state.selectedActionMapIndex;
             var actionMaps = state.serializedObject.FindProperty(nameof(InputActionAsset.m_ActionMaps));
@@ -326,16 +332,17 @@ namespace UnityEngine.InputSystem.Editor
                 .Select(sp => new SerializedInputBinding(sp))
                 .ToList();
 
-            var id = 0;
             var actionItems = new List<TreeViewItemData<ActionOrBindingData>>();
             foreach (var action in actions)
             {
                 var actionBindings = bindings.Where(spb => spb.action == action.name).ToList();
                 var bindingItems = new List<TreeViewItemData<ActionOrBindingData>>();
+                var actionId = new Guid(action.id);
 
                 for (var i = 0; i < actionBindings.Count; i++)
                 {
                     var serializedInputBinding = actionBindings[i];
+                    var inputBindingId = new Guid(serializedInputBinding.id);
 
                     if (serializedInputBinding.isComposite)
                     {
@@ -346,8 +353,8 @@ namespace UnityEngine.InputSystem.Editor
                             var isVisible = ShouldBindingBeVisible(nextBinding, state.selectedControlScheme);
                             if (isVisible)
                             {
-                                var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);
-                                compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(id++,
+                                var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);                        var compositeBindingId = new Guid(nextBinding.id);
+                                compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(new Guid(nextBinding.id), idDictionary),
                                     new ActionOrBindingData(false, name, actionMapIndex, false,
                                         GetControlLayout(nextBinding.path), nextBinding.indexOfBinding)));
                             }
@@ -358,7 +365,7 @@ namespace UnityEngine.InputSystem.Editor
                             nextBinding = actionBindings[i];
                         }
                         i--;
-                        bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(id++,
+                        bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
                             new ActionOrBindingData(false, serializedInputBinding.name, actionMapIndex, true, action.expectedControlType, serializedInputBinding.indexOfBinding),
                             compositeItems.Count > 0 ? compositeItems : null));
                     }
@@ -366,15 +373,25 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         var isVisible = ShouldBindingBeVisible(serializedInputBinding, state.selectedControlScheme);
                         if (isVisible)
-                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(id++,
+                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
                                 new ActionOrBindingData(false, GetHumanReadableBindingName(serializedInputBinding, state.selectedControlScheme, controlSchemes), actionMapIndex,
                                     false, GetControlLayout(serializedInputBinding.path), serializedInputBinding.indexOfBinding)));
                     }
                 }
-                actionItems.Add(new TreeViewItemData<ActionOrBindingData>(id++,
+                actionItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(actionId, idDictionary),
                     new ActionOrBindingData(true, action.name, actionMapIndex, false, action.expectedControlType), bindingItems.Count > 0 ? bindingItems : null));
             }
             return actionItems;
+        }
+
+        private static int GetIdForGuid(Guid guid, Dictionary<Guid, int> idDictionary)
+        {
+            if (!idDictionary.TryGetValue(guid, out var id))
+            {
+                id = idDictionary.Values.Count > 0 ? idDictionary.Values.Max() + 1 : 0;
+                idDictionary.Add(guid, id);
+            }
+            return id;
         }
 
         private static string GetHumanReadableBindingName(SerializedInputBinding serializedInputBinding, InputControlScheme? currentControlScheme, SerializedProperty allControlSchemes)


### PR DESCRIPTION
### Description

On deleting or duplicating bindings in composites the TreeView was collapsing all items sometimes. Another behavior (not tracked in the ticket) was that the collapsed/expanded states of the actions and bindings were often not correct after adding/duplicating and deleting actions and bindings on the TreeView. This behavior got worse when having more items in the TreeView. The main cause was that the id's of the visual elements did not match the items anymore and the auto save mode of expansion states was not turned on on the TreeView. The ticket to the issue can be found [here](https://jira.unity3d.com/browse/ISX-1626).

### Changes made

fixed:
- changed index of VisualElements to be constant through all Rebuilds of the UI to make the saving of their expand state possible
- added viewDataKey to start the automatic saving of expanded states in TreeView

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
