### PR TITLE
FIX: Conditional API signature selection for asset processor

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -357,7 +357,12 @@ namespace UnityEngine.InputSystem.Editor
                 }
             }
 
+// Note: Callback prior to Unity 2021.2 did not provide a boolean indicating domain relaod.
+#if UNITY_2021_2_OR_NEWER
             private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+#else
+            private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+#endif
             {
                 if (assetFilesNeedingRefresh == null)
                     return;


### PR DESCRIPTION
### Description

FIX: Conditional API signature selection for asset processor based on Unity version whether domain reload boolean is available or not. This fix makes it compatible back to Unity 2019. This corrects a problem introduced with https://github.com/Unity-Technologies/InputSystem/pull/1836. 

### Changes made

Adds compile-time dynamic selection of API signature.

### Notes

This should have been part of the original solution if 2019 was covered in QA/testing.

Decided to not include a CHANGELOG since this should have been part of the original user-facing fix.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
