### PR TITLE
FIX: Address CI failure in Package validation tests

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
+- Fixed resource designation for "d_InputControl" icon to address CI failure
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Resources/InputActionsEditorStyles.uss
@@ -95,7 +95,7 @@
 
 .tree-view-item-icon{
     justify-content: center;
-    background-image: url("/Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_InputControl.png");
+    background-image: resource('Packages/com.unity.inputsystem/InputSystem/Editor/Icons/d_InputControl.png');
     width: 16px;
     height: 16px;
 }


### PR DESCRIPTION
### Description

An issue with the trunk merge was brought up on [this Slack thread](https://unity.slack.com/archives/C09Q7LYP9/p1715247298560159). I don't fully understand the problem but made a lucky guess.

### Changes made

Changed the d_InputControl.png asset reference from "url" to "resource".
This matches the other asset references within InputActionsEditorStyles.uss and appeared to fix the Package validation test failure.

Proof of fix: https://unity-ci.cds.internal.unity3d.com/project/2354/branch/timke%2Ftrunk-merge-test

NOTE: The fix for Neutron was pushed onto [this trunk-merge branch](https://github.cds.internal.unity3d.com/unity/neutron/tree/trunk-merge/followup-1/result) and should (eventually) land to Neutron main. A forward port shouldn't be necessary.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
