### PR TITLE
FIX: ISXB-766, ISXB-808, ISXB-704 scroll wheel factor bugs

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -122,6 +122,10 @@ namespace UnityEngine.InputSystem.Editor
                 if (!runInBackground)
                     EditorGUILayout.HelpBox("Focus change behavior can only be changed if 'Run In Background' is enabled in Player Settings.", MessageType.Info);
 
+#if UNITY_6000_0_OR_NEWER
+                EditorGUILayout.PropertyField(m_ScrollDeltaBehavior, m_ScrollDeltaBehaviorContent);
+#endif
+
                 EditorGUILayout.Space();
                 EditorGUILayout.PropertyField(m_CompensateForScreenOrientation, m_CompensateForScreenOrientationContent);
 
@@ -266,6 +270,7 @@ namespace UnityEngine.InputSystem.Editor
             // Look up properties.
             m_SettingsObject = new SerializedObject(m_Settings);
             m_UpdateMode = m_SettingsObject.FindProperty("m_UpdateMode");
+            m_ScrollDeltaBehavior = m_SettingsObject.FindProperty("m_ScrollDeltaBehavior");
             m_CompensateForScreenOrientation = m_SettingsObject.FindProperty("m_CompensateForScreenOrientation");
             m_BackgroundBehavior = m_SettingsObject.FindProperty("m_BackgroundBehavior");
             m_EditorInputBehaviorInPlayMode = m_SettingsObject.FindProperty("m_EditorInputBehaviorInPlayMode");
@@ -281,6 +286,9 @@ namespace UnityEngine.InputSystem.Editor
             m_ShortcutKeysConsumeInputs = m_SettingsObject.FindProperty("m_ShortcutKeysConsumeInputs");
 
             m_UpdateModeContent = new GUIContent("Update Mode", "When should the Input System be updated?");
+#if UNITY_6000_0_OR_NEWER
+            m_ScrollDeltaBehaviorContent = new GUIContent("Scroll Delta Behavior", "What value range should be used for scroll wheel delta?");
+#endif
             m_CompensateForScreenOrientationContent = new GUIContent("Compensate Orientation", "Whether sensor input on mobile devices should be transformed to be relative to the current device orientation.");
             m_BackgroundBehaviorContent = new GUIContent("Background Behavior", "If runInBackground is true (and in standalone *development* players and the editor), "
                 + "determines what happens to InputDevices and events when the application moves in and out of running in the foreground.\n\n"
@@ -404,6 +412,7 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private int m_SettingsDirtyCount;
         [NonSerialized] private SerializedObject m_SettingsObject;
         [NonSerialized] private SerializedProperty m_UpdateMode;
+        [NonSerialized] private SerializedProperty m_ScrollDeltaBehavior;
         [NonSerialized] private SerializedProperty m_CompensateForScreenOrientation;
         [NonSerialized] private SerializedProperty m_BackgroundBehavior;
         [NonSerialized] private SerializedProperty m_EditorInputBehaviorInPlayMode;
@@ -427,6 +436,9 @@ namespace UnityEngine.InputSystem.Editor
         [NonSerialized] private GUIStyle m_NewAssetButtonStyle;
 
         private GUIContent m_UpdateModeContent;
+#if UNITY_6000_0_OR_NEWER
+        private GUIContent m_ScrollDeltaBehaviorContent;
+#endif
         private GUIContent m_CompensateForScreenOrientationContent;
         private GUIContent m_BackgroundBehaviorContent;
         private GUIContent m_EditorInputBehaviorInPlayModeContent;

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -174,7 +174,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         Vector2 screenSize { get; }
         ScreenOrientation screenOrientation { get; }
-        bool allowPlatformSpecificInputForScrollWheelDelta { get; set; }
+        bool normalizeScrollWheelDelta { get; set; }
         float scrollWheelDeltaPerTick { get; }
 
         // If analytics are enabled, the runtime receives analytics events from the input manager.

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -174,6 +174,8 @@ namespace UnityEngine.InputSystem.LowLevel
 
         Vector2 screenSize { get; }
         ScreenOrientation screenOrientation { get; }
+        bool allowPlatformSpecificInputForScrollWheelDelta { get; set; }
+        float scrollWheelDeltaPerTick { get; }
 
         // If analytics are enabled, the runtime receives analytics events from the input manager.
         // See InputAnalytics.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -159,6 +159,21 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        public InputSettings.ScrollDeltaBehavior scrollDeltaBehavior
+        {
+            get => m_ScrollDeltaBehavior;
+            set
+            {
+                if (m_ScrollDeltaBehavior == value)
+                    return;
+
+                m_ScrollDeltaBehavior = value;
+
+                InputRuntime.s_Instance.allowPlatformSpecificInputForScrollWheelDelta =
+                    m_ScrollDeltaBehavior == InputSettings.ScrollDeltaBehavior.KeepPlatformSpecificInputRange;
+            }
+        }
+
         public float pollingFrequency
         {
             get => m_PollingFrequency;
@@ -1851,6 +1866,8 @@ namespace UnityEngine.InputSystem
             m_UpdateMask |= InputUpdateType.Editor;
 #endif
 
+            m_ScrollDeltaBehavior = InputSettings.ScrollDeltaBehavior.UniformAcrossAllPlatforms;
+
             // Default polling frequency is 60 Hz.
             m_PollingFrequency = 60;
 
@@ -2066,6 +2083,8 @@ namespace UnityEngine.InputSystem
         internal InputUpdateType m_UpdateMask; // Which of our update types are enabled.
         private InputUpdateType m_CurrentUpdate;
         internal InputStateBuffers m_StateBuffers;
+
+        private InputSettings.ScrollDeltaBehavior m_ScrollDeltaBehavior;
 
         #if UNITY_EDITOR
         // remember time offset to correctly restore it after editor mode is done
@@ -2595,6 +2614,8 @@ namespace UnityEngine.InputSystem
             newUpdateMask |= InputUpdateType.Editor;
             #endif
             updateMask = newUpdateMask;
+
+            scrollDeltaBehavior = m_Settings.scrollDeltaBehavior;
 
             ////TODO: optimize this so that we don't repeatedly recreate state if we add/remove multiple devices
             ////      (same goes for not resolving actions repeatedly)
@@ -3801,6 +3822,7 @@ namespace UnityEngine.InputSystem
             public InputStateBuffers buffers;
             public InputUpdate.SerializedState updateState;
             public InputUpdateType updateMask;
+            public InputSettings.ScrollDeltaBehavior scrollDeltaBehavior;
             public InputMetrics metrics;
             public InputSettings settings;
             public InputActionAsset actions;
@@ -3845,6 +3867,7 @@ namespace UnityEngine.InputSystem
                 buffers = m_StateBuffers,
                 updateState = InputUpdate.Save(),
                 updateMask = m_UpdateMask,
+                scrollDeltaBehavior = m_ScrollDeltaBehavior,
                 metrics = m_Metrics,
                 settings = m_Settings,
                 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
@@ -3862,6 +3885,7 @@ namespace UnityEngine.InputSystem
             m_StateBuffers = state.buffers;
             m_LayoutRegistrationVersion = state.layoutRegistrationVersion + 1;
             updateMask = state.updateMask;
+            scrollDeltaBehavior = state.scrollDeltaBehavior;
             m_Metrics = state.metrics;
             m_PollingFrequency = state.pollingFrequency;
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -169,8 +169,8 @@ namespace UnityEngine.InputSystem
 
                 m_ScrollDeltaBehavior = value;
 
-                InputRuntime.s_Instance.allowPlatformSpecificInputForScrollWheelDelta =
-                    m_ScrollDeltaBehavior == InputSettings.ScrollDeltaBehavior.KeepPlatformSpecificInputRange;
+                InputRuntime.s_Instance.normalizeScrollWheelDelta =
+                    m_ScrollDeltaBehavior == InputSettings.ScrollDeltaBehavior.UniformAcrossAllPlatforms;
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -85,6 +85,23 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
+        /// Controls how platform-specific input should be converted when returning delta values for scroll wheel input actions.
+        /// By default, the range used for the delta is converted to be uniform across all platforms.
+        /// </summary>
+        /// <value>The conversion behavior.</value>
+        public ScrollDeltaBehavior scrollDeltaBehavior
+        {
+            get => m_ScrollDeltaBehavior;
+            set
+            {
+                if (m_ScrollDeltaBehavior == value)
+                    return;
+                m_ScrollDeltaBehavior = value;
+                OnChange();
+            }
+        }
+
+        /// <summary>
         /// If true, sensors that deliver rotation values on handheld devices will automatically adjust
         /// rotations when the screen orientation changes.
         /// </summary>
@@ -748,6 +765,7 @@ namespace UnityEngine.InputSystem
         [Tooltip("Determine when Unity processes events. By default, accumulated input events are flushed out before each fixed update and "
             + "before each dynamic update. This setting can be used to restrict event processing to only where the application needs it.")]
         [SerializeField] private UpdateMode m_UpdateMode = UpdateMode.ProcessEventsInDynamicUpdate;
+        [SerializeField] private ScrollDeltaBehavior m_ScrollDeltaBehavior = ScrollDeltaBehavior.UniformAcrossAllPlatforms;
         [SerializeField] private int m_MaxEventBytesPerUpdate = 5 * 1024 * 1024;
         [SerializeField] private int m_MaxQueuedEventsPerUpdate = 1000;
 
@@ -843,6 +861,29 @@ namespace UnityEngine.InputSystem
             /// accumulating or some input getting lost.
             /// </summary>
             ProcessEventsManually,
+        }
+
+        /// <summary>
+        /// How platform-specific input should be converted when returning delta values for scroll wheel input actions.
+        /// </summary>
+        public enum ScrollDeltaBehavior
+        {
+            /// <summary>
+            /// The range used for the delta is converted to be uniform across all platforms.
+            /// </summary>
+            /// <remarks>
+            /// The resulting range will be [-1, 1] regardless of the platform used.
+            /// </remarks>
+            UniformAcrossAllPlatforms = 0,
+
+            /// <summary>
+            /// The range used for the delta is the same as returned by the platform input.
+            /// </summary>
+            /// <remarks>
+            /// The range will typically be [-120, 120] on Windows and [-1, 1] on MacOS and Linux.
+            /// Other platforms may have different ranges.
+            /// </remarks>
+            KeepPlatformSpecificInputRange = 1
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3423,6 +3423,8 @@ namespace UnityEngine.InputSystem
             set => s_Manager.m_Runtime.runInBackground = value;
         }
 
+        internal static float scrollWheelDeltaPerTick => InputRuntime.s_Instance.scrollWheelDeltaPerTick;
+
         ////REVIEW: restrict metrics to editor and development builds?
         /// <summary>
         /// Get various up-to-date metrics about the input system.

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -281,6 +281,25 @@ namespace UnityEngine.InputSystem.LowLevel
         public Vector2 screenSize => new Vector2(Screen.width, Screen.height);
         public ScreenOrientation screenOrientation => Screen.orientation;
 
+        public bool allowPlatformSpecificInputForScrollWheelDelta
+        {
+#if UNITY_6000_0_OR_NEWER
+            get => NativeInputSystem.allowPlatformSpecificInputForScrollWheelDelta;
+            set => NativeInputSystem.allowPlatformSpecificInputForScrollWheelDelta = value;
+#else
+            get; set;
+#endif
+        }
+
+        public float scrollWheelDeltaPerTick
+        {
+#if UNITY_6000_0_OR_NEWER
+            get { return NativeInputSystem.GetScrollWheelDeltaPerTick(); }
+#else
+            get => 1.0f;
+#endif
+        }
+
         public bool isInBatchMode => Application.isBatchMode;
 
         #if UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -281,11 +281,11 @@ namespace UnityEngine.InputSystem.LowLevel
         public Vector2 screenSize => new Vector2(Screen.width, Screen.height);
         public ScreenOrientation screenOrientation => Screen.orientation;
 
-        public bool allowPlatformSpecificInputForScrollWheelDelta
+        public bool normalizeScrollWheelDelta
         {
 #if UNITY_6000_0_OR_NEWER
-            get => NativeInputSystem.allowPlatformSpecificInputForScrollWheelDelta;
-            set => NativeInputSystem.allowPlatformSpecificInputForScrollWheelDelta = value;
+            get => NativeInputSystem.normalizeScrollWheelDelta;
+            set => NativeInputSystem.normalizeScrollWheelDelta = value;
 #else
             get; set;
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputSystemProvider.cs
@@ -45,7 +45,11 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         NavigationEventRepeatHelper m_RepeatHelper = new();
         bool m_ResetSeenEventsOnUpdate;
 
+#if UNITY_6000_0_OR_NEWER
+        const float kScrollUGUIScaleFactor = UIElements.WheelEvent.scrollDeltaPerTick;
+#else
         const float kScrollUGUIScaleFactor = 3.0f;
+#endif
 
         static Action<InputActionAsset> s_OnRegisterActions;
 
@@ -529,8 +533,9 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
         void OnScrollWheelPerformed(InputAction.CallbackContext ctx)
         {
-            var scrollDelta = ctx.ReadValue<Vector2>();
-            if (scrollDelta.sqrMagnitude < k_SmallestReportedMovementSqrDist)
+            // ISXB-704: convert potentially platform-specific input value to uniform ticks before sending them to UI.
+            var scrollTicks = ctx.ReadValue<Vector2>() / InputSystem.scrollWheelDeltaPerTick;
+            if (scrollTicks.sqrMagnitude < k_SmallestReportedMovementSqrDist)
                 return;
 
             var eventSource = GetEventSource(ctx);
@@ -550,9 +555,12 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
                 targetDisplay = Mouse.current.displayIndex.ReadValue();
             }
 
-            // Make it look similar to IMGUI event scroll values.
-            scrollDelta.x *= kScrollUGUIScaleFactor;
-            scrollDelta.y *= -kScrollUGUIScaleFactor;
+            // Make scrollDelta look similar to IMGUI event scroll values.
+            var scrollDelta = new Vector2
+            {
+                x = scrollTicks.x * kScrollUGUIScaleFactor,
+                y = -scrollTicks.y * kScrollUGUIScaleFactor
+            };
 
             DispatchFromCallback(Event.From(new PointerEvent
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -2062,8 +2062,6 @@ namespace UnityEngine.InputSystem.UI
             return false;
         }
 
-        internal const float kPixelPerLine = 20;
-
         private void OnScrollCallback(InputAction.CallbackContext context)
         {
             var index = GetPointerStateIndexFor(ref context);
@@ -2071,9 +2069,12 @@ namespace UnityEngine.InputSystem.UI
                 return;
 
             ref var state = ref GetPointerStateForIndex(index);
-            // The old input system reported scroll deltas in lines, we report pixels.
-            // Need to scale as the UI system expects lines.
-            state.scrollDelta = context.ReadValue<Vector2>() * (1 / kPixelPerLine);
+
+            var scrollDelta = context.ReadValue<Vector2>();
+
+            // ISXB-704: convert potentially platform-specific input value to BaseInputModule convention.
+            state.scrollDelta = scrollDelta * (scrollWheelDeltaPerTick / InputSystem.scrollWheelDeltaPerTick);
+
 #if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
 #endif

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -371,7 +371,7 @@ namespace UnityEngine.InputSystem
 
         public Vector2 screenSize { get; set; } = new Vector2(1024, 768);
         public ScreenOrientation screenOrientation { set; get; } = ScreenOrientation.Portrait;
-        public bool allowPlatformSpecificInputForScrollWheelDelta { get; set; }
+        public bool normalizeScrollWheelDelta { get; set; } = true;
         public float scrollWheelDeltaPerTick { get; } = 1.0f;
 
         public List<PairedUser> userAccountPairings

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -371,6 +371,8 @@ namespace UnityEngine.InputSystem
 
         public Vector2 screenSize { get; set; } = new Vector2(1024, 768);
         public ScreenOrientation screenOrientation { set; get; } = ScreenOrientation.Portrait;
+        public bool allowPlatformSpecificInputForScrollWheelDelta { get; set; }
+        public float scrollWheelDeltaPerTick { get; } = 1.0f;
 
         public List<PairedUser> userAccountPairings
         {


### PR DESCRIPTION
### Description

Fixes ISXB-766, ISXB-808, ISXB-704, conditionally to [trunk PR](https://github.cds.internal.unity3d.com/unity/unity/pull/49932) landing beforehand.

Details of what was changed and the thought process can be found in this Google Document:
https://docs.google.com/document/d/1XCC6GqaWzKf1M1jm-UmKRn6sIlmvF7rvF1C8Ws5Yxa4/edit?usp=sharing

### Changes made

_Please write down a short description of what changes were made._

### Notes

_Please write down any additional notes, remove the section if not applicable._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
