### PR TITLE
CHANGE: prevent editing of composite parts

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,6 +11,9 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
 
+### Changed
+- Removed editor controls for modifying parts of a composite action. [ISXB-804](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-804)
+
 ## [1.8.2] - 2024-04-29
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -53,7 +53,7 @@ namespace UnityEngine.InputSystem.Editor
                     ContextMenu.GetContextMenuForCompositeItem(this, treeViewItem, i);
                 else if (item.isAction)
                     ContextMenu.GetContextMenuForActionItem(this, treeViewItem, item.controlLayout, i);
-                else
+                else if(!item.isPartOfComposite) // composite parts should not be altered: ISXB-804
                     ContextMenu.GetContextMenuForBindingItem(this, treeViewItem, i);
 
                 if (item.isAction)
@@ -391,6 +391,8 @@ namespace UnityEngine.InputSystem.Editor
             if (allowUICommandExecution)
             {
                 var data = (ActionOrBindingData)m_ActionsTreeView.selectedItem;
+                if (data.isPartOfComposite) // composite parts should not be changeable: ISXB-804
+                    return;
                 switch (evt.commandName)
                 {
                     case CmdEvents.Rename:


### PR DESCRIPTION
### Description

When deleting parts of a composite action, the deletion of the last part raises an exception.

### Changes made

Preventing changes to a composite part via context menu and commands.

### Notes

We decided to do this as it does not make sense from a user perspective to modify a composite action. Composite actions are created and configured with the appropriate parts using menu items, which create create the composite using pre-determined patterns. The user is already prevented from adding parts to the composite by the absence of the '+' menu, so it makes sense to remove the corresponding cut/paste/delete items.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
