### PR TITLE
FIX: Listen for standard events rather than hardcoding keybindings (ISX-1745).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed missing confirmation popup when deleting a control scheme.
+- Fixed support for menu bar/customisable keyboard shortcuts used when interacting with Actions and Action Maps.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorConstants.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorConstants.cs
@@ -30,6 +30,14 @@ namespace UnityEngine.InputSystem.Editor
             "Whether in the next input update after the action was enabled, the action should "
             + "immediately trigger if any of its bound controls are currently in a non-default state. "
             + "This check happens implicitly for Value actions but can be explicitly enabled for Button and Pass-Through actions.";
+
+        public struct CommandEvents
+        {
+            public const string Rename = "Rename";
+            public const string Delete = "Delete";
+            public const string SoftDelete = "SoftDelete";
+            public const string Duplicate = "Duplicate";
+        }
     }
 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -1,4 +1,5 @@
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+using CmdEvents = UnityEngine.InputSystem.Editor.InputActionsEditorConstants.CommandEvents;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.InputSystem.Utilities;
@@ -11,11 +12,6 @@ namespace UnityEngine.InputSystem.Editor
     /// </summary>
     internal class ActionMapsView : ViewBase<ActionMapsView.ViewState>
     {
-        private const string kCmd_Rename = "Rename";
-        private const string kCmd_Delete = "Delete";
-        private const string kCmd_SoftDelete = "SoftDelete";
-        private const string kCmd_Duplicate = "Duplicate";
-
         public ActionMapsView(VisualElement root, StateContainer stateContainer)
             : base(stateContainer)
         {
@@ -122,14 +118,14 @@ namespace UnityEngine.InputSystem.Editor
         {
             switch (evt.commandName)
             {
-                case kCmd_Rename:
+                case CmdEvents.Rename:
                     ((InputActionMapsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex))?.FocusOnRenameTextField();
                     break;
-                case kCmd_Delete:
-                case kCmd_SoftDelete:
+                case CmdEvents.Delete:
+                case CmdEvents.SoftDelete:
                     ((InputActionMapsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex))?.DeleteItem();
                     break;
-                case kCmd_Duplicate:
+                case CmdEvents.Duplicate:
                     ((InputActionMapsTreeViewItem)m_ListView.GetRootElementForIndex(m_ListView.selectedIndex))?.DuplicateItem();
                     break;
                 default:
@@ -143,10 +139,10 @@ namespace UnityEngine.InputSystem.Editor
             // Mark commands as supported for Execute by stopping propagation of the event
             switch (evt.commandName)
             {
-                case kCmd_Rename:
-                case kCmd_Delete:
-                case kCmd_SoftDelete:
-                case kCmd_Duplicate:
+                case CmdEvents.Rename:
+                case CmdEvents.Delete:
+                case CmdEvents.SoftDelete:
+                case CmdEvents.Duplicate:
                     evt.StopPropagation();
                     break;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -1,6 +1,7 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+using CmdEvents = UnityEngine.InputSystem.Editor.InputActionsEditorConstants.CommandEvents;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,11 +25,6 @@ namespace UnityEngine.InputSystem.Editor
 
         //save TreeView element id's of individual input actions and bindings to ensure saving of expanded state
         private Dictionary<Guid, int> m_GuidToTreeViewId;
-
-        private const string kCmd_Rename = "Rename";
-        private const string kCmd_Delete = "Delete";
-        private const string kCmd_SoftDelete = "SoftDelete";
-        private const string kCmd_Duplicate = "Duplicate";
 
         public ActionsTreeView(VisualElement root, StateContainer stateContainer)
             : base(stateContainer)
@@ -262,18 +258,18 @@ namespace UnityEngine.InputSystem.Editor
         {
             switch (evt.commandName)
             {
-                case kCmd_Rename:
+                case CmdEvents.Rename:
                     var data = (ActionOrBindingData)m_ActionsTreeView.selectedItem;
                     if (data.isAction || data.isComposite)
                         m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.FocusOnRenameTextField();
                     else
                         return;
                     break;
-                case kCmd_Delete:
-                case kCmd_SoftDelete:
+                case CmdEvents.Delete:
+                case CmdEvents.SoftDelete:
                     m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.DeleteItem();
                     break;
-                case kCmd_Duplicate:
+                case CmdEvents.Duplicate:
                     m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.DuplicateItem();
                     break;
                 default:
@@ -287,10 +283,10 @@ namespace UnityEngine.InputSystem.Editor
             // Mark commands as supported for Execute by stopping propagation of the event
             switch (evt.commandName)
             {
-                case kCmd_Rename:
-                case kCmd_Delete:
-                case kCmd_SoftDelete:
-                case kCmd_Duplicate:
+                case CmdEvents.Rename:
+                case CmdEvents.Delete:
+                case CmdEvents.SoftDelete:
+                case CmdEvents.Duplicate:
                     evt.StopPropagation();
                     break;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -113,16 +113,6 @@ namespace UnityEngine.InputSystem.Editor
         private IViewStateSelector<TViewState> m_ViewStateSelector;
         private IList<IView> m_ChildViews;
         private bool m_IsFirstUpdate = true;
-
-
-        protected bool IsDuplicateShortcutPressed(KeyDownEvent keyDownEvent)
-        {
-#if UNITY_STANDALONE_OSX
-            return keyDownEvent.keyCode == KeyCode.D && keyDownEvent.modifiers == EventModifiers.Command;
-#else
-            return keyDownEvent.keyCode == KeyCode.D && keyDownEvent.modifiers == EventModifiers.Control;
-#endif
-        }
     }
 
     internal class ViewStateSelector<TReturn> : IViewStateSelector<TReturn>


### PR DESCRIPTION
### Description

Fix for [ISX-1745](https://jira.unity3d.com/browse/ISX-1745). Previously, keyboard shortcuts for rename/delete/duplicate were hardcoded to receive specific keyboard presses, which meant users would not be able to make use of the standard customisable shortcuts across the editor, nor use the matching menu bar action (eg. Edit > Delete). This updates the code to receive [Command Events](https://docs.unity3d.com/2023.2/Documentation/Manual/UIE-Command-Events.html) instead.

### Changes made

Fixed: Menu bar/customisable keyboard shortcut support used when interacting with Actions and Action Maps.

### Notes

One downside is that F2 isn't (by default) set to Rename in Unity - which it probably _should_ be on Windows and Linux - so that no longer works to rename without editing the shortcuts manager. But Edit > Rename from the menu bar now works, or (on Mac) using the Return/Enter key, as well as other existing methods (double click an item; right click > Rename).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
