### PR TITLE
FIX: reenable editor tests after changes to mock dialogues (ISX-1896)

### DIFF
--- a/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
@@ -260,7 +260,7 @@ public class ControlSchemesEditorTests
     }
 
     [Test]
-    [Category("AssetEditor")]    
+    [Category("AssetEditor")]
     public void DeleteControlSchemeCommand_DeletesSelectedControlScheme()
     {
         var asset = TestData.inputActionAsset.WithControlScheme(TestData.controlScheme.WithOptionalDevice()).Generate();
@@ -281,7 +281,7 @@ public class ControlSchemesEditorTests
     [TestCase(3, 1, 1, "Test2")]
     [TestCase(3, 2, 1, "Test1")]
     [TestCase(1, 0, -1, null)]
-    [Category("AssetEditor")]  
+    [Category("AssetEditor")]
     public void DeleteControlSchemeCommand_SelectsAnotherControlSchemeAfterDelete(
         int controlSchemeCount,
         int selectedControlSchemeIndex,

--- a/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
@@ -263,17 +263,20 @@ public class ControlSchemesEditorTests
     [Category("AssetEditor")]
     public void DuplicateControlSchemeCommand_CreatesCopyOfControlSchemeWithUniqueNameEndingOnIntJumpsExistingNumbers()
     {
-        var asset = TestData.inputActionAsset
-            .WithControlScheme(TestData.controlScheme.Select(s => s.WithName("Test")))
-            .Generate();
+        var asset = TestData.inputActionAsset.Generate();
 
+        asset.AddControlScheme(new InputControlScheme(("Test")));
         asset.AddControlScheme(new InputControlScheme(("Test1")));
 
+        //select "Test" Control Scheme
         var state = TestData.EditorStateWithAsset(asset).Generate().With(selectedControlScheme: asset.controlSchemes[0]);
 
         state.serializedObject.Update();
+
+        //duplicate "Test"
         var newState = ControlSchemeCommands.DuplicateSelectedControlScheme()(in state);
 
+        //duplicated Control Scheme should be names "Test2", skipping "Test1"
         Assert.That(newState.selectedControlScheme.name, Is.EqualTo("Test2"));
     }
 

--- a/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
@@ -259,6 +259,24 @@ public class ControlSchemesEditorTests
         Assert.That(newState.selectedControlScheme.deviceRequirements, Is.EqualTo(state.selectedControlScheme.deviceRequirements));
     }
 
+    [Test(Description = "Verifies that when duplicating Control Scheme ending on an Int it increments that Int and jumps already existing Int names")]
+    [Category("AssetEditor")]
+    public void DuplicateControlSchemeCommand_CreatesCopyOfControlSchemeWithUniqueNameEndingOnIntJumpsExistingNumbers()
+    {
+        var asset = TestData.inputActionAsset
+            .WithControlScheme(TestData.controlScheme.Select(s => s.WithName("Test")))
+            .Generate();
+
+        asset.AddControlScheme(new InputControlScheme(("Test1")));
+
+        var state = TestData.EditorStateWithAsset(asset).Generate().With(selectedControlScheme: asset.controlSchemes[0]);
+
+        state.serializedObject.Update();
+        var newState = ControlSchemeCommands.DuplicateSelectedControlScheme()(in state);
+
+        Assert.That(newState.selectedControlScheme.name, Is.EqualTo("Test2"));
+    }
+
     [Test]
     [Category("AssetEditor")]
     public void DeleteControlSchemeCommand_DeletesSelectedControlScheme()

--- a/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/ControlSchemeEditorTests.cs
@@ -197,7 +197,6 @@ public class ControlSchemesEditorTests
 
     [Test]
     [Category("AssetEditor")]
-    [Ignore("Instability ISX-1905")]
     public void WhenControlSchemeIsSelected_SelectedControlSchemeIsPopulatedWithSelection()
     {
         var asset = TestData.inputActionAsset
@@ -261,8 +260,7 @@ public class ControlSchemesEditorTests
     }
 
     [Test]
-    [Category("AssetEditor")]
-    [Ignore("Disabled: This should not be called in batch mode.")]
+    [Category("AssetEditor")]    
     public void DeleteControlSchemeCommand_DeletesSelectedControlScheme()
     {
         var asset = TestData.inputActionAsset.WithControlScheme(TestData.controlScheme.WithOptionalDevice()).Generate();
@@ -283,8 +281,7 @@ public class ControlSchemesEditorTests
     [TestCase(3, 1, 1, "Test2")]
     [TestCase(3, 2, 1, "Test1")]
     [TestCase(1, 0, -1, null)]
-    [Category("AssetEditor")]
-    [Ignore("Disabled: This should not be called in batch mode.")]
+    [Category("AssetEditor")]  
     public void DeleteControlSchemeCommand_SelectsAnotherControlSchemeAfterDelete(
         int controlSchemeCount,
         int selectedControlSchemeIndex,


### PR DESCRIPTION
### Description

- After adding mock dialogues in https://github.com/Unity-Technologies/InputSystem/issues/1866 the tests can get reenabled.
- Add one more Control Scheme test for checking basic functionality or incrementing names of duplicated schemes

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
