### PR TITLE
FIX: Fixed an issue where the InputActionAsset editor window would remove the unsaved changes asterisk when cancelling the window.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -68,6 +68,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed duplication of project wide input actions when loading/unloading scenes.
 - Fixed an issue in the Input Action Editor window where entries being cut would be deleted instantly and not after being pasted.
 - Fixed an issue where preloaded InputActionAsset objects added by a Unity developer could accidentally be selected as the project-wide actions asset instead of the configured asset in built players.
+- Fixed an issue where the InputActionAsset editor window would remove the unsaved changes asterisk when cancelling the window. [ISXB-797](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-797).
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -315,17 +315,28 @@ namespace UnityEngine.InputSystem.Editor
         private void ReshowEditorWindowWithUnsavedChanges()
         {
             var window = CreateWindow<InputActionsEditorWindow>();
-            CopyOldStatsToNewWindow(window);
+
+            // Move/transfer ownership of m_AssetObjectForEditing to new window
+            window.m_AssetObjectForEditing = m_AssetObjectForEditing;
+            m_AssetObjectForEditing = null;
+
+            // Move/transfer ownership of m_State to new window (struct)
+            window.m_State = m_State;
+            m_State = new InputActionsEditorState();
+
+            // Just copy trivial arguments
+            window.m_AssetGUID = m_AssetGUID;
+            window.m_AssetId = m_AssetId;
+            window.m_AssetJson = m_AssetJson;
+            window.m_IsDirty = m_IsDirty;
+
+            // Note that view and state container will get destroyed with this window instance
+            // and recreated for this window below
             window.BuildUI();
             window.Show();
-        }
 
-        private void CopyOldStatsToNewWindow(InputActionsEditorWindow window)
-        {
-            window.m_AssetId = m_AssetId;
-            window.m_State = m_State;
-            window.m_AssetJson = m_AssetJson;
-            window.m_IsDirty = true;
+            // Make sure window title is up to date
+            window.UpdateWindowTitle();
         }
 
         private bool TryUpdateFromAsset()


### PR DESCRIPTION
### Description

FIX: Fixed an issue where the InputActionAsset editor window would remove the unsaved changes asterisk when cancelling the window. https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-797

FIX: Fixed an issue introduced lately where canceling an editor window with changes would result in an exception. Didn't add a changelog entry for this since introduced lately.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
