### PR TITLE
FIX: Re-add asset name to window title (ISX-1726).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -30,6 +30,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed possible exceptions thrown when deleting and adding Action Maps.
 - Fixed potential race condition on access to GCHandle in DefferedResolutionOfBindings and halved number of calls to GCHandle resolution [ISXB-726](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-726)
 - Fixed issue where composite part dropdown manipulates binding path and leaves composite part field unchanged.
+- Fixed missing name in window title for Input Action assets.
 
 ### Added
 - Added Copy, Paste and Cut support for Action Maps, Actions and Bindings via context menu and key command shortcuts.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -479,7 +479,7 @@ namespace UnityEngine.InputSystem
         /// Xbox gamepad and PS4 gamepad are both connected to a PC and the user is playing with the
         /// Xbox gamepad, the PS4 gamepad would still constantly make itself <see cref="Gamepad.current"/>
         /// by simply flooding the system with events. Hence why by default,  noise on <c>.current</c> getters
-        /// will be filtered out and a device will only see <c>MakeCurrent</c> getting called if there input
+        /// will be filtered out and a device will only see <c>MakeCurrent</c> getting called if their input
         /// was detected on non-noisy controls.
         /// </remarks>
         /// <seealso cref="Pointer.current"/>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -28,7 +28,7 @@ namespace UnityEngine.InputSystem.Editor
         private int m_AssetId;
         private string m_AssetPath;
         private string m_AssetJson;
-        private string m_AssetName;
+        private string m_AssetTitleName;
         private bool m_IsDirty;
         static readonly Vector2 k_MinWindowSize = new Vector2(650, 450);
 
@@ -89,8 +89,8 @@ namespace UnityEngine.InputSystem.Editor
 
             window.m_IsDirty = false;
             window.m_AssetId = instanceId;
-            window.m_AssetName = asset.name;
-            window.titleContent = new GUIContent(asset.name + " (Input Actions Editor)");
+            window.m_AssetTitleName = asset.name + " (Input Actions Editor)";
+            window.titleContent = new GUIContent(window.m_AssetTitleName);
             window.minSize = k_MinWindowSize;
             window.SetAsset(asset, actionToSelect, actionMapToSelect);
             window.Show();
@@ -192,9 +192,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void UpdateWindowTitle()
         {
-            titleContent = m_IsDirty ?
-                new GUIContent(m_AssetName + "(*) (Input Actions Editor)") :
-                new GUIContent(m_AssetName + " (Input Actions Editor)");
+            titleContent = m_IsDirty ? new GUIContent("(*) " + m_AssetTitleName) : new GUIContent(m_AssetTitleName);
         }
 
         private void Save()
@@ -290,7 +288,7 @@ namespace UnityEngine.InputSystem.Editor
             window.m_State = m_State;
             window.m_AssetPath = m_AssetPath;
             window.m_AssetJson = m_AssetJson;
-            window.m_AssetName = m_AssetName;
+            window.m_AssetTitleName = m_AssetTitleName;
             window.m_IsDirty = true;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -28,6 +28,7 @@ namespace UnityEngine.InputSystem.Editor
         private int m_AssetId;
         private string m_AssetPath;
         private string m_AssetJson;
+        private string m_AssetName;
         private bool m_IsDirty;
         static readonly Vector2 k_MinWindowSize = new Vector2(650, 450);
 
@@ -88,7 +89,8 @@ namespace UnityEngine.InputSystem.Editor
 
             window.m_IsDirty = false;
             window.m_AssetId = instanceId;
-            window.titleContent = new GUIContent("Input Actions Editor");
+            window.m_AssetName = asset.name;
+            window.titleContent = new GUIContent(asset.name + " (Input Actions Editor)");
             window.minSize = k_MinWindowSize;
             window.SetAsset(asset, actionToSelect, actionMapToSelect);
             window.Show();
@@ -190,7 +192,9 @@ namespace UnityEngine.InputSystem.Editor
 
         private void UpdateWindowTitle()
         {
-            titleContent = m_IsDirty ? new GUIContent("(*) Input Actions Editor") : new GUIContent("Input Actions Editor");
+            titleContent = m_IsDirty ?
+                new GUIContent(m_AssetName + "(*) (Input Actions Editor)") :
+                new GUIContent(m_AssetName + " (Input Actions Editor)");
         }
 
         private void Save()
@@ -286,6 +290,7 @@ namespace UnityEngine.InputSystem.Editor
             window.m_State = m_State;
             window.m_AssetPath = m_AssetPath;
             window.m_AssetJson = m_AssetJson;
+            window.m_AssetName = m_AssetName;
             window.m_IsDirty = true;
         }
 


### PR DESCRIPTION
### Description

Fix for [ISX-1726](https://jira.unity3d.com/browse/ISX-1726) - Include asset name in window title, matching behaviour from before UITK work.

### Changes made

As above.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
