### PR TITLE
[ISXB-505] Fixed disabling composite binding while pressed

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -1458,13 +1458,13 @@ partial class CoreTests
         actionWithModifier.AddCompositeBinding("OneModifier")
             .With("Binding", "<Keyboard>/space")
             .With("Modifier", "<Keyboard>/ctrl");
-        actionWithModifier.performed += _ => ++withModiferReceivedCalls;
+        actionWithModifier.performed += _ => ++ withModiferReceivedCalls;
 
         var actionWithoutModifier = map.AddAction("One", type: InputActionType.Button, binding: "<Keyboard>/space");
         actionWithoutModifier.performed += _ => actionWithModifier.Disable();
 
         map.Enable();
-       
+
         PressAndRelease(keyboard.spaceKey);
         InputSystem.Update();
         Assume.That(actionWithModifier.enabled, Is.False);

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -1465,16 +1465,22 @@ partial class CoreTests
 
         map.Enable();
 
+        // Press the SPACE key used by both binding
+        // actionWithModifier : SPACE key binding state will have current time but without a preceding CTRL key it will not trigger
+        // actionWithoutModifier : SPACE key binding will trigger the performed lambda which will disable actionWithModifier
         PressAndRelease(keyboard.spaceKey);
         InputSystem.Update();
         Assume.That(actionWithModifier.enabled, Is.False);
 
-        // Re-enable action which has been disabled by space
+        // Re-enable action which has been disabled by actionWithoutModifier
         actionWithModifier.Enable();
+
+        // Press the CTRL+SPACE to trigger actionWithModifier and not actionWithoutModifier
         Press(keyboard.leftCtrlKey, queueEventOnly: true);
         Press(keyboard.spaceKey);
         InputSystem.Update();
         Assert.That(withModiferReceivedCalls, Is.EqualTo(1));
+        Assert.That(actionWithModifier.enabled, Is.True);
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
+- Fixed Composite binding isn't triggered after disabling action while there are in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505)
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1163,6 +1163,9 @@ namespace UnityEngine.InputSystem
                 if (bindingStatePtr->wantsInitialStateCheck)
                     SetInitialStateCheckPending(bindingStatePtr, false);
                 manager.RemoveStateChangeMonitor(controls[controlIndex], this, mapControlAndBindingIndex);
+                
+                // Ensure that pressTime is reset if the composite binding is reenable. ISXB-505
+                bindingStatePtr->pressTime = default;
 
                 SetControlEnabled(controlIndex, false);
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1163,7 +1163,7 @@ namespace UnityEngine.InputSystem
                 if (bindingStatePtr->wantsInitialStateCheck)
                     SetInitialStateCheckPending(bindingStatePtr, false);
                 manager.RemoveStateChangeMonitor(controls[controlIndex], this, mapControlAndBindingIndex);
-                
+
                 // Ensure that pressTime is reset if the composite binding is reenable. ISXB-505
                 bindingStatePtr->pressTime = default;
 


### PR DESCRIPTION
### Description

Fixed Composite binding isn't triggered after disabling action while there are in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).

Within the settings shortcutKeysConsumeInput at true,
The bug was due to the fact that when using modifier it require that the modifier is pressed before. But if it's disabled while the key is pressed the binding state will keep the old time and and when reactivated it will discard any modifier since it will arrive after the old key press time which was not reset.

### Changes made

When disabling an action, it now reset the pressTime of the binding state to ensure that if re-enabled it will not prevent modifier key to trigger.

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [X] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
