### PR TITLE
FIX: (Tentative) Modified constraint for enabling project-wide actions

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2890,27 +2890,10 @@ partial class CoreTests
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0.75f).Within(0.00001f));
     }
 
-    private static void DisableProjectWideActions()
-    {
-#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
-        // If the system has project-wide input actions they will also trigger enable/disable via
-        // play mode change triggers above. Hence we adjust extra variable to compensate of
-        // state allocated by project-wide actions.
-        if (InputSystem.actions)
-        {
-            Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(1));
-            InputSystem.actions.Disable();
-            InputActionState.DestroyAllActionMapStates();
-        }
-#endif
-    }
-
     [Test]
     [Category("Editor")]
     public void Editor_LeavingPlayMode_DestroysAllActionStates()
     {
-        DisableProjectWideActions();
-
         // Initial state
         Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(0));
 
@@ -2919,8 +2902,6 @@ partial class CoreTests
         // Enter play mode.
         InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingEditMode);
         InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredPlayMode);
-
-        DisableProjectWideActions();
 
         var action = new InputAction(binding: "<Gamepad>/buttonSouth");
         action.Enable();

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2890,10 +2890,27 @@ partial class CoreTests
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0.75f).Within(0.00001f));
     }
 
+    private static void DisableProjectWideActions() // AlexT - testing
+    {
+#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+        // If the system has project-wide input actions they will also trigger enable/disable via
+        // play mode change triggers above. Hence we adjust extra variable to compensate of
+        // state allocated by project-wide actions.
+        if (InputSystem.actions)
+        {
+            Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(1));
+            InputSystem.actions.Disable();
+            InputActionState.DestroyAllActionMapStates();
+        }
+#endif
+    }
+
     [Test]
     [Category("Editor")]
     public void Editor_LeavingPlayMode_DestroysAllActionStates()
     {
+        DisableProjectWideActions();    // AlexT - testing
+
         // Initial state
         Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(0));
 
@@ -2902,6 +2919,8 @@ partial class CoreTests
         // Enter play mode.
         InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingEditMode);
         InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredPlayMode);
+
+        DisableProjectWideActions();    // AlexT - testing
 
         var action = new InputAction(binding: "<Gamepad>/buttonSouth");
         action.Enable();

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -2890,7 +2890,7 @@ partial class CoreTests
         Assert.That(action.ReadValue<float>(), Is.EqualTo(0.75f).Within(0.00001f));
     }
 
-    private static void DisableProjectWideActions() // AlexT - testing
+    private static void DisableProjectWideActions()
     {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
         // If the system has project-wide input actions they will also trigger enable/disable via
@@ -2909,7 +2909,7 @@ partial class CoreTests
     [Category("Editor")]
     public void Editor_LeavingPlayMode_DestroysAllActionStates()
     {
-        DisableProjectWideActions();    // AlexT - testing
+        DisableProjectWideActions();
 
         // Initial state
         Assert.That(InputActionState.s_GlobalState.globalList.length, Is.EqualTo(0));
@@ -2920,7 +2920,7 @@ partial class CoreTests
         InputSystem.OnPlayModeChange(PlayModeStateChange.ExitingEditMode);
         InputSystem.OnPlayModeChange(PlayModeStateChange.EnteredPlayMode);
 
-        DisableProjectWideActions();    // AlexT - testing
+        DisableProjectWideActions();
 
         var action = new InputAction(binding: "<Gamepad>/buttonSouth");
         action.Enable();

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3024,7 +3024,7 @@ namespace UnityEngine.InputSystem
         {
 #if UNITY_EDITOR
             // Abort if not in play-mode in editor
-            if (!EditorApplication.isPlaying)
+            if (!EditorApplication.isPlayingOrWillChangePlaymode)
                 return;
 #endif // UNITY_EDITOR
             if (actions == null)


### PR DESCRIPTION
### Description

Modified constraint for enabling project-wide actions to allow similar behaviour in player and play-mode.

### Changes made

Modified constraint to enable project-wide actions.

### Notes

Not sure whether we want to include this in 1.8.0 or not but if CI is happy I lean to saying yes. Putting it up for discussion. Fix originally suggested by @AlexTyrer in https://github.com/Unity-Technologies/InputSystem/pull/1866.

The idea is to provide consistent behavior between play-mode and player. Without this fix the following happens:

```
void Awake() { Debug.Log(InputSystem.actions.enabled); } // false in play-mode, true in player
void Start() { Debug.Log(InputSystem.actions.enabled); } // false in play-mode, true in player
void OnEnable() { Debug.Log(InputSystem.actions.enabled); } // false in play-mode, true in player
```

with this fix its consistently true in both.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
