### PR TITLE
FIX: InputActionReference when using FEPM (ISX-1968)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where `InputActionAsset.FindAction(string, bool)` would throw `System.NullReferenceException` instead of returning `null` if searching for a non-existent action with an explicit action path and using `throwIfNotFound: false`, e.g. searching for "Map/Action" when `InputActionMap` "Map" exists but no `InputAction` named "Action" exists within that map [ISXB-895](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-895).
 - Fixed an issue where adding a `OnScreenButton` or `OnScreenStick` to a regular GameObject would lead to exception in editor.
 - Fixed an issue where adding a `OnScreenStick` to a regular GameObject and entering play-mode would lead to exceptions being generated.
+- Fixed InputActionReference issues when domain reloads are disabled [ISXB-601](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-601), [ISXB-718](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-718), [ISXB-900](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-900)
 
 ### Added
 - Added additional device information when logging the error due to exceeding the maximum number of events processed

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionReference.cs
@@ -199,6 +199,24 @@ namespace UnityEngine.InputSystem
             return reference;
         }
 
+        /// <summary>
+        /// Clears the cached <see cref="m_Action"/> field for all current <see cref="InputActionReference"/> objects.
+        /// </summary>
+        /// <remarks>
+        /// After calling this, the next call to <see cref="action"/> will retrieve a new <see cref="InputAction"/> reference from the existing <see cref="InputActionAsset"/> just as if
+        /// using it for the first time. The serialized <see cref="m_Asset"/> and <see cref="m_ActionId"/> fields are not touched and will continue to hold their current values.
+        ///
+        /// This method is used to clear the Action references when exiting PlayMode since those objects are no longer valid.
+        /// </remarks>
+        internal static void ResetCachedAction()
+        {
+            var allActionRefs = Resources.FindObjectsOfTypeAll(typeof(InputActionReference));
+            foreach (InputActionReference obj in allActionRefs)
+            {
+                obj.m_Action = null;
+            }
+        }
+
         [SerializeField] internal InputActionAsset m_Asset;
         // Can't serialize System.Guid and Unity's GUID is editor only so these
         // go out as strings.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3662,6 +3662,9 @@ namespace UnityEngine.InputSystem
                     // Nuke all InputActionMapStates. Releases their unmanaged memory.
                     InputActionState.DestroyAllActionMapStates();
 
+                    // Clear the Action reference from all InputActionReference objects
+                    InputActionReference.ResetCachedAction();
+
                     // Restore settings.
                     if (!string.IsNullOrEmpty(s_SystemObject.settings))
                     {


### PR DESCRIPTION
### Description

When Domain Reloads are disabled, InputActionReference instances continue to reference the "old" InputAction object from the previous PlayMode session. This fix clears the InputAction reference when exiting PlayMode allowing it to be reloaded in the next session.

Although Configurable PlayMode options, aka Fast Enter PlayMode, isn't currently supported, a number of tickets have been filed against this issue including:

- [ISXB-601](https://jira.unity3d.com/browse/ISXB-601)
- [ISXB-718](https://jira.unity3d.com/browse/ISXB-718)
- [ISXB-900](https://jira.unity3d.com/browse/ISXB-900)
- [ISXB-469](https://jira.unity3d.com/browse/ISXB-469)
- [ISXB-598](https://jira.unity3d.com/browse/ISXB-598)

indicating FEPM is quite a popular feature and fixing this issue is beneficial to our customers.

Furthermore, the underlying problem is a bug in its own right regardless of FEPM: the underlying Action instance is invalid for EditMode and holding the reference is dangerous as it keeps the object "alive" along with the pointers to native memory buffers that are de-allocated when exiting PlayMode. In short, attempting to access the ActionReference after leaving PlayMode can cause an AV and crash the Editor.

### Changes made

When exiting PlayMode, all `InputActionReference` instances are queried and their `m_Action` field is reset. This forces a "reload" of the Action from the Asset the next time its accessed just as if a Domain Reload had occured.

### Notes

This issue is completely separate from my CoreCLR refactor and can be fixed independently of it.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444. 