### PR TITLE
FIX: Composite types missing in context menu when "Any" ControlType selected (ISXB-769)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -59,6 +59,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Save shortcut (ctrl/cmd + S by default) not saving changes in Input Actions Editor windows. [ISXB-659](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-659).
 - Fixed headers in InputActionEditor windows becoming squashed when there is a large number of Action Maps/Actions.
 - Fixed duplication of project wide input actions when loading/unloading scenes
+- Fixed Composite types missing in context menu when "Any" ControlType selected. [ISXB-769](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-769).
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -125,7 +125,8 @@ namespace UnityEngine.InputSystem.Editor
                     continue;
 
                 // Skip composites that don't match the expected control layout
-                if (expectedControlLayout != "Any" && expectedControlLayout != "")
+                // NOTE: "Any" is a special case and expected to be null
+                if (!string.IsNullOrEmpty(expectedControlLayout))
                 {
                     var valueType = InputBindingComposite.GetValueType(compositeName);
                     if (valueType != null &&


### PR DESCRIPTION
### Description

Simple fix to the filtering logic of CompostieTypes added to the context menu.

### Changes made

Changed the condition for "Any" to check for a null string.

From my investigation, this functionality was refactored and improved [in this PR](https://github.com/Unity-Technologies/InputSystem/pull/1757), but it exposed [another bug]([ISX-1650](https://jira.unity3d.com/browse/ISX-1650)), which was fixed by [this other PR](https://github.com/Unity-Technologies/InputSystem/pull/1788).

As I understand it, the 2nd PR changed the handling of the "Any" ControlType, so it's always index 0 and doesn't have a set value, i.e. expected to be null. However, the condition for the context menu was missed with this change.

### Notes

I'm not familiar with the expected CompositeTypes for "Any". I tried to compare with IMGUI implementation in 1.7 version, both the ControlTypes seemed to have changed, and there's now a "Custom" CompositeType in current version. So it's not a 1-1 comparison, and hopefully this is the correct functionality.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.