### PR TITLE
Fix resource leaks in Input Actions Editor window.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.
 - Fixed DualSense Edge's vibration and light bar not working on Windows
 - Fixed Project-wide Actions asset failing to reload properly after deleting project's Library folder.
+- Fixed Input Actions Editor window resource leak that could result in unexpected exceptions [ISXB-865](https://jira.unity3d.com/browse/ISXB-865)
 
 ### Changed
 - For Unity 6.0 and above, when an `EventSystem` GameObject is created in the Editor it will have the

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,7 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where `System.ObjectDisposedException` would be thrown when deleting the last ActionMap item in the Input Actions Asset editor.
 - Fixed DualSense Edge's vibration and light bar not working on Windows
 - Fixed Project-wide Actions asset failing to reload properly after deleting project's Library folder.
-- Fixed Input Actions Editor window resource leak that could result in unexpected exceptions [ISXB-865](https://jira.unity3d.com/browse/ISXB-865)
+- Fixed Input Actions Editor window resource leak that could result in unexpected exceptions [ISXB-865]
 
 ### Changed
 - For Unity 6.0 and above, when an `EventSystem` GameObject is created in the Editor it will have the

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -105,11 +105,11 @@ namespace UnityEngine.InputSystem.Editor
 
         void SaveAssetOnFocusLost()
         {
-            #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
+#if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
             var asset = GetAsset();
             if (asset != null)
                 ValidateAndSaveAsset(asset);
-            #endif
+#endif
         }
 
         public static void SetIMGUIDropdownVisible(bool visible, bool optionWasSelected)
@@ -161,14 +161,14 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnStateChanged(InputActionsEditorState newState)
         {
-            #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
+#if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
             // No action, auto-saved on edit-focus lost
-            #else
+#else
             // Project wide input actions always auto save - don't check the asset auto save status
             var asset = GetAsset();
             if (asset != null)
                 ValidateAndSaveAsset(asset);
-            #endif
+#endif
         }
 
         private void ValidateAndSaveAsset(InputActionAsset asset)
@@ -234,23 +234,18 @@ namespace UnityEngine.InputSystem.Editor
 
             // Remove input action editor if already present
             {
-                VisualElement element;
-                do
-                {
-                    element = m_RootVisualElement.Q("action-editor");
-                    if (element != null)
-                        m_RootVisualElement.Remove(element);
-                }
-                while (element != null);
+                VisualElement element = m_RootVisualElement.Q("action-editor");
+                if (element != null)
+                    m_RootVisualElement.Remove(element);
             }
 
             // If the editor is associated with an asset we show input action editor
             if (hasAsset)
             {
-                m_StateContainer = new StateContainer(m_RootVisualElement, m_State);
+                m_StateContainer = new StateContainer(m_State);
                 m_StateContainer.StateChanged += OnStateChanged;
                 m_View = new InputActionsEditorView(m_RootVisualElement, m_StateContainer, true, null);
-                m_StateContainer.Initialize();
+                m_StateContainer.Initialize(m_RootVisualElement.Q("action-editor"));
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -10,6 +10,8 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class InputActionsEditorSettingsProvider : SettingsProvider
     {
+        private static InputActionsEditorSettingsProvider s_Provider;
+
         public static string SettingsPath => InputSettingsPath.kSettingsRootPath;
 
         [SerializeField] InputActionsEditorState m_State;
@@ -284,7 +286,10 @@ namespace UnityEngine.InputSystem.Editor
         [SettingsProvider]
         public static SettingsProvider CreateGlobalInputActionsEditorProvider()
         {
-            return new InputActionsEditorSettingsProvider(SettingsPath, SettingsScope.Project);
+            if (s_Provider == null)
+                s_Provider = new InputActionsEditorSettingsProvider(SettingsPath, SettingsScope.Project);
+
+            return s_Provider;
         }
 
         #region Shortcuts

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -7,6 +7,8 @@ using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.PackageManager.UI;
 using UnityEditor.ShortcutManagement;
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
 
 namespace UnityEngine.InputSystem.Editor
 {
@@ -212,7 +214,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             CleanupStateContainer();
 
-            m_StateContainer = new StateContainer(rootVisualElement, m_State);
+            m_StateContainer = new StateContainer(m_State);
             m_StateContainer.StateChanged += OnStateChanged;
 
             rootVisualElement.Clear();
@@ -220,7 +222,7 @@ namespace UnityEngine.InputSystem.Editor
                 rootVisualElement.styleSheets.Add(InputActionsEditorWindowUtils.theme);
             m_View = new InputActionsEditorView(rootVisualElement, m_StateContainer, false, Save);
 
-            m_StateContainer.Initialize();
+            m_StateContainer.Initialize(rootVisualElement.Q("action-editor"));
         }
 
         private void OnStateChanged(InputActionsEditorState newState)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
@@ -45,6 +45,9 @@ namespace UnityEngine.InputSystem.Editor
 
         public void Initialize(VisualElement rootVisualElement)
         {
+            // We need to use a root element for the TrackSerializedObjectValue that is destroyed with the view.
+            // Using a root element from the settings window would not enable the tracking callback to be destroyed or garbage collected.
+
             m_RootVisualElement = rootVisualElement;
 
             m_RootVisualElement.Unbind();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
@@ -11,20 +11,12 @@ namespace UnityEngine.InputSystem.Editor
     {
         public event Action<InputActionsEditorState> StateChanged;
 
-        private readonly VisualElement m_RootVisualElement;
+        private VisualElement m_RootVisualElement;
         private InputActionsEditorState m_State;
 
-        public StateContainer(VisualElement rootVisualElement, InputActionsEditorState initialState)
+        public StateContainer(InputActionsEditorState initialState)
         {
-            m_RootVisualElement = rootVisualElement;
             m_State = initialState;
-
-            rootVisualElement.Unbind();
-            m_RootVisualElement.TrackSerializedObjectValue(initialState.serializedObject, so =>
-            {
-                StateChanged?.Invoke(m_State);
-            });
-            rootVisualElement.Bind(initialState.serializedObject);
         }
 
         public void Dispatch(Command command)
@@ -51,9 +43,17 @@ namespace UnityEngine.InputSystem.Editor
             });
         }
 
-        public void Initialize()
+        public void Initialize(VisualElement rootVisualElement)
         {
+            m_RootVisualElement = rootVisualElement;
+
+            m_RootVisualElement.Unbind();
+            m_RootVisualElement.TrackSerializedObjectValue(m_State.serializedObject, so =>
+            {
+                StateChanged?.Invoke(m_State);
+            });
             StateChanged?.Invoke(m_State);
+            rootVisualElement.Bind(m_State.serializedObject);
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

This PR addresses resource leaks in the Input Actions Editor window.

These resource leaks could lead to unexpected exceptions being thrown.

### Changes made

InputActionsEditorSettingsProvider is now handled by a single static instance to work around UIToolkit callback order issues identified.

Fix VisualElement handling on the StateContainer that manages the tracked serialized object representing the Input Actions.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

- [x] Commit message for squash-merge is prefixed with one of the list:
    - FIX: Fixed Input Actions Editor window resource leak that could result in unexpected exceptions [ISXB-865](https://jira.unity3d.com/browse/ISXB-865)
