### PR TITLE
FIX: Suppressed compile-time warning generated when building Unity Remote sample.

### DIFF
--- a/Assets/Samples/UnityRemote/UnityRemoteTestScript.cs
+++ b/Assets/Samples/UnityRemote/UnityRemoteTestScript.cs
@@ -7,7 +7,12 @@ using Touch = UnityEngine.InputSystem.EnhancedTouch.Touch;
 
 public class UnityRemoteTestScript : MonoBehaviour
 {
+// Suppress harmless warning about overriding camera from UnityEngine.Component.camera where this property have been
+// marked obsolete/deprecated and depending on Unity version this warning may trigger when building a player.
+// warning CS0109: The member 'UnityRemoteTestScript.camera' does not hide an accessible member. The new keyword is not required.
+#pragma warning disable 0109
     public new Camera camera;
+#pragma warning restore 0109
 
     public Text accelerometerInputText;
     public Text touchInputText;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -68,6 +68,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed duplication of project wide input actions when loading/unloading scenes.
 - Fixed an issue in the Input Action Editor window where entries being cut would be deleted instantly and not after being pasted.
 - Fixed an issue where preloaded InputActionAsset objects added by a Unity developer could accidentally be selected as the project-wide actions asset instead of the configured asset in built players.
+- Fixed a compile-time warning: `warning CS0109: The member 'UnityRemoteTestScript.camera' does not hide an accessible member. The new keyword is not required.` showing up in the Console window when building a player including the Input System Unity Remote sample.
 
 ## [1.8.0-pre.2] - 2023-11-09
 


### PR DESCRIPTION
### Description

Suppresses a harmless warning generated in the console when building Unity Remote sample in player.

### Changes made

Suppressed the warning for the single offending property override using new (which is valid) but warned about anyway since there is an unfortunate mismatch of overridden property vs member and deprecation attribute involved.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
