### PR TITLE
removing wrongly re-added exception

### DIFF
--- a/Packages/com.unity.inputsystem/ValidationExceptions.json
+++ b/Packages/com.unity.inputsystem/ValidationExceptions.json
@@ -1,9 +1,4 @@
 {
-    "ErrorExceptions": [
-        {
-             "ValidationTest": "API Updater Configuration Validation",
-             "PackageVersion": "1.8.1"
-        }
-    ],
+    "ErrorExceptions": [],
     "WarningExceptions": []
 }


### PR DESCRIPTION
### Description

got removed https://github.com/Unity-Technologies/InputSystem/commit/c8c9e8a7b3c2356369e2b16019bdbdc5247eae5b by James and I wrongly added it back in

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
