### PR TITLE
CHANGE: Disable tvOS CI on 6000 and 22.3 (ISXB-879)

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -2,6 +2,7 @@ editors:
   - version: 2021.3
   - version: 2022.3
   - version: 6000.0
+    disable_tvos_run: true
   - version: trunk
     disable_tvos_run: true
 

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,6 +1,7 @@
 editors:
   - version: 2021.3
   - version: 2022.3
+    disable_tvos_run: true
   - version: 6000.0
     disable_tvos_run: true
   - version: trunk


### PR DESCRIPTION
### Description

Disabled tvOS CI from running on 6000 and 22.3 due to the instabilities.

### Risk

The risk is that tvOS could have issues without the CI catching it. But that's already the thing with it always failing

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
