### PR TITLE
FIX: Error thrown when Cancelling Control Scheme creation in Input actions Editor (ISXB-892)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,7 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed resource designation for "d_InputControl" icon to address CI failure.
 - Fixed an issue where a composite binding would not be consecutively triggered after disabling actions while there are action modifiers in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).
 - Fixed prefabs and missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818)
-- Fixed error thrown when Cancelling Control Scheme creation in Input Actions Editor [ISXB-892](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-892)
+- Fixed error thrown when Cancelling Control Scheme creation in Input Actions Editor.
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed resource designation for "d_InputControl" icon to address CI failure.
 - Fixed an issue where a composite binding would not be consecutively triggered after disabling actions while there are action modifiers in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).
 - Fixed prefabs and missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818)
+- Fixed error thrown when Cancelling Control Scheme creation in Input Actions Editor [ISXB-892](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-892)
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/ControlSchemeCommands.cs
@@ -135,9 +135,10 @@ namespace UnityEngine.InputSystem.Editor
         {
             return (in InputActionsEditorState state) =>
             {
-                var controlSchemeSerializedProperty = state.serializedObject
-                    .FindProperty(nameof(InputActionAsset.m_ControlSchemes))
-                    .GetArrayElementAtIndex(state.selectedControlSchemeIndex);
+                var controlSchemeSerializedProperty = state.selectedControlSchemeIndex == -1 ? null :
+                    state.serializedObject
+                        .FindProperty(nameof(InputActionAsset.m_ControlSchemes))
+                        .GetArrayElementAtIndex(state.selectedControlSchemeIndex);
 
                 if (controlSchemeSerializedProperty == null)
                 {


### PR DESCRIPTION
### Description

Fixed error thrown when Cancelling Control Scheme creation in Input actions Editor 
[ISXB-892](https://jira.unity3d.com/browse/ISXB-892)

### Changes made

Added a check in ControlSchemeCommands::ResetSelectedControlScheme() to ensure that we are not searching for a non existing scheme when deleted.

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
