### PR TITLE
fix: remove globalnamespace from filter.yml as it removes *all* API docs

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed missing confirmation popup when deleting a control scheme.
+- Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/Documentation~/filter.yml
+++ b/Packages/com.unity.inputsystem/Documentation~/filter.yml
@@ -32,9 +32,6 @@ apiRules:
         uid: System.ObsoleteAttribute
       type: Type
   - exclude:
-      uidRegex: ^Global Namespace$
-      type: Namespace
-  - exclude:
       uidRegex: ^UnityEngine\.InputSystem\.Samples\..*$
       type: Namespace
   - exclude:

--- a/Packages/com.unity.inputsystem/Documentation~/projectMetadata.json
+++ b/Packages/com.unity.inputsystem/Documentation~/projectMetadata.json
@@ -1,0 +1,3 @@
+{
+    "hideGlobalNamespace": true
+}


### PR DESCRIPTION
### Description

Filtering the GlobalNamespace in filter.yml for the docs filters *everything* in DocFX 2.70.0+.
The hideGlobalNamespace config variable is preferred for this use-case.

### Changes made

Removed GlobalNamespace API documentation filter.
Replaced with hideGlobalNamespace config variable as described [here](https://docs.unity3d.com/Packages/com.unity.package-manager-doctools@3.0/manual/package-metadata.html?q=hideGlobalNamespace).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
