### PR TITLE
FIX: Changing ActionType in asset editor also sets ControlType (ISX-1916)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -73,6 +73,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Composite types missing in context menu when "Any" ControlType selected. [ISXB-769](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-769).
 - Fixed 3D Vector and 1D Axis binding dropdown usage in Input Actions Editor throwing NotImplementedExceptions.
 - Fixed several missing tooltips from the Action/Binding Properties pane in Input Actions Editor.
+- Fixed an issue in the InputActionAsset Editor where ControlType wasn't updated when ActionType changed.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionPropertiesView.cs
@@ -76,7 +76,17 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     Dispatch(Commands.ChangeActionControlType(inputAction, controlType.index));
                 });
+
+                // ISX-1916 - When changing ActionType to a non-Button type, we must also update the ControlType
+                // to the currently selected value; the ValueChangedCallback is not fired in this scenario.
+                Dispatch(Commands.ChangeActionControlType(inputAction, controlType.index));
+
                 rootElement.Add(controlType);
+            }
+            else
+            {
+                // ISX-1916 - When changing ActionType to a Button, we must also reset the ControlType
+                Dispatch(Commands.ChangeActionControlType(inputAction, 0));
             }
 
             if (inputAction.type != InputActionType.Value)


### PR DESCRIPTION
### Description

Fixes an issue in the InputActionAsset editor where an Action's ControlType wasn't being updated when ActionType changed. This was only just uncovered while [fixing another, related bug](https://github.com/Unity-Technologies/InputSystem/pull/1869).

### Changes made

Dispatches a `ChangeActionControlType` command when the ActionType changes from a Button to a non-Button type:

- Set ControlType to currently selected index from DropDown menu for Value and PassThrough types
- Reset ControlType to 0 for Button type

Although this function wires up `ValueChangedCallback` on the ControlType UI, this callback isn't fired in this scenario, and we must manually dispatch the command.

### Notes

This functionality doesn't exactly match that in IMGUI: the ControlType value is "remembered" when switching ActionType between Button, Value, and PassThrough. Also, Changing from Button type to a non-Button type will set the ControlType selection (in the dropdown) to "Button".

With UITK implementation: selected ControlType is only "remembered" when switching between Value and "PassThrough types, and switching from a Button to non-Button type defaults ControlType to "Any".

These are minor deviations which cannot be easily fixed due to the way the ControlType dropdown menu is handled in UITK. That is, the DropDownMenu object is created only when a non-Button ActionType is selected and destroyed (instead of hidden) when switching back to Button.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
