### PR TITLE
DRAFT - NEW: Add setting for logging processed input events

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3380,7 +3380,10 @@ namespace UnityEngine.InputSystem
                                 haveChangedStateOtherThanNoise = UpdateState(device, eventPtr, updateType);
                             }
 
+
                             totalEventBytesProcessed += eventPtr.sizeInBytes;
+                            if (Debug.isDebugBuild)
+                                LogProcessedEventForDevice(device, totalEventBytesProcessed, eventPtr);
 
                             // Update timestamp on device.
                             // NOTE: We do this here and not in UpdateState() so that InputState.Change() will *NOT* change timestamps.
@@ -3491,6 +3494,17 @@ namespace UnityEngine.InputSystem
             ////       same goes for events that someone may queue from a change monitor callback
             InvokeAfterUpdateCallback(updateType);
             m_CurrentUpdate = default;
+        }
+
+        private void LogProcessedEventForDevice(InputDevice device, uint totalEventBytesProcessed, InputEventPtr eventPtr)
+        {
+            if (m_Settings.debugLogProcessedEventForDevice && (m_CurrentUpdate != InputUpdateType.Editor))
+            {
+                Debug.Log("Frame Count: " + Time.frameCount +
+                    ", Device: " + device.name +
+                    ", Bytes Processed: " + totalEventBytesProcessed +
+                    ", Event Size: " + eventPtr.sizeInBytes);
+            }
         }
 
         // Only do this check in editor in hope that it will be sufficient to catch any misuse during development.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -702,6 +702,27 @@ namespace UnityEngine.InputSystem
             }
         }
 
+
+        /// <summary>
+        /// Enables or disables logging of amount of processed input events for each device. This is done per
+        /// InputSystem.Update() call.
+        /// </summary>
+        ///
+        /// This should only be used for debugging purposes. It is useful to track down devices that are sending
+        /// a lot of input events per frame. It will pollute the console log with a lot of messages.
+        public bool debugLogProcessedEventForDevice
+        {
+            get => m_DebugLogProcessedEventForDevice;
+            set
+            {
+                if (m_DebugLogProcessedEventForDevice == value)
+                    return;
+
+                m_DebugLogProcessedEventForDevice = value;
+                OnChange();
+            }
+        }
+
         /// <summary>
         /// Enable or disable an internal feature by its name.
         /// </summary>
@@ -770,6 +791,8 @@ namespace UnityEngine.InputSystem
         [SerializeField] private float m_MultiTapDelayTime = 0.75f;
         [SerializeField] private bool m_DisableRedundantEventsMerging = false;
         [SerializeField] private bool m_ShortcutKeysConsumeInputs = false; // This is the shortcut support from v1.4. Temporarily moved here as an opt-in feature, while it's issues are investigated.
+        [SerializeField] private bool m_DebugLogProcessedEventForDevice = false;
+
 
         [NonSerialized] internal HashSet<string> m_FeatureFlags;
 


### PR DESCRIPTION
### Description

This PR adds a setting to improve debugging of received device events on the Input System.

It helps track down devices that might be sending a lot of events per frame. 
It can also help when looking for issues with the Input System.

The idea came while trying to fix https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-61472.
The customer needed more information to track down a problem with `InputSettings.maxEventBytesPerUpdate` being exceeded in certain situations. 
Our engine support engineers had to go back and forth to help the customer add logging of events to their Input System package. 

This PR pretends to improve that and fulfill the customer request to have more logging information about which device is causing the problem.

### Changes made

Added a new setting to `InputSettings`.

When enabled, the Console output will be "polluted" with data like this (Player build logging example).
![image](https://github.com/Unity-Technologies/InputSystem/assets/123556071/288ada0a-5bcc-4a18-92db-748be3dc4e87)


### Notes

📣 
This is a very naive solution to avoid making customers have to add this kind of logs manually to `InputManager`. It is not "super elegant", but it works.
I did not find a better location for this: I thought about `InputMetrics` or `InputDiagnostics`, but they all depend on the `Input Debugger` window which might not be ideal as it lacks saving history AFAIK.

With this PR I'm mostly looking for comments on this solution. The goal is to improve observability when we have problems in the Input System and allow for developers to have more information about input devices event processing.

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
