### PR TITLE
CHANGE: Update Input for UI provider to use project-wide input actions

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_ProjectWideActions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ProjectWideActions.cs
@@ -158,8 +158,8 @@ internal partial class CoreTests
 
         ProjectWideActionsAsset.CheckForDefaultUIActionMapChanges();
 
-        LogAssert.Expect(LogType.Warning, new Regex($"The UI action \"{defaultActionName0}\" name has been modified"));
-        LogAssert.Expect(LogType.Warning, new Regex($"The UI action \"{defaultActionName1}\" name has been modified"));
+        LogAssert.Expect(LogType.Warning, new Regex($"The UI action '{defaultActionName0}' name has been modified"));
+        LogAssert.Expect(LogType.Warning, new Regex($"The UI action '{defaultActionName1}' name has been modified"));
     }
 
     #endif

--- a/Assets/Tests/InputSystem/CoreTests_ProjectWideActions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ProjectWideActions.cs
@@ -4,10 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Utilities;
+using UnityEngine.TestTools;
 
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
@@ -20,10 +23,11 @@ internal partial class CoreTests
     string m_TemplateAssetPath;
 
 #if UNITY_EDITOR
-    const int initialActionCount = 2;
-    const int initialMapCount = 1;
+    const int initialTotalActionCount = 12;
+    const int initialMapCount = 2;
+    const int initialFirstActionMapCount = 2;
 #else
-    const int initialActionCount = 19;
+    const int initialTotalActionCount = 19;
     const int initialMapCount = 2;
 #endif
 
@@ -41,6 +45,8 @@ internal partial class CoreTests
         var testAsset = ScriptableObject.CreateInstance<TestActionsAsset>();
         AssetDatabase.CreateAsset(testAsset, TestAssetPath);
 
+        var defaultUIMapTemplate = ProjectWideActionsAsset.GetDefaultUIActionMap();
+
         // Create a template `InputActionAsset` containing some test actions.
         // This will then be used to populate the initially empty `TestActionsAsset` when it is first acessed.
         var templateActions = ScriptableObject.CreateInstance<InputActionAsset>();
@@ -48,6 +54,9 @@ internal partial class CoreTests
         var map = templateActions.AddActionMap("InitialActionMapOne");
         map.AddAction("InitialActionOne");
         map.AddAction("InitialActionTwo");
+
+        // Add the default UI map to the template
+        templateActions.AddActionMap(defaultUIMapTemplate);
 
         m_TemplateAssetPath = Path.Combine(Environment.CurrentDirectory, "Assets/ProjectWideActionsTemplate.inputactions");
         File.WriteAllText(m_TemplateAssetPath, templateActions.ToJson());
@@ -82,7 +91,7 @@ internal partial class CoreTests
 
         Assert.That(asset, Is.Not.Null);
         Assert.That(asset.actionMaps.Count, Is.EqualTo(initialMapCount));
-        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(initialActionCount));
+        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(initialFirstActionMapCount));
         Assert.That(asset.actionMaps[0].actions[0].name, Is.EqualTo("InitialActionOne"));
     }
 
@@ -94,7 +103,7 @@ internal partial class CoreTests
 
         Assert.That(asset, Is.Not.Null);
         Assert.That(asset.actionMaps.Count, Is.EqualTo(initialMapCount));
-        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(initialActionCount));
+        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(initialFirstActionMapCount));
         Assert.That(asset.actionMaps[0].actions[0].name, Is.EqualTo("InitialActionOne"));
 
         asset.Disable(); // Cannot modify active actions
@@ -107,7 +116,7 @@ internal partial class CoreTests
         asset.actionMaps[0].actions[0].Rename("FirstAction");
 
         // Add another map
-        asset.AddActionMap("ActionMapTwo").AddAction("AnotherAction");
+        asset.AddActionMap("ActionMapThree").AddAction("AnotherAction");
 
         // Save
         AssetDatabase.SaveAssets();
@@ -117,11 +126,43 @@ internal partial class CoreTests
 
         Assert.That(asset, Is.Not.Null);
         Assert.That(asset.actionMaps.Count, Is.EqualTo(initialMapCount + 1));
-        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(initialActionCount + 2));
-        Assert.That(asset.actionMaps[1].actions.Count, Is.EqualTo(1));
+        Assert.That(asset.actionMaps[0].actions.Count, Is.EqualTo(initialFirstActionMapCount + 2));
+        Assert.That(asset.actionMaps[1].actions.Count, Is.EqualTo(10));
         Assert.That(asset.actionMaps[0].actions[0].name, Is.EqualTo("FirstAction"));
-        Assert.That(asset.actionMaps[1].actions[0].name, Is.EqualTo("AnotherAction"));
+        Assert.That(asset.actionMaps[2].actions[0].name, Is.EqualTo("AnotherAction"));
     }
+
+    #if UNITY_2023_2_OR_NEWER
+    [Test]
+    [Category(TestCategory)]
+    public void ProjectWideActions_ShowsErrorWhenUIActionMapHasNameChanges()  // This test is only relevant for the InputForUI module
+    {
+        var asset = ProjectWideActionsAsset.GetOrCreate();
+        var indexOf = asset.m_ActionMaps.IndexOf(x => x.name == "UI");
+        var uiMap = asset.m_ActionMaps[indexOf];
+
+        // Change the name of the UI action map
+        uiMap.m_Name = "UI2";
+
+        ProjectWideActionsAsset.CheckForDefaultUIActionMapChanges();
+
+        LogAssert.Expect(LogType.Warning, new Regex("The action map named 'UI' does not exist"));
+
+        // Change the name of some UI map back to default and change the name of the actions
+        uiMap.m_Name = "UI";
+        var defaultActionName0 = uiMap.m_Actions[0].m_Name;
+        var defaultActionName1 = uiMap.m_Actions[1].m_Name;
+
+        uiMap.m_Actions[0].Rename("Navigation");
+        uiMap.m_Actions[1].Rename("Show");
+
+        ProjectWideActionsAsset.CheckForDefaultUIActionMapChanges();
+
+        LogAssert.Expect(LogType.Warning, new Regex($"The UI action \"{defaultActionName0}\" name has been modified"));
+        LogAssert.Expect(LogType.Warning, new Regex($"The UI action \"{defaultActionName1}\" name has been modified"));
+    }
+
+    #endif
 
 #endif
 
@@ -141,7 +182,7 @@ internal partial class CoreTests
         Assert.That(InputSystem.actions.actionMaps.Count, Is.EqualTo(initialMapCount));
 
 #if UNITY_EDITOR
-        Assert.That(InputSystem.actions.actionMaps[0].actions.Count, Is.EqualTo(initialActionCount));
+        Assert.That(InputSystem.actions.actionMaps[0].actions.Count, Is.EqualTo(initialFirstActionMapCount));
         Assert.That(InputSystem.actions.actionMaps[0].actions[0].name, Is.EqualTo("InitialActionOne"));
 #else
         Assert.That(InputSystem.actions.actionMaps[0].actions.Count, Is.EqualTo(9));
@@ -154,14 +195,14 @@ internal partial class CoreTests
     public void ProjectWideActions_AppearInEnabledActions()
     {
         var enabledActions = InputSystem.ListEnabledActions();
-        Assert.That(enabledActions, Has.Count.EqualTo(initialActionCount));
+        Assert.That(enabledActions, Has.Count.EqualTo(initialTotalActionCount));
 
         // Add more actions also work
         var action = new InputAction(name: "standaloneAction");
         action.Enable();
 
         enabledActions = InputSystem.ListEnabledActions();
-        Assert.That(enabledActions, Has.Count.EqualTo(initialActionCount + 1));
+        Assert.That(enabledActions, Has.Count.EqualTo(initialTotalActionCount + 1));
         Assert.That(enabledActions, Has.Exactly(1).SameAs(action));
 
         // Disabling works
@@ -179,7 +220,7 @@ internal partial class CoreTests
         Assert.That(InputSystem.actions, Is.Not.Null);
         Assert.That(InputSystem.actions.enabled, Is.True);
         var enabledActions = InputSystem.ListEnabledActions();
-        Assert.That(enabledActions, Has.Count.EqualTo(initialActionCount));
+        Assert.That(enabledActions, Has.Count.EqualTo(initialTotalActionCount));
 
         // Build new asset
         var asset = ScriptableObject.CreateInstance<InputActionAsset>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased]
 
 ### Changed
-- UI toolkit now uses the "UI" action map of project-wide actions as their default input actions. Removing bindings or renaming actions will break UI input for UI toolkit.
+- From 2023.2 forward: UI toolkit now uses the "UI" action map of project-wide actions as their default input actions. Previously, the actions were hardcoded and were based on `DefaultInputActions` asset which didn't allow user changes. Also, removing bindings or renaming the 'UI' action map of project wide actions will break UI input for UI toolkit.
 
 ### Fixed
 - Fixed missing confirmation popup when deleting a control scheme.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased]
 
+### Changed
+- UI toolkit now uses the "UI" action map of project-wide actions as their default input actions. Removing bindings or renaming actions will break UI input for UI toolkit.
+
 ### Fixed
 - Fixed missing confirmation popup when deleting a control scheme.
 - Fixed support for menu bar/customisable keyboard shortcuts used when interacting with Actions and Action Maps.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -140,8 +140,8 @@ namespace UnityEngine.InputSystem.Editor
                     // "UI" actions have been modified.
                     if (uiMap.FindAction(action.name) == null)
                     {
-                        Debug.LogWarning($"The UI action \"{action.name}\" name has been modified.\r\n " +
-                            $"This will break the UI input at runtime. Please make sure the action name with \"{action.name}\" exists.");
+                        Debug.LogWarning($"The UI action '{action.name}' name has been modified.\r\n" +
+                            $"This will break the UI input at runtime. Please make sure the action name with '{action.name}' exists.");
                     }
                 }
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -114,6 +114,7 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
+        #if UNITY_2023_2_OR_NEWER
         /// <summary>
         /// Checks if the default UI action map has been modified or removed, to let the user know if their changes will
         /// break the UI input at runtime, when using the UI Toolkit.
@@ -141,11 +142,12 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         Debug.LogWarning($"The UI action \"{action.name}\" name has been modified.\r\n " +
                             $"This will break the UI input at runtime. Please make sure the action name with \"{action.name}\" exists.");
-                        return;
                     }
                 }
             }
         }
+
+        #endif
 
         /// <summary>
         /// Updates the input action references in the asset by updating names, removing dangling references

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -95,7 +95,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private static InputActionMap GetDefaultUIActionMap()
         {
-            var json = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, s_DefaultAssetPath));
+            var json = File.ReadAllText(FileUtil.GetPhysicalPath(s_DefaultAssetPath));
             var actionMaps = InputActionMap.FromJson(json);
             return actionMaps[actionMaps.IndexOf(x => x.name == "UI")];
         }
@@ -136,7 +136,7 @@ namespace UnityEngine.InputSystem.Editor
                     if (uiMap.FindAction(action.name) == null)
                     {
                         Debug.LogWarning($"The UI action \"{action.name}\" name has been modified.\r\n " +
-                            $"This will break the UI input at runtime. Please make sure the action name with {action.name} exists.");
+                            $"This will break the UI input at runtime. Please make sure the action name with \"{action.name}\" exists.");
                         return;
                     }
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -93,7 +93,7 @@ namespace UnityEngine.InputSystem.Editor
             return asset;
         }
 
-        private static InputActionMap GetDefaultUIActionMap()
+        internal static InputActionMap GetDefaultUIActionMap()
         {
             var json = File.ReadAllText(FileUtil.GetPhysicalPath(s_DefaultAssetPath));
             var actionMaps = InputActionMap.FromJson(json);
@@ -114,25 +114,29 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
+        /// <summary>
+        /// Checks if the default UI action map has been modified or removed, to let the user know if their changes will
+        /// break the UI input at runtime, when using the UI Toolkit.
+        /// </summary>
         internal static void CheckForDefaultUIActionMapChanges()
         {
             var asset = GetOrCreate();
             if (asset != null)
             {
                 var defaultUIActionMap = GetDefaultUIActionMap();
+                var uiMapIndex = asset.actionMaps.IndexOf(x => x.name == "UI");
 
-                var uiMap = asset.actionMaps[asset.actionMaps.IndexOf(x => x.name == "UI")];
                 // "UI" action map has been removed or renamed.
-                if (uiMap == null)
+                if (uiMapIndex == -1)
                 {
                     Debug.LogWarning("The action map named 'UI' does not exist.\r\n " +
                         "This will break the UI input at runtime. Please revert the changes to have an action map named 'UI'.");
                     return;
                 }
-
-                // "UI" action map has been modified.
+                var uiMap = asset.m_ActionMaps[uiMapIndex];
                 foreach (var action in defaultUIActionMap.actions)
                 {
+                    // "UI" actions have been modified.
                     if (uiMap.FindAction(action.name) == null)
                     {
                         Debug.LogWarning($"The UI action \"{action.name}\" name has been modified.\r\n " +

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindowUtils.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindowUtils.cs
@@ -18,7 +18,9 @@ namespace UnityEngine.InputSystem.Editor
             // For project-wide actions asset save works differently. The asset is in YAML format, not JSON.
             if (asset.name == ProjectWideActionsAsset.kAssetName)
             {
+#if UNITY_2023_2_OR_NEWER
                 ProjectWideActionsAsset.CheckForDefaultUIActionMapChanges();
+#endif
                 ProjectWideActionsAsset.UpdateInputActionReferences();
                 AssetDatabase.SaveAssets();
                 return;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindowUtils.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindowUtils.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
             // For project-wide actions asset save works differently. The asset is in YAML format, not JSON.
             if (asset.name == ProjectWideActionsAsset.kAssetName)
             {
+                ProjectWideActionsAsset.CheckForDefaultUIActionMapChanges();
                 ProjectWideActionsAsset.UpdateInputActionReferences();
                 AssetDatabase.SaveAssets();
                 return;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -640,8 +640,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
             // The Next/Previous action is not part of the input actions asset
             UnregisterNextPreviousAction();
-
-            UnityEngine.Object.Destroy(m_InputActionAsset); // TODO check if this is ok
         }
 
         public struct Configuration
@@ -658,7 +656,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
             public static Configuration GetDefaultConfiguration()
             {
-                
                 return new Configuration
                 {
                     ActionAsset = InputSystem.actions,

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -78,7 +78,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             m_TouchState.Reset();
             m_SeenTouchEvents = false;
 
-            // TODO should UITK somehow override this?
             m_Cfg = Configuration.GetDefaultConfiguration();
             RegisterActions(m_Cfg);
         }
@@ -564,7 +563,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         void RegisterActions(Configuration cfg)
         {
-            m_InputActionAsset = InputActionAsset.FromJson(cfg.InputActionAssetAsJson);
+            m_InputActionAsset = cfg.ActionAsset;
 
             m_PointAction = InputActionReference.Create(m_InputActionAsset.FindAction(m_Cfg.PointAction));
             m_MoveAction = InputActionReference.Create(m_InputActionAsset.FindAction(m_Cfg.MoveAction));
@@ -642,16 +641,12 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             // The Next/Previous action is not part of the input actions asset
             UnregisterNextPreviousAction();
 
-#if UNITY_EDITOR
-            UnityEngine.Object.DestroyImmediate(m_InputActionAsset);
-#else
-            UnityEngine.Object.Destroy(m_InputActionAsset);
-#endif
+            UnityEngine.Object.Destroy(m_InputActionAsset); // TODO check if this is ok
         }
 
         public struct Configuration
         {
-            public string InputActionAssetAsJson;
+            public InputActionAsset ActionAsset;
             public string PointAction;
             public string MoveAction;
             public string SubmitAction;
@@ -663,14 +658,10 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
             public static Configuration GetDefaultConfiguration()
             {
-                // TODO this is a weird way of doing that, is there an easier way?
-                var asset = new DefaultInputActions();
-                var json = asset.asset.ToJson();
-                UnityEngine.Object.DestroyImmediate(asset.asset); // TODO just Dispose doesn't work in edit mode
-
+                
                 return new Configuration
                 {
-                    InputActionAssetAsJson = json,
+                    ActionAsset = InputSystem.actions,
                     PointAction = "UI/Point",
                     MoveAction = "UI/Navigate",
                     SubmitAction = "UI/Submit",


### PR DESCRIPTION
### Description

[ISX-1528
](https://jira.unity3d.com/browse/ISX-1528)
### Changes made

- Change InputSystemProvider for Input For UI module to work with the Project Wide Actions instead of DefaultInputActions. This makes UI TK use project-wide action bindings that can be modified by users.

- Added some warnings when the asset is saved with changes to the "UI" action maps. By doing this only in save, it makes sure that other parts of the code are decoupled from Project Wide Actions. 

❓
- ~Should there be a way to reset specific action maps? Besides having just "Reset", also have "Reset UI map" and "Reset Player map" as well?~
- ~Some might prefer to have an Editor UI visual warning (e.g. like a warning icon) when the UI action map is modified. But that would take more time than expected, as it involves UI TK UI changes. Please let me know if there should be any extra effort to change the UI~.


### Notes

ℹ️  The project to be used for QA is specified in the [JIRA ticket](https://jira.unity3d.com/browse/ISX-1528).

I'll add doc changes in another PR after talking with Ben Pitt.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
