### PR TITLE
CHANGE: Improve error logging when events get discarded (ISXB-691)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -2382,8 +2382,11 @@ partial class CoreTests
         var eventCount = 0;
         InputSystem.onEvent += (eventPtr, device) => ++ eventCount;
 
+        var totalProcessedMouseStateEventBytes = InputSystem.settings.maxEventBytesPerUpdate;
         LogAssert.Expect(LogType.Error, "Exceeded budget for maximum input event throughput per InputSystem.Update(). Discarding remaining events. "
-            + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to remove the limit.");
+            + "Increase InputSystem.settings.maxEventBytesPerUpdate or set it to 0 to remove the limit.\n"
+            + "Total events processed by devices in last update call:\n"
+            + $" - {totalProcessedMouseStateEventBytes} bytes processed by Mouse:/Mouse\n");
 
         InputSystem.Update();
 

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -2365,13 +2365,16 @@ partial class CoreTests
     [Category("Events")]
     public void Events_MaximumEventLoadPerUpdateIsLimited()
     {
-        // Default setting is 5MB.
+        // Default limit setting is 5MB.
         Assert.That(InputSystem.settings.maxEventBytesPerUpdate, Is.EqualTo(5 * 1024 * 1024));
 
+        // Limit the maximum events to be processed per update to 2 Mouse state events.
         InputSystem.settings.maxEventBytesPerUpdate = StateEvent.GetEventSizeWithPayload<MouseState>() * 2;
 
         var mouse = InputSystem.AddDevice<Mouse>();
 
+        // Queue 3 events, where the 3rd one will raise a log error.
+        // Only 2 events from 3 should be processed.
         InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Left));
         InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Right));
         InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Middle));
@@ -2387,6 +2390,15 @@ partial class CoreTests
         Assert.That(eventCount, Is.EqualTo(2));
         Assert.That(mouse.rightButton.isPressed, Is.True);
         Assert.That(mouse.middleButton.isPressed, Is.False);
+
+        // Queue 1 event after error has been raised
+        InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Right, false));
+        InputSystem.Update();
+
+        // Check that we have only processed the new event.
+        // Confirms that the 3rd event setting MouseButton.middle was discarded.
+        Assert.That(eventCount, Is.EqualTo(3));
+        Assert.That(mouse.rightButton.isPressed, Is.False);
 
         eventCount = 0;
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,11 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Scheme Name in Control Scheme editor menu that gets reset when editing devices [ISXB-763](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-763).
 - Fixed an issue where `InputActionAsset.FindAction(string, bool)` would throw `System.NullReferenceException` instead of returning `null` if searching for a non-existent action with an explicit action path and using `throwIfNotFound: false`, e.g. searching for "Map/Action" when `InputActionMap` "Map" exists but no `InputAction` named "Action" exists within that map [ISXB-895](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-895).
 
+## Added
+- Added additional device information when logging the error due to exceeding the maximum number of events processed
+  set by `InputSystem.settings.maxEventsBytesPerUpdate`. This additional information is available in development builds
+  only.
+
 ## [1.8.2] - 2024-04-29
 
 ### Added

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -672,7 +672,10 @@ namespace UnityEngine.InputSystem
         internal DeviceFlags m_DeviceFlags;
         internal int m_DeviceId;
         internal int m_ParticipantId;
-        internal int m_DeviceIndex; // Index in InputManager.m_Devices.
+        // Index in InputManager.m_Devices.
+        internal int m_DeviceIndex;
+        // Amount of bytes processed in the current update step. Used only for logging purposes.
+        internal uint m_CurrentProcessedEventBytesOnUpdate; 
         internal InputDeviceDescription m_Description;
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDevice.cs
@@ -675,7 +675,7 @@ namespace UnityEngine.InputSystem
         // Index in InputManager.m_Devices.
         internal int m_DeviceIndex;
         // Amount of bytes processed in the current update step. Used only for logging purposes.
-        internal uint m_CurrentProcessedEventBytesOnUpdate; 
+        internal uint m_CurrentProcessedEventBytesOnUpdate;
         internal InputDeviceDescription m_Description;
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Unity.Collections;
 using UnityEngine.InputSystem.Composites;
 using UnityEngine.InputSystem.Controls;
@@ -3497,15 +3498,12 @@ namespace UnityEngine.InputSystem
             if (m_Settings.maxEventBytesPerUpdate > 0 &&
                 totalEventBytesProcessed >= m_Settings.maxEventBytesPerUpdate)
             {
-                var eventsProcessedByDeviceLog = "";
+                var eventsProcessedByDeviceLog = String.Empty;
                 // Only log the events processed by devices in last update call if we are in debug mode.
                 // This is to avoid the slightest overhead in release builds of having to iterate over all devices and
                 // reset the byte count, by the end of every update call with ResetCurrentProcessedEventBytesForDevices().
                 if (Debug.isDebugBuild)
-                {
-                    eventsProcessedByDeviceLog = "Total events processed by devices in last update call:\n" +
-                        MakeStringWithEventsProcessedByDevice();
-                }
+                    eventsProcessedByDeviceLog = $"Total events processed by devices in last update call:\n{MakeStringWithEventsProcessedByDevice()}";
 
                 Debug.LogError(
                     "Exceeded budget for maximum input event throughput per InputSystem.Update(). Discarding remaining events. "
@@ -3520,18 +3518,14 @@ namespace UnityEngine.InputSystem
 
         private string MakeStringWithEventsProcessedByDevice()
         {
-            string eventsProcessedByDeviceLog = "";
-
+            var eventsProcessedByDeviceLog = new StringBuilder();
             for (int i = 0; i < m_DevicesCount; i++)
             {
                 var deviceToLog = devices[i];
                 if (deviceToLog != null && deviceToLog.m_CurrentProcessedEventBytesOnUpdate > 0)
-                {
-                    eventsProcessedByDeviceLog += $" - {deviceToLog.m_CurrentProcessedEventBytesOnUpdate} bytes processed by {deviceToLog}\n";
-                }
+                    eventsProcessedByDeviceLog.Append($" - {deviceToLog.m_CurrentProcessedEventBytesOnUpdate} bytes processed by {deviceToLog}\n");
             }
-
-            return eventsProcessedByDeviceLog;
+            return eventsProcessedByDeviceLog.ToString();
         }
 
         // Reset the number of bytes processed by devices in the current update, for debug builds.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3062,10 +3062,6 @@ namespace UnityEngine.InputSystem
                 // Handle events.
                 while (m_InputEventStream.remainingEventCount > 0)
                 {
-                    // Discard events in case the maximum event bytes per update has been exceeded
-                    if (WasMaximumEventBytesPerUpdateExceeded(totalEventBytesProcessed))
-                        break;
-
                     InputDevice device = null;
                     var currentEventReadPtr = m_InputEventStream.currentEventPtr;
 
@@ -3461,6 +3457,10 @@ namespace UnityEngine.InputSystem
                     }
 
                     m_InputEventStream.Advance(leaveEventInBuffer: false);
+
+                    // Discard events in case the maximum event bytes per update has been exceeded
+                    if (AreMaximumEventBytesPerUpdateExceeded(totalEventBytesProcessed))
+                        break;
                 }
 
                 m_Metrics.totalEventProcessingTime +=
@@ -3492,7 +3492,7 @@ namespace UnityEngine.InputSystem
             m_CurrentUpdate = default;
         }
 
-        bool WasMaximumEventBytesPerUpdateExceeded(uint totalEventBytesProcessed)
+        bool AreMaximumEventBytesPerUpdateExceeded(uint totalEventBytesProcessed)
         {
             if (m_Settings.maxEventBytesPerUpdate > 0 &&
                 totalEventBytesProcessed >= m_Settings.maxEventBytesPerUpdate)


### PR DESCRIPTION
### Description

Improves the error logging for the issue [ISXB-691](https://issuetracker.unity3d.com/issues/exceeded-budget-for-maximum-input-event-error-appears-when-entering-play-mode-if-setting-inputsystem-dot-settings-dot-maxeventbytesperupdate-to-more-than-0)  with the amount of events processed by device.

### Changes made

PR adds a way of accumulating the total amount of bytes processed during an update call, per device.
Currently, this data will only be present when `InputSettings.maxEventBytesPerUpdate` is exceeded in an update call.
But in the future, it could potentially be used as well to present the average of bytes processed per frame for a device in the Input Debugger Window

This logging of extra data will only affect development builds.
It allows developers to identify the devices or other issues causing the error.

### Notes

I did not see a performance impact when profiling this with the test `CorePerformanceTest.Performance_Update10Gamepads`.

To test this the error needs to be raised. Just decrease `InputSystem.settings.maxEventBytesPerUpdate` to something like 10 bytes. Try to see the difference between development builds and non-development builds.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
