### PR TITLE
FIX: Visual glitch in Actions list when scrolling the view while renaming an item (ISXB-748)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -77,6 +77,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue in the InputActionAsset Editor where ControlType wasn't updated when ActionType changed.
 - Fixed an issue in the InputActionAsset Editor where Canceling ControlScheme changes didn't reset the values in the UI.
 - Fixed an issue where newly created action map names were not editable.
+- Fixed a visual glitch in the InputActionAsset Editor when scrolling the Actions list with a rename in progress. [ISXB-748](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-748)
 
 ## [1.8.0-pre.2] - 2023-11-09
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -52,10 +52,14 @@ namespace UnityEngine.InputSystem.Editor
             m_ListView.RegisterCallback<ExecuteCommandEvent>(OnExecuteCommand);
             m_ListView.RegisterCallback<ValidateCommandEvent>(OnValidateCommand);
             m_ListView.RegisterCallback<PointerDownEvent>(OnPointerDown, TrickleDown.TrickleDown);
+
+            // ISXB-748 - Scrolling the view causes a visual glitch with the rename TextField. As a work-around we
+            // need to cancel the rename operation in this scenario.
+            m_ListView.RegisterCallback<WheelEvent>(e => InputActionMapsTreeViewItem.CancelRename(), TrickleDown.TrickleDown);
+
             var treeView = root.Q<TreeView>("actions-tree-view");
             m_ListView.AddManipulator(new DropManipulator(OnDroppedHandler, treeView));
             m_ListView.itemIndexChanged += OnReorder;
-
 
             CreateSelector(Selectors.GetActionMapNames, Selectors.GetSelectedActionMap, (actionMapNames, actionMap, state) => new ViewState(actionMap, actionMapNames, state.GetDisabledActionMaps(actionMapNames.ToList())));
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
@@ -19,6 +19,7 @@ namespace UnityEngine.InputSystem.Editor
         public event EventCallback<string> EditTextFinished;
 
         private bool m_IsEditing;
+        private static InputActionMapsTreeViewItem s_EditingItem = null;
 
         public InputActionMapsTreeViewItem()
         {
@@ -89,7 +90,13 @@ namespace UnityEngine.InputSystem.Editor
             DelayCall();
             renameTextfield.SelectAll();
 
+            s_EditingItem = this;
             m_IsEditing = true;
+        }
+
+        public static void CancelRename()
+        {
+            s_EditingItem?.OnEditTextFinished();
         }
 
         async void DelayCall()
@@ -107,6 +114,7 @@ namespace UnityEngine.InputSystem.Editor
 
             renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
             label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            s_EditingItem = null;
             m_IsEditing = false;
 
             var text = renameTextfield.text?.Trim();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
         public event EventCallback<string> EditTextFinished;
 
         private bool m_IsEditing;
+        private static InputActionsTreeViewItem s_EditingItem = null;
 
         public InputActionsTreeViewItem()
         {
@@ -89,7 +90,13 @@ namespace UnityEngine.InputSystem.Editor
             DelayCall();
             renameTextfield.SelectAll();
 
+            s_EditingItem = this;
             m_IsEditing = true;
+        }
+
+        public static void CancelRename()
+        {
+            s_EditingItem?.OnEditTextFinished();
         }
 
         async void DelayCall()
@@ -107,6 +114,7 @@ namespace UnityEngine.InputSystem.Editor
 
             renameTextfield.AddToClassList(InputActionsEditorConstants.HiddenStyleClassName);
             label.RemoveFromClassList(InputActionsEditorConstants.HiddenStyleClassName);
+            s_EditingItem = null;
             m_IsEditing = false;
 
             var text = renameTextfield.text?.Trim();


### PR DESCRIPTION
### Description
In UITK, scrolling List/Tree items off the visible area causes them to be "unbound" from the active item set, which causes [issues with the Rename functionality](https://unity.slack.com/archives/C3414V4UV/p1683713461312229).

In this case, although Reset is called for `ActionTreeViewItem` being unbound, which resets rename tracking fields, the Rename TextEdit control remains active causing items at the top of the list to appear like they've been renamed. Their names haven't _actually_ been changed (just a visual glitch) but it's quite ugly.

This change fixes the problem by canceling the Rename operation (removes Rename TextEdit box) when a `WheelEvent` is received.

### Changes made

- Hooks up a `WheelEvent` handler to ActionTreeView to cancel Rename operation (if one is active)
- Added a static `s_EditingItem` to the Item class for tracking item currently being edited
- Applied same fix to ActionMapsTreeView (has the same bug)
- Some minor refactoring within ActionsTreeView

### Notes

This fix only covers scrolling from the Mouse Wheel and (probably) won't work if the list is scrolled by some other means. For some strange reason, there doesn't appear to be a `ScrollEvent` or a (public) OnScroll() override on the ScrollView.

Note that Rename TextEdit has keyboard focus (so arrow keys aren't a concern) and a left click cancels rename, but dragging via Touch could still be a problem. This fix should be good enough for now, but the Rename functionality should be revisited later.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
