### PR TITLE
FIX: Shortcuts for Save and adding new Maps/Actions/Bindings. (ISXB-659).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -50,11 +50,12 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Opening InputDebugger throws 'Action map must have state at this point' error.
 - Fixed Cut/Paste behaviour to match Editor - Cut items will now be cleared from clipboard after pasting.
 - Improved window layout to avoid elements being hidden (both the Input Actions in Project Settings, and standalone Input Actions Editor windows).
-- Fixed InputAction asset appearing dirty after rename [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-749).
+- Fixed InputAction asset appearing dirty after rename [ISXB-749](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-749).
 - Fixed Error logged when InputActionEditor window opened without a valid asset.
 - Fixed ArgumentNullExceptions thrown when deleting items quickly in the UITK Editor.
 - Fixed Project Settings header title styling for Input Actions editor.
 - Fixed Input Actions Editor losing reference to current ControlScheme upon entering Play Mode [ISXB-770](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-770).
+- Fixed Save shortcut (ctrl/cmd + S by default) not saving changes in Input Actions Editor windows. [ISXB-659](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-659).
 - Fixed headers in InputActionEditor windows becoming squashed when there is a large number of Action Maps/Actions.
 
 ## [1.8.0-pre.2] - 2023-11-09

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -788,6 +788,7 @@ namespace UnityEngine.InputSystem.Editor
             Repaint();
         }
 
+#if !UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         ////TODO: add shortcut to focus search box
 
         ////TODO: show shortcuts in tooltips
@@ -819,6 +820,8 @@ namespace UnityEngine.InputSystem.Editor
             var window = (InputActionEditorWindow)arguments.context;
             window.AddNewBinding();
         }
+
+#endif
 
         private void OnDirtyChanged(bool dirty)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.ShortcutManagement;
 using UnityEngine.UIElements;
 using UnityEditor.UIElements;
 
@@ -16,6 +17,7 @@ namespace UnityEngine.InputSystem.Editor
         private bool m_IgnoreActionChangedCallback;
         private bool m_IsActivated;
         StateContainer m_StateContainer;
+        private static InputActionsEditorSettingsProvider m_ActiveSettingsProvider;
 
         public InputActionsEditorSettingsProvider(string path, SettingsScope scopes, IEnumerable<string> keywords = null)
             : base(path, scopes, keywords)
@@ -82,6 +84,7 @@ namespace UnityEngine.InputSystem.Editor
             if (!m_HasEditFocus)
             {
                 m_HasEditFocus = true;
+                m_ActiveSettingsProvider = this;
             }
         }
 
@@ -206,6 +209,30 @@ namespace UnityEngine.InputSystem.Editor
         {
             return new InputActionsEditorSettingsProvider(SettingsPath, SettingsScope.Project);
         }
+
+        #region Shortcuts
+        [Shortcut("Input Action Editor/Project Settings/Add Action Map", null, KeyCode.M, ShortcutModifiers.Alt)]
+        private static void AddActionMapShortcut(ShortcutArguments arguments)
+        {
+            if (m_ActiveSettingsProvider is { m_HasEditFocus : true })
+                m_ActiveSettingsProvider.m_StateContainer.Dispatch(Commands.AddActionMap());
+        }
+
+        [Shortcut("Input Action Editor/Project Settings/Add Action", null, KeyCode.A, ShortcutModifiers.Alt)]
+        private static void AddActionShortcut(ShortcutArguments arguments)
+        {
+            if (m_ActiveSettingsProvider is { m_HasEditFocus : true })
+                m_ActiveSettingsProvider.m_StateContainer.Dispatch(Commands.AddAction());
+        }
+
+        [Shortcut("Input Action Editor/Project Settings/Add Binding", null, KeyCode.B, ShortcutModifiers.Alt)]
+        private static void AddBindingShortcut(ShortcutArguments arguments)
+        {
+            if (m_ActiveSettingsProvider is { m_HasEditFocus : true })
+                m_ActiveSettingsProvider.m_StateContainer.Dispatch(Commands.AddBinding());
+        }
+
+        #endregion
     }
 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Callbacks;
-using UnityEngine.UIElements;
+using UnityEditor.ShortcutManagement;
 
 namespace UnityEngine.InputSystem.Editor
 {
@@ -30,6 +30,7 @@ namespace UnityEngine.InputSystem.Editor
         private string m_AssetJson;
         private string m_AssetTitleName;
         private bool m_IsDirty;
+        private StateContainer m_StateContainer;
         static readonly Vector2 k_MinWindowSize = new Vector2(650, 450);
 
         [OnOpenAsset]
@@ -177,13 +178,13 @@ namespace UnityEngine.InputSystem.Editor
 
         private void BuildUI()
         {
-            var stateContainer = new StateContainer(rootVisualElement, m_State);
-            stateContainer.StateChanged += OnStateChanged;
+            m_StateContainer = new StateContainer(rootVisualElement, m_State);
+            m_StateContainer.StateChanged += OnStateChanged;
 
             rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
-            var view = new InputActionsEditorView(rootVisualElement, stateContainer, false);
+            var view = new InputActionsEditorView(rootVisualElement, m_StateContainer, false);
             view.postSaveAction += PostSaveAction;
-            stateContainer.Initialize();
+            m_StateContainer.Initialize();
         }
 
         private void OnStateChanged(InputActionsEditorState newState)
@@ -311,6 +312,37 @@ namespace UnityEngine.InputSystem.Editor
             var assetPath = AssetDatabase.GUIDToAssetPath(m_AssetGUID);
             return AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
         }
+
+        #region Shortcuts
+        [Shortcut("Input Action Editor/Save", typeof(InputActionsEditorWindow), KeyCode.S, ShortcutModifiers.Action)]
+        private static void SaveShortcut(ShortcutArguments arguments)
+        {
+            var window = (InputActionsEditorWindow)arguments.context;
+            window.Save();
+        }
+
+        [Shortcut("Input Action Editor/Add Action Map", typeof(InputActionsEditorWindow), KeyCode.M, ShortcutModifiers.Alt)]
+        private static void AddActionMapShortcut(ShortcutArguments arguments)
+        {
+            var window = (InputActionsEditorWindow)arguments.context;
+            window.m_StateContainer.Dispatch(Commands.AddActionMap());
+        }
+
+        [Shortcut("Input Action Editor/Add Action", typeof(InputActionsEditorWindow), KeyCode.A, ShortcutModifiers.Alt)]
+        private static void AddActionShortcut(ShortcutArguments arguments)
+        {
+            var window = (InputActionsEditorWindow)arguments.context;
+            window.m_StateContainer.Dispatch(Commands.AddAction());
+        }
+
+        [Shortcut("Input Action Editor/Add Binding", typeof(InputActionsEditorWindow), KeyCode.B, ShortcutModifiers.Alt)]
+        private static void AddBindingShortcut(ShortcutArguments arguments)
+        {
+            var window = (InputActionsEditorWindow)arguments.context;
+            window.m_StateContainer.Dispatch(Commands.AddBinding());
+        }
+
+        #endregion
     }
 }
 


### PR DESCRIPTION
### Description

Fix shortcut commands for Save and adding new Maps/Actions/Bindings.

### Changes made

The [Shortcut] tag means that the IMGUI paths need to be #if'd out (now done). Due to the way the shortcut system works, we also need separate entries for the standalone windows and the Project Settings window - the latter of which can't specifically be listened to, so we have to listen globally and only act when in focus.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
