### PR TITLE
FIX: ObjectDisposedException regression when deleting actions maps (ISXB-831)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Physical keyboards used on Android/ChromeOS could have keys "stuck" reporting as pressed after a long press and release [ISXB-475](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-475).
 - NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
+- Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.
 
 ## [1.8.1] - 2024-03-14
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputAction.cs
@@ -18,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
             type = (InputActionType)serializedProperty.FindPropertyRelative(nameof(InputAction.m_Type)).intValue;
             interactions = serializedProperty.FindPropertyRelative(nameof(InputAction.m_Interactions)).stringValue;
             processors = serializedProperty.FindPropertyRelative(nameof(InputAction.m_Processors)).stringValue;
+            propertyPath = wrappedProperty.propertyPath;
             initialStateCheck = ReadInitialStateCheck(serializedProperty);
             actionTypeTooltip = serializedProperty.FindPropertyRelative(nameof(InputAction.m_Type)).GetTooltip();
             expectedControlTypeTooltip = serializedProperty.FindPropertyRelative(nameof(InputAction.m_ExpectedControlType)).GetTooltip();
@@ -29,6 +30,7 @@ namespace UnityEngine.InputSystem.Editor
         public InputActionType type { get; }
         public string interactions { get; }
         public string processors { get; }
+        public string propertyPath { get; }
         public bool initialStateCheck { get; }
         public string actionTypeTooltip { get; }
         public string expectedControlTypeTooltip { get; }
@@ -60,7 +62,7 @@ namespace UnityEngine.InputSystem.Editor
                 && initialStateCheck == other.initialStateCheck
                 && actionTypeTooltip == other.actionTypeTooltip
                 && expectedControlTypeTooltip == other.expectedControlTypeTooltip
-                && wrappedProperty.propertyPath == other.wrappedProperty.propertyPath;
+                && propertyPath == other.propertyPath;
         }
 
         public override bool Equals(object obj)
@@ -79,7 +81,7 @@ namespace UnityEngine.InputSystem.Editor
             hashCode.Add(initialStateCheck);
             hashCode.Add(actionTypeTooltip);
             hashCode.Add(expectedControlTypeTooltip);
-            hashCode.Add(wrappedProperty.propertyPath);
+            hashCode.Add(propertyPath);
             return hashCode.ToHashCode();
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/SerializedInputBinding.cs
@@ -24,6 +24,7 @@ namespace UnityEngine.InputSystem.Editor
             interactions = serializedProperty.FindPropertyRelative("m_Interactions").stringValue;
             processors = serializedProperty.FindPropertyRelative("m_Processors").stringValue;
             action = serializedProperty.FindPropertyRelative("m_Action").stringValue;
+            propertyPath = wrappedProperty.propertyPath;
             var bindingGroups = serializedProperty.FindPropertyRelative(nameof(InputBinding.m_Groups)).stringValue;
             controlSchemes = bindingGroups != null
                 ? bindingGroups.Split(InputBinding.kSeparatorString, StringSplitOptions.RemoveEmptyEntries)
@@ -44,6 +45,7 @@ namespace UnityEngine.InputSystem.Editor
         public string interactions { get; }
         public string processors { get; }
         public string action { get; }
+        public string propertyPath { get; }
         public string[] controlSchemes { get; }
         public InputBinding.Flags flags { get; }
 
@@ -88,7 +90,7 @@ namespace UnityEngine.InputSystem.Editor
                 && isPartOfComposite == other.isPartOfComposite
                 && compositePath == other.compositePath
                 && controlSchemes.SequenceEqual(other.controlSchemes)
-                && wrappedProperty.propertyPath == other.wrappedProperty.propertyPath;
+                && propertyPath == other.propertyPath;
         }
 
         public override bool Equals(object obj)
@@ -110,7 +112,7 @@ namespace UnityEngine.InputSystem.Editor
             hashCode.Add(isPartOfComposite);
             hashCode.Add(compositePath);
             hashCode.Add(controlSchemes);
-            hashCode.Add(wrappedProperty.propertyPath);
+            hashCode.Add(propertyPath);
             return hashCode.ToHashCode();
         }
     }


### PR DESCRIPTION

### Description

Fixes regression introduced with this bug fix: https://github.com/Unity-Technologies/InputSystem/pull/1861

The original fix added `propertyPath` to the SerializedInputAction/Binding Equals method, but it retrieved the value directly from the cached SerializedProperty. In this scenario (deleting last ActionMap) the underlying Property is disposed and causes this exception. Instead, this change saves `propertyPath` to a separate string during initialization when the SerializedProperty is known to be valid.

### Changes made

Added a `propertyPath` property to SerializedInputAction/Binding which holds the value retrieved from `wrappedProperty`.
This string is used during Equals() method.

### Notes

I verified this change doesn't break https://jira.unity3d.com/browse/ISX-1873 but there's still a small concern about caching `propertyPath`. If the it changes in the underlying Property it won't be updated here. But I don't think this is a real problem given how this struct is used.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
