### PR TITLE
FIX: Fixed a performance issue with many objects using multiple action maps [ISXB-573]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where `InputActionAsset.FindAction(string, bool)` would throw `System.NullReferenceException` instead of returning `null` if searching for a non-existent action with an explicit action path and using `throwIfNotFound: false`, e.g. searching for "Map/Action" when `InputActionMap` "Map" exists but no `InputAction` named "Action" exists within that map [ISXB-895](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-895).
 - Fixed an issue where adding a `OnScreenButton` or `OnScreenStick` to a regular GameObject would lead to exception in editor.
 - Fixed an issue where adding a `OnScreenStick` to a regular GameObject and entering play-mode would lead to exceptions being generated.
+- Fixed a performance issue with many objects using multiple action maps [ISXB-573](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-573).
 
 ### Added
 - Added additional device information when logging the error due to exceeding the maximum number of events processed

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionMap.cs
@@ -318,6 +318,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         public InputActionMap()
         {
+            s_NeedToResolveBindings = true;
         }
 
         /// <summary>
@@ -810,6 +811,7 @@ namespace UnityEngine.InputSystem
         }
 
         internal static int s_DeferBindingResolution;
+        internal static bool s_NeedToResolveBindings;
 
         internal struct DeviceArray
         {
@@ -1192,6 +1194,9 @@ namespace UnityEngine.InputSystem
             // Clear cached controls for actions. Don't need to necessarily clear m_BindingsForEachAction.
             m_ControlsForEachAction = null;
             controlsForEachActionInitialized = false;
+
+            // Indicate that there is at least one action map that has a change
+            s_NeedToResolveBindings = true;
 
             // If we haven't had to resolve bindings yet, we can wait until when we
             // actually have to.
@@ -1982,6 +1987,9 @@ namespace UnityEngine.InputSystem
         /// </summary>
         public void OnAfterDeserialize()
         {
+            // Indicate that there is at least one action map that has a change
+            s_NeedToResolveBindings = true;
+
             m_State = null;
             m_MapIndexInState = InputActionState.kInvalidIndex;
             m_EnabledActionsCount = 0;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -4491,23 +4491,27 @@ namespace UnityEngine.InputSystem
             ++InputActionMap.s_DeferBindingResolution;
             try
             {
-                for (var i = 0; i < s_GlobalState.globalList.length; ++i)
+                if (InputActionMap.s_NeedToResolveBindings)
                 {
-                    var handle = s_GlobalState.globalList[i];
-
-                    var state = handle.IsAllocated ? (InputActionState)handle.Target : null;
-                    if (state == null)
+                    for (var i = 0; i < s_GlobalState.globalList.length; ++i)
                     {
-                        // Stale entry in the list. State has already been reclaimed by GC. Remove it.
-                        if (handle.IsAllocated)
-                            s_GlobalState.globalList[i].Free();
-                        s_GlobalState.globalList.RemoveAtWithCapacity(i);
-                        --i;
-                        continue;
-                    }
+                        var handle = s_GlobalState.globalList[i];
 
-                    for (var n = 0; n < state.totalMapCount; ++n)
-                        state.maps[n].ResolveBindingsIfNecessary();
+                        var state = handle.IsAllocated ? (InputActionState)handle.Target : null;
+                        if (state == null)
+                        {
+                            // Stale entry in the list. State has already been reclaimed by GC. Remove it.
+                            if (handle.IsAllocated)
+                                s_GlobalState.globalList[i].Free();
+                            s_GlobalState.globalList.RemoveAtWithCapacity(i);
+                            --i;
+                            continue;
+                        }
+
+                        for (var n = 0; n < state.totalMapCount; ++n)
+                            state.maps[n].ResolveBindingsIfNecessary();
+                    }
+                    InputActionMap.s_NeedToResolveBindings = false;
                 }
             }
             finally


### PR DESCRIPTION
### Description

Avoid costly (and pointless) iterations over all messages / objects / maps when we don't need to.

Issue: https://jira.unity3d.com/browse/ISXB-573

This codepath can be very expensive when there are a lot of messages to send to lots of objects with maps - much of the cost is in dereferencing **handle.Target** in **DeferredResolutionOfBindings**() which involves taking a mutex lock.

Further, once the lock is taken for each object, **ResolveBindingsIfNecessary**() is called for each of that object's **InputActionMaps** which in the general case does nothing (when there is nothing to do).

In the supplied (ridiculous to show the point) test project with 900 objects, each with 6 maps receiving 4500 mouse move messages this leads to:

- over 21 million calls to **ResolveBindingsIfNecessary**() that do nothing
- over 4 million mutex locks in resolving **handle.Target** in **DeferredResolutionOfBindings**()
- frame times over 1 second!

### Changes made

This change adds a static **InputActionMap.s_NeedToResolveBindings** that is set when we know that at least one InputActionMap has changes that need resolving. This is cleared when a resolve pass has been completed.

With this change the frame time in the example only increases by about 2-3ms when the mouse is moving.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - FogBugz ticket attached, example `([case %number%](https://issuetracker.unity3d.com/issues/...))`.
    - FogBugz is marked as "Resolved" with *next* release version correctly set.
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444. 