### PR TITLE
FIX: ISXB-1013-prevent-ui-update-loop

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
@@ -109,6 +109,8 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
         m_Window.rootVisualElement.Q<ListView>("action-maps-list-view").Focus();
         m_Window.rootVisualElement.Q<ListView>("action-maps-list-view").selectedIndex = 1;
 
+        // changing the selection triggers a state change, wait for the scheduler to process the frame
+        yield return WaitForSchedulerLoop();
         yield return WaitForNotDirty();
         yield return WaitForFocus(m_Window.rootVisualElement.Q("action-maps-list-view"));
 

--- a/Assets/Tests/InputSystem.Editor/UIToolkitBaseTestWindow.cs
+++ b/Assets/Tests/InputSystem.Editor/UIToolkitBaseTestWindow.cs
@@ -121,6 +121,17 @@ public class UIToolkitBaseTestWindow<T> where T : EditorWindow
     }
 
     /// <summary>
+    /// Wait for UI toolkit scheduler to process the frame
+    /// </summary>
+    /// <param name="timeoutSecs">Maximum time to wait in seconds.</param>
+    protected IEnumerator WaitForSchedulerLoop(double timeoutSecs = 5.0)
+    {
+        bool done = false;
+        m_Window.rootVisualElement.schedule.Execute(() => done = true);
+        return WaitUntil(() => done == true, "WaitForSchedulerLoop", timeoutSecs);
+    }
+
+    /// <summary>
     /// Wait for the visual element to be focused
     /// </summary>
     /// <param name="ve">VisualElement to be focused</param>

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed memory allocation on every frame when using UIDocument without EventSystem. [ISXB-953](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-953)
 - Fixed Action Maps name edition which could be inconsistent in Input Action Editor UI.
+- Fixed an update loop in the asset editor.
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,7 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed memory allocation on every frame when using UIDocument without EventSystem. [ISXB-953](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-953)
 - Fixed Action Maps name edition which could be inconsistent in Input Action Editor UI.
-- Fixed an update loop in the asset editor.
+- Fixed an update loop in the asset editor that occurs when selecint an Action Map that has no Actions.
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,7 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed memory allocation on every frame when using UIDocument without EventSystem. [ISXB-953](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-953)
 - Fixed Action Maps name edition which could be inconsistent in Input Action Editor UI.
-- Fixed an update loop in the asset editor that occurs when selecint an Action Map that has no Actions.
+- Fixed an update loop in the asset editor that occurs when selecting an Action Map that has no Actions.
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -135,11 +135,6 @@ namespace UnityEngine.InputSystem.Editor
                     var item = m_ActionsTreeView.GetItemDataForIndex<ActionOrBindingData>(m_ActionsTreeView.selectedIndex);
                     Dispatch(item.isAction ? Commands.SelectAction(item.name) : Commands.SelectBinding(item.bindingIndex));
                 }
-                else
-                {
-                    Dispatch(Commands.SelectAction(null));
-                    Dispatch(Commands.SelectBinding(-1));
-                }
             };
 
             m_ActionsTreeView.RegisterCallback<ExecuteCommandEvent>(OnExecuteCommand);


### PR DESCRIPTION
### Description

The asset editor could go into a UI update loop in some circumstances.

### Changes made

Removed an else clause in the code which was executed when selecting an empty action map.

### Testing

Manual and CI tests are successfuly.

### Risk

0

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
