### PR TITLE
FIX: JsonParser / ParseStringValue now creates unescaped strings

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Use `ProfilerMarker` instead of `Profiler.BeginSample` and `Profiler.EndSample` when appropriate to enable recording of profiling data.
+- Improved performance of disconnected device activation (ISX-1450)
 
 ### Added
 -  Added tests for Input Action Editor UI for managing action maps (List, create, rename, delete) (ISX-2087)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an update loop in the asset editor that occurs when selecting an Action Map that has no Actions.
 - Fixed Package compilation when Unity Analytics module is not enabled on 2022.3. [ISXB-996](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-996)
 - Fixed 'OnDrop' event not called when 'IPointerDownHandler' is also listened. [ISXB-1014](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1014)
+- Improved performance of disconnected device activation (ISX-1450)
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.
@@ -25,7 +26,6 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Use `ProfilerMarker` instead of `Profiler.BeginSample` and `Profiler.EndSample` when appropriate to enable recording of profiling data.
-- Improved performance of disconnected device activation (ISX-1450)
 
 ### Added
 - Added tests for Input Action Editor UI for managing action maps (List, create, rename, delete) (ISX-2087)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceDescription.cs
@@ -380,14 +380,14 @@ namespace UnityEngine.InputSystem.Layouts
             };
         }
 
-        internal static bool ComparePropertyToDeviceDescriptor(string propertyName, string propertyValue, string deviceDescriptor)
+        internal static bool ComparePropertyToDeviceDescriptor(string propertyName, JsonParser.JsonString propertyValue, string deviceDescriptor)
         {
             // We use JsonParser instead of JsonUtility.Parse in order to not allocate GC memory here.
 
             var json = new JsonParser(deviceDescriptor);
             if (!json.NavigateToProperty(propertyName))
             {
-                if (string.IsNullOrEmpty(propertyValue))
+                if (propertyValue.text.isEmpty)
                     return true;
                 return false;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2473,6 +2473,45 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        private JsonParser.JsonString MakeEscapedJsonString(string theString)
+        {
+            //
+            // When we create the device description from the (passed from native) deviceDescriptor string in OnNativeDeviceDiscovered()
+            // we remove any escape characters from the capabilties field when we do InputDeviceDescription.FromJson() - this decoded
+            // description is used to create the device.
+            //
+            // This means that the native and managed code can have slightly different representations of the capabilities field.
+            //
+            // Managed: description.capabilities    string, unescaped
+            //                                      eg "{"deviceName":"Oculus Quest", ..."
+            //
+            // Native:  deviceDescriptor            string, containing a Json encoded "capabilities" name/value pair represented by an escaped Json string
+            //                                      eg "{\"deviceName\":\"Oculus Quest\", ..."
+            //
+            // To avoid a very costly escape-skipping character-by-character string comparison in JsonParser.Json.Equals() we
+            // reconstruct an escaped string and make an escaped JsonParser.JsonString and use that for the comparison instead.
+            //
+            var builder = new StringBuilder();
+            var length = theString.Length;
+            var hasEscapes = false;
+            for (var j = 0; j < length; ++j)
+            {
+                var ch = theString[j];
+                if (ch == '\\' || ch == '\"')
+                {
+                    builder.Append('\\');
+                    hasEscapes = true;
+                }
+                builder.Append(ch);
+            }
+            var jsonStringWithEscapes = new JsonParser.JsonString
+            {
+                text = builder.ToString(),
+                hasEscapes = hasEscapes
+            };
+            return jsonStringWithEscapes;
+        }
+
         private InputDevice TryMatchDisconnectedDevice(string deviceDescriptor)
         {
             for (var i = 0; i < m_DisconnectedDevicesCount; ++i)
@@ -2491,39 +2530,7 @@ namespace UnityEngine.InputSystem
                     continue;
                 if (!InputDeviceDescription.ComparePropertyToDeviceDescriptor("type", description.deviceClass, deviceDescriptor))
                     continue;
-                //
-                // When we create the device description from the (passed from native) deviceDescriptor string in OnNativeDeviceDiscovered()
-                // we remove any escape characters from the capabilties field when we do InputDeviceDescription.FromJson() - this decoded
-                // description is used to create the device.
-                //
-                // This means that the native and managed code can have slightly different representations of the capabilities field.
-                //
-                // Managed: description.capabilities    string, unescaped (eg "{"deviceName":"Oculus Quest", ...")
-                // Native:  deviceDescriptor            string, containinf a Json encoded "capabilities" name/value represented with an escaped Json string (eg "{\"deviceName\":\"Oculus Quest\", ...")
-                //
-                // To avoid a very costly escape-skipping character-by-character string comparison in JsonParser.Json.Equals()
-                // reconstruct an escaped string and make an escaped JsonParser.JsonString and use that for the comparison instead.
-                //
-                var builder = new StringBuilder();
-                var length = description.capabilities.Length;
-                var hasEscapes = false;
-                for (var j = 0; j < length; ++j)
-                {
-                    var ch = description.capabilities[j];
-                    if (ch == '\\' || ch == '\"')
-                    {
-                        builder.Append('\\');
-                        hasEscapes = true;
-                    }
-                    builder.Append(ch);
-                }
-                string capabilitiesWithEscapes = builder.ToString();
-                var jsonCapabilitiesWithEscapes = new JsonParser.JsonString
-                {
-                    text = capabilitiesWithEscapes,
-                    hasEscapes = hasEscapes
-                };
-                if (!InputDeviceDescription.ComparePropertyToDeviceDescriptor("capabilities", jsonCapabilitiesWithEscapes, deviceDescriptor))
+                if (!InputDeviceDescription.ComparePropertyToDeviceDescriptor("capabilities", MakeEscapedJsonString(description.capabilities), deviceDescriptor))
                     continue;
                 if (!InputDeviceDescription.ComparePropertyToDeviceDescriptor("serial", description.serial, deviceDescriptor))
                     continue;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -260,11 +260,25 @@ namespace UnityEngine.InputSystem.Utilities
                 else if (ch == '"')
                 {
                     ++m_Position;
-                    result = new JsonString
+
+                    JsonValue escapedResult = new JsonString
                     {
                         text = new Substring(m_Text, startIndex, m_Position - startIndex - 1),
                         hasEscapes = hasEscapes
                     };
+                    if (hasEscapes)
+                    {
+                        result = new JsonString
+                        {
+                            text = escapedResult.ToString(),
+                            hasEscapes = false
+                        };
+                    }
+                    else
+                    {
+                        result = escapedResult;
+                    }
+
                     return true;
                 }
                 ++m_Position;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -261,37 +261,11 @@ namespace UnityEngine.InputSystem.Utilities
                 {
                     ++m_Position;
 
-                    if (hasEscapes)
+                    result = new JsonString
                     {
-                        var builder = new StringBuilder();
-                        var length = m_Position - startIndex - 1;
-                        for (var i = startIndex; i < length; ++i)
-                        {
-                            ch = m_Text[i];
-                            if (ch == '\\')
-                            {
-                                ++i;
-                                if (i == length)
-                                    break;
-                                ch = m_Text[i];
-                            }
-                            builder.Append(ch);
-                        }
-                        result = new JsonString
-                        {
-                            text = builder.ToString(),
-                            hasEscapes = false
-                        };
-                    }
-                    else
-                    {
-                        result = new JsonString
-                        {
-                            text = new Substring(m_Text, startIndex, m_Position - startIndex - 1),
-                            hasEscapes = hasEscapes
-                        };
-                    }
-
+                        text = new Substring(m_Text, startIndex, m_Position - startIndex - 1),
+                        hasEscapes = hasEscapes
+                    };
                     return true;
                 }
                 ++m_Position;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/JsonParser.cs
@@ -261,22 +261,35 @@ namespace UnityEngine.InputSystem.Utilities
                 {
                     ++m_Position;
 
-                    JsonValue escapedResult = new JsonString
-                    {
-                        text = new Substring(m_Text, startIndex, m_Position - startIndex - 1),
-                        hasEscapes = hasEscapes
-                    };
                     if (hasEscapes)
                     {
+                        var builder = new StringBuilder();
+                        var length = m_Position - startIndex - 1;
+                        for (var i = startIndex; i < length; ++i)
+                        {
+                            ch = m_Text[i];
+                            if (ch == '\\')
+                            {
+                                ++i;
+                                if (i == length)
+                                    break;
+                                ch = m_Text[i];
+                            }
+                            builder.Append(ch);
+                        }
                         result = new JsonString
                         {
-                            text = escapedResult.ToString(),
+                            text = builder.ToString(),
                             hasEscapes = false
                         };
                     }
                     else
                     {
-                        result = escapedResult;
+                        result = new JsonString
+                        {
+                            text = new Substring(m_Text, startIndex, m_Position - startIndex - 1),
+                            hasEscapes = hasEscapes
+                        };
                     }
 
                     return true;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/PrimitiveValue.cs
@@ -450,7 +450,7 @@ namespace UnityEngine.InputSystem.Utilities
                 case TypeCode.Single:
                     return !Mathf.Approximately(m_FloatValue, default);
                 case TypeCode.Double:
-                    return NumberHelpers.Approximately(m_DoubleValue, default);
+                    return !NumberHelpers.Approximately(m_DoubleValue, default);
                 default:
                     return default;
             }


### PR DESCRIPTION
### Description

Comparing escaped and non-escaped strings is very slow - this happens when devices are deactivated/reactivated such as when the Quest2 headset and controllers enter and awake from sleep mode.

The high cost comes from having to compare each string character-by-character (skipping '\' escapes) each time entering the C# runtime to perform System.Globalization.ToUpperInvariant.


### Changes made

This change to TryMatchDisconnectedDevice() means that any parsed strings that contain escape characters are converted to non-escaped strings for much quicker comparison.

This saves approximately 0.5ms / frame when an Oculus headset or controller is reactivated.

### Testing

Local testing with the Quest2 headset and controllers using Superluminal to capture the cost of device awakening.

### Risk

We allocate a temporary string where before we did not.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [x] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
