### PR TITLE
FIX: Canceling ControlScheme edits resets the UI to the previously saved values (ISX-1892)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -74,6 +74,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed 3D Vector and 1D Axis binding dropdown usage in Input Actions Editor throwing NotImplementedExceptions.
 - Fixed several missing tooltips from the Action/Binding Properties pane in Input Actions Editor.
 - Fixed an issue in the InputActionAsset Editor where ControlType wasn't updated when ActionType changed.
+- Fixed an issue in the InputActionAsset Editor where Canceling ControlScheme changes didn't reset the values in the UI.
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -131,6 +131,26 @@ namespace UnityEngine.InputSystem.Editor
             };
         }
 
+        public static Command ResetSelectedControlScheme()
+        {
+            return (in InputActionsEditorState state) =>
+            {
+                var controlSchemeSerializedProperty = state.serializedObject
+                    .FindProperty(nameof(InputActionAsset.m_ControlSchemes))
+                    .GetArrayElementAtIndex(state.selectedControlSchemeIndex);
+
+                if (controlSchemeSerializedProperty == null)
+                {
+                    return state.With(
+                        selectedControlSchemeIndex: -1,
+                        selectedControlScheme: new InputControlScheme());
+                }
+
+                return state.With(
+                    selectedControlScheme: new InputControlScheme(controlSchemeSerializedProperty));
+            };
+        }
+
         public static Command SelectDeviceRequirement(int deviceRequirementIndex)
         {
             return (in InputActionsEditorState state) => state.With(selectedDeviceRequirementIndex: deviceRequirementIndex);


### PR DESCRIPTION
### Description

The issue occurred because, although the changes weren't persisted to the SerializedProperty, the UI was still holding changes, and if the ControlScheme Edit dialog is re-opened (without changing ControlSchemes) the old values are displayed. We must explicitly reset the `InputControlScheme` in the ViewState to the last saved values.

### Changes made

- Created `ControlSchemeCommands.ResetSelectedControlScheme()` command to reload `InputControlScheme` from the SerializedProperty (called during Cancel)
- Minor refactoring of "Close" methods in `ControlSchemesView`
- Added comments explaining current functionality

### Notes

I don't know if the current functionality is what we want or not, and so I added verbose comments explaining how it works now. We can change it later if not to everyone's liking.

The new `ResetSelectedControlScheme()` command is nearly identical to `SelectControlScheme`. I decided this was the safer route for now, but maybe there's a better way.

I only did the most basic of testing before opening this PR.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
