### PR TITLE
 Fix for race condition on access to GCHandle in DefferedResolutionOfBindings

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,7 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
 - Fixed `Destroy may not be called from edit mode` error [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-695)
 - Fixed possible exceptions thrown when deleting and adding Action Maps.
-- Fixed potential race condition on access to GCHandle in DefferedResolutionOfBindings and halved number of calls to GCHandle resolution
+- Fixed potential race condition on access to GCHandle in DefferedResolutionOfBindings and halved number of calls to GCHandle resolution [ISXB-726](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-726)
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
 - Fixed `Destroy may not be called from edit mode` error [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-695)
 - Fixed possible exceptions thrown when deleting and adding Action Maps.
+- Fixed potential race condition on access to GCHandle in DefferedResolutionOfBindings and halved number of calls to GCHandle resolution
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -4441,7 +4441,9 @@ namespace UnityEngine.InputSystem
                 for (var i = 0; i < s_GlobalState.globalList.length; ++i)
                 {
                     var handle = s_GlobalState.globalList[i];
-                    if (!handle.IsAllocated || handle.Target == null)
+
+                    var state = handle.IsAllocated ? (InputActionState)handle.Target : null;
+                    if (state == null)
                     {
                         // Stale entry in the list. State has already been reclaimed by GC. Remove it.
                         if (handle.IsAllocated)
@@ -4451,7 +4453,6 @@ namespace UnityEngine.InputSystem
                         continue;
                     }
 
-                    var state = (InputActionState)handle.Target;
                     for (var n = 0; n < state.totalMapCount; ++n)
                         state.maps[n].ResolveBindingsIfNecessary();
                 }


### PR DESCRIPTION
### Description

Fix for race condition on access to GCHandle in DefferedResolutionOfBindings

[case ISXB-726]

### Changes made

dereferencing the gchandle just once and using that rather than testing the state and then dereferencing (which is unsafe as a change in state could occur between them)

### Notes

All tests ran locally edit mode and play mode (spotted a dialog in edit mode which required manual interaction but that's unrelated to this PR). All tests passing on CI

Performance not explicitly measured, but its clearly a reduction in the number of calls to the low level GCHandle code

### Checklist

Before review:

- [X] Changelog entry added.
- No tests added/changed
- No new/changed API's.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
