### PR TITLE
NEW: Add support for right clicking empty space to add new items (ISX-1519).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,6 +23,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller
 - Added drag and drop support in the Input Action Asset Editor for Action Maps, Actions and Bindings.
 - UI Toolkit input action editor now supports showing the derived bindings.
+- Added right-click (context) menu support for empty areas below the Action Maps/Actions.
 
 ### Fixed
 - Fixed syntax of code examples in API documentation for [`AxisComposite`](xref:UnityEngine.InputSystem.Composites.AxisComposite).

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,7 +23,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added Dual Sense Edge controller to be mapped to the same layout as the Dual Sense controller
 - Added drag and drop support in the Input Action Asset Editor for Action Maps, Actions and Bindings.
 - UI Toolkit input action editor now supports showing the derived bindings.
-- Added right-click (context) menu support for empty areas below the Action Maps/Actions.
+- Added right-click (context) menu support for empty areas below the Action Maps/Actions lists in the Project Settings Input Action Editor and Asset Input Action Editor.
 
 ### Fixed
 - Fixed syntax of code examples in API documentation for [`AxisComposite`](xref:UnityEngine.InputSystem.Composites.AxisComposite).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -27,7 +27,7 @@
                 <ui:VisualElement name="body">
                     <ui:ListView focusable="true" name="action-maps-list-view" />
                 </ui:VisualElement>
-                <ui:VisualElement name="action-maps-spacer-element" style="flex-direction: column; flex-grow: 1;" />
+                <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;" />
             </ui:VisualElement>
             <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="400" style="height: auto;">
                 <ui:VisualElement name="actions-container" class="body-panel-container">
@@ -38,7 +38,7 @@
                     <ui:VisualElement name="body">
                         <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />
                     </ui:VisualElement>
-                    <ui:VisualElement name="actions-spacer-element" style="flex-direction: column; flex-grow: 1;" />
+                    <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;" />
                 </ui:VisualElement>
                 <ui:VisualElement name="properties-container" class="body-panel-cointainer body-panel-container">
                     <ui:VisualElement name="header" class="body-panel-header">

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditor.uxml
@@ -27,6 +27,7 @@
                 <ui:VisualElement name="body">
                     <ui:ListView focusable="true" name="action-maps-list-view" />
                 </ui:VisualElement>
+                <ui:VisualElement name="action-maps-spacer-element" style="flex-direction: column; flex-grow: 1;" />
             </ui:VisualElement>
             <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="400" style="height: auto;">
                 <ui:VisualElement name="actions-container" class="body-panel-container">
@@ -37,6 +38,7 @@
                     <ui:VisualElement name="body">
                         <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />
                     </ui:VisualElement>
+                    <ui:VisualElement name="actions-spacer-element" style="flex-direction: column; flex-grow: 1;" />
                 </ui:VisualElement>
                 <ui:VisualElement name="properties-container" class="body-panel-cointainer body-panel-container">
                     <ui:VisualElement name="header" class="body-panel-header">

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -68,7 +68,7 @@ namespace UnityEngine.InputSystem.Editor
             m_AddActionMapButton = root.Q<Button>("add-new-action-map-button");
             m_AddActionMapButton.clicked += AddActionMap;
 
-            ContextMenu.GetContextMenuForActionMapsEmptySpace(this, root.Q<VisualElement>("action-maps-spacer-element"));
+            ContextMenu.GetContextMenuForActionMapsEmptySpace(this, root.Q<VisualElement>("rclick-area-to-add-new-action-map"));
         }
 
         void OnDroppedHandler(int mapIndex)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -36,7 +36,7 @@ namespace UnityEngine.InputSystem.Editor
                 treeViewItem.OnDuplicateItem += treeViewItem.DuplicateCallback;
                 treeViewItem.userData = i;
 
-                ContextMenu.GetContextMenuForActionMapItem(treeViewItem);
+                ContextMenu.GetContextMenuForActionMapItem(this, treeViewItem);
             };
             m_ListView.makeItem = () => new InputActionMapsTreeViewItem();
             m_ListView.unbindItem = (element, i) =>
@@ -67,7 +67,8 @@ namespace UnityEngine.InputSystem.Editor
 
             m_AddActionMapButton = root.Q<Button>("add-new-action-map-button");
             m_AddActionMapButton.clicked += AddActionMap;
-            ContextMenu.GetContextMenuForActionMapListView(this, m_ListView.parent);
+
+            ContextMenu.GetContextMenuForActionMapsEmptySpace(this, root.Q<VisualElement>("action-maps-spacer-element"));
         }
 
         void OnDroppedHandler(int mapIndex)
@@ -138,7 +139,7 @@ namespace UnityEngine.InputSystem.Editor
             Dispatch(Commands.ChangeActionMapName(index, newName));
         }
 
-        private void AddActionMap()
+        internal void AddActionMap()
         {
             Dispatch(Commands.AddActionMap());
             m_EnterRenamingMode = true;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -125,7 +125,7 @@ namespace UnityEngine.InputSystem.Editor
             };
 
             ContextMenu.GetContextMenuForActionListView(this, m_ActionsTreeView, m_ActionsTreeView.parent);
-            ContextMenu.GetContextMenuForActionsEmptySpace(this, m_ActionsTreeView, root.Q<VisualElement>("actions-spacer-element"));
+            ContextMenu.GetContextMenuForActionsEmptySpace(this, m_ActionsTreeView, root.Q<VisualElement>("rclick-area-to-add-new-action"));
 
             m_ActionsTreeViewSelectionChangeFilter = new CollectionViewSelectionChangeFilter(m_ActionsTreeView);
             m_ActionsTreeViewSelectionChangeFilter.selectedIndicesChanged += (_) =>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -50,11 +50,11 @@ namespace UnityEngine.InputSystem.Editor
                 treeViewItem.OnDeleteItem += treeViewItem.DeleteCallback;
                 treeViewItem.OnDuplicateItem += treeViewItem.DuplicateCallback;
                 if (item.isComposite)
-                    ContextMenu.GetContextMenuForCompositeItem(treeViewItem, i);
+                    ContextMenu.GetContextMenuForCompositeItem(this, treeViewItem, i);
                 else if (item.isAction)
-                    ContextMenu.GetContextMenuForActionItem(treeViewItem, item.controlLayout, i);
+                    ContextMenu.GetContextMenuForActionItem(this, treeViewItem, item.controlLayout, i);
                 else
-                    ContextMenu.GetContextMenuForBindingItem(treeViewItem);
+                    ContextMenu.GetContextMenuForBindingItem(this, treeViewItem);
 
                 if (item.isAction)
                 {
@@ -125,6 +125,7 @@ namespace UnityEngine.InputSystem.Editor
             };
 
             ContextMenu.GetContextMenuForActionListView(this, m_ActionsTreeView, m_ActionsTreeView.parent);
+            ContextMenu.GetContextMenuForActionsEmptySpace(this, m_ActionsTreeView, root.Q<VisualElement>("actions-spacer-element"));
 
             m_ActionsTreeViewSelectionChangeFilter = new CollectionViewSelectionChangeFilter(m_ActionsTreeView);
             m_ActionsTreeViewSelectionChangeFilter.selectedIndicesChanged += (_) =>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
@@ -87,6 +87,9 @@ namespace UnityEngine.InputSystem.Editor
 
         private static void CopyItemData(SerializedProperty item, StringBuilder buffer, Type type, SerializedProperty actionMap)
         {
+            if (item == null)
+                return;
+
             buffer.Append(k_StartOfText);
             buffer.Append(item.CopyToJson(true));
             if (type == typeof(InputAction))


### PR DESCRIPTION
### Description

Adds a small QoL feature that was present in the IMGUI frontend. More details on issue: [ISX-1519](https://jira.unity3d.com/browse/ISX-1519).

### Changes made

Added empty elements to handle the context menus of empty areas. Tweaked menu items based on discussion with Rita.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
