### PR TITLE
NEW: Device filtering support (ISX-1481)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added Copy, Paste and Cut support for Action Maps, Actions and Bindings via context menu and key command shortcuts.
 - Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller
 - UI Toolkit input action editor now supports showing the derived bindings.
+- Device filtering support for control schemes in the UI-Toolkit Input Asset Editor.
 
 ### Fixed
 - Fixed syntax of code examples in API documentation for [`AxisComposite`](xref:UnityEngine.InputSystem.Composites.AxisComposite).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -28,8 +28,9 @@ namespace UnityEngine.InputSystem.Editor
         {
             return (in InputActionsEditorState state) =>
             {
+                var newDeviceIndex = state.selectedDeviceRequirementIndex == selectedDeviceIndex ? -1 : state.selectedDeviceRequirementIndex;
                 return state.With(selectedControlScheme: new InputControlScheme(state.selectedControlScheme.name,
-                    state.selectedControlScheme.deviceRequirements.Where((r, i) => i != selectedDeviceIndex)));
+                    state.selectedControlScheme.deviceRequirements.Where((r, i) => i != selectedDeviceIndex)), selectedDeviceRequirementIndex: newDeviceIndex);
             };
         }
 
@@ -164,16 +165,17 @@ namespace UnityEngine.InputSystem.Editor
                 if (serializedArray.arraySize == 0)
                     return state.With(
                         selectedControlSchemeIndex: -1,
-                        selectedControlScheme: new InputControlScheme());
+                        selectedControlScheme: new InputControlScheme(),
+                        selectedDeviceRequirementIndex: -1);
 
                 if (indexOfArrayElement > serializedArray.arraySize - 1)
                     return state.With(
                         selectedControlSchemeIndex: serializedArray.arraySize - 1,
-                        selectedControlScheme: new InputControlScheme(serializedArray.GetArrayElementAtIndex(serializedArray.arraySize - 1)));
+                        selectedControlScheme: new InputControlScheme(serializedArray.GetArrayElementAtIndex(serializedArray.arraySize - 1)), selectedDeviceRequirementIndex: -1);
 
                 return state.With(
                     selectedControlSchemeIndex: indexOfArrayElement,
-                    selectedControlScheme: new InputControlScheme(serializedArray.GetArrayElementAtIndex(indexOfArrayElement)));
+                    selectedControlScheme: new InputControlScheme(serializedArray.GetArrayElementAtIndex(indexOfArrayElement)), selectedDeviceRequirementIndex: -1);
             };
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -28,7 +28,11 @@ namespace UnityEngine.InputSystem.Editor
         {
             return (in InputActionsEditorState state) =>
             {
-                var newDeviceIndex = state.selectedDeviceRequirementIndex == selectedDeviceIndex ? -1 : state.selectedDeviceRequirementIndex;
+                var newDeviceIndex =
+                    Mathf.Clamp(
+                        selectedDeviceIndex <= state.selectedDeviceRequirementIndex
+                        ? state.selectedDeviceRequirementIndex - 1
+                        : state.selectedDeviceRequirementIndex, -1, state.selectedDeviceRequirementIndex);
                 return state.With(selectedControlScheme: new InputControlScheme(state.selectedControlScheme.name,
                     state.selectedControlScheme.deviceRequirements.Where((r, i) => i != selectedDeviceIndex)), selectedDeviceRequirementIndex: newDeviceIndex);
             };

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -126,6 +126,11 @@ namespace UnityEngine.InputSystem.Editor
             };
         }
 
+        public static Command SelectDeviceRequirement(int deviceRequirementIndex)
+        {
+            return (in InputActionsEditorState state) => state.With(selectedDeviceRequirementIndex: deviceRequirementIndex);
+        }
+
         /// <summary>
         /// Duplicate creates a new instance of the selected control scheme and places it in the selected
         /// control scheme property of the state but doesn't persist anything.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.Utilities;
 using UnityEngine.UIElements;
 
 namespace UnityEngine.InputSystem.Editor
@@ -576,7 +578,7 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     var devicePathToMatch = InputControlPath.TryGetDeviceLayout(currentControlScheme.Value.deviceRequirements.ElementAt(deviceIndex).controlPath);
                     var devicePath = InputControlPath.TryGetDeviceLayout(serializedInputBinding.path);
-                    isMatchingDevice = string.Equals(devicePathToMatch, devicePath, StringComparison.InvariantCultureIgnoreCase);
+                    isMatchingDevice = string.Equals(devicePathToMatch, devicePath, StringComparison.InvariantCultureIgnoreCase) || InputControlLayout.s_Layouts.IsBasedOn(new InternedString(devicePath), new InternedString(devicePathToMatch));
                 }
                 return serializedInputBinding.controlSchemes.Contains(currentControlScheme.Value.name) && isMatchingDevice;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -491,17 +491,22 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         var compositeItems = new List<TreeViewItemData<ActionOrBindingData>>();
                         var nextBinding = actionBindings[++i];
+                        var hiddenCompositeParts = false;
                         while (nextBinding.isPartOfComposite)
                         {
                             var isVisible = ShouldBindingBeVisible(nextBinding, state.selectedControlScheme, state.selectedDeviceRequirementIndex);
                             if (isVisible)
                             {
-                                var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);
+                                var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme,
+                                    controlSchemes);
                                 var compositeBindingId = new Guid(nextBinding.id);
-                                compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(new Guid(nextBinding.id), idDictionary),
+                                compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(
+                                    GetIdForGuid(new Guid(nextBinding.id), idDictionary),
                                     new ActionOrBindingData(false, name, actionMapIndex, false,
                                         GetControlLayout(nextBinding.path), nextBinding.indexOfBinding)));
                             }
+                            else
+                                hiddenCompositeParts = true;
 
                             if (++i >= actionBindings.Count)
                                 break;
@@ -509,9 +514,11 @@ namespace UnityEngine.InputSystem.Editor
                             nextBinding = actionBindings[i];
                         }
                         i--;
-                        bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
-                            new ActionOrBindingData(false, serializedInputBinding.name, actionMapIndex, true, action.expectedControlType, serializedInputBinding.indexOfBinding),
-                            compositeItems.Count > 0 ? compositeItems : null));
+                        var shouldCompositeBeVisible = !(compositeItems.Count == 0 && hiddenCompositeParts); //hide composite if all parts are hidden
+                        if (shouldCompositeBeVisible)
+                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
+                                new ActionOrBindingData(false, serializedInputBinding.name, actionMapIndex, true, action.expectedControlType, serializedInputBinding.indexOfBinding),
+                                compositeItems.Count > 0 ? compositeItems : null));
                     }
                     else
                     {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -682,9 +682,6 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (currentControlScheme.HasValue && !string.IsNullOrEmpty(currentControlScheme.Value.name))
             {
-                //if binding is global (not assigned to any control scheme) show always
-                if (serializedInputBinding.controlSchemes.Length <= 0)
-                    return true;
                 var isMatchingDevice = true;
                 if (deviceIndex >= 0)
                 {
@@ -692,7 +689,9 @@ namespace UnityEngine.InputSystem.Editor
                     var devicePath = InputControlPath.TryGetDeviceLayout(serializedInputBinding.path);
                     isMatchingDevice = string.Equals(devicePathToMatch, devicePath, StringComparison.InvariantCultureIgnoreCase) || InputControlLayout.s_Layouts.IsBasedOn(new InternedString(devicePath), new InternedString(devicePathToMatch));
                 }
-                return serializedInputBinding.controlSchemes.Contains(currentControlScheme.Value.name) && isMatchingDevice;
+                var hasNoControlScheme = serializedInputBinding.controlSchemes.Length <= 0; //also show GLOBAL bindings
+                var isAssignedToCurrentControlScheme = serializedInputBinding.controlSchemes.Contains(currentControlScheme.Value.name);
+                return (isAssignedToCurrentControlScheme || hasNoControlScheme) && isMatchingDevice;
             }
             //if no control scheme selected then show all bindings
             return true;


### PR DESCRIPTION
### Description

This PR adds device filtering support for control schemes that was already implemented in the IMGUI input action asset editor. The related ticket can be found [here](https://jira.unity3d.com/browse/ISX-1481).

### Changes made

added:
- enable/disable toolbar menu if device filtering is available/unavailable
- showing the correct menu items and marking current selection
- filtering bindings for matching devices

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
