### PR TITLE
FIX: Correctly select new ActionTree item after delete (ISX-1680)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -58,6 +58,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case ISX-1436 (UI TK Input Action Asset Editor - Error deleting Bindings with DeleteKey on Windows).
 - Fixed issue with UI Toolkit based Input Action Editor not restoring it's selected items after Domain Reload.
 - Fixed the [`GetHapticCapabilitiesCommand`](xref:UnityEngine.InputSystem.XR.Haptics.GetHapticCapabilitiesCommand) always failing to execute due to a mismatch in the size in bytes of the payload and the size expected by XR devices. Changed [`HapticCapabilities`](xref:UnityEngine.InputSystem.XR.Haptics.HapticCapabilities) to include all properties returned by the XR input subsystem. This makes Input System match the functionality provided by the [XR](https://docs.unity3d.com/Manual/com.unity.modules.xr.html) module's [`InputDevice.TryGetHapticCapabilities`](https://docs.unity3d.com/ScriptReference/XR.InputDevice.TryGetHapticCapabilities.html) and [`HapticCapabilities`](https://docs.unity3d.com/ScriptReference/XR.HapticCapabilities.html).
+- Fixed case ISX-1680 (UITK Input Action Asset Editor - Deleting a binding selects a seemingly random binding)
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -58,7 +58,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed case ISX-1436 (UI TK Input Action Asset Editor - Error deleting Bindings with DeleteKey on Windows).
 - Fixed issue with UI Toolkit based Input Action Editor not restoring it's selected items after Domain Reload.
 - Fixed the [`GetHapticCapabilitiesCommand`](xref:UnityEngine.InputSystem.XR.Haptics.GetHapticCapabilitiesCommand) always failing to execute due to a mismatch in the size in bytes of the payload and the size expected by XR devices. Changed [`HapticCapabilities`](xref:UnityEngine.InputSystem.XR.Haptics.HapticCapabilities) to include all properties returned by the XR input subsystem. This makes Input System match the functionality provided by the [XR](https://docs.unity3d.com/Manual/com.unity.modules.xr.html) module's [`InputDevice.TryGetHapticCapabilities`](https://docs.unity3d.com/ScriptReference/XR.InputDevice.TryGetHapticCapabilities.html) and [`HapticCapabilities`](https://docs.unity3d.com/ScriptReference/XR.HapticCapabilities.html).
-- Fixed case ISX-1680 (UITK Input Action Asset Editor - Deleting a binding selects a seemingly random binding)
+- Fixed issue where deleting a binding in the Input Action Editor would usually result in an unexpected item being selected next.
 
 ## [1.8.0-pre.1] - 2023-09-04
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -157,19 +157,10 @@ namespace UnityEngine.InputSystem.Editor
                 var actionID = InputActionSerializationHelpers.GetId(action);
                 InputActionSerializationHelpers.DeleteActionAndBindings(actionMap, actionID);
                 state.serializedObject.ApplyModifiedProperties();
-                if (state.selectedActionIndex >= actionIndex)
-                    return SelectPrevAction(state, actionMap);
-                return state.SelectAction(state.selectedActionIndex);
-            };
-        }
 
-        private static InputActionsEditorState SelectPrevAction(InputActionsEditorState state, SerializedProperty actionMap)
-        {
-            var count = Selectors.GetActionCount(actionMap);
-            int index = -1;
-            if (count != null && count.Value > 0)
-                index = Math.Max(state.selectedActionIndex - 1, 0);
-            return state.SelectAction(index);
+                // ActionsTreeView will dispatch a separate command to select the previous Action
+                return state.With(selectedActionIndex: -1);
+            };
         }
 
         public static Command DeleteBinding(int actionMapIndex, int bindingIndex)
@@ -180,19 +171,10 @@ namespace UnityEngine.InputSystem.Editor
                 var binding = Selectors.GetCompositeOrBindingInMap(actionMap, bindingIndex).wrappedProperty;
                 InputActionSerializationHelpers.DeleteBinding(binding, actionMap);
                 state.serializedObject.ApplyModifiedProperties();
-                if (state.selectedBindingIndex >= bindingIndex)
-                    return SelectPrevBinding(state, actionMap);
-                return state.SelectBinding(state.selectedBindingIndex);
-            };
-        }
 
-        private static InputActionsEditorState SelectPrevBinding(InputActionsEditorState state, SerializedProperty actionMap)
-        {
-            var count = Selectors.GetBindingCount(actionMap);
-            var index = -1;
-            if (count != null && count.Value > 0)
-                index = Math.Max(state.selectedBindingIndex - 1, 0);
-            return state.SelectBinding(index);
+                // ActionsTreeView will dispatch a separate command to select the previous Binding
+                return state.With(selectedBindingIndex: -1);
+            };
         }
 
         public static Command ExpandCompositeBinding(SerializedInputBinding binding)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -159,7 +159,7 @@ namespace UnityEngine.InputSystem.Editor
                 state.serializedObject.ApplyModifiedProperties();
 
                 // ActionsTreeView will dispatch a separate command to select the previous Action
-                return state.With(selectedActionIndex: -1);
+                return state;
             };
         }
 
@@ -173,7 +173,7 @@ namespace UnityEngine.InputSystem.Editor
                 state.serializedObject.ApplyModifiedProperties();
 
                 // ActionsTreeView will dispatch a separate command to select the previous Binding
-                return state.With(selectedBindingIndex: -1);
+                return state;
             };
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -233,9 +233,24 @@ namespace UnityEngine.InputSystem.Editor
         private void DeleteItem(ActionOrBindingData data)
         {
             if (data.isAction)
+            {
+                string actionToSelect = GetPreviousActionNameFromViewTree(data);
                 Dispatch(Commands.DeleteAction(data.actionMapIndex, data.name));
+                Dispatch(Commands.SelectAction(actionToSelect));
+            }
             else
+            {
+                int bindingIndexToSelect = GetPreviousBindingIndexFromViewTree(data, out string parentActionName);
                 Dispatch(Commands.DeleteBinding(data.actionMapIndex, data.bindingIndex));
+
+                if (bindingIndexToSelect >= 0)
+                    Dispatch(Commands.SelectBinding(bindingIndexToSelect));
+                else
+                    Dispatch(Commands.SelectAction(parentActionName));
+            }
+
+            // Deleting an item sometimes causes the UI Panel to lose focus; make sure we keep it
+            m_ActionsTreeView.Focus();
         }
 
         private void DuplicateItem(ActionOrBindingData data)
@@ -291,6 +306,87 @@ namespace UnityEngine.InputSystem.Editor
                     evt.StopPropagation();
                     break;
             }
+        }
+
+        private string GetPreviousActionNameFromViewTree(in ActionOrBindingData data)
+        {
+            Debug.Assert(data.isAction);
+
+            // If TreeView currently (before delete) has more than one Action, select the one immediately
+            // above or immediately below depending (if data is first in the list)
+            var treeView = ViewStateSelector.GetViewState(stateContainer.GetState()).treeViewData;
+            if (treeView.Count > 1)
+            {
+                string actionName = data.name;
+                int index = treeView.FindIndex(item => item.data.name == actionName);
+                if (index > 0)
+                    index--;
+                else
+                    index++;
+
+                return treeView[index].data.name;
+            }
+
+            return string.Empty;
+        }
+
+        private int GetPreviousBindingIndexFromViewTree(in ActionOrBindingData data, out string parentActionName)
+        {
+            Debug.Assert(!data.isAction);
+
+            int retVal = -1;
+            parentActionName = string.Empty;
+
+            // The bindindIndex is global and doesn't correspond to the binding's "child index" within the TreeView.
+            // To find the "previous" Binding to select, after deleting the current one, we must:
+            // 1. Traverse the ViewTree to find the parent of the binding and its index under that parent
+            // 2. Identify the Binding to select after deletion and retrieve its bindingIndex
+            // 3. Return the bindingIndex and the parent Action name (select the Action if bindingIndex is invalid)
+
+            var treeView = ViewStateSelector.GetViewState(stateContainer.GetState()).treeViewData;
+            foreach (var action in treeView)
+            {
+                if (!action.hasChildren)
+                    continue;
+
+                if (FindBindingOrComponentTreeViewParent(action, data.bindingIndex, out var parentNode, out int childIndex))
+                {
+                    parentActionName = action.data.name;
+                    if (parentNode.children.Count() > 1)
+                    {
+                        int prevIndex = Math.Max(childIndex - 1, 0);
+                        var node = parentNode.children.ElementAt(prevIndex);
+                        retVal = node.data.bindingIndex;
+                    }
+                }
+            }
+
+            return retVal;
+        }
+
+        private static bool FindBindingOrComponentTreeViewParent(TreeViewItemData<ActionOrBindingData> root, int bindingIndex, out TreeViewItemData<ActionOrBindingData> parent, out int childIndex)
+        {
+            Debug.Assert(root.hasChildren);
+
+            int index = 0;
+            foreach (var item in root.children)
+            {
+                if (item.data.bindingIndex == bindingIndex)
+                {
+                    parent = root;
+                    childIndex = index;
+                    return true;
+                }
+
+                if (item.hasChildren && FindBindingOrComponentTreeViewParent(item, bindingIndex, out parent, out childIndex))
+                    return true;
+
+                index++;
+            }
+
+            parent = default;
+            childIndex = -1;
+            return false;
         }
 
         internal class ViewState
@@ -362,7 +458,8 @@ namespace UnityEngine.InputSystem.Editor
                             var isVisible = ShouldBindingBeVisible(nextBinding, state.selectedControlScheme);
                             if (isVisible)
                             {
-                                var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);                        var compositeBindingId = new Guid(nextBinding.id);
+                                var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);
+                                var compositeBindingId = new Guid(nextBinding.id);
                                 compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(new Guid(nextBinding.id), idDictionary),
                                     new ActionOrBindingData(false, name, actionMapIndex, false,
                                         GetControlLayout(nextBinding.path), nextBinding.indexOfBinding)));

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -313,7 +313,7 @@ namespace UnityEngine.InputSystem.Editor
             Debug.Assert(data.isAction);
 
             // If TreeView currently (before delete) has more than one Action, select the one immediately
-            // above or immediately below depending (if data is first in the list)
+            // above or immediately below depending if data is first in the list
             var treeView = ViewStateSelector.GetViewState(stateContainer.GetState()).treeViewData;
             if (treeView.Count > 1)
             {
@@ -322,7 +322,7 @@ namespace UnityEngine.InputSystem.Editor
                 if (index > 0)
                     index--;
                 else
-                    index++;
+                    index++; // Also handles case if actionName wasn't found; FindIndex() returns -1 that's incremented to 0
 
                 return treeView[index].data.name;
             }
@@ -357,6 +357,7 @@ namespace UnityEngine.InputSystem.Editor
                         int prevIndex = Math.Max(childIndex - 1, 0);
                         var node = parentNode.children.ElementAt(prevIndex);
                         retVal = node.data.bindingIndex;
+                        break;
                     }
                 }
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -110,6 +110,7 @@ namespace UnityEngine.InputSystem.Editor
         }
 
         protected readonly StateContainer stateContainer;
+        protected IViewStateSelector<TViewState> ViewStateSelector => m_ViewStateSelector;
         private IViewStateSelector<TViewState> m_ViewStateSelector;
         private IList<IView> m_ChildViews;
         private bool m_IsFirstUpdate = true;


### PR DESCRIPTION
### Description

Fix for [ISX-1680](https://jira.unity3d.com/browse/ISX-1680) - Deleting a Binding will correctly select a new item in the tree

### Changes made

Reworks the the logic to select a new Action/Binding after a delete operation by moving the functionality from Command.cs into ActionTreeView.cs.

Searches the ActionTreeView data to find the tree node that's about to be deleted and identify the siblings/parent node in the tree to select next and dispatches a separate Select command.

### Notes

Unlike Actions, the Binding IDs do not correspond to the indexes within the ActionTreeView and there's no way to determine a given Binding's siblings solely from the Action state. We must search through the visual tree to identify the new item to select (after delete) which is best executed within ActionTreeView.

For consistency (and safety should Action IDs change), this approach is applied both to Actions and Bindings.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
