### PR TITLE
CHANGE: Remove redundant FastMouse current time call on InputState.Change (case ISX-1414)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,6 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
 - Fixed resource designation for "d_InputControl" icon to address CI failure
+- Changed FastMouse.OnNextUpdate() to pass the current time as a parameter to InputState.Change() improving performance (case ISX-1414)
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
 - Fixed resource designation for "d_InputControl" icon to address CI failure
-- Changed FastMouse.OnNextUpdate() to pass the current time as a parameter to InputState.Change() improving performance (case ISX-1414)
+- Changed FastMouse.OnNextUpdate() to pass the current time as a parameter to InputState.Change() avoiding a redundant scripting to native call to query the time (case ISX-1414)
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
@@ -8,8 +8,9 @@ namespace UnityEngine.InputSystem
         {
             // Changing these separately seems to not result in much of a difference
             // compared to just doing an InputState.Change with a complete MouseState.
-            InputState.Change(delta, Vector2.zero, InputState.currentUpdateType);
-            InputState.Change(scroll, Vector2.zero, InputState.currentUpdateType);
+            double now = InputRuntime.s_Instance.currentTime;
+            InputState.Change(delta, Vector2.zero, InputState.currentUpdateType, time: now);
+            InputState.Change(scroll, Vector2.zero, InputState.currentUpdateType, time: now);
         }
 
         // For FastMouse, we know that our layout is MouseState so we can just go directly

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Precompiled/FastMouse.partial.cs
@@ -9,8 +9,8 @@ namespace UnityEngine.InputSystem
             // Changing these separately seems to not result in much of a difference
             // compared to just doing an InputState.Change with a complete MouseState.
             double now = InputRuntime.s_Instance.currentTime;
-            InputState.Change(delta, Vector2.zero, InputState.currentUpdateType, time: now);
-            InputState.Change(scroll, Vector2.zero, InputState.currentUpdateType, time: now);
+            InputState.Change(delta, Vector2.zero, now, InputState.currentUpdateType);
+            InputState.Change(scroll, Vector2.zero, now, InputState.currentUpdateType);
         }
 
         // For FastMouse, we know that our layout is MouseState so we can just go directly

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -91,9 +91,9 @@ namespace UnityEngine.InputSystem.LowLevel
         /// device current.
         /// </remarks>
         public static void Change<TState>(InputControl control, TState state, InputUpdateType updateType = default, InputEventPtr eventPtr = default)
-                where TState : struct
+            where TState : struct
         {
-            double time = eventPtr.valid ? default : InputRuntime.s_Instance.currentTime; 
+            double time = eventPtr.valid ? default : InputRuntime.s_Instance.currentTime;
             Change(control, ref state, updateType, eventPtr, time);
         }
 
@@ -109,7 +109,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// device current.
         /// </remarks>
         public static unsafe void Change<TState>(InputControl control, TState state, double time, InputUpdateType updateType = default)
-                where TState : struct
+            where TState : struct
         {
             InputEventPtr eventPtr = new InputEventPtr(null);
             Change(control, ref state, updateType, eventPtr, time);

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -90,10 +90,28 @@ namespace UnityEngine.InputSystem.LowLevel
         /// also performs related tasks such as checking state change monitors, flipping buffers, or making the respective
         /// device current.
         /// </remarks>
-        public static void Change<TState>(InputControl control, TState state, InputUpdateType updateType = default,
-            InputEventPtr eventPtr = default, double time = 0.0)
-            where TState : struct
+        public static void Change<TState>(InputControl control, TState state, InputUpdateType updateType = default, InputEventPtr eventPtr = default)
+                where TState : struct
         {
+            double time = eventPtr.valid ? default : InputRuntime.s_Instance.currentTime; 
+            Change(control, ref state, updateType, eventPtr, time);
+        }
+
+        /// <summary>
+        /// Perform one update of input state specifying the time
+        /// </summary>
+        /// <remarks>
+        /// Incorporates the given state and triggers all state change monitors as needed.
+        ///
+        /// Note that input state changes performed with this method will not be visible on remotes as they will bypass
+        /// event processing. It is effectively equivalent to directly writing into input state memory except that it
+        /// also performs related tasks such as checking state change monitors, flipping buffers, or making the respective
+        /// device current.
+        /// </remarks>
+        public static unsafe void Change<TState>(InputControl control, TState state, double time, InputUpdateType updateType = default)
+                where TState : struct
+        {
+            InputEventPtr eventPtr = new InputEventPtr(null);
             Change(control, ref state, updateType, eventPtr, time);
         }
 
@@ -109,7 +127,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// device current.
         /// </remarks>
         public static unsafe void Change<TState>(InputControl control, ref TState state, InputUpdateType updateType = default,
-            InputEventPtr eventPtr = default, double time = 0.0)
+            InputEventPtr eventPtr = default, double time = default)
             where TState : struct
         {
             if (control == null)
@@ -121,14 +139,6 @@ namespace UnityEngine.InputSystem.LowLevel
             var stateSize = Math.Min(UnsafeUtility.SizeOf<TState>(), control.m_StateBlock.alignedSizeInBytes);
             var statePtr = UnsafeUtility.AddressOf(ref state);
             var stateOffset = control.stateBlock.byteOffset - device.stateBlock.byteOffset;
-
-            // Report any calls with no event and no specified time (relying on both default parameter values)
-            // This may not matter but would like to know about these during testing with more devices
-            //
-            if (!eventPtr.valid && time == 0.0)
-            {
-                Debug.Log($"InputState.Change<>('{control.name}') called with null event and default time=0.0\n");
-            }
 
             InputSystem.s_Manager.UpdateState(device,
                 updateType != default ? updateType : InputSystem.s_Manager.defaultUpdateType, statePtr, stateOffset,

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputState.cs
@@ -91,10 +91,10 @@ namespace UnityEngine.InputSystem.LowLevel
         /// device current.
         /// </remarks>
         public static void Change<TState>(InputControl control, TState state, InputUpdateType updateType = default,
-            InputEventPtr eventPtr = default)
+            InputEventPtr eventPtr = default, double time = 0.0)
             where TState : struct
         {
-            Change(control, ref state, updateType, eventPtr);
+            Change(control, ref state, updateType, eventPtr, time);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// device current.
         /// </remarks>
         public static unsafe void Change<TState>(InputControl control, ref TState state, InputUpdateType updateType = default,
-            InputEventPtr eventPtr = default)
+            InputEventPtr eventPtr = default, double time = 0.0)
             where TState : struct
         {
             if (control == null)
@@ -122,12 +122,20 @@ namespace UnityEngine.InputSystem.LowLevel
             var statePtr = UnsafeUtility.AddressOf(ref state);
             var stateOffset = control.stateBlock.byteOffset - device.stateBlock.byteOffset;
 
+            // Report any calls with no event and no specified time (relying on both default parameter values)
+            // This may not matter but would like to know about these during testing with more devices
+            //
+            if (!eventPtr.valid && time == 0.0)
+            {
+                Debug.Log($"InputState.Change<>('{control.name}') called with null event and default time=0.0\n");
+            }
+
             InputSystem.s_Manager.UpdateState(device,
                 updateType != default ? updateType : InputSystem.s_Manager.defaultUpdateType, statePtr, stateOffset,
                 (uint)stateSize,
                 eventPtr.valid
                 ? eventPtr.internalTime
-                : InputRuntime.s_Instance.currentTime,
+                : time,
                 eventPtr: eventPtr);
         }
 


### PR DESCRIPTION
### Description

Reduce FastMouse calls to get the current time (one of them is redundant).

### Changes made

**FastMouse.OnNextUpdate**() makes two calls to **InputState.Change**() - one each for delta and scroll.

This results in two calls to **InputRuntime.s_Instance.currentTime** inside the **InputSystem.Change**() to pass as a parameter to the InputSystem **UpdateState**().

Instead query the current time and pass that as a parameter to the new templated **Change<>**() function which takes a time parameter. Events have their own internalTime which is used if present.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:
CHANGE: FastMouse.OnNextUpdate() now queries the current time and passes it as a parameter to InputState.Change() avoiding a redundant native call (case ISX-1414)

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
