### PR TITLE
FIX: Avoid nullrefs from right-clicking when there's no Action Maps (ISXB-833).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - YYYY-MM-DD
 
+### Fixed
+- NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
+
 ## [1.8.1] - 2024-03-14
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -67,6 +67,8 @@ namespace UnityEngine.InputSystem.Editor
             m_AddActionMapButton.clicked += AddActionMap;
 
             ContextMenu.GetContextMenuForActionMapsEmptySpace(this, root.Q<VisualElement>("rclick-area-to-add-new-action-map"));
+            // Only bring up this context menu for the List when it's empty, so we can treat it like right-clicking the empty space:
+            ContextMenu.GetContextMenuForActionMapsEmptySpace(this, m_ListView, onlyShowIfListIsEmpty: true);
         }
 
         void OnDroppedHandler(int mapIndex)
@@ -154,6 +156,11 @@ namespace UnityEngine.InputSystem.Editor
             m_EnterRenamingMode = true;
         }
 
+        internal int GetMapCount()
+        {
+            return m_ListView.itemsSource.Count;
+        }
+
         private void OnExecuteCommand(ExecuteCommandEvent evt)
         {
             var selectedItem = m_ListView.GetRootElementForIndex(m_ListView.selectedIndex);
@@ -218,7 +225,8 @@ namespace UnityEngine.InputSystem.Editor
             if (evt.button == (int)MouseButton.RightMouse && evt.clickCount == 1)
             {
                 var actionMap = (evt.target as VisualElement).GetFirstAncestorOfType<InputActionMapsTreeViewItem>();
-                m_ListView.SetSelection(actionMap.parent.IndexOf(actionMap));
+                if (actionMap != null)
+                    m_ListView.SetSelection(actionMap.parent.IndexOf(actionMap));
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
     /// </summary>
     internal class ActionsTreeView : ViewBase<ActionsTreeView.ViewState>
     {
+        private readonly ListView m_ActionMapsListView;
         private readonly TreeView m_ActionsTreeView;
         private readonly Button m_AddActionButton;
         private readonly ScrollView m_PropertiesScrollview;
@@ -31,6 +32,7 @@ namespace UnityEngine.InputSystem.Editor
         public ActionsTreeView(VisualElement root, StateContainer stateContainer)
             : base(root, stateContainer)
         {
+            m_ActionMapsListView = root.Q<ListView>("action-maps-list-view");
             m_AddActionButton = root.Q<Button>("add-new-action-button");
             m_PropertiesScrollview = root.Q<ScrollView>("properties-scrollview");
             m_ActionsTreeView = root.Q<TreeView>("actions-tree-view");
@@ -122,6 +124,8 @@ namespace UnityEngine.InputSystem.Editor
 
             ContextMenu.GetContextMenuForActionListView(this, m_ActionsTreeView, m_ActionsTreeView.parent);
             ContextMenu.GetContextMenuForActionsEmptySpace(this, m_ActionsTreeView, root.Q<VisualElement>("rclick-area-to-add-new-action"));
+            // Only bring up this context menu for the Tree when it's empty, so we can treat it like right-clicking the empty space:
+            ContextMenu.GetContextMenuForActionsEmptySpace(this, m_ActionsTreeView, m_ActionsTreeView, onlyShowIfTreeIsEmpty: true);
 
             m_ActionsTreeViewSelectionChangeFilter = new CollectionViewSelectionChangeFilter(m_ActionsTreeView);
             m_ActionsTreeViewSelectionChangeFilter.selectedIndicesChanged += (_) =>
@@ -372,6 +376,11 @@ namespace UnityEngine.InputSystem.Editor
                 Dispatch(Commands.ChangeActionName(data.actionMapIndex, data.name, newName));
             else if (data.isComposite)
                 Dispatch(Commands.ChangeCompositeName(data.actionMapIndex, data.bindingIndex, newName));
+        }
+
+        internal int GetMapCount()
+        {
+            return m_ActionMapsListView.itemsSource.Count;
         }
 
         private void OnExecuteCommand(ExecuteCommandEvent evt)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -47,17 +47,20 @@ namespace UnityEngine.InputSystem.Editor
 
         // Add "Add Action Map" option to empty space under the ListView. Matches with old IMGUI style (ISX-1519).
         // Include Paste here as well, since it makes sense for adding ActionMaps.
-        public static void GetContextMenuForActionMapsEmptySpace(ActionMapsView mapView, VisualElement listView)
+        public static void GetContextMenuForActionMapsEmptySpace(ActionMapsView mapView, VisualElement element, bool onlyShowIfListIsEmpty = false)
         {
             _ = new ContextualMenuManipulator(menuEvent =>
             {
-                var copiedAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
-                if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
-                    menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copiedAction));
+                if (!onlyShowIfListIsEmpty || mapView.GetMapCount() == 0)
+                {
+                    var copiedAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
+                    if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
+                        menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copiedAction));
 
-                menuEvent.menu.AppendSeparator();
-                menuEvent.menu.AppendAction(add_Action_Map_String, _ => mapView.AddActionMap());
-            }) { target = listView };
+                    menuEvent.menu.AppendSeparator();
+                    menuEvent.menu.AppendAction(add_Action_Map_String, _ => mapView.AddActionMap());
+                }
+            }) { target = element };
         }
 
         #endregion
@@ -77,17 +80,19 @@ namespace UnityEngine.InputSystem.Editor
 
         // Add "Add Action" option to empty space under the TreeView. Matches with old IMGUI style (ISX-1519).
         // Include Paste here as well, since it makes sense for Actions; thus users would expect it for Bindings too.
-        public static void GetContextMenuForActionsEmptySpace(ActionsTreeView actionsTreeView, TreeView treeView, VisualElement target)
+        public static void GetContextMenuForActionsEmptySpace(ActionsTreeView actionsTreeView, TreeView treeView, VisualElement target, bool onlyShowIfTreeIsEmpty = false)
         {
             _ = new ContextualMenuManipulator(menuEvent =>
             {
-                var item = treeView.GetItemDataForIndex<ActionOrBindingData>(treeView.selectedIndex);
-                var hasPastableData = CopyPasteHelper.HasPastableClipboardData(item.isAction ? typeof(InputAction) : typeof(InputBinding));
-                if (hasPastableData)
-                    menuEvent.menu.AppendAction(paste_String, _ => actionsTreeView.PasteItems());
+                if (actionsTreeView.GetMapCount() > 0 && (!onlyShowIfTreeIsEmpty || treeView.GetTreeCount() == 0))
+                {
+                    var item = treeView.GetItemDataForIndex<ActionOrBindingData>(treeView.selectedIndex);
+                    if (CopyPasteHelper.HasPastableClipboardData(item.isAction ? typeof(InputAction) : typeof(InputBinding)))
+                        menuEvent.menu.AppendAction(paste_String, _ => actionsTreeView.PasteItems());
 
-                menuEvent.menu.AppendSeparator();
-                menuEvent.menu.AppendAction(add_Action_String, _ => actionsTreeView.AddAction());
+                    menuEvent.menu.AppendSeparator();
+                    menuEvent.menu.AppendAction(add_Action_String, _ => actionsTreeView.AddAction());
+                }
             }) { target = target };
         }
 


### PR DESCRIPTION
### Description

Fix for [ISXB-833](https://jira.unity3d.com/browse/ISXB-833), and some extra improvements.

### Changes made

Simple nullref avoidance, plus: don't show impossible options (eg. Add Action when there's no Action Maps), and fix the fact that when Actions/Maps were empty, users couldn't right-click the space left by the empty tree/list to add a new item (for Action Maps, this is the "List is empty" text; for Actions the space is unlabelled).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
