### PR TITLE
CHANGE: Restructured main Input System Package settings nodes

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Input Action Asset editors Auto-save feature has been modified to trigger on focus-lost when activated instead of triggering on every modification to the asset in order to reduce impact of processing required to handle modified assets.
 - Project-wide input actions template extension changed from .inputactions to .json. This avoids showing template actions in the action's selector UI that are not intended to be used.
 - Re-enabled some UI tests that were disabled on iOS.
+- Reorganized package Project Settings so that "Input System Package" setting node contains "Input Actions" and "Settings" becomes a child node when Project-wide Actions are available. For Unity versions where Project-wide Actions are not available, the settings structure remains unchanged.
 
 ### Added
 - Support for [Game rotation vector](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR) sensor on Android

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -13,11 +13,23 @@ using UnityEngine.UIElements;
 #pragma warning disable CS0414
 namespace UnityEngine.InputSystem.Editor
 {
+    internal static class InputSettingsPath
+    {
+        public const string kSettingsRootPath = "Project/Input System Package";
+    }
+    
     internal class InputSettingsProvider : SettingsProvider, IDisposable
     {
         public const string kEditorBuildSettingsConfigKey = "com.unity.input.settings";
         public const string kEditorBuildSettingsActionsConfigKey = "com.unity.input.settings.actions";
+
+        #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+        // When Project Wide Actions are enabled we place this as a child node to main settings node.
+        public const string kSettingsPath = InputSettingsPath.kSettingsRootPath + "/Settings";
+        #else
+        // When Project Wide Actions are not enabled we let this be the main settings node.
         public const string kSettingsPath = "Project/Input System Package";
+        #endif
 
         public static void Open()
         {
@@ -27,7 +39,14 @@ namespace UnityEngine.InputSystem.Editor
         [SettingsProvider]
         public static SettingsProvider CreateInputSettingsProvider()
         {
-            return new InputSettingsProvider(kSettingsPath, SettingsScope.Project);
+            return new InputSettingsProvider(kSettingsPath, SettingsScope.Project)
+            {
+                #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+                // We put this in a child node called "Settings" when Project-wide Actions is enabled.
+                // When not enabled it sits on the main package Settings node.
+                label = "Settings"
+                #endif
+            };
         }
 
         private InputSettingsProvider(string path, SettingsScope scopes)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -17,7 +17,7 @@ namespace UnityEngine.InputSystem.Editor
     {
         public const string kSettingsRootPath = "Project/Input System Package";
     }
-    
+
     internal class InputSettingsProvider : SettingsProvider, IDisposable
     {
         public const string kEditorBuildSettingsConfigKey = "com.unity.input.settings";

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -7,7 +7,7 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class InputActionsEditorSettingsProvider : SettingsProvider
     {
-        public const string kSettingsPath = "Project/Input System Package/Actions";
+        public const string kSettingsPath = InputSettingsPath.kSettingsRootPath;
 
         [SerializeField] InputActionsEditorState m_State;
         VisualElement m_RootVisualElement;
@@ -112,12 +112,7 @@ namespace UnityEngine.InputSystem.Editor
         [SettingsProvider]
         public static SettingsProvider CreateGlobalInputActionsEditorProvider()
         {
-            var provider = new InputActionsEditorSettingsProvider(kSettingsPath, SettingsScope.Project)
-            {
-                label = "Input Actions"
-            };
-
-            return provider;
+            return new InputActionsEditorSettingsProvider(kSettingsPath, SettingsScope.Project);
         }
     }
 }


### PR DESCRIPTION
### Description

Restructured main Input System Package settings node to be Input Actions and Settings to be a child node when Project Wide Actions are available. If Project Wide Actions is not available structure is unchanged.

This implements ISX-1554.

### Changes made

Extracted common settings path string into its own constant.
Introduced preconditional compile time checks to use different paths depending on Project Wide Actions availability derived from preprocessor symbol defines. 

### Notes

Recommendations for QA/testing:
- Visual inspection of desired result
- Double check editors open as expected via SettingsService, e.g. when clicking "Edit/Open Asset" in Inspectors.
- Double check visual appearance/structure on Unity version supporting Project Wide Actions and on at least one version that do not.

Unfortunately not covered by automated tests.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
