### PR TITLE
CHANGE: Override UGUI EventSystem with InputSystemUIInputModule

### DIFF
--- a/Assets/Tests/InputSystem.Editor/UGUITests.cs
+++ b/Assets/Tests/InputSystem.Editor/UGUITests.cs
@@ -1,0 +1,50 @@
+#if UNITY_EDITOR && UNITY_6000_0_OR_NEWER
+using System;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.InputSystem.UI;
+
+internal class UGUITests
+{
+    Scene m_Scene;
+    [SetUp]
+    public void SetUp()
+    {
+        // Ensure that the scene is clean before starting the test
+        m_Scene = EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        EditorSceneManager.CloseScene(m_Scene, true);
+    }
+
+    [Test]
+    [Category("UGUITests")]
+    // This test checks that when the Input System is enabled the EventSystem GameObject is created with the
+    // InputSystemUIInputModule component.
+    public void UGUITests_Editor_EventSystemGameObjectUsesUIInputModule()
+    {
+        m_Scene = EditorSceneManager.NewScene(NewSceneSetup.DefaultGameObjects);
+
+        // Creates the EventSystem GameObject using the Editor menu
+        string menuItem = "GameObject/UI/Event System";
+        Assert.AreEqual(2, m_Scene.rootCount);
+        EditorApplication.ExecuteMenuItem(menuItem);
+        Assert.AreEqual(3, m_Scene.rootCount);
+
+        // Get the EventSystem GameObject from the scene to check that it has the correct input module
+        var rootGameObjects = m_Scene.GetRootGameObjects();
+        GameObject eventSystem = rootGameObjects[2].GetComponent<EventSystem>().gameObject;
+
+        Assert.IsNotNull(eventSystem);
+        Assert.IsNotNull(eventSystem.GetComponent<InputSystemUIInputModule>());
+    }
+}
+
+#endif

--- a/Assets/Tests/InputSystem.Editor/UGUITests.cs.meta
+++ b/Assets/Tests/InputSystem.Editor/UGUITests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a04e24d1a99a4fafb8fbe27635ccabe9
+timeCreated: 1712647437

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,10 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
 
+### Changed
+- For Unity 6.0 and above, when an `EventSystem` GameObject is created in the Editor it will have the
+`InputSystemUIInputModule` by default if the Input System package is installed and enabled.
+
 ## [1.8.1] - 2024-03-14
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -2,14 +2,25 @@
 using System;
 using System.Linq;
 using UnityEditor;
+using UnityEditor.EventSystems;
 
 ////TODO: add button to automatically set up gamepad mouse cursor support
 
 namespace UnityEngine.InputSystem.UI.Editor
 {
     [CustomEditor(typeof(InputSystemUIInputModule))]
+    [InitializeOnLoad]
     internal class InputSystemUIInputModuleEditor : UnityEditor.Editor
     {
+        SerializedProperty activeInputBackend;
+        static InputSystemUIInputModuleEditor()
+        {
+#if UNITY_6000_0_OR_NEWER
+            //TODO: only add this if backend selected is ONLY InputSystem
+            InputModuleComponentFactory.SetInputModuleComponentOverride(go => go.AddComponent<InputSystemUIInputModule>());
+#endif
+        }
+
         private static InputActionReference GetActionReferenceFromAssets(InputActionReference[] actions, params string[] actionNames)
         {
             foreach (var actionName in actionNames)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -15,10 +15,9 @@ namespace UnityEngine.InputSystem.UI.Editor
     {
         static InputSystemUIInputModuleEditor()
         {
-#if UNITY_6000_0_OR_NEWER
-            if (EditorPlayerSettingHelpers.newSystemBackendsEnabled && !EditorPlayerSettingHelpers.oldSystemBackendsEnabled)
-                InputModuleComponentFactory.SetInputModuleComponentOverride(
-                    go => ObjectFactory.AddComponent<InputSystemUIInputModule>(go));
+#if UNITY_6000_0_OR_NEWER && ENABLE_INPUT_SYSTEM
+            InputModuleComponentFactory.SetInputModuleComponentOverride(
+                go => ObjectFactory.AddComponent<InputSystemUIInputModule>(go));
 #endif
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.EventSystems;
+using UnityEngine.InputSystem.Editor;
 
 ////TODO: add button to automatically set up gamepad mouse cursor support
 
@@ -12,12 +13,11 @@ namespace UnityEngine.InputSystem.UI.Editor
     [InitializeOnLoad]
     internal class InputSystemUIInputModuleEditor : UnityEditor.Editor
     {
-        SerializedProperty activeInputBackend;
         static InputSystemUIInputModuleEditor()
         {
 #if UNITY_6000_0_OR_NEWER
-            //TODO: only add this if backend selected is ONLY InputSystem
-            InputModuleComponentFactory.SetInputModuleComponentOverride(go => go.AddComponent<InputSystemUIInputModule>());
+            if (EditorPlayerSettingHelpers.newSystemBackendsEnabled && !EditorPlayerSettingHelpers.oldSystemBackendsEnabled)
+                InputModuleComponentFactory.SetInputModuleComponentOverride(go => go.AddComponent<InputSystemUIInputModule>());
 #endif
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModuleEditor.cs
@@ -17,7 +17,8 @@ namespace UnityEngine.InputSystem.UI.Editor
         {
 #if UNITY_6000_0_OR_NEWER
             if (EditorPlayerSettingHelpers.newSystemBackendsEnabled && !EditorPlayerSettingHelpers.oldSystemBackendsEnabled)
-                InputModuleComponentFactory.SetInputModuleComponentOverride(go => go.AddComponent<InputSystemUIInputModule>());
+                InputModuleComponentFactory.SetInputModuleComponentOverride(
+                    go => ObjectFactory.AddComponent<InputSystemUIInputModule>(go));
 #endif
         }
 


### PR DESCRIPTION
### Description

Unity 6 will come with the "new" Input System enabled by default. The `EventSystem` of UGUI uses `StandaloneInputModule` regardless of the enabled input backend.
This PR overrides the `EventSystem` game object default InputModule using a new class,  `InputModuleComponentFactory` , that will be available on Unity 6.

### Changes made

- Event System Input Module is overridden with `InputSystemUIInputModule` when the Input System native backend is enabled. Only with "Legacy Input"  in "Project Settings > Player > Active Input Handling", no override is done.
- Adds an Editor test to validate the behavior we want for `EventSystem`. Once the Input System package is enabled, we want the `EventSystem` to be created with `InputSystemUIInputModule`.

### Notes

PR is in a good state for reviewing the changes it does. After that, it still needs: 
- Check if there is documentation that needs to be updated.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
