### PR TITLE
FIX: Fixed exceptions being thrown by OnScreenStick and improved warnings related to missing UGUI dependencies for current implementations.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Change
+- Added warning messages to `OnScreenStick` and `OnScreenButton` Inspector editors that would display a warning message in case on-screen control components are added to a `GameObject` not part of a valid UI hierarchy.
+
 ### Fixed
 - Avoid potential crashes from `NullReferenceException` in `FireStateChangeNotifications`.
 - Fixed an issue where a composite binding would not be consecutively triggered after ResetDevice() has been called from the associated action handler [ISXB-746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-746).
@@ -19,8 +22,10 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed error thrown when Cancelling Control Scheme creation in Input Actions Editor.
 - Fixed Scheme Name in Control Scheme editor menu that gets reset when editing devices [ISXB-763](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-763).
 - Fixed an issue where `InputActionAsset.FindAction(string, bool)` would throw `System.NullReferenceException` instead of returning `null` if searching for a non-existent action with an explicit action path and using `throwIfNotFound: false`, e.g. searching for "Map/Action" when `InputActionMap` "Map" exists but no `InputAction` named "Action" exists within that map [ISXB-895](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-895).
+- Fixed an issue where adding a `OnScreenButton` or `OnScreenStick` to a regular GameObject would lead to exception in editor.
+- Fixed an issue where adding a `OnScreenStick` to a regular GameObject and entering play-mode would lead to exceptions being generated.
 
-## Added
+### Added
 - Added additional device information when logging the error due to exceeding the maximum number of events processed
   set by `InputSystem.settings.maxEventsBytesPerUpdate`. This additional information is available in development builds
   only.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Change
-- Added warning messages to `OnScreenStick` and `OnScreenButton` Inspector editors that would display a warning message in case on-screen control components are added to a `GameObject` not part of a valid UI hierarchy.
+- Added warning messages to both `OnScreenStick` and `OnScreenButton` Inspector editors that would display a warning message in case on-screen control components are added to a `GameObject` not part of a valid UI hierarchy.
 
 ### Fixed
 - Avoid potential crashes from `NullReferenceException` in `FireStateChangeNotifications`.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenButton.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenButton.cs
@@ -14,15 +14,6 @@ namespace UnityEngine.InputSystem.OnScreen
     [HelpURL(InputSystem.kDocUrl + "/manual/OnScreen.html#on-screen-buttons")]
     public class OnScreenButton : OnScreenControl, IPointerDownHandler, IPointerUpHandler
     {
-        protected override void OnEnable()
-        {
-            base.OnEnable();
-
-            // Current implementation has UGUI dependencies (ISXB-915, ISXB-916)
-            if (UGUIOnScreenControlUtils.GetCanvasRectTransform(transform) == null)
-                Debug.LogWarning(GetWarningMessage());
-        }
-
         public void OnPointerUp(PointerEventData eventData)
         {
             SendValueToControl(0.0f);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenButton.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenButton.cs
@@ -1,5 +1,4 @@
 #if PACKAGE_DOCS_GENERATION || UNITY_INPUT_SYSTEM_ENABLE_UI
-using System;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem.Layouts;
 
@@ -15,6 +14,15 @@ namespace UnityEngine.InputSystem.OnScreen
     [HelpURL(InputSystem.kDocUrl + "/manual/OnScreen.html#on-screen-buttons")]
     public class OnScreenButton : OnScreenControl, IPointerDownHandler, IPointerUpHandler
     {
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+
+            // Current implementation has UGUI dependencies (ISXB-915, ISXB-916)
+            if (UGUIOnScreenControlUtils.GetCanvasRectTransform(transform) == null)
+                Debug.LogWarning(GetWarningMessage());
+        }
+
         public void OnPointerUp(PointerEventData eventData)
         {
             SendValueToControl(0.0f);
@@ -45,6 +53,29 @@ namespace UnityEngine.InputSystem.OnScreen
             get => m_ControlPath;
             set => m_ControlPath = value;
         }
+
+#if UNITY_EDITOR
+        [UnityEditor.CustomEditor(typeof(OnScreenButton))]
+        internal class OnScreenButtonEditor : UnityEditor.Editor
+        {
+            private UnityEditor.SerializedProperty m_ControlPathInternal;
+
+            public void OnEnable()
+            {
+                m_ControlPathInternal = serializedObject.FindProperty(nameof(OnScreenButton.m_ControlPath));
+            }
+
+            public override void OnInspectorGUI()
+            {
+                // Current implementation has UGUI dependencies (ISXB-915, ISXB-916)
+                UGUIOnScreenControlEditorUtils.ShowWarningIfNotPartOfCanvasHierarchy((OnScreenButton)target);
+
+                UnityEditor.EditorGUILayout.PropertyField(m_ControlPathInternal);
+
+                serializedObject.ApplyModifiedProperties();
+            }
+        }
+#endif
     }
 }
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
@@ -299,5 +299,30 @@ namespace UnityEngine.InputSystem.OnScreen
         }
 
         private static InlinedArray<OnScreenDeviceInfo> s_OnScreenDevices;
+
+        internal string GetWarningMessage()
+        {
+            return $"{GetType()} needs to be attached as a child to a UI Canvas and have a RectTransform component to function properly.";
+        }
     }
+
+    internal static class UGUIOnScreenControlUtils
+    {
+        public static RectTransform GetCanvasRectTransform(Transform transform)
+        {
+            var parentTransform = transform.parent;
+            return parentTransform != null ? transform.parent.GetComponentInParent<RectTransform>() : null;
+        }
+    }
+
+#if UNITY_EDITOR
+    internal static class UGUIOnScreenControlEditorUtils
+    {
+        public static void ShowWarningIfNotPartOfCanvasHierarchy(OnScreenControl target)
+        {
+            if (UGUIOnScreenControlUtils.GetCanvasRectTransform(target.transform) == null)
+                UnityEditor.EditorGUILayout.HelpBox(target.GetWarningMessage(), UnityEditor.MessageType.Warning);
+        }
+    }
+#endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -440,8 +440,6 @@ namespace UnityEngine.InputSystem.OnScreen
         [CustomEditor(typeof(OnScreenStick))]
         internal class OnScreenStickEditor : UnityEditor.Editor
         {
-            private const string kWarningMessage = "OnScreenStick needs to be attached as a child to a UI Canvas and have a RectTransform component to function properly.";
-
             private AnimBool m_ShowDynamicOriginOptions;
             private AnimBool m_ShowIsolatedInputActions;
 


### PR DESCRIPTION
### Description

CHANGE: Added warning messages to both `OnScreenStick` and `OnScreenButton` Inspector editors that would display a warning message in case on-screen control components are added to a `GameObject` not part of a valid UI hierarchy.
FIX: ISXB-915 OnScreenStick throws System.Exception if added to a GameObject not part of a UGUI object hierarchy.
FIX: ISXB-916 Entering play-mode with a OnScreenStick attached to a non UI hierarchy Game Object floods console with InvalidCastException.

### Changes made

See Description. Changes introduced on `OnScreenStick` and `OnScreenButton` repectively to respect the fact that base class `OnScreenControl` is currently agnostic to UI system while `OnScreenStick` and `OnScreenButton` currently only support UGUI (UnityEngine.UI).

### Notes

Recommend testing with repro steps from linked tickets.

There is also a UX or potential docs perspective to review in how the changes to warning messaged in UI and Console are affected.

Changes require manual verification.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444. 