### PR TITLE
FIX: ISXB-621 disable all action maps except default map when input system is started

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,6 +15,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where a composite binding would not be consecutively triggered after ResetDevice() has been called from the associated action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
 - Fixed resource designation for "d_InputControl" icon to address CI failure.
 - Fixed an issue where a composite binding would not be consecutively triggered after disabling actions while there are action modifiers in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).
+- Fixed issue where all action maps default to enabled when InputSystem is enabled [ISXB-621](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-621). Now, only the default map is enabled.
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -983,8 +983,22 @@ namespace UnityEngine.InputSystem
                 Debug.LogError($"Cannot find action map '{mapNameOrId}' in actions '{m_Actions}'", this);
                 return;
             }
-
+            
+            if (currentActionMap == null)
+            {
+                //Disabling all action maps, because we don't know which one is currently enabled
+                foreach(var i in m_Actions.actionMaps)
+                {
+                    i.Disable();
+                }
+            }
+            else
+            {
+                //Disabling the currently enabled action map
+                currentActionMap.Disable();
+            }
             currentActionMap = actionMap;
+            currentActionMap.Enable();
         }
 
         /// <summary>
@@ -1621,6 +1635,11 @@ namespace UnityEngine.InputSystem
 
         #endif
 
+        private void Start()
+        {
+            ActivateInput();
+        }
+
         private void OnEnable()
         {
             m_Enabled = true;
@@ -1630,7 +1649,6 @@ namespace UnityEngine.InputSystem
                 AssignPlayerIndex();
                 InitializeActions();
                 AssignUserAndDevices();
-                ActivateInput();
             }
 
             // Split-screen index defaults to player index.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -983,11 +983,11 @@ namespace UnityEngine.InputSystem
                 Debug.LogError($"Cannot find action map '{mapNameOrId}' in actions '{m_Actions}'", this);
                 return;
             }
-            
+
             if (currentActionMap == null)
             {
                 //Disabling all action maps, because we don't know which one is currently enabled
-                foreach(var i in m_Actions.actionMaps)
+                foreach (var i in m_Actions.actionMaps)
                 {
                     i.Disable();
                 }


### PR DESCRIPTION
### Description

When the InputSystem MonoBehaviour is enabled, all actions maps default to enabled. Only the default action map should be enabled. [ISXB-621](https://jira.unity3d.com/browse/ISXB-621)

### Changes made

TODO


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
