### PR TITLE
FIX: InvalidOperationException thrown entering PlayMode if PWA changes didn't save (ISX-1953)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.
 - Fixed DualSense Edge's vibration and light bar not working on Windows
 - Fixed Project-wide Actions asset failing to reload properly after deleting project's Library folder.
+- Fixed an issue where `System.InvalidOperationException` is thrown when entering PlayMode after deleting an ActionMap from Project-wide actions and later resetting it.
 
 ### Changed
 - For Unity 6.0 and above, when an `EventSystem` GameObject is created in the Editor it will have the

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -76,6 +76,9 @@ namespace UnityEngine.InputSystem.Editor
                 m_RootVisualElement.UnregisterCallback<FocusInEvent>(OnEditFocus);
             }
 
+            // Make sure any remaining changes are actually saved
+            SaveAssetOnFocusLost();
+
             // Note that OnDeactivate will also trigger when opening the Project Settings (existing instance).
             // Hence we guard against duplicate OnDeactivate() calls.
             if (m_HasEditFocus)
@@ -272,6 +275,8 @@ namespace UnityEngine.InputSystem.Editor
                     SetObjectFieldEnabled(true);
                     break;
                 case PlayModeStateChange.ExitingEditMode:
+                    // Ensure any changes are saved to the asset; FocusLost isn't always triggered when entering PlayMode.
+                    SaveAssetOnFocusLost();
                     SetObjectFieldEnabled(false);
                     break;
                 case PlayModeStateChange.EnteredPlayMode:


### PR DESCRIPTION
### Description

Changes to Project-wide Actions within the Project Settings are saved (to the Asset) automatically when the window looses focus, however I found a few scenarios were this doesn't occur and changes to the ActionMap aren't properly saved [causing an exception](https://jira.unity3d.com/browse/ISX-1953) when entering PlayMode.

There's a strange disconnect between the problem this PR fixes and the issue detailed in the ticket. As I understand it, restoring the UI ActionMap updates the Actions state in memory _but_ it links the "old" Asset within `ReadFromJson.ToAsset()` (from InputActionAsset.cs) to the ActionMap. Typically, the changes are saved and serialized to the Asset at which point the `ToAsset()` operation is performed again and the correct Asset is linked to the ActionMap, but if we skip saving the Asset (as is the case with this bug) the `InputActionMap.m_Asset` never gets updated and remains null.

Ensuring the Asset is always properly saved in ProjectSettings fixes this issue and may address other issues as well.

### Changes made

Adds calls to `SaveAssetOnFocusLost()` within `InputActionsEditorSettingsProvider` to cover additional scenario in which the asset needs to be saved (FocusLost isn't fired in these cases):

- `OnDeactivate()` save after changing the "active" settings within ProjectSettings window or the window is closed
- `ModeChanged()` save before enter PlayMode

### Notes

I updated the ticket with repro steps to cover the previously mentioned scenarios, and so far haven't been able to discover any other corner cases.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
