### PR TITLE
FIX: Scheme Name in Control Scheme editor menu that gets reset when editing devices (ISXB-763)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,7 +15,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where a composite binding would not be consecutively triggered after ResetDevice() has been called from the associated action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
 - Fixed resource designation for "d_InputControl" icon to address CI failure.
 - Fixed an issue where a composite binding would not be consecutively triggered after disabling actions while there are action modifiers in progress [ISXB-505](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-505).
-- Fixed prefabs and missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818)
+- Fixed prefabs and missing default control scheme used by PlayerInput component are now correctly shown in the inspector [ISXB-818](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-818).
+- Fixed Scheme Name in Control Scheme editor menu that gets reset when editing devices [ISXB-763](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-763).
 
 ## [1.8.2] - 2024-04-29
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -35,7 +35,7 @@ namespace UnityEngine.InputSystem.Editor
                     var newName = ((TextField)evt.currentTarget).value.Trim();
                     if (string.IsNullOrEmpty(newName) || String.Compare(newName, state.selectedControlScheme.name) == 0)
                     {
-                        m_NewName = "";
+                        m_NewName = String.Empty;
                         // write back the value to the text field if the name was empty
                         ((TextField)evt.currentTarget).value = state.selectedControlScheme.name;
                     }
@@ -146,7 +146,7 @@ namespace UnityEngine.InputSystem.Editor
             // the changes retained. However, if a different ControlScheme is selected or the Asset
             // Editor window is closed, then the changes are lost.
 
-            m_NewName = "";
+            m_NewName = string.Empty;
             OnClosing?.Invoke(this);
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -33,9 +33,11 @@ namespace UnityEngine.InputSystem.Editor
                 {
                     // If the name is the same as the current name, don't change it
                     var newName = ((TextField)evt.currentTarget).value.Trim();
-                    if (String.Compare(newName, state.selectedControlScheme.name) == 0)
+                    if (string.IsNullOrEmpty(newName) || String.Compare(newName, state.selectedControlScheme.name) == 0)
                     {
                         m_NewName = "";
+                        // write back the value to the text field if the name was empty
+                        ((TextField)evt.currentTarget).value = state.selectedControlScheme.name;
                     }
                     else
                     {
@@ -43,6 +45,7 @@ namespace UnityEngine.InputSystem.Editor
                         // write back the value to the text field if the name was not unique
                         ((TextField)evt.currentTarget).value = m_NewName;
                     }
+
                     return state.With(selectedControlScheme: state.selectedControlScheme);
                 });
             });

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -31,8 +31,18 @@ namespace UnityEngine.InputSystem.Editor
             {
                 Dispatch((in InputActionsEditorState state) =>
                 {
-                    m_NewName = ControlSchemeCommands.MakeUniqueControlSchemeName(state,
-                        ((TextField)evt.currentTarget).value);
+                    // If the name is the same as the current name, don't change it
+                    var newName = ((TextField)evt.currentTarget).value.Trim();
+                    if (String.Compare(newName, state.selectedControlScheme.name) == 0)
+                    {
+                        m_NewName = "";
+                    }
+                    else
+                    {
+                        m_NewName = ControlSchemeCommands.MakeUniqueControlSchemeName(state, newName);
+                        // write back the value to the text field if the name was not unique
+                        ((TextField)evt.currentTarget).value = m_NewName;
+                    }
                     return state.With(selectedControlScheme: state.selectedControlScheme);
                 });
             });
@@ -95,7 +105,7 @@ namespace UnityEngine.InputSystem.Editor
 
         public override void RedrawUI(InputControlScheme viewState)
         {
-            rootElement.Q<TextField>(kControlSchemeNameTextField).value = viewState.name;
+            rootElement.Q<TextField>(kControlSchemeNameTextField).value = string.IsNullOrEmpty(m_NewName) ? viewState.name : m_NewName;
 
             m_ListView.itemsSource?.Clear();
             m_ListView.itemsSource = viewState.deviceRequirements.Count > 0 ?


### PR DESCRIPTION
### Description

Fixed Scheme Name in Control Scheme editor menu that gets reset when editing devices

### Changes made

In ControlSchemesView
* Fixed RedrawUI to use the control scheme name or new/renamed one currently in edition
* Fixed control scheme name text box change callback to now support :
1. Trim the name to prevent having space at the begin/end of the name
2. Prevent renaming the scheme if you change the name and put back the original name in the same edition without saving
3. Write back in the UI if a unique name has been generated


### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
