### PR TITLE
FIX: ArgumentNullExceptions thrown when deleting items quickly in the…

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -43,6 +43,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed InputManager.asset file growing in size on each Reset call.
 - Fixed Opening InputDebugger throws 'Action map must have state at this point' error
 - Fixed Cut/Paste behaviour to match Editor - Cut items will now be cleared from clipboard after pasting.
+- Fixed ArgumentNullExceptions thrown when deleting items quickly in the UITK Editor.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -148,31 +148,38 @@ namespace UnityEngine.InputSystem.Editor
             var selectedItem = m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
             if (selectedItem == null)
                 return;
-            switch (evt.commandName)
+
+            if (allowUICommandExecution)
             {
-                case CmdEvents.Rename:
-                    ((InputActionMapsTreeViewItem)selectedItem).FocusOnRenameTextField();
-                    break;
-                case CmdEvents.Delete:
-                case CmdEvents.SoftDelete:
-                    ((InputActionMapsTreeViewItem)selectedItem).DeleteItem();
-                    break;
-                case CmdEvents.Duplicate:
-                    ((InputActionMapsTreeViewItem)selectedItem).DuplicateItem();
-                    break;
-                case CmdEvents.Copy:
-                    CopyItems();
-                    break;
-                case CmdEvents.Cut:
-                    CutItems();
-                    break;
-                case CmdEvents.Paste:
-                    var isActionCopied = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
-                    if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
-                        PasteItems(isActionCopied);
-                    break;
-                default:
-                    return; // Skip StopPropagation if we didn't execute anything
+                switch (evt.commandName)
+                {
+                    case CmdEvents.Rename:
+                        ((InputActionMapsTreeViewItem)selectedItem).FocusOnRenameTextField();
+                        break;
+                    case CmdEvents.Delete:
+                    case CmdEvents.SoftDelete:
+                        ((InputActionMapsTreeViewItem)selectedItem).DeleteItem();
+                        break;
+                    case CmdEvents.Duplicate:
+                        ((InputActionMapsTreeViewItem)selectedItem).DuplicateItem();
+                        break;
+                    case CmdEvents.Copy:
+                        CopyItems();
+                        break;
+                    case CmdEvents.Cut:
+                        CutItems();
+                        break;
+                    case CmdEvents.Paste:
+                        var isActionCopied = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
+                        if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
+                            PasteItems(isActionCopied);
+                        break;
+                    default:
+                        return; // Skip StopPropagation if we didn't execute anything
+                }
+
+                // Prevent any UI commands from executing until after UI has been updated
+                allowUICommandExecution = false;
             }
             evt.StopPropagation();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -373,35 +373,41 @@ namespace UnityEngine.InputSystem.Editor
             if (m_ActionsTreeView.selectedItem == null)
                 return;
 
-            var data = (ActionOrBindingData)m_ActionsTreeView.selectedItem;
-            switch (evt.commandName)
+            if (allowUICommandExecution)
             {
-                case CmdEvents.Rename:
-                    if (data.isAction || data.isComposite)
-                        m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.FocusOnRenameTextField();
-                    else
-                        return;
-                    break;
-                case CmdEvents.Delete:
-                case CmdEvents.SoftDelete:
-                    m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.DeleteItem();
-                    break;
-                case CmdEvents.Duplicate:
-                    m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.DuplicateItem();
-                    break;
-                case CmdEvents.Copy:
-                    CopyItems();
-                    break;
-                case CmdEvents.Cut:
-                    CutItems();
-                    break;
-                case CmdEvents.Paste:
-                    var hasPastableData = CopyPasteHelper.HasPastableClipboardData(data.isAction ? typeof(InputAction) : typeof(InputBinding));
-                    if (hasPastableData)
-                        PasteItems();
-                    break;
-                default:
-                    return; // Skip StopPropagation if we didn't execute anything
+                var data = (ActionOrBindingData)m_ActionsTreeView.selectedItem;
+                switch (evt.commandName)
+                {
+                    case CmdEvents.Rename:
+                        if (data.isAction || data.isComposite)
+                            m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.FocusOnRenameTextField();
+                        else
+                            return;
+                        break;
+                    case CmdEvents.Delete:
+                    case CmdEvents.SoftDelete:
+                        m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.DeleteItem();
+                        break;
+                    case CmdEvents.Duplicate:
+                        m_ActionsTreeView.GetRootElementForIndex(m_ActionsTreeView.selectedIndex)?.Q<InputActionsTreeViewItem>()?.DuplicateItem();
+                        break;
+                    case CmdEvents.Copy:
+                        CopyItems();
+                        break;
+                    case CmdEvents.Cut:
+                        CutItems();
+                        break;
+                    case CmdEvents.Paste:
+                        var hasPastableData = CopyPasteHelper.HasPastableClipboardData(data.isAction ? typeof(InputAction) : typeof(InputBinding));
+                        if (hasPastableData)
+                            PasteItems();
+                        break;
+                    default:
+                        return; // Skip StopPropagation if we didn't execute anything
+                }
+
+                // Prevent any UI commands from executing until after UI has been updated
+                allowUICommandExecution = false;
             }
             evt.StopPropagation();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -56,6 +56,10 @@ namespace UnityEngine.InputSystem.Editor
             {
                 view.UpdateView(state);
             }
+
+            // We can execute UI Commands now that the UI is fully updated
+            // NOTE: This isn't used with Input Commands
+            allowUICommandExecution = true;
         }
 
         public TView CreateChildView<TView>(TView view) where TView : IView
@@ -119,6 +123,8 @@ namespace UnityEngine.InputSystem.Editor
 
         protected readonly VisualElement rootElement;
         protected readonly StateContainer stateContainer;
+        protected bool allowUICommandExecution { get; set; } = true;
+
         protected IViewStateSelector<TViewState> ViewStateSelector => m_ViewStateSelector;
         private IViewStateSelector<TViewState> m_ViewStateSelector;
         private IList<IView> m_ChildViews;


### PR DESCRIPTION
### Description

The issue occurs because the Delete command gets "repeated" when holding down the keyboard key, which is dispatched to the view before the UI has updated from the previous one. This causes the execution of the Delete to reference an Action that no longer exists within the backing data leading to a null SerializedPropery reference when we try to retrieve it.

To guard against this, block UI commands from executing until the UI has updated form the previous one. This won't impact human usage (occurs far too quickly) but will block program driven commands like key repeat and other programmatic sources.

### Changes made

Added a flag to act as a type of Semaphore and only allow a single UI command to execute per UI Update. Since it's single-threaded we don't need an _actual_ Semaphore.

### Notes

This could affect UI tests, if they send multiple UI commands per frame, causing them to fail.
Might be some other side-effects with corner cases.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
