### PR TITLE
FIX: OnScreenStick leaking when destroyed

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
+- Fixed memory leak when the OnScreenStick component was destroyed [ISXB-1070](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1070). Contribution by [LukeUnityDev](https://github.com/LukeUnityDev).
+
 ### Changed
 - Renamed editor Resources directories to PackageResources to fix package validation warnings.
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -136,6 +136,15 @@ namespace UnityEngine.InputSystem.OnScreen
             image.alphaHitTestMinimumThreshold = 0.5f;
         }
 
+        private void OnDestroy()
+        {
+            if (m_UseIsolatedInputActions)
+            {
+                m_PointerDownAction.started -= OnPointerDown;
+                m_PointerDownAction.canceled -= OnPointerUp;
+            }
+        }
+
         private void BeginInteraction(Vector2 pointerPosition, Camera uiCamera)
         {
             var canvasRectTransform = UGUIOnScreenControlUtils.GetCanvasRectTransform(transform);


### PR DESCRIPTION
### Description

Relayed original fix by [@LukeUnityDev](https://github.com/LukeUnityDev) from here: https://github.com/Unity-Technologies/InputSystem/pull/1960/files to make it easier to land.

### Changes made

Unregistering handlers on destroy from associated action.

### Testing

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Risk

_Please describe the potential risks of your changes for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
