### PR TITLE
FIX: Avoid jumping around Actions list due to premature asset saving (ISXB-801)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -162,7 +162,9 @@ namespace UnityEngine.InputSystem.Editor
 
         private void ShowDropdown(Rect rect, SerializedProperty serializedProperty, Action modifiedCallback)
         {
+            #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(true, false);
+            #endif
             if (m_PickerDropdown == null)
             {
                 m_PickerDropdown = new InputControlPickerDropdown(

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -162,6 +162,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void ShowDropdown(Rect rect, SerializedProperty serializedProperty, Action modifiedCallback)
         {
+            InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(true, false);
             if (m_PickerDropdown == null)
             {
                 m_PickerDropdown = new InputControlPickerDropdown(

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -65,7 +65,9 @@ namespace UnityEngine.InputSystem.Editor
 
         protected override void OnDestroy()
         {
+            #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(false, false);
+            #endif
             m_RebindingOperation?.Dispose();
             m_RebindingOperation = null;
         }
@@ -121,7 +123,9 @@ namespace UnityEngine.InputSystem.Editor
 
         protected override void ItemSelected(AdvancedDropdownItem item)
         {
+            #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(false, true);
+            #endif
             var path = ((InputControlDropdownItem)item).controlPathWithDevice;
             m_OnPickCallback(path);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -65,6 +65,7 @@ namespace UnityEngine.InputSystem.Editor
 
         protected override void OnDestroy()
         {
+            InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(false, false);
             m_RebindingOperation?.Dispose();
             m_RebindingOperation = null;
         }
@@ -120,6 +121,7 @@ namespace UnityEngine.InputSystem.Editor
 
         protected override void ItemSelected(AdvancedDropdownItem item)
         {
+            InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(false, true);
             var path = ((InputControlDropdownItem)item).controlPathWithDevice;
             m_OnPickCallback(path);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -16,6 +16,7 @@ namespace UnityEngine.InputSystem.Editor
         private bool m_HasEditFocus;
         private bool m_IgnoreActionChangedCallback;
         private bool m_IsActivated;
+        private static bool m_IMGUIDropdownVisible;
         StateContainer m_StateContainer;
         private static InputActionsEditorSettingsProvider m_ActiveSettingsProvider;
 
@@ -95,7 +96,39 @@ namespace UnityEngine.InputSystem.Editor
             {
                 m_HasEditFocus = true;
                 m_ActiveSettingsProvider = this;
+                SetIMGUIDropdownVisible(false, false);
             }
+        }
+
+        void SaveAssetOnFocusLost()
+        {
+            #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
+            var asset = GetAsset();
+            if (asset != null)
+                ValidateAndSaveAsset(asset);
+            #endif
+        }
+
+        public static void SetIMGUIDropdownVisible(bool visible, bool optionWasSelected)
+        {
+            // If we selected an item from the dropdown, we *should* still be focused on this settings window - but
+            // since the IMGUI dropdown is technically a separate window, we have to refocus manually.
+            //
+            // If we didn't select a dropdown option, there's not a simple way to know where the focus has gone,
+            // so assume we lost focus and save if appropriate. ISXB-801
+            if (!visible && m_IMGUIDropdownVisible)
+            {
+                if (optionWasSelected)
+                    m_ActiveSettingsProvider.m_RootVisualElement.Focus();
+                else
+                    m_ActiveSettingsProvider.SaveAssetOnFocusLost();
+            }
+            else if (visible && !m_IMGUIDropdownVisible)
+            {
+                m_ActiveSettingsProvider.m_HasEditFocus = false;
+            }
+
+            m_IMGUIDropdownVisible = visible;
         }
 
         private void OnEditFocusLost(FocusOutEvent @event)
@@ -105,15 +138,10 @@ namespace UnityEngine.InputSystem.Editor
             // elements outside of project settings Editor Window. Also note that @event is null when we call this
             // from OnDeactivate().
             var element = (VisualElement)@event?.relatedTarget;
-            if (element == null && m_HasEditFocus)
+            if (element == null && m_HasEditFocus && !m_IMGUIDropdownVisible)
             {
                 m_HasEditFocus = false;
-
-                #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
-                var asset = GetAsset();
-                if (asset != null)
-                    ValidateAndSaveAsset(asset);
-                #endif
+                SaveAssetOnFocusLost();
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -131,12 +131,12 @@ namespace UnityEngine.InputSystem.Editor
 
             m_IMGUIDropdownVisible = visible;
         }
-        
+
         private async void DelayFocusLost(bool relatedTargetWasNull)
         {
             await Task.Delay(120);
 
-            // We delay this call to ensure that the IMGUI flag has a chance to change first. 
+            // We delay this call to ensure that the IMGUI flag has a chance to change first.
             if (relatedTargetWasNull && m_HasEditFocus && !m_IMGUIDropdownVisible)
             {
                 m_HasEditFocus = false;


### PR DESCRIPTION
### Description

Fix for [ISXB-801](https://jira.unity3d.com/browse/ISXB-801), where editing the binding path for a newly added action's binding would cause the selection to jump to the top action instead.

### Changes made

Use the opening and closing of the IMGUI dropdown window to inform the settings window of how to act. 

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
