### PR TITLE
FIX: Make `DisableAndResetAllDevices` handle events while player runs in the background

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2933,9 +2933,10 @@ namespace UnityEngine.InputSystem
                 // Early out if there's no events to process.
                 eventBuffer.eventCount == 0
                 || canFlushBuffer
+
+#if UNITY_EDITOR
                 // If we're in the background and not supposed to process events in this update (but somehow
                 // still ended up here), we're done.
-#if UNITY_EDITOR
                 || ((!gameHasFocus || gameShouldGetInputRegardlessOfFocus) &&
                     ((m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.ResetAndDisableAllDevices && updateType != InputUpdateType.Editor)
                         || (m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDevicesRespectGameViewFocus && updateType != InputUpdateType.Editor)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2686,9 +2686,7 @@ namespace UnityEngine.InputSystem
                 m_HasFocus = focus;
                 return;
             }
-            #endif
 
-            #if UNITY_EDITOR
             var gameViewFocus = m_Settings.editorInputBehaviorInPlayMode;
             #endif
 
@@ -2934,22 +2932,19 @@ namespace UnityEngine.InputSystem
             var canEarlyOut =
                 // Early out if there's no events to process.
                 eventBuffer.eventCount == 0
-                || canFlushBuffer ||
+                || canFlushBuffer
                 // If we're in the background and not supposed to process events in this update (but somehow
                 // still ended up here), we're done.
-                ((!gameHasFocus || gameShouldGetInputRegardlessOfFocus) &&
-                    ((m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.ResetAndDisableAllDevices && updateType != InputUpdateType.Editor)
 #if UNITY_EDITOR
-                        || (m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDevicesRespectGameViewFocus && updateType != InputUpdateType.Editor)
+                || ((!gameHasFocus || gameShouldGetInputRegardlessOfFocus) &&
+                    ((m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDevicesRespectGameViewFocus && updateType != InputUpdateType.Editor)
                         || (m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus && m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView && updateType == InputUpdateType.Editor)
-#endif
                     )
-#if UNITY_EDITOR
                     // When the game is playing and has focus, we never process input in editor updates. All we
                     // do is just switch to editor state buffers and then exit.
-                    || (gameIsPlaying && gameHasFocus && updateType == InputUpdateType.Editor)
+                    || (gameIsPlaying && gameHasFocus && updateType == InputUpdateType.Editor))
 #endif
-                );
+            ;
 
 
 #if UNITY_EDITOR
@@ -3124,7 +3119,7 @@ namespace UnityEngine.InputSystem
                             }
                         }
                     }
-                    #endif
+#endif
 
                     // If device is disabled, we let the event through only in certain cases.
                     // Removal and configuration change events should always be processed.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2937,7 +2937,8 @@ namespace UnityEngine.InputSystem
                 // still ended up here), we're done.
 #if UNITY_EDITOR
                 || ((!gameHasFocus || gameShouldGetInputRegardlessOfFocus) &&
-                    ((m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDevicesRespectGameViewFocus && updateType != InputUpdateType.Editor)
+                    ((m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.ResetAndDisableAllDevices && updateType != InputUpdateType.Editor)
+                        || (m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDevicesRespectGameViewFocus && updateType != InputUpdateType.Editor)
                         || (m_Settings.backgroundBehavior == InputSettings.BackgroundBehavior.IgnoreFocus && m_Settings.editorInputBehaviorInPlayMode == InputSettings.EditorInputBehaviorInPlayMode.AllDeviceInputAlwaysGoesToGameView && updateType == InputUpdateType.Editor)
                     )
                     // When the game is playing and has focus, we never process input in editor updates. All we


### PR DESCRIPTION
### Description

https://jira.unity3d.com/browse/ISXB-615

### Changes made

This PR addresses an issue when the player runs in the background (`InputSystem.runInBackground == true` )and `InputSystem.settings.backgroundBehavior = DisableAndResetAllDevices` is set. These settings were previously introduced in #1324.

With this change, `DisableAndResetAllDevices` has a behavior similar to `DisableAndResetNonBackgroundDevices`, where events that are enqueued while the app is in the background will be [discarded based on their type](https://github.com/Unity-Technologies/InputSystem/blob/bcf381095d5108aee26fbaaf2021efd1ccb909ad/Packages/com.unity.inputsystem/InputSystem/InputManager.cs#L3126). [`canEarlyOut`](https://github.com/Unity-Technologies/InputSystem/blob/bcf381095d5108aee26fbaaf2021efd1ccb909ad/Packages/com.unity.inputsystem/InputSystem/InputManager.cs#L2932) no longer depends on `DisableAndResetAllDevices`, which means we won't early out in this situation.

This solves the issue of having to process input events only when the focus was regained which could lead to the wrong triggering of callbacks. Also, the event buffer could grow to big such that we could see errors of type ` Exceeded budget for maximum input event throughput per InputSystem.Update()` is being raised, in case the player stayed out of focus for the time it took to fill the buffer to its max allowed size.

A test was added to test this behavior in the player.

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
