### PR TITLE
Temporary fix to avoid exceptions being thrown by `InputControlPathEditor` editor inside UITK `IMGUIContainer` when deleting binding

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -42,7 +42,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fix for BindingSyntax `WithInteraction()` which was incorrectly using processors.
 - Fix for UITK Input Action Editor binding 'Listen' button which wasn't working in the case for Control Type 'Any'.
 - Fixed issue of visual elements being null during editing project-wide actions in project settings which prompted console errors.
-
+- Fixed case ISX-1436 (UI TK Input Action Asset Editor - Error deleting Bindings with DeleteKey on Windows).
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -109,7 +109,19 @@ namespace UnityEngine.InputSystem.Editor
             editButtonRect.width = 20;
             editButtonRect.height = 15;
 
-            var path = serializedProperty.stringValue;
+            var path = String.Empty;
+            try
+            {
+                path = serializedProperty.stringValue;
+            }
+            catch
+            {
+                // This try-catch block is a temporary fix for ISX-1436
+                // The plan is to convert InputControlPathEditor entirely to UITK and therefore this fix will
+                // no longer be required.
+                return;
+            }
+
             ////TODO: this should be cached; generates needless GC churn
             var displayName = InputControlPath.ToHumanReadableString(path);
 


### PR DESCRIPTION
### Description

When deleting the binding at the end of the list 2 exceptions would be thrown (Windows only). This is very likely to be something to do with how IMGUI `OnGUI` events are scheduled throughout the frame.

In my testing, we're looking to close down the area of the window (switch it to either another binding or the associated action if there are no bindings) but some `OnGUI` events are sneaking in before the UITK panel has a chance to cleanup.

This PR adds a try-catch block around the offending line to stop the exceptions from firing, it isn't the best fix but since there is a plan to reimplement the widget in UITK - this fix will tide us over until that task is complete.

### Changes made

- Added try-catch block around serialised property access to avoid exceptions when deleting a binding
