### PR TITLE
FIX: Exceptions thrown in Binding properties (ISX-1816, ISX-1817)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -39,7 +39,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Documentation~/filter.yml GlobalNamespace rule removing all API documentation.
 - Fixed `Destroy may not be called from edit mode` error [ISXB-695](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-695)
 - Fixed possible exceptions thrown when deleting and adding Action Maps.
-- Fixed selection not changing when right-clicking an Action Map or Action in the Project Settings Input Action Editor.
+- Fixed selection not changing when right-clicking an Action Map or Action in the Project Settings Input Actions Editor.
 - Fixed potential race condition on access to GCHandle in DefferedResolutionOfBindings and halved number of calls to GCHandle resolution [ISXB-726](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-726)
 - Fixed issue where composite part dropdown manipulates binding path and leaves composite part field unchanged.
 - Fixed lingering highlight effect on Save Asset button after clicking.
@@ -52,26 +52,27 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Cut/Paste behaviour to match Editor - Cut items will now be cleared from clipboard after pasting.
 - Improved window layout to avoid elements being hidden (both the Input Actions in Project Settings, and standalone Input Actions Editor windows).
 - Fixed InputAction asset appearing dirty after rename [ISXB-749](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-749).
-- Fixed Error logged when InputActionEditor window opened without a valid asset.
+- Fixed Error logged when InputActionsEditor window opened without a valid asset.
 - Fixed ArgumentNullExceptions thrown when deleting items quickly in the UITK Editor.
 - Fixed Project Settings header title styling for Input Actions editor.
 - Fixed Input Actions Editor losing reference to current ControlScheme upon entering Play Mode [ISXB-770](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-770).
 - Fixed Save shortcut (ctrl/cmd + S by default) not saving changes in Input Actions Editor windows. [ISXB-659](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-659).
-- Fixed headers in InputActionEditor windows becoming squashed when there is a large number of Action Maps/Actions.
+- Fixed headers in InputActionsEditor windows becoming squashed when there is a large number of Action Maps/Actions.
 - Fixed duplication of project wide input actions when loading/unloading scenes.
 - Fixed an issue where UI Toolkit based editor would not close itself if the associated asset would be deleted (To mimic IMGUI Input Action Editor behavior).
 - Fixed a regression in IMGUI Input Action Editor where editor would auto-save on focus lost even when the auto-save toggle was disabled.
 - Fixed an issue where UI Toolkit based editor would not properly track tentative changes associated with a moved asset file.
 - Fixed an issue where selection state of UI Toolkit editor state would not be preserved when associated with a new serialized copy of the asset.
 - Fixed an issue where any exceptions throw from within UI Toolkit event queue would only log the error message and not the full exception stack trace, making debugging more difficult.
-- Fixed an issue where UI Toolkit Input Action Editor wouldn't provide a correct modification state when coming back from domain reload.
-- Fixed an issue in the Input Action Editor window where entries being cut would be deleted instantly and not after being pasted.
+- Fixed an issue where UI Toolkit Input Actions Editor wouldn't provide a correct modification state when coming back from domain reload.
+- Fixed an issue in the Input Actions Editor window where entries being cut would be deleted instantly and not after being pasted.
 - Fixed an issue where preloaded InputActionAsset objects added by a Unity developer could accidentally be selected as the project-wide actions asset instead of the configured asset in built players.
 - Fixed a compile-time warning: `warning CS0109: The member 'UnityRemoteTestScript.camera' does not hide an accessible member. The new keyword is not required.` showing up in the Console window when building a player including the Input System Unity Remote sample.
 - Fixed an issue where the InputActionAsset editor window would remove the unsaved changes asterisk when cancelling the window. [ISXB-797](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-797).
-- Fixed an issue in the Input Action Editor window where entries being cut would be deleted instantly and not after being pasted.
-- Fixed an issue in the Input Action Editor window where deleting items unfolded other actions or the selection switched unintended.
+- Fixed an issue in the Input Actions Editor window where deleting items unfolded other actions or the selection switched unintended.
 - Fixed Composite types missing in context menu when "Any" ControlType selected. [ISXB-769](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-769).
+- Fixed 3D Vector and 1D Axis binding dropdown usage in Input Actions Editor throwing NotImplementedExceptions.
+- Fixed several missing tooltips from the Action/Binding Properties pane in Input Actions Editor.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -3,6 +3,13 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
 
+#if UNITY_EDITOR
+using System;
+using UnityEditor;
+using UnityEngine.InputSystem.Editor;
+using UnityEngine.UIElements;
+#endif
+
 namespace UnityEngine.InputSystem.Composites
 {
     /// <summary>
@@ -201,4 +208,38 @@ namespace UnityEngine.InputSystem.Composites
             Negative = 2,
         }
     }
+
+    #if UNITY_EDITOR
+    internal class AxisCompositeEditor : InputParameterEditor<AxisComposite>
+    {
+        private GUIContent m_WhichAxisWinsLabel = new GUIContent("Which Side Wins",
+            "Determine which axis 'wins' if both are actuated at the same time. "
+            + "If 'Neither' is selected, the result is 0 (or, more precisely, "
+            + "the midpoint between minValue and maxValue).");
+
+        public override void OnGUI()
+        {
+            target.whichSideWins = (AxisComposite.WhichSideWins)EditorGUILayout.EnumPopup(m_WhichAxisWinsLabel, target.whichSideWins);
+        }
+
+#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+        public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
+        {
+            var modeField = new EnumField(m_WhichAxisWinsLabel.text, target.whichSideWins)
+            {
+                tooltip = m_WhichAxisWinsLabel.tooltip
+            };
+
+            modeField.RegisterValueChangedCallback(evt =>
+            {
+                target.whichSideWins = (AxisComposite.WhichSideWins)evt.newValue;
+                onChangedCallback();
+            });
+
+            root.Add(modeField);
+        }
+
+#endif
+    }
+    #endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -3,13 +3,11 @@ using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine.Scripting;
 
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
 #endif
 
 ////TODO: add support for ramp up/down
@@ -207,9 +205,9 @@ namespace UnityEngine.InputSystem.Composites
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField("Mode", target.mode)
+            var modeField = new EnumField(m_ModeLabel.text, target.mode)
             {
-                tooltip = m_ModeLabel.text
+                tooltip = m_ModeLabel.tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -2,13 +2,11 @@ using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine.Scripting;
 
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
 #endif
 
 namespace UnityEngine.InputSystem.Composites
@@ -172,7 +170,7 @@ namespace UnityEngine.InputSystem.Composites
     }
 
     #if UNITY_EDITOR
-    internal class Vector3CompositeEditor : InputParameterEditor<Vector2Composite>
+    internal class Vector3CompositeEditor : InputParameterEditor<Vector3Composite>
     {
         private GUIContent m_ModeLabel = new GUIContent("Mode",
             "How to synthesize a Vector3 from the inputs. Digital "
@@ -181,20 +179,20 @@ namespace UnityEngine.InputSystem.Composites
 
         public override void OnGUI()
         {
-            target.mode = (Vector2Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
+            target.mode = (Vector3Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField("Mode", target.mode)
+            var modeField = new EnumField(m_ModeLabel.text, target.mode)
             {
-                tooltip = m_ModeLabel.text
+                tooltip = m_ModeLabel.tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>
             {
-                target.mode = (Vector2Composite.Mode)evt.newValue;
+                target.mode = (Vector3Composite.Mode)evt.newValue;
                 onChangedCallback();
             });
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -205,7 +205,11 @@ namespace UnityEngine.InputSystem.Interactions
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var tapCountField = new IntegerField(m_TapCountLabel.text) { value = target.tapCount };
+            var tapCountField = new IntegerField(m_TapCountLabel.text)
+            {
+                value = target.tapCount,
+                tooltip = m_TapCountLabel.tooltip
+            };
             tapCountField.RegisterValueChangedCallback(evt =>
             {
                 target.tapCount = evt.newValue;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -223,7 +223,10 @@ namespace UnityEngine.InputSystem.Interactions
         {
             root.Add(new HelpBox(s_HelpBoxText.text, HelpBoxMessageType.None));
 
-            var behaviourDropdown = new EnumField(s_PressBehaviorLabel.text, target.behavior);
+            var behaviourDropdown = new EnumField(s_PressBehaviorLabel.text, target.behavior)
+            {
+                tooltip = s_PressBehaviorLabel.tooltip
+            };
             behaviourDropdown.RegisterValueChangedCallback(evt =>
             {
                 target.behavior = (PressBehavior)evt.newValue;


### PR DESCRIPTION
### Description

When trying to use dropdown selectors for 3D Vector and 1D Axis, NotImplementedExceptions would be thrown. ([ISX-1816](https://jira.unity3d.com/browse/ISX-1816), [ISX-1817](https://jira.unity3d.com/browse/ISX-1817))

### Changes made

- Fixed copypasta from 2D Vector
- Fixed 1D Axis to use the same system as 2D/3D Vector (inheriting from InputParameterEditor)
- Fixed tooltips in classes inheriting from InputParameterEditor
- Fixed minor issues with changelog (duplicate entry, Input Action Editor -> Input Action**s** Editor)

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
