### PR TITLE
FIX: Avoid null reference. (ISX-1920)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -80,7 +80,7 @@ namespace UnityEngine.InputSystem.Editor
 
             m_IsActivated = false;
 
-            m_View.DestroyView();
+            m_View?.DestroyView();
         }
 
         private void OnEditFocus(FocusInEvent @event)


### PR DESCRIPTION
### Description

As title. [ISX-1920](https://jira.unity3d.com/browse/ISX-1920)

### Changes made

Avoid nullref if views haven't been created because no asset was selected when exiting the settings page.

### Notes

No changelog entry, as this error was added after the previous public release.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
