### PR TITLE
FIX: Update DualSense HID support so OutputReports function properly (ISXB-787)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Physical keyboards used on Android/ChromeOS could have keys "stuck" reporting as pressed after a long press and release [ISXB-475](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-475).
 - NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
 - Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.
+- Fixed DualSense Edge's vibration and light bar not working on Windows
 
 ### Changed
 - For Unity 6.0 and above, when an `EventSystem` GameObject is created in the Editor it will have the

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepad.cs
@@ -86,7 +86,13 @@ namespace UnityEngine.InputSystem.DualShock
         /// <summary>
         /// The last used/added DualShock controller.
         /// </summary>
+        /// <value>Equivalent to <see cref="Gamepad.leftTrigger"/>.</value>
         public new static DualShockGamepad current { get; private set; }
+
+        /// <summary>
+        /// If the controller is connected over HID, returns <see cref="HID.HID.HIDDeviceDescriptor"/> data parsed from <see cref="InputDeviceDescription.capabilities"/>.
+        /// </summary>
+        internal HID.HID.HIDDeviceDescriptor hidDescriptor { get; private set; }
 
         /// <inheritdoc />
         public override void MakeCurrent()
@@ -118,6 +124,9 @@ namespace UnityEngine.InputSystem.DualShock
             R2 = rightTrigger;
             L3 = leftStickButton;
             R3 = rightStickButton;
+
+            if (m_Description.capabilities != null && m_Description.interfaceName == "HID")
+                hidDescriptor = HID.HID.HIDDeviceDescriptor.FromJson(m_Description.capabilities);
         }
 
         /// <inheritdoc />

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockGamepadHID.cs
@@ -99,11 +99,11 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public byte reportId;
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 1)] public DualSenseHIDOutputReportPayload payload;
 
-        public static DualSenseHIDUSBOutputReport Create(DualSenseHIDOutputReportPayload payload)
+        public static DualSenseHIDUSBOutputReport Create(DualSenseHIDOutputReportPayload payload, int outputReportSize)
         {
             return new DualSenseHIDUSBOutputReport
             {
-                baseCommand = new InputDeviceCommand(Type, kSize),
+                baseCommand = new InputDeviceCommand(Type, InputDeviceCommand.kBaseCommandSize + outputReportSize),
                 reportId = 2,
                 payload = payload
             };
@@ -127,11 +127,11 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
 
         [FieldOffset(InputDeviceCommand.BaseCommandSize + 0)] public unsafe fixed byte rawData[74];
 
-        public static DualSenseHIDBluetoothOutputReport Create(DualSenseHIDOutputReportPayload payload, byte outputSequenceId)
+        public static DualSenseHIDBluetoothOutputReport Create(DualSenseHIDOutputReportPayload payload, byte outputSequenceId, int outputReportSize)
         {
             var report = new DualSenseHIDBluetoothOutputReport
             {
-                baseCommand = new InputDeviceCommand(Type, kSize),
+                baseCommand = new InputDeviceCommand(Type, InputDeviceCommand.kBaseCommandSize + outputReportSize),
                 reportId = 0x31,
                 tag1 = (byte)((outputSequenceId & 0xf) << 4),
                 tag2 = 0x10,
@@ -317,11 +317,11 @@ namespace UnityEngine.InputSystem.DualShock.LowLevel
             blueColor = (byte)Mathf.Clamp(color.b * 255, 0, 255);
         }
 
-        public static DualShockHIDOutputReport Create()
+        public static DualShockHIDOutputReport Create(int outputReportSize)
         {
             return new DualShockHIDOutputReport
             {
-                baseCommand = new InputDeviceCommand(Type, kSize),
+                baseCommand = new InputDeviceCommand(Type, InputDeviceCommand.kBaseCommandSize + outputReportSize),
                 reportId = kReportId,
             };
         }
@@ -439,7 +439,7 @@ namespace UnityEngine.InputSystem.DualShock
 
             ////FIXME: Bluetooth reports are not working
             //var command = DualSenseHIDBluetoothOutputReport.Create(payload, ++outputSequenceId);
-            var command = DualSenseHIDUSBOutputReport.Create(payload);
+            var command = DualSenseHIDUSBOutputReport.Create(payload, hidDescriptor.outputReportSize);
             return ExecuteCommand(ref command) >= 0;
         }
 
@@ -732,7 +732,7 @@ namespace UnityEngine.InputSystem.DualShock
             if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue && !m_LightBarColor.HasValue)
                 return;
 
-            var command = DualShockHIDOutputReport.Create();
+            var command = DualShockHIDOutputReport.Create(hidDescriptor.outputReportSize);
             command.SetMotorSpeeds(0f, 0f);
             ////REVIEW: when pausing&resuming haptics, you probably don't want the lightbar color to change
             if (m_LightBarColor.HasValue)
@@ -746,7 +746,7 @@ namespace UnityEngine.InputSystem.DualShock
             if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue && !m_LightBarColor.HasValue)
                 return;
 
-            var command = DualShockHIDOutputReport.Create();
+            var command = DualShockHIDOutputReport.Create(hidDescriptor.outputReportSize);
             command.SetMotorSpeeds(0f, 0f);
             if (m_LightBarColor.HasValue)
                 command.SetColor(Color.black);
@@ -763,7 +763,7 @@ namespace UnityEngine.InputSystem.DualShock
             if (!m_LowFrequencyMotorSpeed.HasValue && !m_HighFrequenceyMotorSpeed.HasValue && !m_LightBarColor.HasValue)
                 return;
 
-            var command = DualShockHIDOutputReport.Create();
+            var command = DualShockHIDOutputReport.Create(hidDescriptor.outputReportSize);
 
             if (m_LowFrequencyMotorSpeed.HasValue || m_HighFrequenceyMotorSpeed.HasValue)
                 command.SetMotorSpeeds(m_LowFrequencyMotorSpeed.Value, m_HighFrequenceyMotorSpeed.Value);
@@ -777,7 +777,7 @@ namespace UnityEngine.InputSystem.DualShock
 
         public override void SetLightBarColor(Color color)
         {
-            var command = DualShockHIDOutputReport.Create();
+            var command = DualShockHIDOutputReport.Create(hidDescriptor.outputReportSize);
             command.SetColor(color);
 
             ExecuteCommand(ref command);
@@ -787,7 +787,7 @@ namespace UnityEngine.InputSystem.DualShock
 
         public override void SetMotorSpeeds(float lowFrequency, float highFrequency)
         {
-            var command = DualShockHIDOutputReport.Create();
+            var command = DualShockHIDOutputReport.Create(hidDescriptor.outputReportSize);
             command.SetMotorSpeeds(lowFrequency, highFrequency);
 
             ExecuteCommand(ref command);
@@ -815,7 +815,7 @@ namespace UnityEngine.InputSystem.DualShock
         /// for the respective documentation regarding setting rumble and light bar color.</remarks>
         public bool SetMotorSpeedsAndLightBarColor(float lowFrequency, float highFrequency, Color color)
         {
-            var command = DualShockHIDOutputReport.Create();
+            var command = DualShockHIDOutputReport.Create(hidDescriptor.outputReportSize);
             command.SetMotorSpeeds(lowFrequency, highFrequency);
             command.SetColor(color);
 


### PR DESCRIPTION

### Description

The OutputReport size for the DualSense Edge controller is larger than the basic DS controller: 64 bytes vs. 32 bytes. This causes IOCTL commands for setting bumble and light bar values to be rejected by the Windows back-end, i.e. the command buffer size didn't match the feature report.

To fix this problem we need to dispatch output commands with the same buffer size reported by the HID descriptor.

### Changes made

I modified all the DualShockHID output commands to take an `outputReportSize` parameter, which is used instead of the constant `kSize` when creating the output buffer. This value should, of course come from the controller's HID descriptor. Note that the const `kSize` is still used (and unchanged) for the field serialization, but the parameter is used for initializing the command buffer.

I added an (internal) property to `DualShockGamepad` returning said HID descriptor parsed from InputDevice's Description, if the DS controller is connected via HID.

### Notes

I verified the fix using the (wired) DualSense Edge and PS4 DualShock controllers.
I tested these controllers over Bluetooth, but that still doesn't work; the WriteFile API fails with INVALID_ARGUMENT error, which I guess is expected.

I did _not_ test with a standard DualSense controller (I don't currently have one), and I also didn't test with the PS5 package.

I noticed the SwitchPro HID controller has a similar implementation: output commands use a hard-coded size instead of the value from HID descriptor. It could potentially have a similar issue if Nintendo released a new rev. of the hardware, but it's not worth the risk right now and so I left it alone.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
