### PR TITLE
FIX: "Listen" button listening for wrong type (ISX-1832).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed issue where composite part dropdown manipulates binding path and leaves composite part field unchanged.
 - Fixed lingering highlight effect on Save Asset button after clicking.
 - Fixed missing name in window title for Input Action assets.
+- Fixed "Listen" functionality for selecting an input sometimes expecting the wrong input type.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -213,6 +213,11 @@ namespace UnityEngine.InputSystem.Editor
                 ?.wrappedProperty.FindPropertyRelative(nameof(InputActionMap.m_Actions));
             if (actions == null || actions.arraySize - 1 < state.selectedActionIndex || state.selectedActionIndex < 0)
                 return null;
+
+            // If we've currently selected a binding, get the parent input action for it.
+            if (state.selectionType == SelectionType.Binding)
+                return GetRelatedInputAction(state);
+
             return new SerializedInputAction(actions.GetArrayElementAtIndex(state.selectedActionIndex));
         }
 


### PR DESCRIPTION
### Description

The "Listen" button would sometimes be listening to the wrong type of input. This was due to part of the code assuming that the selected item was an Action, when it would be a Binding. [ISX-1832](https://jira.unity3d.com/browse/ISX-1832)

### Changes made

In GetSelectedAction, we now return the relevant "parent" action if the user had a Binding selected.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
