### PR TITLE
FIX: Input System 1.9.0 does not compile on Console Platforms (ISXB-963)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -393,22 +393,24 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public void SendAnalytic(InputAnalytics.IInputAnalytic analytic)
         {
-        #if (UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS)
-            #if (UNITY_2023_2_OR_NEWER)
+        #if ENABLE_CLOUD_SERVICES_ANALYTICS
+            #if (UNITY_EDITOR)
+                #if (UNITY_2023_2_OR_NEWER)
             EditorAnalytics.SendAnalytic(analytic);
-            #else
+                #else
             var info = analytic.info;
             EditorAnalytics.RegisterEventWithLimit(info.Name, info.MaxEventsPerHour, info.MaxNumberOfElements, InputAnalytics.kVendorKey);
             EditorAnalytics.SendEventWithLimit(info.Name, analytic);
-            #endif // UNITY_2023_2_OR_NEWER
-        #elif (!UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS) // Implicitly: !UNITY_EDITOR
+                #endif // UNITY_2023_2_OR_NEWER
+            #elif (UNITY_ANALYTICS) // Implicitly: !UNITY_EDITOR
             var info = analytic.info;
             Analytics.Analytics.RegisterEvent(info.Name, info.MaxEventsPerHour, info.MaxNumberOfElements, InputAnalytics.kVendorKey);
             if (analytic.TryGatherData(out var data, out var error))
                 Analytics.Analytics.SendEvent(info.Name, data);
             else
-                Debug.Log(error); // Non fatal
-        #endif //UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS
+                Debug.Log(error);     // Non fatal
+            #endif //UNITY_EDITOR
+        #endif //ENABLE_CLOUD_SERVICES_ANALYTICS
         }
 
         #endif // UNITY_ANALYTICS || UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -9,7 +9,6 @@ using UnityEngineInternal.Input;
 using System.Reflection;
 using UnityEditor;
 using UnityEditorInternal;
-
 #endif
 
 // This should be the only file referencing the API at UnityEngineInternal.Input.
@@ -394,7 +393,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public void SendAnalytic(InputAnalytics.IInputAnalytic analytic)
         {
-            #if (UNITY_EDITOR)
+        #if (UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS)
             #if (UNITY_2023_2_OR_NEWER)
             EditorAnalytics.SendAnalytic(analytic);
             #else
@@ -402,14 +401,14 @@ namespace UnityEngine.InputSystem.LowLevel
             EditorAnalytics.RegisterEventWithLimit(info.Name, info.MaxEventsPerHour, info.MaxNumberOfElements, InputAnalytics.kVendorKey);
             EditorAnalytics.SendEventWithLimit(info.Name, analytic);
             #endif // UNITY_2023_2_OR_NEWER
-            #elif UNITY_ANALYTICS // Implicitly: !UNITY_EDITOR
+        #elif (!UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS) // Implicitly: !UNITY_EDITOR
             var info = analytic.info;
             Analytics.Analytics.RegisterEvent(info.Name, info.MaxEventsPerHour, info.MaxNumberOfElements, InputAnalytics.kVendorKey);
             if (analytic.TryGatherData(out var data, out var error))
                 Analytics.Analytics.SendEvent(info.Name, data);
             else
                 Debug.Log(error); // Non fatal
-            #endif // UNITY_EDITOR
+        #endif //UNITY_EDITOR && ENABLE_CLOUD_SERVICES_ANALYTICS
         }
 
         #endif // UNITY_ANALYTICS || UNITY_EDITOR


### PR DESCRIPTION
### Description

Fix build issues on console platforms that do not support analytics.

### Changes made

Guards code with `ENABLE_CLOUD_SERVICES_ANALYTICS` which was raising compilation errors on console platforms.

From [documentation](https://docs.unity3d.com/ScriptReference/Analytics.Analytics.html):
> Important: Always make calls to the Analytics API inside the scope of an #if ENABLE_CLOUD_SERVICES_ANALYTICS statement to prevent compilation errors on platforms that do not support Analytics:

Possible there's some things we can do to improve our `UNITY_ANALYTICS` defines vs `ENABLE_CLOUD_SERVICES_ANALYTICS` use. I raised the question on what's the difference between them. cc @ekcoh for further discussions.

For now, this will likely unblock the console platform but we should revisit this in the future IMO. Raised task here

### Testing

I tested data data was sent from the macOS editor and that there apparently there's no regression in the data that is being sent. But maybe @ekcoh can validate 100% once he's back from vacation. @Pauliusd01 if you can check that there's no regression in the data sent to the backend, that would be great (I mentioning you because you approved the PR with analytics #1808 ).

Also validated that at least one console platform the build error was fixed. @lewish-unity please make sure this branch fixes the error you reported.

### Risk

I validated that the Editor analytics were sent with Unity 6, but couldn't validate with 2022.3f as the analytics debugger is not available for that version. 

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
