### PR TITLE
Basic DS Edge support [ISX-1367]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 - Added Copy, Paste and Cut support for Action Maps, Actions and Bindings via context menu and key command shortcuts.
+- Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -31,7 +31,12 @@ namespace UnityEngine.InputSystem.DualShock
                 matches: new InputDeviceMatcher()
                     .WithInterface("HID")
                     .WithCapability("vendorId", 0x54C) // Sony Entertainment.
-                    .WithCapability("productId", 0xCE6));
+                    .WithCapability("productId", 0xDF2)); // Dual Sense Edge
+            InputSystem.RegisterLayout<DualSenseGamepadHID>(
+                matches: new InputDeviceMatcher()
+                    .WithInterface("HID")
+                    .WithCapability("vendorId", 0x54C) // Sony Entertainment.
+                    .WithCapability("productId", 0xCE6)); // Dual Sense
             InputSystem.RegisterLayout<DualShock4GamepadHID>(
                 matches: new InputDeviceMatcher()
                     .WithInterface("HID")


### PR DESCRIPTION
### Description

Dual Sense Edge controller is now matched the same way the normal Dual Sense controller works on Win, OSX, WSA, Editor.

### Changes made

DS Edge is mapped as DS controller. DS buttons and sticks work, but none of the extra functions of from the normal DS nor the extra bits from Edge.

Tested on Win+OSX editor + standalone.

### Notes

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
