### PR TITLE
FIX: Bindings pasted to Action appear at top of the list (ISX-1899)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using UnityEditor;
 
@@ -225,10 +224,7 @@ namespace UnityEngine.InputSystem.Editor
 
             int newBindingIndex;
             if (state.selectionType == SelectionType.Action)
-            {
-                var bindingsForAction = Selectors.GetBindingsForAction(state, actionMap, state.selectedActionIndex);
-                newBindingIndex = bindingsForAction.Count > 0 ? bindingsForAction.Select(b => b.GetIndexOfArrayElement()).Max() : 0;
-            }
+                newBindingIndex = Selectors.GetLastBindingIndexForSelectedAction(state);
             else
                 newBindingIndex = state.selectedBindingIndex;
 
@@ -319,16 +315,13 @@ namespace UnityEngine.InputSystem.Editor
                     return index;
             }
 
-            // Update the target index for special cases
-            if (pastePartOfComposite && !currentPartOfComposite)
+            // Update the target index for special cases when pasting a Binding
+            if (s_State.selectionType != SelectionType.Action && createCompositeParts)
             {
-                // Pasting into a Composite and CompositePart isn't the target, i.e. Composite "root" selected, paste at the end of the composite
-                index = Selectors.GetSelectedBindingIndexAfterCompositeBindings(s_State) + 1;
-            }
-            else if (!pastePartOfComposite && s_State.selectionType != SelectionType.Action)
-            {
-                // Pasting with a Binding selected needs to skip all the CompositeParts (if any)
-                index = Selectors.GetSelectedBindingIndexAfterCompositeBindings(s_State) + 1;
+                // - Pasting into a Composite with CompositePart not the target, i.e. Composite "root" selected, paste at the end of the composite
+                // - Pasting a non-CompositePart, i.e. regular Binding, needs to skip all the CompositeParts (if any)
+                if ((pastePartOfComposite && !currentPartOfComposite) || !pastePartOfComposite)
+                    index = Selectors.GetSelectedBindingIndexAfterCompositeBindings(s_State) + 1;
             }
 
             if (json.Contains(k_BindingData)) //copied data is composite with bindings - only true for directly copied composites, not for composites from copied actions

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
@@ -306,6 +306,9 @@ namespace UnityEngine.InputSystem.Editor
             bool currentPartOfComposite = false;
             bool currentIsComposite = false;
 
+            if (arrayProperty.arraySize == 0)
+                index = 0;
+
             if (index > 0)
             {
                 var currentProperty = arrayProperty.GetArrayElementAtIndex(index - 1);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -86,7 +86,8 @@ namespace UnityEngine.InputSystem.Editor
             var item = new SerializedInputBinding(bindings?.GetArrayElementAtIndex(state.selectedBindingIndex));
             var index = state.selectedBindingIndex + (item.isComposite || item.isPartOfComposite ? 1 : 0);
             var toSkip = 0;
-            while (new SerializedInputBinding(bindings?.GetArrayElementAtIndex(index)).isPartOfComposite)
+
+            while (index < bindings.arraySize && new SerializedInputBinding(bindings?.GetArrayElementAtIndex(index)).isPartOfComposite)
             {
                 toSkip++;
                 index++;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -73,6 +73,13 @@ namespace UnityEngine.InputSystem.Editor
             return GetBindingsForAction(action.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue, state);
         }
 
+        public static int GetLastBindingIndexForSelectedAction(InputActionsEditorState state)
+        {
+            var actionName = GetSelectedAction(state)?.wrappedProperty.FindPropertyRelative("m_Name").stringValue;
+            var bindingsOfAction = GetBindingsForAction(actionName, state);
+            return bindingsOfAction.Count > 0 ? bindingsOfAction.Select(b => b.GetIndexOfArrayElement()).Max() : 0;
+        }
+
         public static int GetSelectedBindingIndexAfterCompositeBindings(InputActionsEditorState state)
         {
             var bindings = GetSelectedActionMap(state)?.wrappedProperty.FindPropertyRelative(nameof(InputActionMap.m_Bindings));


### PR DESCRIPTION
### Description

Fixes a couple copy/paste issues in the UITK Editor in which pasted bindings appeared at the top of the list instead of the bottom.

### Changes made

Modified the logic within `PasteBindingsFromClipboard()` and `PasteBindingOrComposite()` to update the "index" of pasted items so it appears at the bottom of their respective sets when their "root" node is selected:

- Bindings pasted to an Action are inserted at the end of the Action's current Binding list
- CompositePart Bindings are inserted at the end of the Component Binding's current set

When a Binding or CompositePart is selected during paste, the pasted item will still appear immediately below the selected item.

### Notes

I was only able to do a little of bit of testing myself, and would've like to do more before opening the PR but ran out of time. I figured it's better to just get the PR open and deal with any issues next week.

Having automated tests to cover these scenarios would be really good, but that'll take some time/effort, which I didn't think is appropriate at this point.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
