### PR TITLE
[Input] Ensure newly created action maps have their name editable immediately after creation (case ISX-1886)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -73,6 +73,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Composite types missing in context menu when "Any" ControlType selected. [ISXB-769](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-769).
 - Fixed 3D Vector and 1D Axis binding dropdown usage in Input Actions Editor throwing NotImplementedExceptions.
 - Fixed several missing tooltips from the Action/Binding Properties pane in Input Actions Editor.
+- Fixed an issue where newly created action map names were not editable
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -108,7 +108,6 @@ namespace UnityEngine.InputSystem.Editor
             if (element == null)
                 return;
             ((InputActionMapsTreeViewItem)element).FocusOnRenameTextField();
-            m_EnterRenamingMode = false;
         }
 
         private void DeleteActionMap(int index)
@@ -138,6 +137,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void ChangeActionMapName(int index, string newName)
         {
+            m_EnterRenamingMode = false;
             Dispatch(Commands.ChangeActionMapName(index, newName));
         }
 


### PR DESCRIPTION
### Description

A newly created action map was not in rename mode - this PR fixes that.

### Changes made

Fixed the logic controlling renaming of new action maps in ActionMapsView.cs


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    
    FIX: Fixed an issue where newly created action map names were not editable