### PR TITLE
CHANGE: Fix project-wide actions variable naming style

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3011,7 +3011,7 @@ namespace UnityEngine.InputSystem
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
 
-        private static InputActionAsset s_projectWideActions;
+        private static InputActionAsset s_ProjectWideActions;
         internal const string kProjectWideActionsAssetName = "ProjectWideInputActions";
 
         /// <summary>
@@ -3028,18 +3028,18 @@ namespace UnityEngine.InputSystem
         {
             get
             {
-                if (s_projectWideActions != null)
-                    return s_projectWideActions;
+                if (s_ProjectWideActions != null)
+                    return s_ProjectWideActions;
 
                 #if UNITY_EDITOR
-                s_projectWideActions = Editor.ProjectWideActionsAsset.GetOrCreate();
+                s_ProjectWideActions = ProjectWideActionsAsset.GetOrCreate();
                 #else
-                s_projectWideActions = Resources.FindObjectsOfTypeAll<InputActionAsset>().FirstOrDefault(o => o != null && o.name == kProjectWideActionsAssetName);
+                s_ProjectWideActions = Resources.FindObjectsOfTypeAll<InputActionAsset>().FirstOrDefault(o => o != null && o.name == kProjectWideActionsAssetName);
                 #endif
 
-                if (s_projectWideActions == null)
+                if (s_ProjectWideActions == null)
                     Debug.LogError($"Couldn't initialize project-wide input actions");
-                return s_projectWideActions;
+                return s_ProjectWideActions;
             }
 
             set
@@ -3047,12 +3047,12 @@ namespace UnityEngine.InputSystem
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                if (s_projectWideActions == value)
+                if (s_ProjectWideActions == value)
                     return;
 
-                s_projectWideActions?.Disable();
-                s_projectWideActions = value;
-                s_projectWideActions.Enable();
+                s_ProjectWideActions?.Disable();
+                s_ProjectWideActions = value;
+                s_ProjectWideActions.Enable();
             }
         }
 #endif
@@ -3746,11 +3746,11 @@ namespace UnityEngine.InputSystem
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             // Avoid touching the `actions` property directly here, to prevent unwanted initialisation.
-            if (s_projectWideActions)
+            if (s_ProjectWideActions)
             {
-                s_projectWideActions.Disable();
-                s_projectWideActions?.OnSetupChanged();  // Cleanup ActionState (remove unused controls after disabling)
-                s_projectWideActions = null;
+                s_ProjectWideActions.Disable();
+                s_ProjectWideActions?.OnSetupChanged();  // Cleanup ActionState (remove unused controls after disabling)
+                s_ProjectWideActions = null;
             }
 #endif
 


### PR DESCRIPTION
### Description

Fix variable naming convention used on private member variable

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
