### PR TITLE
FIX: InputDeviceTester only shows first touch contact (ISXB-1017)

### DIFF
--- a/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/TouchISX.cs
+++ b/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/TouchISX.cs
@@ -84,7 +84,8 @@ public class TouchISX : MonoBehaviour
         int id = control.touchId.ReadValue();
 
         // Sometimes the Began phase is detected twice. The redundant one needs to be filtered out
-        if (m_HighlightPool.Find(id.ToString()) != null) return;
+        if (m_HighlightPool.Find(id.ToString())?.gameObject?.activeSelf ?? false)
+            return;
 
         Vector2 pos = Camera.main.ScreenToWorldPoint(control.position.ReadValue());
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed memory allocation on every frame when using UIDocument without EventSystem. [ISXB-953](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-953)
 - Fixed Action Maps name edition which could be inconsistent in Input Action Editor UI.
+- Fixed InputDeviceTester sample only visualizing a given touch contact once. [ISXB-1017](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1017)
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.


### PR DESCRIPTION
### Description

The logic checking for duplicate "Began" phases with a touch contact was incorrect. The first touch contact will show correctly but successive interactions were filtered out.

### Changes made

Corrected the filter logic: to check the GameObject's active state and not just for null: if GO is active (for given touchID) then it's a duplicate.

### Testing

Verified the fix locally.

### Risk

Minimal risk: only changes the sample, which apparently has been broken for years.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
