### PR TITLE
NEW: Added InputDeviceMatcher.WithManufacturerContains(string noRegexMatch) to improve DualShockSupport initialization performance

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.
+- Added InputDeviceMatcher.WithManufacturerContains(string noRegexMatch) API to improved DualShockSupport.Initialize performance (ISX-1411)
 
 ### Changed
 - Use `ProfilerMarker` instead of `Profiler.BeginSample` and `Profiler.EndSample` when appropriate to enable recording of profiling data.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,7 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 - Added Hinge Angle sensor support for foldable devices.
-- Added InputDeviceMatcher.WithManufacturerContains(string noRegexMatch) API to improved DualShockSupport.Initialize performance (ISX-1411)
+- Added InputDeviceMatcher.WithManufacturerContains(string noRegexMatch) API to improve DualShockSupport.Initialize performance (ISX-1411)
 
 ### Changed
 - Use `ProfilerMarker` instead of `Profiler.BeginSample` and `Profiler.EndSample` when appropriate to enable recording of profiling data.

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -378,7 +378,7 @@ namespace UnityEngine.InputSystem.Layouts
         {
             // String match.
             if (pattern is string str)
-                return str.Contains(value, StringComparison.OrdinalIgnoreCase);
+                return value.Contains(str, StringComparison.OrdinalIgnoreCase);
 
             return false;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -150,7 +150,7 @@ namespace UnityEngine.InputSystem.Layouts
         /// <seealso cref="InputDeviceDescription.manufacturer"/>
         public InputDeviceMatcher WithManufacturerContains(string noRegExPattern)
         {
-            return With(kManufacturerContainsKey, noRegExPattern, supportRegex:false);
+            return With(kManufacturerContainsKey, noRegExPattern, supportRegex: false);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace UnityEngine.InputSystem.Layouts
                 else if (key == kManufacturerContainsKey)
                 {
                     if (string.IsNullOrEmpty(deviceDescription.manufacturer)
-                          || !MatchSinglePropertyContains(pattern, deviceDescription.manufacturer))
+                        || !MatchSinglePropertyContains(pattern, deviceDescription.manufacturer))
                         return 0;
                 }
                 else if (key == kProductKey)

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -145,12 +145,12 @@ namespace UnityEngine.InputSystem.Layouts
         /// <summary>
         /// Add a pattern (simple string) to <see cref="patterns"/> to match a <see cref="InputDeviceDescription.manufacturer"/>.
         /// </summary>
-        /// <param name="pattern">String to match - simple keyword search in a device manufacturer string (eg "SONY").</param>
+        /// <param name="noRegExPattern">String to match - simple keyword search in a device manufacturer string (eg "SONY").</param>
         /// <returns>The modified device matcher with the added pattern.</returns>
         /// <seealso cref="InputDeviceDescription.manufacturer"/>
-        public InputDeviceMatcher WithManufacturerContains(string pattern)
+        public InputDeviceMatcher WithManufacturerContains(string noRegExPattern)
         {
-            return With(kManufacturerContainsKey, pattern, supportRegex:false);
+            return With(kManufacturerContainsKey, noRegExPattern, supportRegex:false);
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -143,6 +143,17 @@ namespace UnityEngine.InputSystem.Layouts
         }
 
         /// <summary>
+        /// Add a pattern (simple string) to <see cref="patterns"/> to match a <see cref="InputDeviceDescription.manufacturer"/>.
+        /// </summary>
+        /// <param name="pattern">String to match - simple keyword search in a device manufacturer string (eg "SONY").</param>
+        /// <returns>The modified device matcher with the added pattern.</returns>
+        /// <seealso cref="InputDeviceDescription.manufacturer"/>
+        public InputDeviceMatcher WithManufacturerContains(string pattern)
+        {
+            return With(kManufacturerContainsKey, pattern, supportRegex:false);
+        }
+
+        /// <summary>
         /// Add a pattern to <see cref="patterns"/> to match a <see cref="InputDeviceDescription.product"/>.
         /// </summary>
         /// <param name="pattern">String to match.</param>
@@ -309,6 +320,12 @@ namespace UnityEngine.InputSystem.Layouts
                         || !MatchSingleProperty(pattern, deviceDescription.manufacturer))
                         return 0;
                 }
+                else if (key == kManufacturerContainsKey)
+                {
+                    if (string.IsNullOrEmpty(deviceDescription.manufacturer)
+                          || !MatchSinglePropertyContains(pattern, deviceDescription.manufacturer))
+                        return 0;
+                }
                 else if (key == kProductKey)
                 {
                     if (string.IsNullOrEmpty(deviceDescription.product)
@@ -353,6 +370,15 @@ namespace UnityEngine.InputSystem.Layouts
             // Regex match.
             if (pattern is Regex regex)
                 return regex.IsMatch(value);
+
+            return false;
+        }
+
+        private static bool MatchSinglePropertyContains(object pattern, string value)
+        {
+            // String match.
+            if (pattern is string str)
+                return str.Contains(value, StringComparison.OrdinalIgnoreCase);
 
             return false;
         }
@@ -518,6 +544,7 @@ namespace UnityEngine.InputSystem.Layouts
         private static readonly InternedString kInterfaceKey = new InternedString("interface");
         private static readonly InternedString kDeviceClassKey = new InternedString("deviceClass");
         private static readonly InternedString kManufacturerKey = new InternedString("manufacturer");
+        private static readonly InternedString kManufacturerContainsKey = new InternedString("manufacturerContains");
         private static readonly InternedString kProductKey = new InternedString("product");
         private static readonly InternedString kVersionKey = new InternedString("version");
 
@@ -529,6 +556,7 @@ namespace UnityEngine.InputSystem.Layouts
             public string deviceClass;
             public string[] deviceClasses;
             public string manufacturer;
+            public string manufacturerContains;
             public string[] manufacturers;
             public string product;
             public string[] products;
@@ -617,12 +645,16 @@ namespace UnityEngine.InputSystem.Layouts
                     foreach (var value in deviceClasses)
                         matcher = matcher.WithDeviceClass(value);
 
-                // Manufacturer.
+                // Manufacturer (string or regex)
                 if (!string.IsNullOrEmpty(manufacturer))
                     matcher = matcher.WithManufacturer(manufacturer);
                 if (manufacturers != null)
                     foreach (var value in manufacturers)
                         matcher = matcher.WithManufacturer(value);
+
+                // ManufacturerContains (simple string, can occur anywhere in the reported manufacturer string)
+                if (!string.IsNullOrEmpty(manufacturerContains))
+                    matcher = matcher.WithManufacturerContains(manufacturerContains);
 
                 // Product.
                 if (!string.IsNullOrEmpty(product))

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -68,7 +68,7 @@ namespace UnityEngine.InputSystem.DualShock
                     .WithInterface("HID")
                     .WithManufacturerContains("Sony")
                     .WithManufacturerContains("Entertainment")
-                    .WithProduct("PLAYSTATION(R)3 Controller", supportRegex:false));
+                    .WithProduct("PLAYSTATION(R)3 Controller", supportRegex: false));
             #endif
         }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/DualShock/DualShockSupport.cs
@@ -53,7 +53,8 @@ namespace UnityEngine.InputSystem.DualShock
             InputSystem.RegisterLayoutMatcher<DualShock4GamepadHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithManufacturer("Sony.+Entertainment")
+                    .WithManufacturerContains("Sony")
+                    .WithManufacturerContains("Entertainment")
                     .WithProduct("Wireless Controller"));
 
             InputSystem.RegisterLayout<DualShock3GamepadHID>(
@@ -65,8 +66,9 @@ namespace UnityEngine.InputSystem.DualShock
             InputSystem.RegisterLayoutMatcher<DualShock3GamepadHID>(
                 new InputDeviceMatcher()
                     .WithInterface("HID")
-                    .WithManufacturer("Sony.+Entertainment")
-                    .WithProduct("PLAYSTATION(R)3 Controller"));
+                    .WithManufacturerContains("Sony")
+                    .WithManufacturerContains("Entertainment")
+                    .WithProduct("PLAYSTATION(R)3 Controller", supportRegex:false));
             #endif
         }
     }


### PR DESCRIPTION
### Description

The **InputDeviceMatcher.WithManufacturer**() can perform a regex match even for simple patterns (eg "Sony.+Entertainment" and "PLAYSTATION(R)3 Controller" are both treated as Regexes) which is surprisingly costly on initialization.

This PR addresses that by adding an API to perform a simple string keyword match on the device manufacturer string,

### Changes made

The new **WithManufacturerContains**(string **noRegexMatch**) API performs a String.**Contains**() check instead looking for the simple pattern in the manufacturer string.

Changed the DualShockSupport for **DualShock4Gamepad** and **DualShock3Gamepad** to avoid regex matching.

These changes save 25ms in **DualShockSupport.Initialize** during player start-up (26ms -> 1ms)


### Testing

Local testing using SONY controllers and Quest VR devices.

### Risk

Previously a controller that reported the manufacturer as "SONY Entertainment" would match - with this change a hypothetical device that reported the manufacturer as "Entertainment Not SONY" would also match. I think this is a risk worth taking.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
