### PR TITLE
FIX: Properly reset ActionMap state in OnAfterDeserialize (ISXB-737)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -39,6 +39,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "Listen" functionality for selecting an input sometimes expecting the wrong input type.
 - Fixed console errors that can be produced when opening input package settings from the Inspector.
 - Fixed InputManager.asset file growing in size on each Reset call.
+- Fixed Opening InputDebugger throws 'Action map must have state at this point' error
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -1984,6 +1984,7 @@ namespace UnityEngine.InputSystem
         {
             m_State = null;
             m_MapIndexInState = InputActionState.kInvalidIndex;
+            m_EnabledActionsCount = 0;
 
             // Restore references of actions linking back to us.
             if (m_Actions != null)


### PR DESCRIPTION
### Description

Simple fix for [ISXB-737](https://jira.unity3d.com/browse/ISXB-737) and [ISX-1861](https://jira.unity3d.com/browse/ISX-1861).

### Changes made

The `m_EnabledActionsCount = 0` is used to determine if the ActionMap is "enabled" but wasn't being reset within `OnAfterDeserialize()`. This caused the ActionMap to fall into a bad state: it was effectively disabled but calling `Enable()` would early out because `m_EnabledActionsCount` indicated it was still enabled. Setting this field 0 along with nulling `m_State` fixes the bug.

### Notes

This issue only seems to occur when importing the InputSystem package; this code path isn't hit when opening a project that already has InputSystem imported. Currently this bug doesn't cause any (visible) problems, since the domain reload when entering PlayMode wipes out the bad state, but Project Wide Actions and Fast Enter PlayMode are now exposing the problem.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
