### PR TITLE
FIX: clean up after the XRI package test (ISX-1909)

### DIFF
--- a/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
+++ b/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
@@ -28,6 +28,12 @@ public class XRIPackageTests
         {
             yield return null;
         }
+
+        //Delete the Assets/XRI folder (and its content) that the XRI package creates
+        if (AssetDatabase.IsValidFolder("Assets/XRI"))
+        {
+            AssetDatabase.DeleteAsset("Assets/XRI");
+        }
     }
 
     [UnityTest]

--- a/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs.meta
+++ b/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: b69fa2235c5cf9140936a639fd7f0005
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Changes made

XRI package creates a folder with settings files which I forgot to clean up after the test finishes.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
