### PR TITLE
FIX: Fixed 'OnDrop' event not called when 'IPointerDownHandler' is also listened. (ISXB-1014)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed InputDeviceTester sample only visualizing a given touch contact once. [ISXB-1017](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1017)
 - Fixed an update loop in the asset editor that occurs when selecting an Action Map that has no Actions.
 - Fixed Package compilation when Unity Analytics module is not enabled on 2022.3. [ISXB-996](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-996)
+- Fixed 'OnDrop' event not called when 'IPointerDownHandler' is also listened. [ISXB-1014](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1014)
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -496,10 +496,12 @@ namespace UnityEngine.InputSystem.UI
                 // Invoke OnPointerDown, if present.
                 var newPressed = ExecuteEvents.ExecuteHierarchy(currentOverGo, eventData, ExecuteEvents.pointerDownHandler);
 
+                var pointerClickHandler = ExecuteEvents.GetEventHandler<IPointerClickHandler>(currentOverGo);
+
                 // If no GO responded to OnPointerDown, look for one that responds to OnPointerClick.
                 // NOTE: This only looks up the handler. We don't invoke OnPointerClick here.
                 if (newPressed == null)
-                    newPressed = ExecuteEvents.GetEventHandler<IPointerClickHandler>(currentOverGo);
+                    newPressed = pointerClickHandler;
 
                 // Reset click state if delay to last release was too long or if we didn't
                 // press on the same object as last time. The latter part we don't know until
@@ -515,7 +517,7 @@ namespace UnityEngine.InputSystem.UI
                 // become null.
                 eventData.pointerPress = newPressed;
                 #if UNITY_2020_1_OR_NEWER // pointerClick doesn't exist before this.
-                eventData.pointerClick = ExecuteEvents.GetEventHandler<IPointerClickHandler>(currentOverGo);
+                eventData.pointerClick = pointerClickHandler;
                 #endif
                 eventData.rawPointerPress = currentOverGo;
 
@@ -538,9 +540,9 @@ namespace UnityEngine.InputSystem.UI
                 //          click and OnPointerClick is thus never invoked.
                 var pointerClickHandler = ExecuteEvents.GetEventHandler<IPointerClickHandler>(currentOverGo);
                 #if UNITY_2020_1_OR_NEWER
-                var isClick = eventData.pointerClick == pointerClickHandler && eventData.eligibleForClick;
+                var isClick = eventData.pointerClick != null && eventData.pointerClick == pointerClickHandler && eventData.eligibleForClick;
                 #else
-                var isClick = eventData.pointerPress == pointerClickHandler && eventData.eligibleForClick;
+                var isClick = eventData.pointerPress != null && eventData.pointerPress == pointerClickHandler && eventData.eligibleForClick;
                 #endif
                 if (isClick)
                 {


### PR DESCRIPTION
### Description

When IPointerDownHandler is registered it enable the clic detector and after that PR #1911 it trigger all the time even if there is no pointerClickHandler.

`var isClick = eventData.pointerClick == pointerClickHandler && eventData.eligibleForClick;`
Is always true since pointerClickHandler and eventData.pointerClick are null.

### Changes made

Added a null check to prevent a bad clic detection.
Also changed the code to prevent calling `ExecuteEvents.GetEventHandler<IPointerClickHandler>(currentOverGo);` twice

### Testing

Tested with client project and some extra test with multiple MonoBehavior that use a combinaison of 
 IBeginDragHandler, IDragHandler, IDropHandler, IEndDragHandler, IPointerDownHandler, IPointerEnterHandler, IPointerExitHandler, IPointerClickHandler

### Risk

_Please describe the potential risks of your changes for the reviewers._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
