### PR TITLE
CHANGE: switch yamato trigger to always run performance tests even with no changes to branch

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -259,10 +259,10 @@ performance_tests_only:
     recurring:
         - branch: develop
           frequency: daily
-          rerun: on_new_revision            
+          rerun: always
         - branch: stable
           frequency: weekly
-          rerun: on_new_revision              
+          rerun: always
 
 {% for run in (1..2) %}
 publish{% cycle "", "_dryrun" %}:


### PR DESCRIPTION
### Description

The trigger was the wrong way around which I didn't catch on my work branch because it had daily changes.

### Changes made

Performance test are noe always rerun as per schedule.

### Risk

None, only auto triggered test runs affected

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
