### PR TITLE
FIX: Selection highlight lingering after clicking save button (ISX-1482).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,8 @@ however, it has to be formatted properly to pass verification tests.
   - [`InputAction.activeValueType`](xref:UnityEngine.InputSystem.InputAction.activeValueType) returns the `Type` expected by `ReadValue<TValue>` based on the currently active control that is driving the action.
   - [`InputAction.GetMagnitude`](xref:UnityEngine.InputSystem.InputAction.GetMagnitude) returns the current amount of actuation of the control that is driving the action.
   - [`InputAction.WasCompletedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasCompletedThisFrame) returns `true` on the frame that the action stopped being in the performed phase. This allows for similar functionality to [`WasPressedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasPressedThisFrame)/[`WasReleasedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasReleasedThisFrame) when paired with [`WasPerformedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasPerformedThisFrame) except it is directly based on the interactions driving the action. For example, you can use it to distinguish between the button being released or whether it was released after being held for long enough to perform when using the Hold interaction.
+- Added Copy, Paste and Cut support for Action Maps, Actions and Bindings via context menu and key command shortcuts.
+- Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller
 
 ### Fixed
 - Fixed syntax of code examples in API documentation for [`AxisComposite`](xref:UnityEngine.InputSystem.Composites.AxisComposite).
@@ -30,10 +32,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed possible exceptions thrown when deleting and adding Action Maps.
 - Fixed potential race condition on access to GCHandle in DefferedResolutionOfBindings and halved number of calls to GCHandle resolution [ISXB-726](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-726)
 - Fixed issue where composite part dropdown manipulates binding path and leaves composite part field unchanged.
-
-### Added
-- Added Copy, Paste and Cut support for Action Maps, Actions and Bindings via context menu and key command shortcuts.
-- Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller
+- Fixed lingering highlight effect on Save Asset button after clicking.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -84,6 +84,11 @@ namespace UnityEngine.InputSystem.Editor
         private void OnSaveButton()
         {
             Dispatch(Commands.SaveAsset(postSaveAction));
+
+            // Don't let focus linger after clicking (ISX-1482). Ideally this would be only applied on mouse click,
+            // rather than if the user is using tab to navigate UI, but there doesn't seem to be a way to differentiate
+            // between those interactions at the moment.
+            m_Root.Q<ToolbarButton>(name: saveButtonId).Blur();
         }
 
         private void OnAutoSaveToggle(ChangeEvent<bool> evt)


### PR DESCRIPTION
### Description

Fix for [ISX-1482](https://jira.unity3d.com/browse/ISX-1482) - Don't leave the Save Asset button as highlighted (focused) after clicking.

### Changes made

As above.

### Notes

Relating to my comments in the code, tabbing through the UI _should_ highlight each object in turn per accessibility guidelines (https://unity.slack.com/archives/C3414V4UV/p1689871437531979?thread_ts=1689865302.307989&cid=C3414V4UV), so it's actually a bug that not everything gets highlighted when tabbing through the UI. But it's also one that seems to be extremely widespread across the whole editor, so probably not a top priority for us...

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
