### PR TITLE
[ISXB-544] Fix for 1.6.X: Wrong value is chosen when selecting GamepadButton in a dropdown menu

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/EnumPropertyDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/EnumPropertyDrawer.cs
@@ -1,0 +1,98 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.UIElements;
+
+namespace UnityEngine.InputSystem.Editor
+{
+    /// <summary>
+    /// Abstract base class for a generic property drawer for enums.
+    /// </summary>
+    internal abstract class EnumDrawer<T> : PropertyDrawer where T : Enum
+    {
+        protected string[] m_EnumDisplayNames;
+
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            ProcessDisplayNamesForAliasedEnums();
+            return base.CreatePropertyGUI(property);
+        }
+
+        protected abstract string GetNonAliasedNames(string enumValue);
+
+        private void ProcessDisplayNamesForAliasedEnums()
+        {
+            Dictionary<string, int> dictEnumNamesAndValues = new Dictionary<string, int>();
+            string[] enumDisplayNames = Enum.GetNames(typeof(T));
+            Array enumValues = Enum.GetValues(typeof(T));
+            List<string> enumStringValues = enumValues.Cast<T>().Select(v => v.ToString()).ToList();
+
+            for (int iEnumCounter = 0; iEnumCounter < enumDisplayNames.Length; iEnumCounter++)
+            {
+                string enumName = enumDisplayNames[iEnumCounter];
+                string aliasedName = GetNonAliasedNames(enumStringValues[iEnumCounter]);
+
+                if (!string.IsNullOrEmpty(aliasedName) && enumName != aliasedName)
+                {
+                    enumName = enumName + " (" + aliasedName + ")";
+                }
+
+                dictEnumNamesAndValues.Add(enumName, (int)enumValues.GetValue(iEnumCounter));
+            }
+
+            var sortedEntries = dictEnumNamesAndValues.OrderBy(x => x.Value).ThenBy(x => x.Key.Contains("("));
+
+            m_EnumDisplayNames = sortedEntries.Select(x => x.Key).ToArray();
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.BeginProperty(position, label, property);
+
+            if (property.propertyType == SerializedPropertyType.Enum)
+            {
+                property.enumValueIndex = EditorGUI.Popup(position, label.text, property.enumValueIndex, m_EnumDisplayNames);
+            }
+
+            EditorGUI.EndProperty();
+        }
+    }
+
+    /// <summary>
+    ///Property drawer for <see cref = "GamepadButton" />.s
+    //// </ summary >
+    [CustomPropertyDrawer(typeof(GamepadButton))]
+    internal class GpadButtonDrawer : EnumDrawer<GamepadButton>
+    {
+        protected override string GetNonAliasedNames(string gpadValue)
+        {
+            switch(gpadValue) 
+            {
+                case "North":
+                case "Y":
+                case "Triangle":
+                    return "North";
+
+                case "South":
+                case "A":
+                case "Cross":
+                    return "South";
+                case "East":
+                case "B":
+                case "Circle":
+                    return "East";
+                case "West":
+                case "X":
+                case "Square":
+                    return "West";
+                    
+
+                default: return string.Empty;
+            }
+        }      
+    }
+}
+#endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/EnumPropertyDrawer.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/EnumPropertyDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 496af666e7143fa49b0a653256e529b2


### PR DESCRIPTION
### Description

[Case ISXB-544] (https://jira.unity3d.com/browse/ISXB-544)

The GamepadButton enum has aliased enum members, and when detected by Unity as enum exposed as field and uses default property drawer, it causes confusing behaviour in the UI.
This PR tries to introduce a generic property drawers for aliased types, such that the UI now has aliased entries appended with names of the aliasing member in paranthesis (). This will be intuitive to the user and they would be aware that the selected value may be remapped on assignment

### Changes made

A new property drawer for aliased enums has been introduced. It is made generic, so as to be extendable by any aliased enums in the Input System Package,

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
