### PR TITLE
NEW: restore default settings (ISX-1564)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Support for [Game rotation vector](https://developer.android.com/reference/android/hardware/Sensor#TYPE_GAME_ROTATION_VECTOR) sensor on Android
 - Duplicate Input Action Items in the new Input Action Asset Editor with Ctrl+D (Windows) or Cmd+D (Mac)
 - Selection of InputActionReferences from project-wide actions on fields that are of type InputActionReference. Uses a new advanced object picker that allows better searching and filtering of actions.
+- Reset project wide Input Settings to default via a new Kebab-menu in Input System Project Settings.
 
 ### Fixed
 - Partially fixed case ISX-1357 (Investigate performance regressing over time).  A sample showed that leaving an InputActionMap enabled could lead to an internal list of listeners growing.  This leads to slow-down, so we now warn if we think this is happening.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -32,6 +32,11 @@ namespace UnityEngine.InputSystem.Editor
 
 #endif
 
+        internal static InputActionAsset ResetAssetToDefault()
+        {
+            return CreateNewActionAsset();
+        }
+
         [InitializeOnLoadMethod]
         internal static void InstallProjectWideActions()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -32,11 +32,6 @@ namespace UnityEngine.InputSystem.Editor
 
 #endif
 
-        internal static InputActionAsset ResetAssetToDefault()
-        {
-            return CreateNewActionAsset();
-        }
-
         [InitializeOnLoadMethod]
         internal static void InstallProjectWideActions()
         {
@@ -56,7 +51,7 @@ namespace UnityEngine.InputSystem.Editor
             return CreateNewActionAsset();
         }
 
-        private static InputActionAsset CreateNewActionAsset()
+        internal static InputActionAsset CreateNewActionAsset()
         {
             var json = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, s_DefaultAssetPath));
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -366,6 +366,16 @@ namespace UnityEngine.InputSystem.Editor
                 return state;
             };
         }
+
+        public static Command ResetGlobalInputAsset(Action<InputActionAsset> postResetAction)
+        {
+            return (in InputActionsEditorState state) =>
+            {
+                var asset = ProjectWideActionsAsset.CreateNewActionAsset();
+                postResetAction?.Invoke(asset);
+                return state;
+            };
+        }
     }
 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -96,7 +96,7 @@ namespace UnityEngine.InputSystem.Editor
             m_StateContainer = new StateContainer(m_RootVisualElement, m_State);
             m_StateContainer.StateChanged += OnStateChanged;
             m_RootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            var view = new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null);
+            var view = new InputActionsEditorView(m_RootVisualElement, m_StateContainer);
             view.postResetAction += OnResetAsset;
             m_StateContainer.Initialize();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -96,7 +96,7 @@ namespace UnityEngine.InputSystem.Editor
             m_StateContainer = new StateContainer(m_RootVisualElement, m_State);
             m_StateContainer.StateChanged += OnStateChanged;
             m_RootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null);
+            new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null, OnResetAsset);
             m_StateContainer.Initialize();
 
             // Hide the save / auto save buttons in the project wide input actions
@@ -107,6 +107,12 @@ namespace UnityEngine.InputSystem.Editor
                 element.style.visibility = Visibility.Hidden;
                 element.style.display = DisplayStyle.None;
             }
+        }
+
+        private void OnResetAsset(InputActionAsset newAsset)
+        {
+            var serializedAsset = new SerializedObject(newAsset);
+            m_State = new InputActionsEditorState(serializedAsset);
         }
 
         [SettingsProvider]

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -96,7 +96,8 @@ namespace UnityEngine.InputSystem.Editor
             m_StateContainer = new StateContainer(m_RootVisualElement, m_State);
             m_StateContainer.StateChanged += OnStateChanged;
             m_RootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null, OnResetAsset);
+            var view = new InputActionsEditorView(m_RootVisualElement, m_StateContainer, null);
+            view.postResetAction += OnResetAsset;
             m_StateContainer.Initialize();
 
             // Hide the save / auto save buttons in the project wide input actions

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -169,7 +169,8 @@ namespace UnityEngine.InputSystem.Editor
             stateContainer.StateChanged += OnStateChanged;
 
             rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            var view = new InputActionsEditorView(rootVisualElement, stateContainer, PostSaveAction);
+            var view = new InputActionsEditorView(rootVisualElement, stateContainer);
+            view.postSaveAction += PostSaveAction;
             stateContainer.Initialize();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -169,7 +169,7 @@ namespace UnityEngine.InputSystem.Editor
             stateContainer.StateChanged += OnStateChanged;
 
             rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            var view = new InputActionsEditorView(rootVisualElement, stateContainer, PostSaveAction, OnResetAsset);
+            var view = new InputActionsEditorView(rootVisualElement, stateContainer, PostSaveAction);
             stateContainer.Initialize();
         }
 
@@ -202,12 +202,6 @@ namespace UnityEngine.InputSystem.Editor
             m_IsDirty = false;
             m_AssetJson = File.ReadAllText(m_AssetPath);
             UpdateWindowTitle();
-        }
-
-        private void OnResetAsset(InputActionAsset newAsset)
-        {
-            var serializedAsset = new SerializedObject(newAsset);
-            m_State = new InputActionsEditorState(serializedAsset);
         }
 
         private void DirtyInputActionsEditorWindow(InputActionsEditorState newState)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -169,7 +169,7 @@ namespace UnityEngine.InputSystem.Editor
             stateContainer.StateChanged += OnStateChanged;
 
             rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            var view = new InputActionsEditorView(rootVisualElement, stateContainer, PostSaveAction);
+            var view = new InputActionsEditorView(rootVisualElement, stateContainer, PostSaveAction, OnResetAsset);
             stateContainer.Initialize();
         }
 
@@ -202,6 +202,12 @@ namespace UnityEngine.InputSystem.Editor
             m_IsDirty = false;
             m_AssetJson = File.ReadAllText(m_AssetPath);
             UpdateWindowTitle();
+        }
+
+        private void OnResetAsset(InputActionAsset newAsset)
+        {
+            var serializedAsset = new SerializedObject(newAsset);
+            m_State = new InputActionsEditorState(serializedAsset);
         }
 
         private void DirtyInputActionsEditorWindow(InputActionsEditorState newState)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -3,7 +3,7 @@
     <ui:VisualElement name="header" class="header">
         <ui:Label text="Input Actions" display-tooltip-when-elided="true" name="title-label" class="header-label" style="width: auto; margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0;" />
         <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
-        <ui:Button display-tooltip-when-elided="true" name="asset-menu" style="height: 19px; width: 3px; background-color: rgba(255, 255, 255, 0); background-image: url(&apos;project://database/Assets/Tests/InputSystem/Assets/UnityDefaultTheme.tss?fileID=4456449167576933126&amp;guid=c8d2bb3a75984bf49871b90fee28739a&amp;type=3#check-dash@2x&apos;); -unity-background-scale-mode: scale-to-fit; border-left-color: rgba(255, 255, 255, 0); border-right-color: rgba(255, 255, 255, 0); border-top-color: rgba(255, 255, 255, 0); border-bottom-color: rgba(255, 255, 255, 0);" />
+        <ui:Label tabindex="-1" display-tooltip-when-elided="true" name="asset-menu" style="background-image: url(&apos;project://database/Assets/Tests/InputSystem/Assets/UnityDefaultTheme.tss?fileID=4154780841294389669&amp;guid=c8d2bb3a75984bf49871b90fee28739a&amp;type=3#arrow-down&apos;); height: 21px; width: 12px; -unity-background-image-tint-color: rgb(255, 255, 255); background-color: rgba(255, 255, 255, 0);" />
     </ui:VisualElement>
     <ui:VisualElement name="control-schemes-toolbar-container">
         <uie:Toolbar>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -3,7 +3,7 @@
     <ui:VisualElement name="header" class="header">
         <ui:Label text="Input Actions" display-tooltip-when-elided="true" name="title-label" class="header-label" style="width: auto; margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0;" />
         <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
-        <ui:Label tabindex="-1" display-tooltip-when-elided="true" name="asset-menu" class="asset-menu-button" style="background-image: url(&apos;project://database/Assets/Tests/InputSystem/Assets/UnityDefaultTheme.tss?fileID=-1304905567622442630&amp;guid=c8d2bb3a75984bf49871b90fee28739a&amp;type=3#arrow-down@2x&apos;); height: 21px; width: 12px; -unity-background-image-tint-color: rgb(255, 255, 255); background-color: rgba(255, 255, 255, 0);" />
+        <ui:VisualElement name="asset-menu" style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); width: 16px; flex-shrink: 0; -unity-background-scale-mode: scale-to-fit;" />
     </ui:VisualElement>
     <ui:VisualElement name="control-schemes-toolbar-container">
         <uie:Toolbar>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -3,7 +3,7 @@
     <ui:VisualElement name="header" class="header">
         <ui:Label text="Input Actions" display-tooltip-when-elided="true" name="title-label" class="header-label" style="width: auto; margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0;" />
         <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
-        <ui:Label tabindex="-1" display-tooltip-when-elided="true" name="asset-menu" style="background-image: url(&apos;project://database/Assets/Tests/InputSystem/Assets/UnityDefaultTheme.tss?fileID=4154780841294389669&amp;guid=c8d2bb3a75984bf49871b90fee28739a&amp;type=3#arrow-down&apos;); height: 21px; width: 12px; -unity-background-image-tint-color: rgb(255, 255, 255); background-color: rgba(255, 255, 255, 0);" />
+        <ui:Label tabindex="-1" display-tooltip-when-elided="true" name="asset-menu" class="asset-menu-button" style="background-image: url(&apos;project://database/Assets/Tests/InputSystem/Assets/UnityDefaultTheme.tss?fileID=-1304905567622442630&amp;guid=c8d2bb3a75984bf49871b90fee28739a&amp;type=3#arrow-down@2x&apos;); height: 21px; width: 12px; -unity-background-image-tint-color: rgb(255, 255, 255); background-color: rgba(255, 255, 255, 0);" />
     </ui:VisualElement>
     <ui:VisualElement name="control-schemes-toolbar-container">
         <uie:Toolbar>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -2,7 +2,8 @@
     <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
     <ui:VisualElement name="header" class="header">
         <ui:Label text="Input Actions" display-tooltip-when-elided="true" name="title-label" class="header-label" style="width: auto; margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0;" />
-        <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" />
+        <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
+        <ui:Button display-tooltip-when-elided="true" name="asset-menu" style="height: 19px; width: 3px; background-color: rgba(255, 255, 255, 0); background-image: url(&apos;project://database/Assets/Tests/InputSystem/Assets/UnityDefaultTheme.tss?fileID=4456449167576933126&amp;guid=c8d2bb3a75984bf49871b90fee28739a&amp;type=3#check-dash@2x&apos;); -unity-background-scale-mode: scale-to-fit; border-left-color: rgba(255, 255, 255, 0); border-right-color: rgba(255, 255, 255, 0); border-top-color: rgba(255, 255, 255, 0); border-bottom-color: rgba(255, 255, 255, 0);" />
     </ui:VisualElement>
     <ui:VisualElement name="control-schemes-toolbar-container">
         <uie:Toolbar>
@@ -10,7 +11,7 @@
                 <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;" />
                 <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu" />
             </ui:VisualElement>
-            <ui:VisualElement style="flex-direction: row; justify-content: flex-end;" name="save-asset-toolbar-container">
+            <ui:VisualElement name="save-asset-toolbar-container" style="flex-direction: row; justify-content: flex-end;">
                 <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;" />
                 <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 69px;" />
             </ui:VisualElement>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
@@ -1,9 +1,14 @@
-/*****************************************************************************/
-/* Global                                                                      */
-/*****************************************************************************/
-
 .unity-input-actions-editor-hidden {
     display: none;
+}
+
+.asset-menu-button-dark-theme {
+    background-image: resource('d__Menu.png');
+}
+
+.asset-menu-button {
+    background-image: resource('_Menu.png');
+    -unity-background-scale-mode: scale-to-fit;
 }
 
 .body-panel-container {
@@ -152,10 +157,6 @@
     display: initial;
 }
 
-.asset-menu-button {
-    background-image: resource('d__Menu.png');
-}
-
 .name-and-parameters-list-view .up {
     background-image: resource('Packages/com.unity.inputsystem/InputSystem/Editor/Icons/ChevronUp.png');
 }
@@ -175,12 +176,12 @@
 .name-and-parameters-list-view .delete {
     background-image: resource('Toolbar Minus.png');
 }
+
 .name-and-parameters-list-view .deleteDarkTheme {
     background-image: resource('d_Toolbar Minus.png');
 }
 
 .search-field {
-    /* hide while not implemented */
     display: none;
     width: 190px;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
@@ -29,7 +29,7 @@
     border-width: 0;
 }
 
-#add-new-action-button  {
+#add-new-action-button {
     background-color: transparent;
     border-width: 0;
 }
@@ -150,6 +150,10 @@
 .float-field {
     width: 50px;
     display: initial;
+}
+
+.asset-menu-button {
+    background-image: resource('d__Menu.png');
 }
 
 .name-and-parameters-list-view .up {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -17,9 +17,6 @@ namespace UnityEngine.InputSystem.Editor
 
         private static readonly string add_Action_String = "Add Action";
         private static readonly string add_Binding_String = "Add Binding";
-        private static readonly string add_positiveNegative_Binding_String = "Add Positive\\Negative Binding";
-        private static readonly string add_oneModifier_Binding_String = "Add Binding With One Modifier";
-        private static readonly string add_twoModifier_Binding_String = "Add Binding With Two Modifiers";
         public static void GetContextMenuForActionMapItem(InputActionMapsTreeViewItem treeViewItem)
         {
             var _ = new ContextualMenuManipulator(menuEvent =>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -14,14 +14,13 @@ namespace UnityEngine.InputSystem.Editor
         private const string autoSaveToggleId = "auto-save-toolbar-toggle";
         private const string menuButtonId = "asset-menu";
 
-        Action m_PostSaveAction;
+        internal Action postSaveAction;
         internal Action<InputActionAsset> postResetAction;
 
-        public InputActionsEditorView(VisualElement root, StateContainer stateContainer, Action mpostSaveAction)
+        public InputActionsEditorView(VisualElement root, StateContainer stateContainer)
             : base(stateContainer)
         {
             m_Root = root;
-            m_PostSaveAction = mpostSaveAction;
             BuildUI();
         }
 
@@ -84,12 +83,12 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnSaveButton()
         {
-            Dispatch(Commands.SaveAsset(m_PostSaveAction));
+            Dispatch(Commands.SaveAsset(postSaveAction));
         }
 
         private void OnAutoSaveToggle(ChangeEvent<bool> evt)
         {
-            Dispatch(Commands.ToggleAutoSave(evt.newValue, m_PostSaveAction));
+            Dispatch(Commands.ToggleAutoSave(evt.newValue, postSaveAction));
         }
 
         public override void RedrawUI(ViewState viewState)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -15,15 +15,13 @@ namespace UnityEngine.InputSystem.Editor
         private const string menuButtonId = "asset-menu";
 
         Action m_PostSaveAction;
-        Action<InputActionAsset> m_PostResetAction;
+        internal Action<InputActionAsset> postResetAction;
 
-        public InputActionsEditorView(VisualElement root, StateContainer stateContainer, Action mpostSaveAction, Action<InputActionAsset> postResetAction = null)
+        public InputActionsEditorView(VisualElement root, StateContainer stateContainer, Action mpostSaveAction)
             : base(stateContainer)
         {
             m_Root = root;
             m_PostSaveAction = mpostSaveAction;
-            if (postResetAction != null)
-                m_PostResetAction = postResetAction;
             BuildUI();
         }
 
@@ -57,7 +55,8 @@ namespace UnityEngine.InputSystem.Editor
 
 
             var assetMenuButton = m_Root.Q<VisualElement>(name: menuButtonId);
-            assetMenuButton.visible = m_PostResetAction != null;
+            var isGlobalAsset = stateContainer.GetState().serializedObject.targetObject.name == "ProjectWideInputActions";
+            assetMenuButton.visible = isGlobalAsset;
             assetMenuButton.AddToClassList(EditorGUIUtility.isProSkin ? "asset-menu-button-dark-theme" : "asset-menu-button");
             var _ = new ContextualMenuManipulator(menuEvent =>
             {
@@ -80,8 +79,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnReset()
         {
-            var asset = ProjectWideActionsAsset.ResetAssetToDefault();
-            m_PostResetAction?.Invoke(asset);
+            Dispatch(Commands.ResetGlobalInputAsset(postResetAction));
         }
 
         private void OnSaveButton()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -54,11 +54,12 @@ namespace UnityEngine.InputSystem.Editor
             autoSaveToggle.value = InputEditorUserSettings.autoSaveInputActionAssets;
             autoSaveToggle.RegisterValueChangedCallback(OnAutoSaveToggle);
 
-            var assetMenuButton = m_Root.Q<Button>(name: menuButtonId);
+            var assetMenuButton = m_Root.Q<TextElement>(name: menuButtonId);
+            assetMenuButton.AddToClassList("kebab-menu-button");
             var _ = new ContextualMenuManipulator(menuEvent =>
             {
                 menuEvent.menu.AppendAction("Reset", _ => OnReset());
-            }) { target = assetMenuButton, activators = { new ManipulatorActivationFilter() }};
+            }) { target = assetMenuButton, activators = { new ManipulatorActivationFilter() {button = MouseButton.LeftMouse} }};
 
             // only register the state changed event here in the parent. Changes will be cascaded
             // into child views.
@@ -76,7 +77,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnReset()
         {
-            var asset= ProjectWideActionsAsset.ResetAssetToDefault();
+            var asset = ProjectWideActionsAsset.ResetAssetToDefault();
             m_PostResetAction?.Invoke(asset);
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -55,8 +55,10 @@ namespace UnityEngine.InputSystem.Editor
             autoSaveToggle.value = InputEditorUserSettings.autoSaveInputActionAssets;
             autoSaveToggle.RegisterValueChangedCallback(OnAutoSaveToggle);
 
-            var assetMenuButton = m_Root.Q<TextElement>(name: menuButtonId);
+
+            var assetMenuButton = m_Root.Q<VisualElement>(name: menuButtonId);
             assetMenuButton.visible = m_PostResetAction != null;
+            assetMenuButton.AddToClassList(EditorGUIUtility.isProSkin ? "asset-menu-button-dark-theme" : "asset-menu-button");
             var _ = new ContextualMenuManipulator(menuEvent =>
             {
                 menuEvent.menu.AppendAction("Reset", _ => OnReset());

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -17,12 +17,13 @@ namespace UnityEngine.InputSystem.Editor
         Action m_PostSaveAction;
         Action<InputActionAsset> m_PostResetAction;
 
-        public InputActionsEditorView(VisualElement root, StateContainer stateContainer, Action mpostSaveAction, Action<InputActionAsset> postResetAction)
+        public InputActionsEditorView(VisualElement root, StateContainer stateContainer, Action mpostSaveAction, Action<InputActionAsset> postResetAction = null)
             : base(stateContainer)
         {
             m_Root = root;
             m_PostSaveAction = mpostSaveAction;
-            m_PostResetAction = postResetAction;
+            if (postResetAction != null)
+                m_PostResetAction = postResetAction;
             BuildUI();
         }
 
@@ -55,7 +56,7 @@ namespace UnityEngine.InputSystem.Editor
             autoSaveToggle.RegisterValueChangedCallback(OnAutoSaveToggle);
 
             var assetMenuButton = m_Root.Q<TextElement>(name: menuButtonId);
-            assetMenuButton.AddToClassList("kebab-menu-button");
+            assetMenuButton.visible = m_PostResetAction != null;
             var _ = new ContextualMenuManipulator(menuEvent =>
             {
                 menuEvent.menu.AppendAction("Reset", _ => OnReset());


### PR DESCRIPTION
### Description

This PR adds a kebab menu to the global input project settings view with the option to reset. Find details in the [ticket](https://jira.unity3d.com/browse/ISX-1564).

### Changes made

added:
- kebab menu with option to reset
- reset global input settings to default logic

fixed: 
- fixed warnings for unused properties in ContextMenu

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
