### PR TITLE
FIX: Avoid potential for NullReferenceException in FireStateChangeNotifications (ISXB-724).

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,10 +11,10 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Fixed
-- Avoid potential crashes from NullReferenceException in FireStateChangeNotifications.
-- Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
-- Fixed resource designation for "d_InputControl" icon to address CI failure
-- Fixed Composite binding isn't triggered after disabling action while there are in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505)
+- Avoid potential crashes from `NullReferenceException` in `FireStateChangeNotifications`.
+- Fixed an issue where a composite binding would not be consecutively triggered after ResetDevice() has been called from the associated action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
+- Fixed resource designation for "d_InputControl" icon to address CI failure.
+- Fixed an issue where a composite binding would not be consecutively triggered after disabling actions while there are action modifiers in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,8 +11,8 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Fixed
-- Avoid potential crashes from NullReferenceException in FireStateChangeNotifications [ISXB-724](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-724)
-- Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
+- Avoid potential crashes from NullReferenceException in FireStateChangeNotifications.
+- Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,9 @@ Due to package verification, the latest version below is the unpublished version
 however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
+
+### Fixed
+- Avoid potential crashes from NullReferenceException in FireStateChangeNotifications [ISXB-724](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-724)
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
 
 ## [1.8.2] - 2024-04-29

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -86,7 +86,7 @@ namespace UnityEngine.InputSystem.LowLevel
         internal const string ButtonSouthShortDisplayName = "Cross";
         internal const string ButtonNorthShortDisplayName = "Triangle";
         internal const string ButtonWestShortDisplayName = "Square";
-        internal const string ButtonEastShortDisplayName = "East";
+        internal const string ButtonEastShortDisplayName = "Circle";
         #elif UNITY_SWITCH
         internal const string ButtonSouthShortDisplayName = "B";
         internal const string ButtonNorthShortDisplayName = "X";

--- a/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
@@ -351,6 +351,11 @@ namespace UnityEngine.InputSystem
         {
             Debug.Assert(m_StateChangeMonitors != null);
             Debug.Assert(m_StateChangeMonitors.Length > deviceIndex);
+            Debug.Assert(m_StateChangeMonitors[deviceIndex].listeners != null);
+            
+            if (m_StateChangeMonitors == null || m_StateChangeMonitors.Length <= deviceIndex ||
+                m_StateChangeMonitors[deviceIndex].listeners == null)
+                return; 
 
             // NOTE: This method must be safe for mutating the state change monitor arrays from *within*
             //       NotifyControlStateChanged()! This includes all monitors for the device being wiped

--- a/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
@@ -352,10 +352,10 @@ namespace UnityEngine.InputSystem
             Debug.Assert(m_StateChangeMonitors != null);
             Debug.Assert(m_StateChangeMonitors.Length > deviceIndex);
             Debug.Assert(m_StateChangeMonitors[deviceIndex].listeners != null);
-            
+
             if (m_StateChangeMonitors == null || m_StateChangeMonitors.Length <= deviceIndex ||
                 m_StateChangeMonitors[deviceIndex].listeners == null)
-                return; 
+                return;
 
             // NOTE: This method must be safe for mutating the state change monitor arrays from *within*
             //       NotifyControlStateChanged()! This includes all monitors for the device being wiped

--- a/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManagerStateMonitors.cs
@@ -349,19 +349,28 @@ namespace UnityEngine.InputSystem
 
         internal unsafe void FireStateChangeNotifications(int deviceIndex, double internalTime, InputEvent* eventPtr)
         {
-            Debug.Assert(m_StateChangeMonitors != null);
-            Debug.Assert(m_StateChangeMonitors.Length > deviceIndex);
-            Debug.Assert(m_StateChangeMonitors[deviceIndex].listeners != null);
-
-            if (m_StateChangeMonitors == null || m_StateChangeMonitors.Length <= deviceIndex ||
-                m_StateChangeMonitors[deviceIndex].listeners == null)
+            if (m_StateChangeMonitors == null)
+            {
+                Debug.Assert(false, "m_StateChangeMonitors is null - has AddStateChangeMonitor been called?");
                 return;
+            }
+            if (m_StateChangeMonitors.Length <= deviceIndex)
+            {
+                Debug.Assert(false, $"deviceIndex {deviceIndex} passed to FireStateChangeNotifications is out of bounds (current length {m_StateChangeMonitors.Length}).");
+                return;
+            }
 
             // NOTE: This method must be safe for mutating the state change monitor arrays from *within*
             //       NotifyControlStateChanged()! This includes all monitors for the device being wiped
             //       completely or arbitrary additions and removals having occurred.
 
             ref var signals = ref m_StateChangeMonitors[deviceIndex].signalled;
+            if (signals.AnyBitIsSet() && m_StateChangeMonitors[deviceIndex].listeners == null)
+            {
+                Debug.Assert(false, $"A state change for device {deviceIndex} has been set, but list of listeners is null.");
+                return;
+            }
+
             ref var listeners = ref m_StateChangeMonitors[deviceIndex].listeners;
             var time = internalTime - InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DynamicBitfield.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DynamicBitfield.cs
@@ -51,6 +51,16 @@ namespace UnityEngine.InputSystem
             array[bitIndex / 64] &= ~(1UL << (bitIndex % 64));
         }
 
+        public bool AnyBitIsSet()
+        {
+            for (var i = 0; i < array.length; ++i)
+            {
+                if (array[i] != 0)
+                    return true;
+            }
+            return false;
+        }
+
         private static int BitCountToULongCount(int bitCount)
         {
             return (bitCount + 63) / 64;


### PR DESCRIPTION
### Description

A tentative fix, given no known repro, for [ISXB-724](https://jira.unity3d.com/browse/ISXB-724).

### Changes made

Added early returns in cases we'd otherwise crash.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
