### PR TITLE
NEW: Add check for PR titles prefixes in CI

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on pull request creation and edit events but only for the "main" branch
+  pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+    branches: [ "develop" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  check-pr-title:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a bash script from the specified working directory
+      - name: Check PR Title begins with the required prefix
+        shell: bash
+        working-directory: .github/workflows
+        env:
+            TITLE: ${{github.event.pull_request.title}}
+        run: bash verify-pr-title-prefix.sh $TITLE "NEW:" "CHANGE:" "FIX:" "DOCS:" "RELEASE:"
+

--- a/.github/workflows/verify-pr-title-prefix.sh
+++ b/.github/workflows/verify-pr-title-prefix.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+exit_with_failure()
+{
+    echo "❌ $*" 1>&2 ; exit 1;
+}
+
+TITLE_STRING="$1"
+shift  # Shift all arguments to the left, so $2 becomes $1, $3 becomes $2, etc.
+
+# The remaining arguments are treated as an array of strings
+PREFIXES_REQUIRED=("$@")
+
+# Validate the title string prefix based on prefixes required
+for PREFIX in "${PREFIXES_REQUIRED[@]}";
+do
+    if [[ "$TITLE_STRING" =~ ^$PREFIX ]]; then
+        echo "✅"
+        exit 0
+    fi
+done
+
+PREFIXES_REQUIRED_STRING="${PREFIXES_REQUIRED[*]}"
+
+exit_with_failure "PR Title needs the required prefixes: $PREFIXES_REQUIRED_STRING"


### PR DESCRIPTION
### Description

This PR adds a check for PR titles prefixes in our repo. It tries to enforce our strict PR title prefixes to make sure we have a consistent commit history when we squash-merge.

### Changes made

Added a GitHub Action, instead of Yamato, because we don't need any Unity infrastructure for this.

Runs a script to validate the PR title once it is created and edited. 

**Impact:**

If the PR has the wrong prefix, checks will fail. ❌
To fix it, just edit the PR title and the CI check will run again automatically.  ✅


### Notes

This can always be bypassed when we squash the commits and create the title for the new squashed commit in GitHubs UI. 

No Jira link. 
I did this on my own time since I wanted to have automated checks of things that usually are done during a PR review and now don't need to. We have one less thing to review :) 

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
