### PR TITLE
change downloader-cli options to use --fast for il2cpp builds

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -28,7 +28,7 @@ platforms_win:
     flavor: b1.large
     runtime: StandaloneWindows64
     scripting-backend: Il2Cpp
-    installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP -w -u
+    installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP --wait --fast -u 
 platforms_nix:
   - name: mac
     type: Unity::VM::osx
@@ -45,7 +45,7 @@ platforms_nix:
     flavor: m1.mac
     runtime: StandaloneOSX
     scripting-backend: Il2Cpp
-    installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP -w -u
+    installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP --wait --fast -u
 scripting_backends:
   - name: mono
   - name: il2cpp

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -85,7 +85,7 @@ build_ios_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast -w
+    - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   artifacts:
     players:
@@ -122,7 +122,7 @@ build_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c AppleTV -u {{ editor.version }} --fast -w
+    - unity-downloader-cli -c Editor -c AppleTV -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   artifacts:
     players:
@@ -159,7 +159,7 @@ build_android_{{ editor.version }}_{{ backend.name }}:
   commands:
     - {{ utr_install_win }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast -w
+    - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode --platform=Android --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --scripting-backend={{ backend.name }} --build-only --repository --performance-project-id=InputSystem
   artifacts:
     players:


### PR DESCRIPTION
### Description

Il2cpp builds sometimes take a long time or even time out waiting for the latest to be built for the platform components.
Switch to use '--fast' in order to speed the builders up the same way the rest of the platform builders work.

### Changes made

-enabled --fast for il2cpp builder
-spelled out --wait option

### Notes

Internal change only.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
