### PR TITLE
FIX: Only allow a single Paste after Cutting an item (ISX-1821)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -40,6 +40,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed console errors that can be produced when opening input package settings from the Inspector.
 - Fixed InputManager.asset file growing in size on each Reset call.
 - Fixed Opening InputDebugger throws 'Action map must have state at this point' error
+- Fixed Cut/Paste behaviour to match Editor - Cut items will now be cleared from clipboard after pasting.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             return (in InputActionsEditorState state) =>
             {
-                CopyPasteHelper.CopyActionMap(state);
+                CopyPasteHelper.CutActionMap(state);
                 return DeleteActionMap(state.selectedActionMapIndex).Invoke(state);
             };
         }
@@ -128,7 +128,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             return (in InputActionsEditorState state) =>
             {
-                CopyPasteHelper.Copy(state);
+                CopyPasteHelper.Cut(state);
                 return state.selectionType == SelectionType.Action ?
                     DeleteAction(state.selectedActionMapIndex, Selectors.GetSelectedAction(state)?.wrappedProperty.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue).Invoke(state)
                     : DeleteBinding(state.selectedActionMapIndex, state.selectedBindingIndex).Invoke(state);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
@@ -173,7 +173,7 @@ namespace UnityEngine.InputSystem.Editor
 
             // Don't want to be able to paste repeatedly after a cut - ISX-1821
             if (s_lastAddedElement != null && s_lastClipboardActionWasCut)
-                EditorGUIUtility.systemCopyBuffer = "";
+                EditorGUIUtility.systemCopyBuffer = string.Empty;
 
             return s_lastAddedElement;
         }
@@ -190,7 +190,7 @@ namespace UnityEngine.InputSystem.Editor
 
             // Don't want to be able to paste repeatedly after a cut - ISX-1821
             if (s_lastAddedElement != null && s_lastClipboardActionWasCut)
-                EditorGUIUtility.systemCopyBuffer = "";
+                EditorGUIUtility.systemCopyBuffer = string.Empty;
 
             return s_lastAddedElement;
         }


### PR DESCRIPTION
### Description

Expected behaviour in editor (and in file systems) is to only be able to paste an item once after cutting - so match that. ([ISX-1821](https://jira.unity3d.com/browse/ISX-1821)).

### Changes made

Simple bool to check if the last action was Cut and not Copy. It's only checked on Paste, and if the Paste operation was successful, we clear the clipboard. Other paths shouldn't be affected (eg. Duplicate won't touch these lines).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
