### PR TITLE
CHANGE: pin linux bokken image

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -48,16 +48,16 @@ platforms_nix:
     installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP --wait --fast -u
   - name: linux
     type: Unity::VM
-    image: package-ci/ubuntu-22.04:v4
+    image: package-ci/ubuntu-20.04:v4.50.0
     flavor: b1.large
   - name: linux_standalone
     type: Unity::VM
-    image: package-ci/ubuntu-22.04:v4
+    image: package-ci/ubuntu-20.04:v4.50.0
     flavor: b1.large
     runtime: StandaloneLinux64
   - name: linux_standalone_il2cpp
     type: Unity::VM
-    image: package-ci/ubuntu-22.04:v4
+    image: package-ci/ubuntu-20.04:v4.50.0
     flavor: b1.large
     runtime: StandaloneLinux64
     scripting-backend: Il2Cpp


### PR DESCRIPTION
### Description

Git LFS errors got introduced with new bokken image for Linux. Moving back by one.

### Changes made

Pin the underlying bokken image for Linux testing to 4.50

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
