### PR TITLE
FIX: Processors/Interactions not added to selected item after reordering (ISX-1873)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
@@ -59,7 +59,8 @@ namespace UnityEngine.InputSystem.Editor
                 && processors == other.processors
                 && initialStateCheck == other.initialStateCheck
                 && actionTypeTooltip == other.actionTypeTooltip
-                && expectedControlTypeTooltip == other.expectedControlTypeTooltip;
+                && expectedControlTypeTooltip == other.expectedControlTypeTooltip
+                && wrappedProperty.propertyPath == other.wrappedProperty.propertyPath;
         }
 
         public override bool Equals(object obj)
@@ -69,15 +70,17 @@ namespace UnityEngine.InputSystem.Editor
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(
-                name,
-                expectedControlType,
-                (int)type,
-                interactions,
-                processors,
-                initialStateCheck,
-                actionTypeTooltip,
-                expectedControlTypeTooltip);
+            var hashCode = new HashCode();
+            hashCode.Add(name);
+            hashCode.Add(expectedControlType);
+            hashCode.Add((int)type);
+            hashCode.Add(interactions);
+            hashCode.Add(processors);
+            hashCode.Add(initialStateCheck);
+            hashCode.Add(actionTypeTooltip);
+            hashCode.Add(expectedControlTypeTooltip);
+            hashCode.Add(wrappedProperty.propertyPath);
+            return hashCode.ToHashCode();
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
@@ -87,7 +87,8 @@ namespace UnityEngine.InputSystem.Editor
                 && isComposite == other.isComposite
                 && isPartOfComposite == other.isPartOfComposite
                 && compositePath == other.compositePath
-                && controlSchemes.SequenceEqual(other.controlSchemes);
+                && controlSchemes.SequenceEqual(other.controlSchemes)
+                && wrappedProperty.propertyPath == other.wrappedProperty.propertyPath;
         }
 
         public override bool Equals(object obj)
@@ -109,6 +110,7 @@ namespace UnityEngine.InputSystem.Editor
             hashCode.Add(isPartOfComposite);
             hashCode.Add(compositePath);
             hashCode.Add(controlSchemes);
+            hashCode.Add(wrappedProperty.propertyPath);
             return hashCode.ToHashCode();
         }
     }


### PR DESCRIPTION
### Description

When reordering Actions/Bindings, the selection doesn't change and neither do any of the other values used by PropertyView's Selectors to detect state changes. That is, PropertyView didn't detect the reordering and therefore didn't update it's UI.

However, with this operation, the SerializedProperty's `propertyPath` changes, but PropertyView (since it wasn't updated) was still referencing the old `propertyPath`. This caused the Processor/Interaction to be added to the wrong item.

### Changes made

To fix this issue, I added the `propertyPath` string to `SerializedInputAction` and `SerializedInputBinding` equality checkers. This allows reordering of Actions/Bindings to trigger state change for PropertyView (and other views).

### Notes

This isn't the change I proposed at Standup; turns out my original idea caused other problems. But I think this is a better and more eloquent fix.

Since this fix is related to Drag/Drop feature, I'll forego adding a CHANGELOG entry; I see this as an implementation detail for the larger feature.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
