### PR TITLE
FIX: Avoid errors logged when opening settings menu (ISX-1721)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -35,6 +35,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed lingering highlight effect on Save Asset button after clicking.
 - Fixed missing name in window title for Input Action assets.
 - Fixed "Listen" functionality for selecting an input sometimes expecting the wrong input type.
+- Fixed console errors that can be produced when opening input package settings from the Inspector.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -13,11 +13,9 @@ namespace UnityEngine.InputSystem.Editor
     internal class ActionMapsView : ViewBase<ActionMapsView.ViewState>
     {
         public ActionMapsView(VisualElement root, StateContainer stateContainer)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
-
-            m_ListView = m_Root?.Q<ListView>("action-maps-list-view");
+            m_ListView = rootElement?.Q<ListView>("action-maps-list-view");
             m_ListView.selectionType = UIElements.SelectionType.Single;
 
             m_ListViewSelectionChangeFilter = new CollectionViewSelectionChangeFilter(m_ListView);
@@ -65,7 +63,7 @@ namespace UnityEngine.InputSystem.Editor
             ContextMenu.GetContextMenuForActionMapListView(this, m_ListView.parent);
         }
 
-        private Button addActionMapButton => m_Root?.Q<Button>("add-new-action-map-button");
+        private Button addActionMapButton => rootElement?.Q<Button>("add-new-action-map-button");
 
         public override void RedrawUI(ViewState viewState)
         {
@@ -183,7 +181,6 @@ namespace UnityEngine.InputSystem.Editor
 
         private readonly CollectionViewSelectionChangeFilter m_ListViewSelectionChangeFilter;
         private bool m_EnterRenamingMode;
-        private readonly VisualElement m_Root;
         private ListView m_ListView;
 
         internal class ViewState

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -15,7 +15,7 @@ namespace UnityEngine.InputSystem.Editor
         public ActionMapsView(VisualElement root, StateContainer stateContainer)
             : base(root, stateContainer)
         {
-            m_ListView = rootElement?.Q<ListView>("action-maps-list-view");
+            m_ListView = root.Q<ListView>("action-maps-list-view");
             m_ListView.selectionType = UIElements.SelectionType.Single;
 
             m_ListViewSelectionChangeFilter = new CollectionViewSelectionChangeFilter(m_ListView);
@@ -59,11 +59,10 @@ namespace UnityEngine.InputSystem.Editor
             CreateSelector(s => new ViewStateCollection<string>(Selectors.GetActionMapNames(s)),
                 (actionMapNames, state) => new ViewState(Selectors.GetSelectedActionMap(state), actionMapNames));
 
-            addActionMapButton.clicked += AddActionMap;
+            m_AddActionMapButton = root.Q<Button>("add-new-action-map-button");
+            m_AddActionMapButton.clicked += AddActionMap;
             ContextMenu.GetContextMenuForActionMapListView(this, m_ListView.parent);
         }
-
-        private Button addActionMapButton => rootElement?.Q<Button>("add-new-action-map-button");
 
         public override void RedrawUI(ViewState viewState)
         {
@@ -79,7 +78,7 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void DestroyView()
         {
-            addActionMapButton.clicked -= AddActionMap;
+            m_AddActionMapButton.clicked -= AddActionMap;
         }
 
         private void RenameNewActionMaps()
@@ -181,7 +180,8 @@ namespace UnityEngine.InputSystem.Editor
 
         private readonly CollectionViewSelectionChangeFilter m_ListViewSelectionChangeFilter;
         private bool m_EnterRenamingMode;
-        private ListView m_ListView;
+        private readonly ListView m_ListView;
+        private readonly Button m_AddActionMapButton;
 
         internal class ViewState
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
@@ -10,13 +10,11 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class ActionPropertiesView : ViewBase<(SerializedInputAction?, List<string>)>
     {
-        private readonly VisualElement m_Root;
         private readonly Foldout m_ParentFoldout;
 
         public ActionPropertiesView(VisualElement root, Foldout foldout, StateContainer stateContainer)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
             m_ParentFoldout = foldout;
 
             // TODO: Consider IEquatable<T> and how to compare selector data
@@ -37,7 +35,7 @@ namespace UnityEngine.InputSystem.Editor
             m_ParentFoldout.text = "Action";
             var inputAction = viewState.Item1.Value;
 
-            m_Root.Clear();
+            rootElement.Clear();
 
             var actionType = new EnumField("Action Type", inputAction.type)
             {
@@ -47,7 +45,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Dispatch(Commands.ChangeActionType(inputAction, (InputActionType)evt.newValue));
             });
-            m_Root.Add(actionType);
+            rootElement.Add(actionType);
 
             if (inputAction.type != InputActionType.Button)
             {
@@ -65,7 +63,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     Dispatch(Commands.ChangeActionControlType(inputAction, controlType.index));
                 });
-                m_Root.Add(controlType);
+                rootElement.Add(controlType);
             }
 
             if (inputAction.type != InputActionType.Value)
@@ -79,7 +77,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     Dispatch(Commands.ChangeInitialStateCheck(inputAction, evt.newValue));
                 });
-                m_Root.Add(initialStateCheck);
+                rootElement.Add(initialStateCheck);
             }
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -29,9 +29,9 @@ namespace UnityEngine.InputSystem.Editor
         public ActionsTreeView(VisualElement root, StateContainer stateContainer)
             : base(root, stateContainer)
         {
-            m_AddActionButton = rootElement.Q<Button>("add-new-action-button");
-            m_PropertiesScrollview = rootElement.Q<ScrollView>("properties-scrollview");
-            m_ActionsTreeView = rootElement.Q<TreeView>("actions-tree-view");
+            m_AddActionButton = root.Q<Button>("add-new-action-button");
+            m_PropertiesScrollview = root.Q<ScrollView>("properties-scrollview");
+            m_ActionsTreeView = root.Q<TreeView>("actions-tree-view");
             //assign unique viewDataKey to store treeView states like expanded/collapsed items - make it unique to avoid conflicts with other TreeViews
             m_ActionsTreeView.viewDataKey = "InputActionTreeView " + stateContainer.GetState().serializedObject.targetObject.GetInstanceID();
             m_GuidToTreeViewId = new Dictionary<Guid, int>();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -193,6 +193,13 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void RedrawUI(ViewState viewState)
         {
+            // It's possible for RedrawUI to be called when m_Root is empty, throwing errors in the console.
+            // This can happen when the view is discarded immediately after being loaded, i.e. jumping to the input settings
+            // page in Preferences when the last window shown there was the main view, which the editor (briefly) loads first.
+            // Compare against the number of m_ChildViews as a cheap way to know we should skip redrawing. (ISX-1721)
+            if (m_Root.childCount != ChildViewCount())
+                return;
+
             m_ActionsTreeView.Clear();
             m_ActionsTreeView.SetRootItems(viewState.treeViewData);
             m_ActionsTreeView.Rebuild();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -203,7 +203,7 @@ namespace UnityEngine.InputSystem.Editor
             m_AddActionButton.SetEnabled(viewState.actionMapCount > 0);
 
             // Don't want to show action properties if there's no actions.
-            m_Root.Q<VisualElement>("properties-scrollview").visible = m_ActionsTreeView.GetTreeCount() > 0;
+            rootElement.Q<VisualElement>("properties-scrollview").visible = m_ActionsTreeView.GetTreeCount() > 0;
         }
 
         private void RenameNewAction(int id)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
     {
         private readonly TreeView m_ActionsTreeView;
         private readonly Button m_AddActionButton;
+        private readonly ScrollView m_PropertiesScrollview;
 
         private bool m_RenameOnActionAdded;
         private readonly CollectionViewSelectionChangeFilter m_ActionsTreeViewSelectionChangeFilter;
@@ -29,6 +30,7 @@ namespace UnityEngine.InputSystem.Editor
             : base(root, stateContainer)
         {
             m_AddActionButton = rootElement.Q<Button>("add-new-action-button");
+            m_PropertiesScrollview = rootElement.Q<ScrollView>("properties-scrollview");
             m_ActionsTreeView = rootElement.Q<TreeView>("actions-tree-view");
             //assign unique viewDataKey to store treeView states like expanded/collapsed items - make it unique to avoid conflicts with other TreeViews
             m_ActionsTreeView.viewDataKey = "InputActionTreeView " + stateContainer.GetState().serializedObject.targetObject.GetInstanceID();
@@ -203,7 +205,7 @@ namespace UnityEngine.InputSystem.Editor
             m_AddActionButton.SetEnabled(viewState.actionMapCount > 0);
 
             // Don't want to show action properties if there's no actions.
-            rootElement.Q<VisualElement>("properties-scrollview").visible = m_ActionsTreeView.GetTreeCount() > 0;
+            m_PropertiesScrollview.visible = m_ActionsTreeView.GetTreeCount() > 0;
         }
 
         private void RenameNewAction(int id)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/BindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/BindingPropertiesView.cs
@@ -7,15 +7,13 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class BindingPropertiesView : ViewBase<BindingPropertiesView.ViewState>
     {
-        private readonly VisualElement m_Root;
         private readonly Foldout m_ParentFoldout;
         private CompositeBindingPropertiesView m_CompositeBindingPropertiesView;
         private CompositePartBindingPropertiesView m_CompositePartBindingPropertiesView;
 
         public BindingPropertiesView(VisualElement root, Foldout foldout, StateContainer stateContainer)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
             m_ParentFoldout = foldout;
 
             CreateSelector(state => state.selectedBindingIndex,
@@ -37,7 +35,7 @@ namespace UnityEngine.InputSystem.Editor
             if (selectedBindingIndex == -1)
                 return;
 
-            m_Root.Clear();
+            rootElement.Clear();
 
             var binding = viewState.selectedBinding;
             if (!binding.HasValue)
@@ -47,11 +45,11 @@ namespace UnityEngine.InputSystem.Editor
             if (binding.Value.isComposite)
             {
                 m_ParentFoldout.text = "Composite";
-                m_CompositeBindingPropertiesView = CreateChildView(new CompositeBindingPropertiesView(m_Root, stateContainer));
+                m_CompositeBindingPropertiesView = CreateChildView(new CompositeBindingPropertiesView(rootElement, stateContainer));
             }
             else if (binding.Value.isPartOfComposite)
             {
-                m_CompositePartBindingPropertiesView = CreateChildView(new CompositePartBindingPropertiesView(m_Root, stateContainer));
+                m_CompositePartBindingPropertiesView = CreateChildView(new CompositePartBindingPropertiesView(rootElement, stateContainer));
                 DrawControlSchemeToggles(viewState, binding.Value);
             }
             else
@@ -64,7 +62,7 @@ namespace UnityEngine.InputSystem.Editor
                 controlPathEditor.SetExpectedControlLayout(inputAction?.expectedControlType ?? "");
 
                 var controlPathContainer = new IMGUIContainer(controlPathEditor.OnGUI);
-                m_Root.Add(controlPathContainer);
+                rootElement.Add(controlPathContainer);
 
                 DrawControlSchemeToggles(viewState, binding.Value);
             }
@@ -81,7 +79,7 @@ namespace UnityEngine.InputSystem.Editor
             if (!viewState.controlSchemes.Any()) return;
 
             var useInControlSchemeLabel = new Label("Use in control scheme");
-            m_Root.Add(useInControlSchemeLabel);
+            rootElement.Add(useInControlSchemeLabel);
 
             foreach (var controlScheme in viewState.controlSchemes)
             {
@@ -89,7 +87,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     value = binding.controlSchemes.Any(scheme => controlScheme.name == scheme)
                 };
-                m_Root.Add(checkbox);
+                rootElement.Add(checkbox);
                 checkbox.RegisterValueChangedCallback(changeEvent =>
                 {
                     Dispatch(ControlSchemeCommands.ChangeSelectedBindingsControlSchemes(controlScheme.name, changeEvent.newValue));

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositeBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositeBindingPropertiesView.cs
@@ -11,7 +11,6 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class CompositeBindingPropertiesView : ViewBase<CompositeBindingPropertiesView.ViewState>
     {
-        private readonly VisualElement m_Root;
         private readonly DropdownField m_CompositeTypeField;
         private EventCallback<ChangeEvent<string>> m_CompositeTypeFieldChangedHandler;
 
@@ -20,12 +19,11 @@ namespace UnityEngine.InputSystem.Editor
             InputActionsEditorConstants.CompositeBindingPropertiesViewUxml;
 
         public CompositeBindingPropertiesView(VisualElement root, StateContainer stateContainer)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
             var visualTreeAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UxmlName);
             var container = visualTreeAsset.CloneTree();
-            m_Root.Add(container);
+            rootElement.Add(container);
 
             m_CompositeTypeField = container.Q<DropdownField>("composite-type-dropdown");
 
@@ -46,7 +44,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Dispatch(Commands.UpdatePathNameAndValues(viewState.parameterListView.GetParameters(), viewState.selectedBindingPath));
             };
-            viewState.parameterListView.OnDrawVisualElements(m_Root);
+            viewState.parameterListView.OnDrawVisualElements(rootElement);
         }
 
         public override void DestroyView()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositePartBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositePartBindingPropertiesView.cs
@@ -9,7 +9,6 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class CompositePartBindingPropertiesView : ViewBase<CompositePartBindingPropertiesView.ViewState>
     {
-        private readonly VisualElement m_Root;
         private readonly DropdownField m_CompositePartField;
         private readonly IMGUIContainer m_PathEditorContainer;
 
@@ -18,12 +17,11 @@ namespace UnityEngine.InputSystem.Editor
             InputActionsEditorConstants.CompositePartBindingPropertiesViewUxml;
 
         public CompositePartBindingPropertiesView(VisualElement root, StateContainer stateContainer)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
             var visualTreeAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(UxmlName);
             var container = visualTreeAsset.CloneTree();
-            m_Root.Add(container);
+            rootElement.Add(container);
 
             m_PathEditorContainer = container.Q<IMGUIContainer>("path-editor-container");
             m_CompositePartField = container.Q<DropdownField>("composite-part-dropdown");

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -48,7 +48,7 @@ namespace UnityEngine.InputSystem.Editor
             };
             popupWindow.contentContainer.Add(controlSchemeVisualElement);
             m_ModalWindow.Add(popupWindow);
-            rootElement.Add(m_ModalWindow);
+            root.Add(m_ModalWindow);
             m_ModalWindow.StretchToParentSize();
             m_ModalWindow.RegisterCallback<ClickEvent>(evt => Close());
             popupWindow.RegisterCallback<ClickEvent>(evt => evt.StopPropagation());

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -15,9 +15,8 @@ namespace UnityEngine.InputSystem.Editor
         public event Action<ViewBase<InputControlScheme>> OnClosing;
 
         public ControlSchemesView(VisualElement root, StateContainer stateContainer, bool updateExisting = false)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
             m_UpdateExisting = updateExisting;
 
             var controlSchemeEditor = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(
@@ -49,7 +48,7 @@ namespace UnityEngine.InputSystem.Editor
             };
             popupWindow.contentContainer.Add(controlSchemeVisualElement);
             m_ModalWindow.Add(popupWindow);
-            m_Root.Add(m_ModalWindow);
+            rootElement.Add(m_ModalWindow);
             m_ModalWindow.StretchToParentSize();
             m_ModalWindow.RegisterCallback<ClickEvent>(evt => Close());
             popupWindow.RegisterCallback<ClickEvent>(evt => evt.StopPropagation());
@@ -96,7 +95,7 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void RedrawUI(InputControlScheme viewState)
         {
-            m_Root.Q<TextField>(kControlSchemeNameTextField).value = viewState.name;
+            rootElement.Q<TextField>(kControlSchemeNameTextField).value = viewState.name;
 
             m_ListView.itemsSource?.Clear();
             m_ListView.itemsSource = viewState.deviceRequirements.Count > 0 ?
@@ -161,7 +160,6 @@ namespace UnityEngine.InputSystem.Editor
             ((Label)visualElement).text = (((string, bool))m_ListView.itemsSource[rowIndex]).Item1;
         }
 
-        private readonly VisualElement m_Root;
         private readonly bool m_UpdateExisting;
         private MultiColumnListView m_ListView;
         private VisualElement m_ModalWindow;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -14,45 +14,43 @@ namespace UnityEngine.InputSystem.Editor
         private const string autoSaveToggleId = "auto-save-toolbar-toggle";
         private const string menuButtonId = "asset-menu";
 
+        private readonly ToolbarMenu m_MenuButtonToolbar;
+        private readonly ToolbarButton m_SaveButton;
+
         internal Action postSaveAction;
         internal Action<InputActionAsset> postResetAction;
 
         public InputActionsEditorView(VisualElement root, StateContainer stateContainer)
             : base(root, stateContainer)
         {
-            BuildUI();
-        }
-
-        public void BuildUI()
-        {
             var mainEditorAsset = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(
                 InputActionsEditorConstants.PackagePath +
                 InputActionsEditorConstants.ResourcesPath +
                 InputActionsEditorConstants.MainEditorViewNameUxml);
 
-            mainEditorAsset.CloneTree(rootElement);
-            var actionsTreeView = new ActionsTreeView(rootElement, stateContainer);
-            CreateChildView(new ActionMapsView(rootElement, stateContainer));
+            mainEditorAsset.CloneTree(root);
+            var actionsTreeView = new ActionsTreeView(root, stateContainer);
+            CreateChildView(new ActionMapsView(root, stateContainer));
             CreateChildView(actionsTreeView);
-            CreateChildView(new PropertiesView(rootElement, stateContainer));
-            InputActionViewsControlsHolder.Initialize(rootElement, actionsTreeView);
+            CreateChildView(new PropertiesView(root, stateContainer));
+            InputActionViewsControlsHolder.Initialize(root, actionsTreeView);
 
-            var menuButton = rootElement.Q<ToolbarMenu>("control-schemes-toolbar-menu");
-            menuButton.menu.AppendAction("Add Control Scheme...", _ => AddOrUpdateControlScheme(rootElement));
-            menuButton.menu.AppendAction("Edit Control Scheme...", _ => AddOrUpdateControlScheme(rootElement, true), DropdownMenuAction.Status.Disabled);
-            menuButton.menu.AppendAction("Duplicate Control Scheme...", _ => DuplicateControlScheme(rootElement), DropdownMenuAction.Status.Disabled);
-            menuButton.menu.AppendAction("Delete Control Scheme...", DeleteControlScheme, DropdownMenuAction.Status.Disabled);
+            m_MenuButtonToolbar = root.Q<ToolbarMenu>("control-schemes-toolbar-menu");
+            m_MenuButtonToolbar.menu.AppendAction("Add Control Scheme...", _ => AddOrUpdateControlScheme(root));
+            m_MenuButtonToolbar.menu.AppendAction("Edit Control Scheme...", _ => AddOrUpdateControlScheme(root, true), DropdownMenuAction.Status.Disabled);
+            m_MenuButtonToolbar.menu.AppendAction("Duplicate Control Scheme...", _ => DuplicateControlScheme(root), DropdownMenuAction.Status.Disabled);
+            m_MenuButtonToolbar.menu.AppendAction("Delete Control Scheme...", DeleteControlScheme, DropdownMenuAction.Status.Disabled);
 
-            var saveButton = rootElement.Q<ToolbarButton>(name: saveButtonId);
-            saveButton.SetEnabled(InputEditorUserSettings.autoSaveInputActionAssets == false);
-            saveButton.clicked += OnSaveButton;
+            m_SaveButton = root.Q<ToolbarButton>(name: saveButtonId);
+            m_SaveButton.SetEnabled(InputEditorUserSettings.autoSaveInputActionAssets == false);
+            m_SaveButton.clicked += OnSaveButton;
 
-            var autoSaveToggle = rootElement.Q<ToolbarToggle>(name: autoSaveToggleId);
+            var autoSaveToggle = root.Q<ToolbarToggle>(name: autoSaveToggleId);
             autoSaveToggle.value = InputEditorUserSettings.autoSaveInputActionAssets;
             autoSaveToggle.RegisterValueChangedCallback(OnAutoSaveToggle);
 
 
-            var assetMenuButton = rootElement.Q<VisualElement>(name: menuButtonId);
+            var assetMenuButton = root.Q<VisualElement>(name: menuButtonId);
             var isGlobalAsset = stateContainer.GetState().serializedObject.targetObject.name == "ProjectWideInputActions";
             assetMenuButton.visible = isGlobalAsset;
             assetMenuButton.AddToClassList(EditorGUIUtility.isProSkin ? "asset-menu-button-dark-theme" : "asset-menu-button");
@@ -87,7 +85,7 @@ namespace UnityEngine.InputSystem.Editor
             // Don't let focus linger after clicking (ISX-1482). Ideally this would be only applied on mouse click,
             // rather than if the user is using tab to navigate UI, but there doesn't seem to be a way to differentiate
             // between those interactions at the moment.
-            rootElement.Q<ToolbarButton>(name: saveButtonId).Blur();
+            m_SaveButton.Blur();
         }
 
         private void OnAutoSaveToggle(ChangeEvent<bool> evt)
@@ -97,33 +95,31 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void RedrawUI(ViewState viewState)
         {
-            var toolbarMenu = rootElement.Q<ToolbarMenu>("control-schemes-toolbar-menu");
-            toolbarMenu.menu.MenuItems().Clear();
+            m_MenuButtonToolbar.menu.MenuItems().Clear();
 
             if (viewState.controlSchemes.Any())
             {
-                toolbarMenu.text = viewState.selectedControlSchemeIndex == -1
+                m_MenuButtonToolbar.text = viewState.selectedControlSchemeIndex == -1
                     ? "All Control Schemes"
                     : viewState.controlSchemes.ElementAt(viewState.selectedControlSchemeIndex).name;
 
-                toolbarMenu.menu.AppendAction("All Control Schemes", _ => SelectControlScheme(-1),
+                m_MenuButtonToolbar.menu.AppendAction("All Control Schemes", _ => SelectControlScheme(-1),
                     viewState.selectedControlSchemeIndex == -1 ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
                 viewState.controlSchemes.ForEach((scheme, i) =>
-                    toolbarMenu.menu.AppendAction(scheme.name, _ => SelectControlScheme(i),
+                    m_MenuButtonToolbar.menu.AppendAction(scheme.name, _ => SelectControlScheme(i),
                         viewState.selectedControlSchemeIndex == i ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal));
-                toolbarMenu.menu.AppendSeparator();
+                m_MenuButtonToolbar.menu.AppendSeparator();
             }
 
-            toolbarMenu.menu.AppendAction("Add Control Scheme...", _ => AddOrUpdateControlScheme(rootElement));
-            toolbarMenu.menu.AppendAction("Edit Control Scheme...", _ => AddOrUpdateControlScheme(rootElement, true),
+            m_MenuButtonToolbar.menu.AppendAction("Add Control Scheme...", _ => AddOrUpdateControlScheme(rootElement));
+            m_MenuButtonToolbar.menu.AppendAction("Edit Control Scheme...", _ => AddOrUpdateControlScheme(rootElement, true),
                 viewState.selectedControlSchemeIndex != -1 ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
-            toolbarMenu.menu.AppendAction("Duplicate Control Scheme...", _ => DuplicateControlScheme(rootElement),
+            m_MenuButtonToolbar.menu.AppendAction("Duplicate Control Scheme...", _ => DuplicateControlScheme(rootElement),
                 viewState.selectedControlSchemeIndex != -1 ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
-            toolbarMenu.menu.AppendAction("Delete Control Scheme...", DeleteControlScheme,
+            m_MenuButtonToolbar.menu.AppendAction("Delete Control Scheme...", DeleteControlScheme,
                 viewState.selectedControlSchemeIndex != -1 ? DropdownMenuAction.Status.Normal : DropdownMenuAction.Status.Disabled);
 
-            var saveButton = rootElement.Q<ToolbarButton>(name: saveButtonId);
-            saveButton.SetEnabled(InputEditorUserSettings.autoSaveInputActionAssets == false);
+            m_SaveButton.SetEnabled(InputEditorUserSettings.autoSaveInputActionAssets == false);
         }
 
         private void AddOrUpdateControlScheme(VisualElement parent, bool updateExisting = false)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -98,6 +98,13 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void RedrawUI(ViewState viewState)
         {
+            // It's possible for RedrawUI to be called when m_Root is empty, throwing errors in the console.
+            // This can happen when the view is discarded immediately after being loaded, i.e. jumping to the input settings
+            // page in Preferences when the last window shown there was the main view, which the editor (briefly) loads first.
+            // Compare against the number of m_ChildViews as a cheap way to know we should skip redrawing. (ISX-1721)
+            if (m_Root.childCount != ChildViewCount())
+                return;
+
             var toolbarMenu = m_Root.Q<ToolbarMenu>("control-schemes-toolbar-menu");
             toolbarMenu.menu.MenuItems().Clear();
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -13,6 +13,7 @@ namespace UnityEngine.InputSystem.Editor
     {
         private readonly Func<InputActionsEditorState, IEnumerable<ParameterListView>> m_ParameterListViewSelector;
         private VisualElement m_ContentContainer;
+        private readonly Label m_NoParamsLabel;
 
         private SerializedProperty m_ListProperty;
 
@@ -21,6 +22,7 @@ namespace UnityEngine.InputSystem.Editor
             : base(root, stateContainer)
         {
             m_ListProperty = listProperty;
+            m_NoParamsLabel = root.Q<Label>("no-parameters-added-label");
             m_ParameterListViewSelector = parameterListViewSelector;
 
             CreateSelector(state => state);
@@ -99,11 +101,11 @@ namespace UnityEngine.InputSystem.Editor
             var parameterListViews = m_ParameterListViewSelector(state).ToList();
             if (parameterListViews.Count == 0)
             {
-                rootElement.Q<Label>("no-parameters-added-label").style.display = new StyleEnum<DisplayStyle>(DisplayStyle.Flex);
+                m_NoParamsLabel.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.Flex);
                 return;
             }
 
-            rootElement.Q<Label>("no-parameters-added-label").style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
+            m_NoParamsLabel.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
             m_ContentContainer.Clear();
             for (int i = 0; i < parameterListViews.Count; i++)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -11,7 +11,6 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class NameAndParametersListView : ViewBase<InputActionsEditorState>
     {
-        private readonly VisualElement m_Root;
         private readonly Func<InputActionsEditorState, IEnumerable<ParameterListView>> m_ParameterListViewSelector;
         private VisualElement m_ContentContainer;
 
@@ -19,9 +18,8 @@ namespace UnityEngine.InputSystem.Editor
 
         public NameAndParametersListView(VisualElement root, StateContainer stateContainer, SerializedProperty listProperty,
                                          Func<InputActionsEditorState, IEnumerable<ParameterListView>> parameterListViewSelector)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
             m_ListProperty = listProperty;
             m_ParameterListViewSelector = parameterListViewSelector;
 
@@ -93,19 +91,19 @@ namespace UnityEngine.InputSystem.Editor
         public override void RedrawUI(InputActionsEditorState state)
         {
             if (m_ContentContainer != null)
-                m_Root.Remove(m_ContentContainer);
+                rootElement.Remove(m_ContentContainer);
 
             m_ContentContainer = new VisualElement();
-            m_Root.Add(m_ContentContainer);
+            rootElement.Add(m_ContentContainer);
 
             var parameterListViews = m_ParameterListViewSelector(state).ToList();
             if (parameterListViews.Count == 0)
             {
-                m_Root.Q<Label>("no-parameters-added-label").style.display = new StyleEnum<DisplayStyle>(DisplayStyle.Flex);
+                rootElement.Q<Label>("no-parameters-added-label").style.display = new StyleEnum<DisplayStyle>(DisplayStyle.Flex);
                 return;
             }
 
-            m_Root.Q<Label>("no-parameters-added-label").style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
+            rootElement.Q<Label>("no-parameters-added-label").style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
             m_ContentContainer.Clear();
             for (int i = 0; i < parameterListViews.Count; i++)
             {
@@ -127,7 +125,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (m_ContentContainer != null)
             {
-                m_Root.Remove(m_ContentContainer);
+                rootElement.Remove(m_ContentContainer);
                 m_ContentContainer = null;
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/PropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/PropertiesView.cs
@@ -8,23 +8,20 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class PropertiesView : ViewBase<PropertiesView.ViewState>
     {
-        private readonly VisualElement m_Root;
         private ActionPropertiesView m_ActionPropertyView;
         private BindingPropertiesView m_BindingPropertyView;
         private NameAndParametersListView m_InteractionsListView;
         private NameAndParametersListView m_ProcessorsListView;
 
-        private Foldout interactionsFoldout => m_Root.Q<Foldout>("interactions-foldout");
-        private Foldout processorsFoldout => m_Root.Q<Foldout>("processors-foldout");
+        private Foldout interactionsFoldout => rootElement.Q<Foldout>("interactions-foldout");
+        private Foldout processorsFoldout => rootElement.Q<Foldout>("processors-foldout");
 
         private TextElement addInteractionButton;
         private TextElement addProcessorButton;
 
         public PropertiesView(VisualElement root, StateContainer stateContainer)
-            : base(stateContainer)
+            : base(root, stateContainer)
         {
-            m_Root = root;
-
             CreateSelector(
                 Selectors.GetSelectedAction,
                 Selectors.GetSelectedBinding,
@@ -130,7 +127,7 @@ namespace UnityEngine.InputSystem.Editor
             DestroyChildView(m_InteractionsListView);
             DestroyChildView(m_ProcessorsListView);
 
-            var propertiesContainer = m_Root.Q<VisualElement>("properties-container");
+            var propertiesContainer = rootElement.Q<VisualElement>("properties-container");
 
             var foldout = propertiesContainer.Q<Foldout>("properties-foldout");
             foldout.Clear();
@@ -145,12 +142,12 @@ namespace UnityEngine.InputSystem.Editor
             switch (viewState.selectionType)
             {
                 case SelectionType.Action:
-                    m_Root.Q<Label>("properties-header-label").text = "Action Properties";
+                    rootElement.Q<Label>("properties-header-label").text = "Action Properties";
                     m_ActionPropertyView = CreateChildView(new ActionPropertiesView(visualElement, foldout, stateContainer));
                     break;
 
                 case SelectionType.Binding:
-                    m_Root.Q<Label>("properties-header-label").text = "Binding Properties";
+                    rootElement.Q<Label>("properties-header-label").text = "Binding Properties";
                     m_BindingPropertyView = CreateChildView(new BindingPropertiesView(visualElement, foldout, stateContainer));
                     inputAction = viewState.relatedInputAction;
                     inputActionOrBinding = viewState.inputBinding?.wrappedProperty;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -19,8 +19,9 @@ namespace UnityEngine.InputSystem.Editor
 
     internal abstract class ViewBase<TViewState> : IView
     {
-        protected ViewBase(StateContainer stateContainer)
+        protected ViewBase(VisualElement root, StateContainer stateContainer)
         {
+            this.rootElement = root;
             this.stateContainer = stateContainer;
             m_ChildViews = new List<IView>();
         }
@@ -40,7 +41,14 @@ namespace UnityEngine.InputSystem.Editor
                 return;
             }
 
-            if (m_ViewStateSelector.HasStateChanged(state) || m_IsFirstUpdate)
+
+            // It's possible for RedrawUI to be called when rootElement is empty, throwing errors in the console.
+            // This can happen when the view is discarded immediately after being loaded, i.e. jumping to the input settings
+            // page in Preferences when the last window shown there was the main view, which the editor (briefly) loads first.
+            // Compare against the number of m_ChildViews as a cheap way to know we should skip redrawing. (ISX-1721)
+            var correctChildren = rootElement.childCount >= m_ChildViews.Count;
+
+            if (correctChildren && (m_ViewStateSelector.HasStateChanged(state) || m_IsFirstUpdate))
                 RedrawUI(m_ViewStateSelector.GetViewState(state));
 
             m_IsFirstUpdate = false;
@@ -63,11 +71,6 @@ namespace UnityEngine.InputSystem.Editor
 
             m_ChildViews.Remove(view);
             view.DestroyView();
-        }
-
-        public int ChildViewCount()
-        {
-            return m_ChildViews.Count;
         }
 
         public void Dispatch(Command command)
@@ -114,6 +117,7 @@ namespace UnityEngine.InputSystem.Editor
             m_ViewStateSelector = new ViewStateSelector<T1, T2, T3, TViewState>(func1, func2, func3, selector);
         }
 
+        protected readonly VisualElement rootElement;
         protected readonly StateContainer stateContainer;
         protected IViewStateSelector<TViewState> ViewStateSelector => m_ViewStateSelector;
         private IViewStateSelector<TViewState> m_ViewStateSelector;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -65,6 +65,11 @@ namespace UnityEngine.InputSystem.Editor
             view.DestroyView();
         }
 
+        public int ChildViewCount()
+        {
+            return m_ChildViews.Count;
+        }
+
         public void Dispatch(Command command)
         {
             stateContainer.Dispatch(command);


### PR DESCRIPTION
### Description

It's possible for RedrawUI to be called when m_Root is empty, throwing errors in the console.
This can happen when the view is discarded immediately after being loaded, i.e. jumping to the input settings
page in Preferences when the last window shown there was the main view, which the editor (briefly) loads first. ([ISX-1721](https://jira.unity3d.com/browse/ISX-1721))

### Changes made

Compare against the number of m_ChildViews as a cheap way to know we should skip redrawing.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
