### PR TITLE
FIX: InputActionCodeGenerator if an action map is named debug (ISXB-851)

### DIFF
--- a/Assets/Samples/InGameHints/InGameHintsActions.cs
+++ b/Assets/Samples/InGameHints/InGameHintsActions.cs
@@ -14,7 +14,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine;
 
 namespace UnityEngine.InputSystem.Samples.InGameHints
 {
@@ -275,7 +274,7 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
 
         ~@InGameHintsActions()
         {
-            Debug.Assert(!m_Gameplay.enabled, "This will cause a leak and performance issues, InGameHintsActions.Gameplay.Disable() has not been called.");
+            UnityEngine.Debug.Assert(!m_Gameplay.enabled, "This will cause a leak and performance issues, InGameHintsActions.Gameplay.Disable() has not been called.");
         }
 
         public void Dispose()

--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -14,7 +14,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine;
 
 public partial class @SimpleControls: IInputActionCollection2, IDisposable
 {
@@ -170,7 +169,7 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
 
     ~@SimpleControls()
     {
-        Debug.Assert(!m_gameplay.enabled, "This will cause a leak and performance issues, SimpleControls.gameplay.Disable() has not been called.");
+        UnityEngine.Debug.Assert(!m_gameplay.enabled, "This will cause a leak and performance issues, SimpleControls.gameplay.Disable() has not been called.");
     }
 
     public void Dispose()

--- a/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
+++ b/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
@@ -14,7 +14,6 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
-using UnityEngine;
 
 public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, IDisposable
 {
@@ -83,7 +82,7 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
 
     ~@InputActionCodeGeneratorActions()
     {
-        Debug.Assert(!m_gameplay.enabled, "This will cause a leak and performance issues, InputActionCodeGeneratorActions.gameplay.Disable() has not been called.");
+        UnityEngine.Debug.Assert(!m_gameplay.enabled, "This will cause a leak and performance issues, InputActionCodeGeneratorActions.gameplay.Disable() has not been called.");
     }
 
     public void Dispose()

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed default scroll speed in uGUI being slower than before. [ISXB-766](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-766)
 - Fixed an issue when multiple interactions drive an action and perform during the cancelation of the current active interaction [ISXB-310](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-310).
+- Fixed an issue when generating C# class of Input Actions that contain an action map named `Debug` [ISXB-851](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-851).
 
 ### Added
 - Added `InputSystemUIInputModule.scrollDeltaPerTick` property, a customizable multiplicative factor applied to the scroll wheel speed before it is sent to UI components. Note that this has no effect on UI Toolkit content, only uGUI.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -83,7 +83,6 @@ namespace UnityEngine.InputSystem.Editor
             writer.WriteLine("using System.Collections.Generic;");
             writer.WriteLine("using UnityEngine.InputSystem;");
             writer.WriteLine("using UnityEngine.InputSystem.Utilities;");
-            writer.WriteLine("using UnityEngine;");
             writer.WriteLine("");
 
             // Begin namespace.
@@ -127,7 +126,7 @@ namespace UnityEngine.InputSystem.Editor
             foreach (var map in maps)
             {
                 var mapName = CSharpCodeHelpers.MakeIdentifier(map.name);
-                writer.WriteLine($"Debug.Assert(!m_{mapName}.enabled, \"This will cause a leak and performance issues, {options.className}.{mapName}.Disable() has not been called.\");");
+                writer.WriteLine($"UnityEngine.Debug.Assert(!m_{mapName}.enabled, \"This will cause a leak and performance issues, {options.className}.{mapName}.Disable() has not been called.\");");
             }
             writer.EndBlock();
             writer.WriteLine();


### PR DESCRIPTION
### Description

When generation an input action with an action map named "Debug" it generate a code that doesn't compile.
https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-851
`Assets\InputSystem.cs(65,15): error CS1061: 'InputSystem.DebugActions' does not contain a definition for 'Assert' and no accessible extension method 'Assert' accepting a first argument of type 'InputSystem.DebugActions' could be found (are you missing a using directive or an assembly reference?)`

### Changes made

Added the prefix UnityEngine prefix to Debug to remove the ambiguity in the generated code

### Testing

local test

### Risk

_Please describe the potential risks of your changes for the reviewers._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
