### PR TITLE
Change Max Player Count error type to warning - ISXB-719

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - From 2023.2 forward: UI toolkit now uses the "UI" action map of project-wide actions as their default input actions. Previously, the actions were hardcoded and were based on `DefaultInputActions` asset which didn't allow user changes. Also, removing bindings or renaming the 'UI' action map of project wide actions will break UI input for UI toolkit.
+- Changed the 'Max player count reached' error to a warning instead.
 
 ### Added
 - Added new methods and properties to [`InputAction`](xref:UnityEngine.InputSystem.InputAction):

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -501,7 +501,7 @@ namespace UnityEngine.InputSystem
 
             if (m_MaxPlayerCount >= 0 && playerCount >= m_MaxPlayerCount)
             {
-                Debug.LogWarning("Have reached maximum player count of " + maxPlayerCount, this);
+                Debug.LogWarning("Maximum number of supported players reached: " + maxPlayerCount, this);
                 return false;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputManager.cs
@@ -501,7 +501,7 @@ namespace UnityEngine.InputSystem
 
             if (m_MaxPlayerCount >= 0 && playerCount >= m_MaxPlayerCount)
             {
-                Debug.LogError("Have reached maximum player count of " + maxPlayerCount, this);
+                Debug.LogWarning("Have reached maximum player count of " + maxPlayerCount, this);
                 return false;
             }
 


### PR DESCRIPTION
### Description

Changed the error type to warning, I agreed with the user report that from our own descriptions (https://www.foundations.unity.com/patterns/errors-and-messaging#Message-Types) the warning type is more fitting. But feel free to disagree if there's a good reason this is an error, will close it

### Changes made

_Please write down a short description of what changes were made._

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
