### PR TITLE
FIX: PWA asset isn't properly restored after deleting Library folder (ISXB-853)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - NullReferenceException thrown when right-clicking an empty Action Map list in Input Actions Editor windows [ISXB-833](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-833).
 - Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.
 - Fixed DualSense Edge's vibration and light bar not working on Windows
+- Fixed Project-wide Actions asset failing to reload properly after deleting project's Library folder.
 
 ### Changed
 - For Unity 6.0 and above, when an `EventSystem` GameObject is created in the Editor it will have the

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -35,6 +35,15 @@ namespace UnityEngine.InputSystem.Editor
                         MoveInputManagerAssetActionsToProjectWideInputActionAsset();
                         migratedInputActionAssets = true;
                     }
+
+                    if (!Application.isPlaying)
+                    {
+                        // If the Library folder is deleted, InputSystem will fail to retrieve the assigned Project-wide Asset because this look-up occurs
+                        // during initialization while the Library is being rebuilt. So, afterwards perform another check and assign PWA asset if needed.
+                        var pwaAsset = ProjectWideActionsBuildProvider.actionsToIncludeInPlayerBuild;
+                        if (InputSystem.actions == null && pwaAsset != null)
+                            InputSystem.actions = pwaAsset;
+                    }
                 }
             }
 


### PR DESCRIPTION
### Description

If the project's Library folder is deleted, the previously assigned Project-wide Actions asset isn't properly restored when launching Unity. The asset is still present, but it's not assigned as the current PWA asset. Re-launching Unity again seems to resolve the issue.

The problem occurs because the logic to load and set the PWA asset runs during InputSystem initialization, before the asset Library has been rebuilt, and the call to load the saved PWA asset from the EditorBuildSettings fails. To fix this, we need to run this operation again after the asset loading has finished.

### Changes made

- Attempt to Load and assigns the PWA asset to `Inputsystem.actions` during `OnPostprocessAllAssets()`

### Notes

I did a little bit of testing with multiple InputAction assets to verify PWA is changed when moving/copying another asset.
Still a little concerned about weird edge-cases, since this operation will run whenever _any_ asset is changed.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
