### PR TITLE
FIX: Avoid exceptions being thrown after deleting all Action Maps (ISX-1718).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,7 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed icon for adding bindings and composites button.
 - Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
 - Fixed `Destroy may not be called from edit mode` error [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-695)
-- Fixed possible exceptions thrown when deleting and adding Action Maps. 
+- Fixed possible exceptions thrown when deleting and adding Action Maps.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed add bindings button to support left button click.
 - Fixed icon for adding bindings and composites button.
 - Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
+- Fixed possible exceptions thrown when deleting and adding Action Maps. 
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -237,6 +237,11 @@ namespace UnityEngine.InputSystem.Editor
             mapProperty.FindPropertyRelative("m_Id").stringValue = Guid.NewGuid().ToString();
             mapProperty.FindPropertyRelative("m_Actions").ClearArray();
             mapProperty.FindPropertyRelative("m_Bindings").ClearArray();
+            // NB: This isn't always required: If there's already values in the mapArrayProperty, then inserting a new
+            // element will duplicate the values from the adjacent element to the new element.
+            // However, if the array has been emptied - i.e. if all action maps have been deleted -
+            // then the m_Asset property is null, and needs setting here.
+            mapProperty.FindPropertyRelative("m_Asset").boxedValue ??= asset.targetObject;
 
             return mapProperty;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputActionSerializationHelpers.cs
@@ -241,7 +241,8 @@ namespace UnityEngine.InputSystem.Editor
             // element will duplicate the values from the adjacent element to the new element.
             // However, if the array has been emptied - i.e. if all action maps have been deleted -
             // then the m_Asset property is null, and needs setting here.
-            mapProperty.FindPropertyRelative("m_Asset").boxedValue ??= asset.targetObject;
+            if (mapProperty.FindPropertyRelative("m_Asset").objectReferenceValue == null)
+                mapProperty.FindPropertyRelative("m_Asset").objectReferenceValue = asset.targetObject;
 
             return mapProperty;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -131,8 +131,9 @@ namespace UnityEngine.InputSystem.Editor
             foreach (var action in asset)
             {
                 // Catch error that's possible to appear in previous versions of the package.
-                action.actionMap.m_Asset ??= asset;
-                    
+                if (action.actionMap.m_Asset == null)
+                    action.actionMap.m_Asset = asset;
+
                 var actionReference = existingReferences.FirstOrDefault(r => r.m_ActionId == action.id.ToString());
                 // The input action doesn't have a reference, create a new one.
                 if (actionReference == null)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -120,8 +120,7 @@ namespace UnityEngine.InputSystem.Editor
             // Check if referenced input action exists in the asset and remove the reference if it doesn't.
             foreach (var actionReference in existingReferences)
             {
-                var action = asset.FindAction(actionReference.action.id);
-                if (action == null)
+                if (actionReference.action != null && asset.FindAction(actionReference.action.id) == null)
                 {
                     actionReference.Set(null);
                     AssetDatabase.RemoveObjectFromAsset(actionReference);
@@ -131,6 +130,9 @@ namespace UnityEngine.InputSystem.Editor
             // Check if all actions have a reference
             foreach (var action in asset)
             {
+                // Catch error that's possible to appear in previous versions of the package.
+                action.actionMap.m_Asset ??= asset;
+                    
                 var actionReference = existingReferences.FirstOrDefault(r => r.m_ActionId == action.id.ToString());
                 // The input action doesn't have a reference, create a new one.
                 if (actionReference == null)


### PR DESCRIPTION
### Description

For [ISX-1718](https://jira.unity3d.com/browse/ISX-1718). It was possible to get in to a state where action maps did not have a valid reference to their owning asset (the project-wide settings file), leading to "Object reference not set to an instance of an object" errors. This would only occur after deleting _all_ action maps that did not have this issue, because otherwise, the act of adding a new action map duplicates an existing one (see SerializedProperty::InsertArrayElementAtIndex in native code), which meant all relevant fields would be set correctly from that.

This change _should_ also fix up cases where this issue has already occurred and the error had been saved to the asset file.

To reproduce the original issue (using the develop branch):
- Go to project settings > Input system package
- Reset to default, if needed
- Delete the two action maps, Player and UI
- Create a new action map
- Click on an area outside of the input actions in the Editor UI, eg. Hierarchy, to change focus
- NullReferenceException will be triggered

### Changes made

Fixed: Possible exceptions thrown when deleting and adding Action Maps.

### Notes

This does _not_ fix the (similar) bug [ISX-1771](https://jira.unity3d.com/browse/ISX-1771).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
