### PR TITLE
FIX: Selected ControlScheme lost upon entering PlayMode (ISXB-770)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -54,6 +54,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Error logged when InputActionEditor window opened without a valid asset.
 - Fixed ArgumentNullExceptions thrown when deleting items quickly in the UITK Editor.
 - Fixed Project Settings header title styling for Input Actions editor.
+- Fixed Input Actions Editor losing reference to current ControlScheme upon entering Play Mode [ISXB-770](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-770).
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -17,8 +17,8 @@ namespace UnityEngine.InputSystem.Editor
         public SerializedObject serializedObject { get; }
 
         // Control schemes
-        public int selectedControlSchemeIndex { get {return m_selectedControlSchemeIndex; } }
-        public int selectedDeviceRequirementIndex { get {return m_selectedDeviceRequirementIndex; } }
+        public int selectedControlSchemeIndex { get { return m_selectedControlSchemeIndex; } }
+        public int selectedDeviceRequirementIndex { get  {return m_selectedDeviceRequirementIndex; } }
         public InputControlScheme selectedControlScheme => m_ControlScheme;
 
         [SerializeField] int m_selectedActionMapIndex;
@@ -41,13 +41,13 @@ namespace UnityEngine.InputSystem.Editor
         {
             serializedObject = inputActionAsset;
 
-            this.m_selectedActionMapIndex = selectedActionMapIndex;
-            this.m_selectedActionIndex = selectedActionIndex;
-            this.m_selectedBindingIndex = selectedBindingIndex;
-            this.m_selectionType = selectionType;
+            m_selectedActionMapIndex = selectedActionMapIndex;
+            m_selectedActionIndex = selectedActionIndex;
+            m_selectedBindingIndex = selectedBindingIndex;
+            m_selectionType = selectionType;
             m_ControlScheme = selectedControlScheme;
-            this.m_selectedControlSchemeIndex = selectedControlSchemeIndex;
-            this.m_selectedDeviceRequirementIndex = selectedDeviceRequirementIndex;
+            m_selectedControlSchemeIndex = selectedControlSchemeIndex;
+            m_selectedDeviceRequirementIndex = selectedDeviceRequirementIndex;
 
             m_ExpandedCompositeBindings = expandedBindingIndices == null ?
                 new Dictionary<(string, string), HashSet<int>>() :
@@ -65,6 +65,18 @@ namespace UnityEngine.InputSystem.Editor
             m_ControlScheme = other.m_ControlScheme;
             m_selectedControlSchemeIndex = other.m_selectedControlSchemeIndex;
             m_selectedDeviceRequirementIndex = other.m_selectedDeviceRequirementIndex;
+
+            // Selected ControlScheme index is serialized but we have to recreated actual object after domain reload
+            if (m_selectedControlSchemeIndex != -1)
+            {
+                var controlSchemeSerializedProperty = serializedObject
+                    .FindProperty(nameof(InputActionAsset.m_ControlSchemes))
+                    .GetArrayElementAtIndex(m_selectedControlSchemeIndex);
+
+                m_ControlScheme = new InputControlScheme(controlSchemeSerializedProperty);
+            }
+            else
+                m_ControlScheme = new InputControlScheme();
 
             // Editor may leave these as null after domain reloads, so recreate them
             m_ExpandedCompositeBindings = (other.m_ExpandedCompositeBindings == null)


### PR DESCRIPTION
### Description

Address an issue when entering PlayMode with the ActionsEditor window is open _and_ a ControlScheme is selected, i.e. something other than "All Control Schemes" is selected. The ControlScheme cannot be properly edited either during PlayMode or after returning to EditMode (due to various problems).

This occurs because the `InputControlScheme` object must be recreated after the domain reload.

### Changes made

Added logic to the overloaded `InputActionsEditorState` ctor to retrieve the selected ControlScheme's SerializedProperty (from the passed in SerializedObject) and initialize a new InputControlScheme() object.

The logic to detect and restore ActionsEditor state after a DR already existed, and simply needed to add the ControlScheme case.

### Notes

Also includes some simple formatting changes to `InputActionsEditorState`. Specifically, removed `this` from the field assignments: it's unnecessary (using m_ prefix for fields) and applied inconsistently.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
