### PR TITLE
FIX: Input Action file is marked as dirty when opening after renaming it (ISXB-749)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -743,6 +743,73 @@ partial class CoreTests
         Assert.That(map.bindings[0].groups, Is.EqualTo(""));
     }
 
+    struct AssetFileTestConstants
+    {
+        public const string kOriginalAssetName = "zzMyInputActions";
+        public const string kOriginalDirectory = "zzStartingDirectory";
+
+        public const string kNewAssetName = "NEWactions";
+        public const string kNewDirectory = "NewDirectory";
+
+        public const string kOriginalAssetPath = "Assets/" + kOriginalDirectory + "/" + kOriginalAssetName + "." + InputActionAsset.Extension;
+        public const string kOriginalAssetContents = "{\"name\": \"" + kOriginalAssetName + "\",\"maps\": [],\"controlSchemes\": []}";
+    }
+
+    [Test]
+    [TestCase("Assets/" + AssetFileTestConstants.kOriginalDirectory + "/" + AssetFileTestConstants.kNewAssetName + "." + InputActionAsset.Extension, AssetFileTestConstants.kNewAssetName, false)]      // Move - Same directory but new filename - expect changed name
+    [TestCase("Assets/" + AssetFileTestConstants.kNewDirectory + "/" + AssetFileTestConstants.kNewAssetName + "." + InputActionAsset.Extension, AssetFileTestConstants.kNewAssetName, false)]           // Move - New directory and new filename - expect changed name
+    [TestCase("Assets/" + AssetFileTestConstants.kNewDirectory + "/" + AssetFileTestConstants.kOriginalAssetName + "." + InputActionAsset.Extension, AssetFileTestConstants.kOriginalAssetName, false)] // Move - New directory but same filename - expect original name
+    [TestCase("Assets/" + AssetFileTestConstants.kOriginalDirectory + "/" + AssetFileTestConstants.kNewAssetName + "." + InputActionAsset.Extension, AssetFileTestConstants.kNewAssetName, true)]       // Copy - Same directory but new filename - expect changed name
+    [TestCase("Assets/" + AssetFileTestConstants.kNewDirectory + "/" + AssetFileTestConstants.kNewAssetName + "." + InputActionAsset.Extension, AssetFileTestConstants.kNewAssetName, true)]            // Copy - New directory and new filename - expect changed name
+    [TestCase("Assets/" + AssetFileTestConstants.kNewDirectory + "/" + AssetFileTestConstants.kOriginalAssetName + "." + InputActionAsset.Extension, AssetFileTestConstants.kOriginalAssetName, true)]  // Copy - New directory but same filename - expect original name
+    [Category("Editor")]
+    public void Editor_InputActions_AssetFileUpdatedAfterMoveOrCopy(string newAssetPath, string expectedAssetName, bool executeCopy)
+    {
+        try
+        {
+            AssetDatabase.CreateFolder("Assets", AssetFileTestConstants.kOriginalDirectory);
+            AssetDatabase.CreateFolder("Assets", AssetFileTestConstants.kNewDirectory);
+
+            File.WriteAllText(AssetFileTestConstants.kOriginalAssetPath, AssetFileTestConstants.kOriginalAssetContents);
+            AssetDatabase.ImportAsset(AssetFileTestConstants.kOriginalAssetPath);
+
+            var asset = AssetDatabase.LoadAssetAtPath<InputActionAsset>(AssetFileTestConstants.kOriginalAssetPath);
+            Assert.NotNull(asset, "Could not load asset: " + AssetFileTestConstants.kOriginalAssetPath);
+
+            try
+            {
+                if (executeCopy)
+                {
+                    AssetDatabase.CopyAsset(AssetFileTestConstants.kOriginalAssetPath, newAssetPath);
+                    AssetDatabase.Refresh();
+                }
+                else AssetDatabase.MoveAsset(AssetFileTestConstants.kOriginalAssetPath, newAssetPath);
+
+                var newAsset = ScriptableObject.CreateInstance<InputActionAsset>();
+                var fileContents = File.ReadAllText(newAssetPath);
+                newAsset.LoadFromJson(fileContents);
+
+                Assert.That(newAsset.name, Is.EqualTo(expectedAssetName));
+            }
+            finally
+            {
+                AssetDatabase.DeleteAsset(AssetFileTestConstants.kOriginalAssetPath);
+                AssetDatabase.DeleteAsset(newAssetPath);
+            }
+        }
+        finally
+        {
+            const string kOriginalPath = "Assets/" + AssetFileTestConstants.kOriginalDirectory;
+            const string kNewPath = "Assets/" + AssetFileTestConstants.kNewDirectory;
+
+            FileUtil.DeleteFileOrDirectory(kOriginalPath);
+            FileUtil.DeleteFileOrDirectory(kOriginalPath + ".meta");
+            FileUtil.DeleteFileOrDirectory(kNewPath);
+            FileUtil.DeleteFileOrDirectory(kNewPath + ".meta");
+            AssetDatabase.Refresh();
+        }
+    }
+
     [Test]
     [Category("Editor")]
     public void Editor_InputActionAssetManager_CanMoveAssetOnDisk()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -44,6 +44,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Opening InputDebugger throws 'Action map must have state at this point' error
 - Fixed Cut/Paste behaviour to match Editor - Cut items will now be cleared from clipboard after pasting.
 - Fixed InputAction asset appearing dirty after rename [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-749)
+- Fixed Error logged when InputActionEditor window opened without a valid asset
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -43,6 +43,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed InputManager.asset file growing in size on each Reset call.
 - Fixed Opening InputDebugger throws 'Action map must have state at this point' error
 - Fixed Cut/Paste behaviour to match Editor - Cut items will now be cleared from clipboard after pasting.
+- Fixed InputAction asset appearing dirty after rename [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-749)
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -256,6 +256,74 @@ namespace UnityEngine.InputSystem.Editor
             ProjectWindowUtil.CreateAssetWithContent("New Controls." + InputActionAsset.Extension,
                 InputActionAsset.kDefaultAssetLayoutJson, InputActionAssetIconLoader.LoadAssetIcon());
         }
+
+        // When an action asset is renamed, copied, or moved in the Editor, the "Name" field in the JSON will
+        // hold the old name and won't match what's in memory (asset looks "dirty"). To work around this, we
+        // must flush the updated JSON to the file whenever this operation occurs.
+        // https://jira.unity3d.com/browse/ISXB-749
+        private class InputActionAssetPostprocessor : AssetPostprocessor
+        {
+            private static List<string> assetFilesNeedingRefresh;
+
+            private void OnPreprocessAsset()
+            {
+                var importer = assetImporter as InputActionImporter;
+                if (importer == null)
+                    return;
+
+                var newName = Path.GetFileNameWithoutExtension(assetPath);
+                var newAsset = ScriptableObject.CreateInstance<InputActionAsset>();
+                var newFileContents = File.ReadAllText(assetPath);
+
+                if (!string.IsNullOrEmpty(newFileContents))
+                {
+                    newAsset.LoadFromJson(newFileContents);
+
+                    // If the serialized Name doesn't match the actual filename this asset file for refresh.
+                    // NOTE: We can't change the file while Asset Importing is in progress.
+                    if (newAsset.name != newName)
+                    {
+                        if (assetFilesNeedingRefresh == null)
+                            assetFilesNeedingRefresh = new List<string>();
+
+                        assetFilesNeedingRefresh.Add(assetPath);
+                    }
+                }
+            }
+
+            private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+            {
+                if (assetFilesNeedingRefresh == null)
+                    return;
+
+                try
+                {
+                    foreach (var assetPath in assetFilesNeedingRefresh)
+                    {
+                        var newAsset = ScriptableObject.CreateInstance<InputActionAsset>();
+
+                        try
+                        {
+                            var fileContents = File.ReadAllText(assetPath);
+
+                            newAsset.LoadFromJson(fileContents);
+                            newAsset.name = Path.GetFileNameWithoutExtension(assetPath);
+                            File.WriteAllText(assetPath, newAsset.ToJson());
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.LogException(ex);
+                        }
+
+                        ScriptableObject.DestroyImmediate(newAsset);
+                    }
+                }
+                finally
+                {
+                    assetFilesNeedingRefresh = null;
+                }
+            }
+        }
     }
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -155,10 +155,20 @@ namespace UnityEngine.InputSystem.Editor
                 if (m_State.serializedObject == null)
                 {
                     var asset = GetAssetFromDatabase();
-                    m_AssetPath = AssetDatabase.GetAssetPath(asset);
-                    m_AssetJson = File.ReadAllText(m_AssetPath);
-                    var serializedAsset = new SerializedObject(asset);
-                    m_State = new InputActionsEditorState(m_State, serializedAsset);
+                    if (asset != null)
+                    {
+                        m_AssetPath = AssetDatabase.GetAssetPath(asset);
+                        m_AssetJson = File.ReadAllText(m_AssetPath);
+                        var serializedAsset = new SerializedObject(asset);
+                        m_State = new InputActionsEditorState(m_State, serializedAsset);
+                    }
+                    else
+                    {
+                        // Asset cannot be retrieved or doesn't exist anymore; abort opening the Window.
+                        Debug.LogWarning($"Failed to open InputActionAsset with GUID {m_AssetGUID}. The asset might have been deleted.");
+                        this.Close();
+                        return;
+                    }
                 }
 
                 BuildUI();


### PR DESCRIPTION
### Description

Fixes issue [ISXB-749](https://jira.unity3d.com/browse/ISXB-749) and also another bug [ISX-1874](https://jira.unity3d.com/browse/ISX-1874) I discovered along the way

### Changes made

Adds AssetPostprocessor handler that checks if the serialized "Name" field in the JSON (for the InputAction being imported) matches the in-memory name. If it doesn't match, then the proper name is written to the file. I discovered this bug also occurs if an InputAction asset is copied (not just renamed) and so a post-process handler was the best way to catch all the scenarios.

I added a new test to validate the asset file contents do indeed match the in memory name during these operations.

I also added a simple fix for another issue I encountered during my investigation: while opening the InputActionEditor window, checks if the target asset is valid. If not it immediately closes the window.

### Notes

Closing the InputActionEditor window from within the CreateGUI() handler will cause a minor visual artifact: it'll briefly display for a frame or two causing a "flash". Since this is such a minor corner-case, and I couldn't find a safe alternative, I figured this would be fine.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
