### PR TITLE
FIX: fix Destroy may not be called from edit mode error

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,7 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed add bindings button to support left button click.
 - Fixed icon for adding bindings and composites button.
 - Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
-
+- Fixed `Destroy may not be called from edit mode` error [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-695)
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -642,7 +642,11 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             // The Next/Previous action is not part of the input actions asset
             UnregisterNextPreviousAction();
 
+#if UNITY_EDITOR
             UnityEngine.Object.DestroyImmediate(m_InputActionAsset);
+#else
+            UnityEngine.Object.Destroy(m_InputActionAsset);
+#endif
         }
 
         public struct Configuration

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -642,7 +642,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             // The Next/Previous action is not part of the input actions asset
             UnregisterNextPreviousAction();
 
-            UnityEngine.Object.Destroy(m_InputActionAsset); // TODO check if this is ok
+            UnityEngine.Object.DestroyImmediate(m_InputActionAsset);
         }
 
         public struct Configuration


### PR DESCRIPTION
### Description

Fixes the `Destroy may not be called from edit mode` error message in InputForUI

Described here:
https://forum.unity.com/threads/case-1426900-error-destroy-may-not-be-called-from-edit-mode-is-shown-when-stopping-play.1279895/#post-9479251

### Changes made

Change to use `DestroyImmediate()`


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
