### PR TITLE
FIX: UITK Listen button not working with Any control types

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case [ISX-1668] (The Profiler shows incorrect data and spams the console with "Missing Profiler.EndSample" errors when there is an Input System Component in Scene).
 - Fixed [ISX-1661](https://jira.unity3d.com/browse/ISX-1661) where undoing duplications of action maps caused console errors
 - Fix for BindingSyntax `WithInteraction()` which was incorrectly using processors.
+- Fix for UITK Input Action Editor binding 'Listen' button which wasn't working in the case for Control Type 'Any'.
 
 
 ## [1.8.0-pre.1] - 2023-09-04

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,9 +34,9 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case [ISXB-580](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-580) (UI Submit / Cancel not working with Switch Pro controller) by adding "Submit" & "Cancel" usages to the Switch Pro controller input controls.
 - Fixed an issue where undoing deletion of Action Maps did not restore Actions correctly.
 - Fixed case [ISXB-628](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-628) (OnIMECompositionChange does not return an empty string on accept when using Microsoft IME) by clarifying expectations and intended usage for the IME composition change event.
-- Fixed case [ISX-1626](https://jira.unity3d.com/browse/ISX-1626) where the expanded/collapsed state of items in the input action editor was not properly saved between rebuilds of the UI.
-- Fixed case [ISX-1668] (The Profiler shows incorrect data and spams the console with "Missing Profiler.EndSample" errors when there is an Input System Component in Scene).
-- Fixed [ISX-1661](https://jira.unity3d.com/browse/ISX-1661) where undoing duplications of action maps caused console errors
+- Fixed issue where the expanded/collapsed state of items in the input action editor was not properly saved between rebuilds of the UI.
+- Fixed issue where The Profiler shows incorrect data and spams the console with "Missing Profiler.EndSample" errors when there is an Input System Component in Scene).
+- Fixed an issue where undoing duplications of action maps caused console errors.
 - Fix for BindingSyntax `WithInteraction()` which was incorrectly using processors.
 - Fix for UITK Input Action Editor binding 'Listen' button which wasn't working in the case for Control Type 'Any'.
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -279,8 +279,11 @@ namespace UnityEngine.InputSystem.Editor
         {
             return (in InputActionsEditorState state) =>
             {
-                var controlTypes = Selectors.BuildSortedControlList(inputAction.type).ToList();
-                inputAction.wrappedProperty.FindPropertyRelative(nameof(InputAction.m_ExpectedControlType)).stringValue = controlTypes[controlTypeIndex];
+                var controlTypes = Selectors.BuildControlTypeList(inputAction.type).ToList();
+
+                // ISX-1650: "Any" (in index 0) should not be put into an InputAction.expectedControlType. It's expected to be null in this case.
+                var controlType = (controlTypeIndex == 0) ? string.Empty : controlTypes[controlTypeIndex];
+                inputAction.wrappedProperty.FindPropertyRelative(nameof(InputAction.m_ExpectedControlType)).stringValue = controlType;
                 state.serializedObject.ApplyModifiedProperties();
                 return state;
             };

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
@@ -25,7 +25,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     if (!inputAction.HasValue)
                         return (null, new List<string>());
-                    return (inputAction.Value, Selectors.BuildSortedControlList(inputAction.Value.type).ToList());
+                    return (inputAction.Value, Selectors.BuildControlTypeList(inputAction.Value.type).ToList());
                 });
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -161,17 +161,13 @@ namespace UnityEngine.InputSystem.Editor
             return new SerializedInputAction(actions.GetArrayElementAtIndex(state.selectedActionIndex));
         }
 
-        public static IEnumerable<string> BuildSortedControlList(InputActionType selectedActionType)
-        {
-            return BuildControlTypeList(selectedActionType)
-                .OrderBy(typeName => typeName, StringComparer.OrdinalIgnoreCase);
-        }
-
         public static IEnumerable<string> BuildControlTypeList(InputActionType selectedActionType)
         {
             var allLayouts = InputSystem.s_Manager.m_Layouts;
 
+            // "Any" is always in first position (index 0)
             yield return "Any";
+
             foreach (var layoutName in allLayouts.layoutTypes.Keys)
             {
                 if (EditorInputControlLayoutCache.TryGetLayout(layoutName).hideInUI)


### PR DESCRIPTION
### Description

Fix issue where the 'Listen' button did not work on the new UITK based editor when the `controlType` was set to `Any`.

### Changes made

Ensure the control types drop-down list always begins with `Any` in the first position. This is the behaviour in the previous editor and `Any` is treated as a special case.
Prevent putting the string `"Any"` into `InputAction.expectedControlType`, it's expected to be null in this case (and serialized as empty string).
Removed internal jira links from the changelog.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
