### PR TITLE
Renamed new 1.8.0-pre.3 method GetMagnitude to GetControlMagnitude to avoid confusion

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -3164,14 +3164,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Disabled));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0f));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         action.Enable();
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0f));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         Set(gamepad.leftTrigger, 0.123f);
 
@@ -3181,14 +3181,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.SameAs(gamepad.leftTrigger));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(expectedValue).Within(0.00001));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0.123f).Within(0.00001));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0.123f).Within(0.00001));
 
         Set(gamepad.leftTrigger, 0f);
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0f));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
     }
 
     [Test]
@@ -3202,14 +3202,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Disabled));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         action.Enable();
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         Set(gamepad.leftStick, new Vector2(0.123f, 0.234f));
 
@@ -3218,14 +3218,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.SameAs(gamepad.leftStick));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(expectedValue).Using(Vector2EqualityComparer.Instance));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(expectedValue.magnitude));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(expectedValue.magnitude));
 
         Set(gamepad.leftStick, Vector2.zero);
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
     }
 
     [Test]
@@ -3247,14 +3247,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Disabled));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0f));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         action.Enable();
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0f));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         Press(keyboard.dKey);
 
@@ -3264,7 +3264,7 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.SameAs(keyboard.dKey));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(expectedValue).Within(0.00001));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(1f).Within(0.00001));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(1f).Within(0.00001));
 
         Release(keyboard.dKey);
         Press(keyboard.aKey);
@@ -3272,14 +3272,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.SameAs(keyboard.aKey));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(-expectedValue).Within(0.00001));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(1f).Within(0.00001));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(1f).Within(0.00001));
 
         Release(keyboard.aKey);
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0f));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
     }
 
     [Test]
@@ -3303,14 +3303,14 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Disabled));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         action.Enable();
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         Press(keyboard.sKey);
 
@@ -3320,7 +3320,7 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.SameAs(keyboard.sKey));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(expectedValue).Using(Vector2EqualityComparer.Instance));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(1f).Within(0.00001));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(1f).Within(0.00001));
 
         Press(keyboard.dKey);
 
@@ -3329,7 +3329,7 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.SameAs(keyboard.dKey));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(expectedValue).Using(Vector2EqualityComparer.Instance));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(new Vector2(1f, -1f).magnitude).Within(0.00001));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(new Vector2(1f, -1f).magnitude).Within(0.00001));
 
         Release(keyboard.dKey);
         Release(keyboard.sKey);
@@ -3337,7 +3337,7 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<Vector2>(), Is.EqualTo(Vector2.zero));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
     }
 
     [Test]
@@ -3356,35 +3356,35 @@ partial class CoreTests
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Disabled));
         Assert.That(action.ReadValue<Quaternion>(), Is.EqualTo(default(Quaternion)));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         action.Enable();
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<Quaternion>(), Is.EqualTo(default(Quaternion)));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
 
         Set(sensor.attitude, Quaternion.Euler(30f, 60f, 45f));
 
         Assert.That(action.activeControl, Is.SameAs(sensor.attitude));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<Quaternion>(), Is.EqualTo(Quaternion.Euler(30f, 60f, 45f)).Using(QuaternionEqualityComparer.Instance));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(-1f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(-1f));
 
         Set(sensor.attitude, Quaternion.identity);
 
         Assert.That(action.activeControl, Is.SameAs(sensor.attitude));
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Started));
         Assert.That(action.ReadValue<Quaternion>(), Is.EqualTo(Quaternion.identity));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(-1f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(-1f));
 
         Set(sensor.attitude, default(Quaternion));
 
         Assert.That(action.activeControl, Is.Null);
         Assert.That(action.phase, Is.EqualTo(InputActionPhase.Waiting));
         Assert.That(action.ReadValue<Quaternion>(), Is.EqualTo(default(Quaternion)));
-        Assert.That(action.GetMagnitude(), Is.EqualTo(0f));
+        Assert.That(action.GetControlMagnitude(), Is.EqualTo(0f));
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,7 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 - Added new methods and properties to [`InputAction`](xref:UnityEngine.InputSystem.InputAction):
   - [`InputAction.activeValueType`](xref:UnityEngine.InputSystem.InputAction.activeValueType) returns the `Type` expected by `ReadValue<TValue>` based on the currently active control that is driving the action.
-  - [`InputAction.GetMagnitude`](xref:UnityEngine.InputSystem.InputAction.GetMagnitude) returns the current amount of actuation of the control that is driving the action.
+  - [`InputAction.GetControlMagnitude`](xref:UnityEngine.InputSystem.InputAction.GetControlMagnitude) returns the current amount of actuation of the control that is driving the action.
   - [`InputAction.WasCompletedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasCompletedThisFrame) returns `true` on the frame that the action stopped being in the performed phase. This allows for similar functionality to [`WasPressedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasPressedThisFrame)/[`WasReleasedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasReleasedThisFrame) when paired with [`WasPerformedThisFrame`](xref:UnityEngine.InputSystem.InputAction.WasPerformedThisFrame) except it is directly based on the interactions driving the action. For example, you can use it to distinguish between the button being released or whether it was released after being held for long enough to perform when using the Hold interaction.
 - Added Copy, Paste and Cut support for Action Maps, Actions and Bindings via context menu and key command shortcuts.
 - Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputAction.cs
@@ -1088,7 +1088,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="InputControl.EvaluateMagnitude()"/>
         /// <seealso cref="InputBindingComposite.EvaluateMagnitude"/>
-        public unsafe float GetMagnitude()
+        public unsafe float GetControlMagnitude()
         {
             var state = GetOrCreateActionMap().m_State;
             if (state != null)


### PR DESCRIPTION
### Description

Processors such as AxisDeadzone or ScaleVector2 can cause the action's value (obtained with `InputAction.ReadValue<TValue>`) to be different from the control's magnitude (obtained with `InputAction.GetMagnitude`). This change makes it explicit that the magnitude is based on the active control to avoid confusion from users.

### Changes made

Renamed method added with https://github.com/Unity-Technologies/InputSystem/pull/1795 in this current 1.8.0-pre.3 that has not yet been released yet. Since it isn't public yet, we should be able to rename.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
