### PR TITLE
CHANGE: Make Project-wide Actions the default for Player Input

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,7 @@ however, it has to be formatted properly to pass verification tests.
 - Project-wide input actions template extension changed from .inputactions to .json. This avoids showing template actions in the action's selector UI that are not intended to be used.
 - Re-enabled some UI tests that were disabled on iOS.
 - Reorganized package Project Settings so that "Input System Package" setting node contains "Input Actions" and "Settings" becomes a child node when Project-wide Actions are available. For Unity versions where Project-wide Actions are not available, the settings structure remains unchanged.
+- Make Project-wide Actions the default actions for Player Input.
 
 ### Added
 - Support for [Game rotation vector](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR) sensor on Android

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1608,7 +1608,7 @@ namespace UnityEngine.InputSystem
             }
         }
 
-        #if UNITY_EDITOR
+        #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         void Reset()
         {
             // Set default actions to project wide actions.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1,10 +1,13 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine.Events;
-using UnityEngine.InputSystem.Editor;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
+
+#if UNITY_EDITOR
+using UnityEngine.InputSystem.Editor;
+#endif
 
 #if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
 using UnityEngine.InputSystem.UI;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine.Events;
+using UnityEngine.InputSystem.Editor;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
@@ -1606,6 +1607,15 @@ namespace UnityEngine.InputSystem
                     m_PlayerIndex = 0;
             }
         }
+
+        #if UNITY_EDITOR
+        void Reset()
+        {
+            // Set default actions to project wide actions.
+            m_Actions = ProjectWideActionsAsset.GetOrCreate();
+        }
+
+        #endif
 
         private void OnEnable()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -74,7 +74,7 @@ namespace UnityEngine.InputSystem.Editor
             EditorGUI.BeginChangeCheck();
             EditorGUILayout.PropertyField(m_ActionsProperty);
             var actionsWereChanged = false;
-            if (EditorGUI.EndChangeCheck() || !m_ActionAssetInitialized)
+            if (EditorGUI.EndChangeCheck() || !m_ActionAssetInitialized || CheckIfActionAssetChanged())
             {
                 OnActionAssetChange();
                 actionsWereChanged = true;
@@ -228,6 +228,22 @@ namespace UnityEngine.InputSystem.Editor
             // Debug UI.
             if (EditorApplication.isPlaying)
                 DoDebugUI();
+        }
+
+        // This checks changes that are not captured by BeginChangeCheck/EndChangeCheck.
+        // One such case is when the user triggers a "Reset" on the component.
+        bool CheckIfActionAssetChanged()
+        {
+            if (m_ActionsProperty.objectReferenceValue != null)
+            {
+                var assetInstanceID = m_ActionsProperty.objectReferenceValue.GetInstanceID();
+                bool result = assetInstanceID != m_ActionAssetInstanceID;
+                m_ActionAssetInstanceID = (int)assetInstanceID;
+                return result;
+            }
+
+            m_ActionAssetInstanceID = -1;
+            return false;
         }
 
         private void DoHelpCreateAssetUI()
@@ -566,6 +582,7 @@ namespace UnityEngine.InputSystem.Editor
 
         [NonSerialized] private bool m_NotificationBehaviorInitialized;
         [NonSerialized] private bool m_ActionAssetInitialized;
+        [NonSerialized] private int m_ActionAssetInstanceID;
     }
 }
 #endif // UNITY_EDITOR


### PR DESCRIPTION
### Description

https://jira.unity3d.com/browse/ISX-1699

### Changes made

- Sets the default value for the PlayerInput asset on Reset(), which is called when the component is first added in the inspector.
- Checks for changes not captured by `EditorGUI.Begin/EndChangeCheck` when users call "Reset
![image](https://github.com/Unity-Technologies/InputSystem/assets/123556071/ca7f5524-b77c-4bc2-a791-6c7728ab88e8)


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
