### PR TITLE
FIX: Asset processor issues ISX-1885 ISX-1887

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionAssetManager.cs
@@ -161,6 +161,21 @@ namespace UnityEngine.InputSystem.Editor
             onDirtyChanged(false);
         }
 
+        internal static bool WriteAsset(string assetPath, string assetJson)
+        {
+            // Attempt to checkout the file path for editing and inform the user if this fails.
+            if (!EditorHelpers.CheckOut(assetPath))
+                return false;
+
+            // (Over)write JSON content to file given by path.
+            EditorHelpers.WriteAllText(assetPath, assetJson);
+
+            // Reimport the asset (indirectly triggers ADB notification callbacks)
+            AssetDatabase.ImportAsset(assetPath);
+
+            return true;
+        }
+
         /// <summary>
         /// Saves an asset to the given <c>assetPath</c> with file content corresponding to <c>assetJson</c>
         /// if the current content of the asset given by <c>assetPath</c> is different or the asset do not exist.
@@ -177,17 +192,11 @@ namespace UnityEngine.InputSystem.Editor
                 return false;
 
             // Attempt to checkout the file path for editing and inform the user if this fails.
-            if (!EditorHelpers.CheckOut(assetPath))
+            if (!WriteAsset(assetPath, assetJson))
             {
                 Debug.LogError($"Unable save asset to \"{assetPath}\" since the asset-path could not be checked-out as editable in the underlying version-control system.");
                 return false;
             }
-
-            // (Over)write JSON content to file given by path.
-            EditorHelpers.WriteAllText(assetPath, assetJson);
-
-            // Reimport the asset (indirectly triggers ADB notification callbacks)
-            AssetDatabase.ImportAsset(assetPath);
 
             return true;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.InputSystem.Editor
                 return false;
 #endif
             var path = AssetDatabase.GetAssetPath(instanceId);
-            if (!path.EndsWith(k_FileExtension, StringComparison.InvariantCultureIgnoreCase))
+            if (!InputActionImporter.IsInputActionAssetPath(path))
                 return false;
 
             string mapToSelect = null;
@@ -847,7 +847,6 @@ namespace UnityEngine.InputSystem.Editor
         private InputActionTreeView m_ActionsTree;
 
         private static bool s_RefreshPending;
-        private static readonly string k_FileExtension = "." + InputActionAsset.Extension;
 
         private Vector2 m_PropertiesScroll;
         private bool m_ForceQuit;
@@ -860,7 +859,7 @@ namespace UnityEngine.InputSystem.Editor
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "options", Justification = "options parameter required by Unity API")]
             public static AssetDeleteResult OnWillDeleteAsset(string path, RemoveAssetOptions options)
             {
-                if (!path.EndsWith(k_FileExtension, StringComparison.InvariantCultureIgnoreCase))
+                if (!InputActionImporter.IsInputActionAssetPath(path))
                     return default;
 
                 // See if we have an open window.
@@ -895,7 +894,7 @@ namespace UnityEngine.InputSystem.Editor
             // ReSharper disable once UnusedMember.Local
             public static AssetMoveResult OnWillMoveAsset(string sourcePath, string destinationPath)
             {
-                if (!sourcePath.EndsWith(k_FileExtension, StringComparison.InvariantCultureIgnoreCase))
+                if (!InputActionImporter.IsInputActionAssetPath(sourcePath))
                     return default;
 
                 var guid = AssetDatabase.AssetPathToGUID(sourcePath);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -346,31 +346,34 @@ namespace UnityEngine.InputSystem.Editor
             {
                 foreach (var assetPath in importedAssets)
                 {
-                    if (!IsInputActionAssetPath(assetPath))
-                        continue;
+                    if (IsInputActionAssetPath(assetPath))
+                        CheckAndModifyJsonNameIfNeeded(assetPath);
+                }
+            }
 
-                    InputActionAsset asset = null;
-                    try
+            private static void CheckAndModifyJsonNameIfNeeded(string assetPath)
+            {
+                InputActionAsset asset = null;
+                try
+                {
+                    asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
+                    var desiredName = Path.GetFileNameWithoutExtension(assetPath);
+                    if (asset.name == desiredName)
+                        return;
+                    asset.name = desiredName;
+                    if (!InputActionAssetManager.WriteAsset(assetPath, asset.ToJson()))
                     {
-                        asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
-                        var desiredName = Path.GetFileNameWithoutExtension(assetPath);
-                        if (asset.name == desiredName)
-                            return;
-                        asset.name = desiredName;
-                        if (!InputActionAssetManager.WriteAsset(assetPath, asset.ToJson()))
-                        {
-                            Debug.LogError($"Unable save asset to \"{assetPath}\" since the asset-path could not be checked-out as editable in the underlying version-control system.");
-                        }
+                        Debug.LogError($"Unable save asset to \"{assetPath}\" since the asset-path could not be checked-out as editable in the underlying version-control system.");
                     }
-                    catch (Exception ex)
-                    {
-                        Debug.LogException(ex);
-                    }
-                    finally
-                    {
-                        if (asset != null)
-                            DestroyImmediate(asset);
-                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogException(ex);
+                }
+                finally
+                {
+                    if (asset != null)
+                        DestroyImmediate(asset);
                 }
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -347,23 +347,22 @@ namespace UnityEngine.InputSystem.Editor
                 foreach (var assetPath in importedAssets)
                 {
                     if (IsInputActionAssetPath(assetPath))
-                        CheckAndModifyJsonNameIfNeeded(assetPath);
+                        CheckAndModifyJsonNameIfDifferent(assetPath);
                 }
             }
 
-            private static void CheckAndModifyJsonNameIfNeeded(string assetPath)
+            private static void CheckAndModifyJsonNameIfDifferent(string assetPath)
             {
                 InputActionAsset asset = null;
                 try
                 {
                     asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
                     var desiredName = Path.GetFileNameWithoutExtension(assetPath);
-                    if (asset.name == desiredName)
-                        return;
-                    asset.name = desiredName;
-                    if (!InputActionAssetManager.WriteAsset(assetPath, asset.ToJson()))
+                    if (asset.name != desiredName)
                     {
-                        Debug.LogError($"Unable save asset to \"{assetPath}\" since the asset-path could not be checked-out as editable in the underlying version-control system.");
+                        asset.name = desiredName;
+                        if (!InputActionAssetManager.WriteAsset(assetPath, asset.ToJson()))
+                            Debug.LogError($"Unable update JSON name in asset \"{assetPath}\" since the asset-path could not be checked-out as editable in the underlying version-control system.");
                     }
                 }
                 catch (Exception ex)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -37,6 +37,14 @@ namespace UnityEngine.InputSystem.Editor
 
         private static InlinedArray<Action> s_OnImportCallbacks;
 
+        private static readonly string k_FileExtension = "." + InputActionAsset.Extension;
+
+        // Evaluates whether the given path is a path to an asset of the associated type based on extension.
+        public static bool IsInputActionAssetPath(string path)
+        {
+            return path.EndsWith(k_FileExtension, StringComparison.InvariantCultureIgnoreCase);
+        }
+
         public static event Action onImport
         {
             add => s_OnImportCallbacks.Append(value);
@@ -326,37 +334,9 @@ namespace UnityEngine.InputSystem.Editor
         // When an action asset is renamed, copied, or moved in the Editor, the "Name" field in the JSON will
         // hold the old name and won't match what's in memory (asset looks "dirty"). To work around this, we
         // must flush the updated JSON to the file whenever this operation occurs.
-        // https://jira.unity3d.com/browse/ISXB-749
+        // https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-749
         private class InputActionAssetPostprocessor : AssetPostprocessor
         {
-            private static List<string> assetFilesNeedingRefresh;
-
-            private void OnPreprocessAsset()
-            {
-                var importer = assetImporter as InputActionImporter;
-                if (importer == null)
-                    return;
-
-                var newName = Path.GetFileNameWithoutExtension(assetPath);
-                var newAsset = ScriptableObject.CreateInstance<InputActionAsset>();
-                var newFileContents = File.ReadAllText(assetPath);
-
-                if (!string.IsNullOrEmpty(newFileContents))
-                {
-                    newAsset.LoadFromJson(newFileContents);
-
-                    // If the serialized Name doesn't match the actual filename this asset file for refresh.
-                    // NOTE: We can't change the file while Asset Importing is in progress.
-                    if (newAsset.name != newName)
-                    {
-                        if (assetFilesNeedingRefresh == null)
-                            assetFilesNeedingRefresh = new List<string>();
-
-                        assetFilesNeedingRefresh.Add(assetPath);
-                    }
-                }
-            }
-
 // Note: Callback prior to Unity 2021.2 did not provide a boolean indicating domain relaod.
 #if UNITY_2021_2_OR_NEWER
             private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
@@ -364,34 +344,33 @@ namespace UnityEngine.InputSystem.Editor
             private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
 #endif
             {
-                if (assetFilesNeedingRefresh == null)
-                    return;
-
-                try
+                foreach (var assetPath in importedAssets)
                 {
-                    foreach (var assetPath in assetFilesNeedingRefresh)
+                    if (!IsInputActionAssetPath(assetPath))
+                        continue;
+
+                    InputActionAsset asset = null;
+                    try
                     {
-                        var newAsset = ScriptableObject.CreateInstance<InputActionAsset>();
-
-                        try
+                        asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
+                        var desiredName = Path.GetFileNameWithoutExtension(assetPath);
+                        if (asset.name == desiredName)
+                            return;
+                        asset.name = desiredName;
+                        if (!InputActionAssetManager.WriteAsset(assetPath, asset.ToJson()))
                         {
-                            var fileContents = File.ReadAllText(assetPath);
-
-                            newAsset.LoadFromJson(fileContents);
-                            newAsset.name = Path.GetFileNameWithoutExtension(assetPath);
-                            File.WriteAllText(assetPath, newAsset.ToJson());
+                            Debug.LogError($"Unable save asset to \"{assetPath}\" since the asset-path could not be checked-out as editable in the underlying version-control system.");
                         }
-                        catch (Exception ex)
-                        {
-                            Debug.LogException(ex);
-                        }
-
-                        ScriptableObject.DestroyImmediate(newAsset);
                     }
-                }
-                finally
-                {
-                    assetFilesNeedingRefresh = null;
+                    catch (Exception ex)
+                    {
+                        Debug.LogException(ex);
+                    }
+                    finally
+                    {
+                        if (asset != null)
+                            DestroyImmediate(asset);
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Description

FIX: Addressed problems in AssetPostProcessor in InputActionImporter causing worker thread issues and causing editor assets to get wiped.

### Changes made

Writing directly to asset file without checking out the file and without reimport seems to cause issues. Hence this was modified to use a common routine which also reduces duplicated code. In addition did some refactoring related to asset extension to remove some redundant logic since relevant for the updated logic in the processor.

### Notes

Intends to solve ISX-1885 and ISX-1887. I have additional updates to asset management, processors and editor behavior related to changes to input actions assets in a pending PR, but decided to isolate these fixes into its own PR and let it go in first. Other PR is here for reference (WIP) https://github.com/Unity-Technologies/InputSystem/pull/1850

No changelog entry added since this is just modifying internals to fix a regression/problem with previous PR: https://github.com/Unity-Technologies/InputSystem/pull/1836

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
