### PR TITLE
FIX: Prefabs and missing default control scheme in the inspector view of playerinput (ISXB-818)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,7 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where a composite binding would not be consecutively triggered after ResetDevice() has been called from the associated action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
 - Fixed resource designation for "d_InputControl" icon to address CI failure.
 - Fixed an issue where a composite binding would not be consecutively triggered after disabling actions while there are action modifiers in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).
-- Fixed Missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818)
+- Fixed prefabs and missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818)
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Composite binding isn't triggered after ResetDevice() called during Action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746)
 - Fixed resource designation for "d_InputControl" icon to address CI failure
 - Fixed Composite binding isn't triggered after disabling action while there are in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505)
+- Fixed Missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818)
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -88,8 +88,11 @@ namespace UnityEngine.InputSystem.Editor
                 // if the invalid DefaultControlSchemeName is selected set the popup draw the BG color in red
                 if (m_InvalidDefaultControlSchemeName != null && m_SelectedDefaultControlScheme == 1)
                     GUI.backgroundColor = Color.red;
-                var selected = EditorGUILayout.Popup(m_DefaultControlSchemeText, m_SelectedDefaultControlScheme,
-                    m_ControlSchemeOptions);
+
+                var rect = EditorGUILayout.GetControlRect();
+                var label = EditorGUI.BeginProperty(rect, m_DefaultControlSchemeText, m_DefaultControlSchemeProperty);
+                var selected = EditorGUI.Popup(rect, label, m_SelectedDefaultControlScheme, m_ControlSchemeOptions);
+                EditorGUI.EndProperty();
                 if (selected != m_SelectedDefaultControlScheme)
                 {
                     if (selected == 0)
@@ -111,8 +114,12 @@ namespace UnityEngine.InputSystem.Editor
                 // Restore the initial color
                 GUI.backgroundColor = currentBg;
 
+
+                rect = EditorGUILayout.GetControlRect();
+                label = EditorGUI.BeginProperty(rect, m_AutoSwitchText, m_NeverAutoSwitchControlSchemesProperty);
                 var neverAutoSwitchValueOld = m_NeverAutoSwitchControlSchemesProperty.boolValue;
-                var neverAutoSwitchValueNew = !EditorGUILayout.Toggle(m_AutoSwitchText, !neverAutoSwitchValueOld);
+                var neverAutoSwitchValueNew = !EditorGUI.Toggle(rect, label, !neverAutoSwitchValueOld);
+                EditorGUI.EndProperty();
                 if (neverAutoSwitchValueOld != neverAutoSwitchValueNew)
                 {
                     m_NeverAutoSwitchControlSchemesProperty.boolValue = neverAutoSwitchValueNew;
@@ -122,9 +129,11 @@ namespace UnityEngine.InputSystem.Editor
             if (m_ActionMapOptions != null && m_ActionMapOptions.Length > 0)
             {
                 // Default action map picker.
-
-                var selected = EditorGUILayout.Popup(m_DefaultActionMapText, m_SelectedDefaultActionMap,
+                var rect = EditorGUILayout.GetControlRect();
+                var label = EditorGUI.BeginProperty(rect, m_DefaultActionMapText, m_DefaultActionMapProperty);
+                var selected = EditorGUI.Popup(rect, label, m_SelectedDefaultActionMap,
                     m_ActionMapOptions);
+                EditorGUI.EndProperty();
                 if (selected != m_SelectedDefaultActionMap)
                 {
                     if (selected == 0)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -499,7 +499,8 @@ namespace UnityEngine.InputSystem.Editor
             var selectedDefaultControlScheme = playerInput.defaultControlScheme;
             m_InvalidDefaultControlSchemeName = null;
             m_SelectedDefaultControlScheme = 0;
-            var controlSchemesNames = asset.controlSchemes.OrderBy(cs => cs.name).Select(cs => cs.name).ToList();
+            ////TODO: sort alphabetically and ensure that the order is the same in the schemes editor
+            var controlSchemesNames = asset.controlSchemes.Select(cs => cs.name).ToList();
 
             // try to find the selected Default Control Scheme
             if (!string.IsNullOrEmpty(selectedDefaultControlScheme))

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -84,7 +84,10 @@ namespace UnityEngine.InputSystem.Editor
             if (m_ControlSchemeOptions != null && m_ControlSchemeOptions.Length > 1) // Don't show if <Any> is the only option.
             {
                 // Default control scheme picker.
-
+                Color currentBg = GUI.backgroundColor;
+                // if the invalid DefaultControlSchemeName is selected set the popup draw the BG color in red
+                if (m_InvalidDefaultControlSchemeName != null && m_SelectedDefaultControlScheme == 1)
+                    GUI.backgroundColor = Color.red;
                 var selected = EditorGUILayout.Popup(m_DefaultControlSchemeText, m_SelectedDefaultControlScheme,
                     m_ControlSchemeOptions);
                 if (selected != m_SelectedDefaultControlScheme)
@@ -93,13 +96,20 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         m_DefaultControlSchemeProperty.stringValue = null;
                     }
+                    // if there is an invalid default scheme name it will be at rank 1.
+                    // we use m_InvalidDefaultControlSchemeName to prevent usage of the string with "name<Not Found>"
+                    else if (m_InvalidDefaultControlSchemeName != null && selected == 1)
+                    {
+                        m_DefaultControlSchemeProperty.stringValue = m_InvalidDefaultControlSchemeName;
+                    }
                     else
                     {
-                        m_DefaultControlSchemeProperty.stringValue =
-                            m_ControlSchemeOptions[selected].text;
+                        m_DefaultControlSchemeProperty.stringValue = m_ControlSchemeOptions[selected].text;
                     }
                     m_SelectedDefaultControlScheme = selected;
                 }
+                // Restore the initial color
+                GUI.backgroundColor = currentBg;
 
                 var neverAutoSwitchValueOld = m_NeverAutoSwitchControlSchemesProperty.boolValue;
                 var neverAutoSwitchValueNew = !EditorGUILayout.Toggle(m_AutoSwitchText, !neverAutoSwitchValueOld);
@@ -424,6 +434,7 @@ namespace UnityEngine.InputSystem.Editor
                 m_ActionNames = null;
                 m_SelectedDefaultActionMap = -1;
                 m_SelectedDefaultControlScheme = -1;
+                m_InvalidDefaultControlSchemeName = null;
                 return;
             }
 
@@ -486,22 +497,35 @@ namespace UnityEngine.InputSystem.Editor
 
             // Read out control schemes.
             var selectedDefaultControlScheme = playerInput.defaultControlScheme;
+            m_InvalidDefaultControlSchemeName = null;
             m_SelectedDefaultControlScheme = 0;
-            var controlSchemes = asset.controlSchemes;
-            m_ControlSchemeOptions = new GUIContent[controlSchemes.Count + 1];
-            m_ControlSchemeOptions[0] = new GUIContent(EditorGUIUtility.TrTextContent("<Any>"));
-            ////TODO: sort alphabetically
-            for (var i = 0; i < controlSchemes.Count; ++i)
-            {
-                var name = controlSchemes[i].name;
-                m_ControlSchemeOptions[i + 1] = new GUIContent(name);
+            var controlSchemesNames = asset.controlSchemes.OrderBy(cs => cs.name).Select(cs => cs.name).ToList();
 
-                if (selectedDefaultControlScheme != null && string.Compare(name, selectedDefaultControlScheme,
-                    StringComparison.InvariantCultureIgnoreCase) == 0)
-                    m_SelectedDefaultControlScheme = i + 1;
+            // try to find the selected Default Control Scheme
+            if (!string.IsNullOrEmpty(selectedDefaultControlScheme))
+            {
+                // +1 since <Any> will be the first in the list
+                m_SelectedDefaultControlScheme = 1 + controlSchemesNames.FindIndex(name => string.Compare(name, selectedDefaultControlScheme,
+                    StringComparison.InvariantCultureIgnoreCase) == 0);
+                // if not found, will insert the invalid name next to <Any>
+                if (m_SelectedDefaultControlScheme == 0)
+                {
+                    m_InvalidDefaultControlSchemeName = selectedDefaultControlScheme;
+                    m_SelectedDefaultControlScheme = 1;
+                    controlSchemesNames.Insert(0, $"{selectedDefaultControlScheme}{L10n.Tr("<Not Found>")}");
+                }
             }
-            if (m_SelectedDefaultControlScheme <= 0)
+            else
+            {
                 playerInput.defaultControlScheme = null;
+            }
+
+            m_ControlSchemeOptions = new GUIContent[controlSchemesNames.Count + 1];
+            m_ControlSchemeOptions[0] = new GUIContent(EditorGUIUtility.TrTextContent("<Any>"));
+            for (var i = 0; i < controlSchemesNames.Count; ++i)
+            {
+                m_ControlSchemeOptions[i + 1] = new GUIContent(controlSchemesNames[i]);
+            }
 
             // Read out action maps.
             var selectedDefaultActionMap = !string.IsNullOrEmpty(playerInput.defaultActionMap)
@@ -562,6 +586,7 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private int[] m_ActionMapIndices;
         [NonSerialized] private int m_NumActionMaps;
         [NonSerialized] private int m_SelectedDefaultControlScheme;
+        [NonSerialized] private string m_InvalidDefaultControlSchemeName;
         [NonSerialized] private GUIContent[] m_ControlSchemeOptions;
         [NonSerialized] private int m_SelectedDefaultActionMap;
         [NonSerialized] private GUIContent[] m_ActionMapOptions;


### PR DESCRIPTION
### Description

Fixed Prefabs and missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818).
Before the change previously defined PlayerInput's default control scheme that doesn't exist exist any more are not shown and produce some error when entering in playmode. Disabling/enabling component silently remove the lost control scheme.
Also Default Scheme, Auto-Switch,Default Map fields was not well displayed(no blue override color and no context actions) for prefabs.

### Changes made

Changed the PlayerInput's inspector the show the missing default control scheme with a red background and a <Not Found> suffix.
![Capture d'écran 2024-05-21 093655](https://github.com/Unity-Technologies/InputSystem/assets/47957918/64c698ff-0b14-4a6c-a02c-e3689801a130)
The missing one is always in second position after <Any> and others schemes are now sorted in the popup.

Changed the ways that Default Scheme, Auto-Switch,Default Map are displayed to support prefabs.
![Capture d'écran 2024-05-24 160723](https://github.com/Unity-Technologies/InputSystem/assets/47957918/d0487fc0-0a05-49da-9c1a-a9554b5986e4)

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
