### PR TITLE
FIX: Allow default UI actions to work without setting up a project-wide actions file (ISXB-811).

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -33,7 +33,7 @@ public class InputForUITests : InputTestFixture
 
         m_InputSystemProvider = new InputSystemProvider();
         EventProvider.SetMockProvider(m_InputSystemProvider);
-        
+
         // Test assumes a compatible action asset configuration exists for UI
         Assert.That(m_InputSystemProvider.inputActionAsset, Is.Not.Null,
             "Test is invalid since InputSystemProvider actions are not available");
@@ -143,7 +143,7 @@ public class InputForUITests : InputTestFixture
         Assert.IsTrue(m_InputForUIEvents.Count == 1);
         Assert.That(m_InputForUIEvents[0].asPointerEvent.scroll, Is.EqualTo(new Vector2(0, 1)));
     }
-    
+
     [Test]
     [Category("InputForUI")]
     [TestCase(true)]
@@ -157,21 +157,21 @@ public class InputForUITests : InputTestFixture
         Update();
         if (!useProjectWideActionsAsset)
         {
-            // Remove the project-wide actions asset in play mode and player. 
+            // Remove the project-wide actions asset in play mode and player.
             // It will call InputSystem.onActionChange and re-set InputSystemProvider.actionAsset
             // This the case where no project-wide actions asset is available in the project.
             InputSystem.s_Manager.actions = null;
         }
         Update();
         MoveWithGamepad();
-        
+
         Assert.IsTrue(m_InputForUIEvents.Count == 1);
         Assert.That(m_InputForUIEvents[0] is Event
         {
             type: Event.Type.NavigationEvent,
             asNavigationEvent: { type: NavigationEvent.Type.Move,
-                direction: NavigationEvent.Direction.Left,
-                eventSource: EventSource.Gamepad}
+                                 direction: NavigationEvent.Direction.Left,
+                                 eventSource: EventSource.Gamepad}
         });
     }
 

--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -34,9 +34,6 @@ public class InputForUITests : InputTestFixture
         m_InputSystemProvider = new InputSystemProvider();
         EventProvider.SetMockProvider(m_InputSystemProvider);
 
-        // Test assumes a compatible action asset configuration exists for UI
-        Assert.IsTrue(m_InputSystemProvider.ActionAssetIsNotNull(),
-            "Test is invalid since InputSystemProvider actions are not available");
         // Register at least one consumer so the mock update gets invoked
         EventProvider.Subscribe(InputForUIOnEvent);
     }
@@ -55,6 +52,15 @@ public class InputForUITests : InputTestFixture
     {
         m_InputForUIEvents.Add(ev);
         return true;
+    }
+
+    [Test]
+    [Category("InputForUI")]
+    public void InputSystemActionAssetIsNotNull()
+    {
+        // Test assumes a compatible action asset configuration exists for UI
+        Assert.IsTrue(m_InputSystemProvider.ActionAssetIsNotNull(),
+            "Test is invalid since InputSystemProvider actions are not available");
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -31,13 +31,12 @@ public class InputForUITests : InputTestFixture
     {
         base.Setup();
 
-        // Test assumes a compatible project-wide action configuration exist for UI
-        // See CoreTests_ProjectWideActions for how its setup via build plugins.
-        Assert.That(InputSystem.actions, Is.Not.Null,
-            "Test is invalid since Project-wide Input System actions have not been setup for play-mode test environment");
-
         m_InputSystemProvider = new InputSystemProvider();
         EventProvider.SetMockProvider(m_InputSystemProvider);
+        
+        // Test assumes a compatible action asset configuration exists for UI
+        Assert.That(m_InputSystemProvider.inputActionAsset, Is.Not.Null,
+            "Test is invalid since InputSystemProvider actions are not available");
         // Register at least one consumer so the mock update gets invoked
         EventProvider.Subscribe(InputForUIOnEvent);
     }

--- a/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/InputForUITests.cs
@@ -35,7 +35,7 @@ public class InputForUITests : InputTestFixture
         EventProvider.SetMockProvider(m_InputSystemProvider);
 
         // Test assumes a compatible action asset configuration exists for UI
-        Assert.That(m_InputSystemProvider.inputActionAsset, Is.Not.Null,
+        Assert.IsTrue(m_InputSystemProvider.ActionAssetIsNotNull(),
             "Test is invalid since InputSystemProvider actions are not available");
         // Register at least one consumer so the mock update gets invoked
         EventProvider.Subscribe(InputForUIOnEvent);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,6 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - YYYY-MM-DD
 
 ### Fixed
+- Default UI actions would not function without a user specifically setting up project-wide actions in Project Settings [ISXB-811](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-811).
 - NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
 
 ## [1.8.1] - 2024-03-14

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - YYYY-MM-DD
 
 ### Fixed
-- Default UI actions would not function without a user specifically setting up project-wide actions in Project Settings [ISXB-811](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-811).
+- Fixed an issue where UI interactions would not function without setting up a project-wide actions asset in Project Settings. Default UI actions are now created on the fly, if no asset for project-wide actions has been set. [ISXB-811](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-811).
 - Physical keyboards used on Android/ChromeOS could have keys "stuck" reporting as pressed after a long press and release [ISXB-475](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-475).
 - NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
 - Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsProjectSettings.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsProjectSettings.uxml
@@ -8,7 +8,7 @@
         <uie:ObjectField name="current-asset" type="UnityEngine.InputSystem.InputActionAsset, Unity.InputSystem" label="Project-wide Actions" />
     </ui:VisualElement>
     <ui:VisualElement name="missing-asset-section">
-        <ui:HelpBox text="Actions for the Input System are stored in an Action Asset. You can assign an Action Asset as project-wide in the field above to make them accessible directly through the InputSystem.actions API.\n\nClick the button below to create a new Action Asset containing default actions, which will be assigned as project-wide." message-type="Info"/>
+        <ui:HelpBox text="Actions for the Input System are stored in an Action Asset. You can assign an Action Asset as project-wide in the field above to make them accessible directly through the InputSystem.actions API.&#10;&#10;Click the button below to create a new Action Asset containing default actions, which will be assigned as project-wide." message-type="Info"/>
         <ui:Button text="Create and assign a default project-wide Action Asset" name="create-asset"/>
     </ui:VisualElement>
 </ui:UXML>

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -16,7 +16,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         Configuration m_Cfg;
 
-        public InputActionAsset inputActionAsset => m_InputActionAsset;
         InputActionAsset m_InputActionAsset;
 
         InputActionReference m_PointAction;
@@ -156,6 +155,11 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         {
             m_SeenTouchEvents = false;
             m_SeenPenEvents = false;
+        }
+
+        public bool ActionAssetIsNotNull()
+        {
+            return m_InputActionAsset != null;
         }
 
         //TODO: Refactor as there is no need for having almost the same implementation in the IM and ISX?

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -81,7 +81,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             m_SeenTouchEvents = false;
 
             m_Cfg = Configuration.GetDefaultConfiguration();
-            RegisterActions(m_Cfg);
+            RegisterActions();
 
             InputSystem.onActionsChange += OnActionsChange;
         }
@@ -101,7 +101,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             UnregisterActions();
 
             m_Cfg = Configuration.GetDefaultConfiguration();
-            RegisterActions(m_Cfg);
+            RegisterActions();
         }
 
         public void Update()
@@ -575,9 +575,9 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
             }
         }
 
-        void RegisterActions(Configuration cfg)
+        void RegisterActions()
         {
-            m_InputActionAsset = cfg.ActionAsset;
+            m_InputActionAsset = m_Cfg.ActionAsset;
 
             m_PointAction = InputActionReference.Create(m_InputActionAsset.FindAction(m_Cfg.PointAction));
             m_MoveAction = InputActionReference.Create(m_InputActionAsset.FindAction(m_Cfg.MoveAction));

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -18,7 +18,7 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         public InputActionAsset inputActionAsset => m_InputActionAsset;
         InputActionAsset m_InputActionAsset;
-        
+
         InputActionReference m_PointAction;
         InputActionReference m_MoveAction;
         InputActionReference m_SubmitAction;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -16,7 +16,9 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         Configuration m_Cfg;
 
+        public InputActionAsset inputActionAsset => m_InputActionAsset;
         InputActionAsset m_InputActionAsset;
+        
         InputActionReference m_PointAction;
         InputActionReference m_MoveAction;
         InputActionReference m_SubmitAction;


### PR DESCRIPTION
### Description

Regression from previous versions: Default UI interactions like clicking, dragging etc should work without users having to set up their own PWA file. [ISXB-811](https://jira.unity3d.com/browse/ISXB-811). Lengthy discussion in Slack [here](https://unity.slack.com/archives/C04RDRXRJ1L/p1711549077482879).

### Changes made

Load DefaultInputActions file if a project-wide action has not been set by the user. Enable the UI functions from it.
Also, fix newlines not functioning correctly in a uxml file - details [here](https://unity.slack.com/archives/C3414V4UV/p1673359236696379?thread_ts=1673347662.674689&cid=C3414V4UV).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
