### PR TITLE
CHANGE: Added message to notify the user if a PlayerInputComponent fails to bind a control scheme (ISXB-1020)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 - Renamed editor Resources directories to PackageResources to fix package validation warnings.
+- PlayerInput component now warns if the system cannot find matching control scheme, which can occur if all control schemes already paired (e.g. to other game objects with PlayerInput components) [ISXB-1020](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1020)
 
 ## [1.11.0] - 2024-09-10
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1469,7 +1469,7 @@ namespace UnityEngine.InputSystem
                         else
                         {
                             // The device count check is here to allow the unit tests to pass (and not trigger this error message)
-                            if (InputSystem.devices.Count>0 && availableDevices.Count==0)
+                            if (InputSystem.devices.Count > 0 && availableDevices.Count == 0)
                                 Debug.LogError($"Cannot find matching control scheme for {this.name} (all control schemes already paired)", this);
                         }
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1470,7 +1470,7 @@ namespace UnityEngine.InputSystem
                         {
                             // The device count check is here to allow the unit tests to pass (and not trigger this error message)
                             if (InputSystem.devices.Count > 0 && availableDevices.Count == 0)
-                                Debug.LogError($"Cannot find matching control scheme for {this.name} (all control schemes are already paired to matching devices)", this);
+                                Debug.LogWarning($"Cannot find matching control scheme for {this.name} (all control schemes are already paired to matching devices)", this);
                         }
                     }
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1470,7 +1470,7 @@ namespace UnityEngine.InputSystem
                         {
                             // The device count check is here to allow the unit tests to pass (and not trigger this error message)
                             if (InputSystem.devices.Count > 0 && availableDevices.Count == 0)
-                                Debug.LogError($"Cannot find matching control scheme for {this.name} (all control schemes already paired)", this);
+                                Debug.LogError($"Cannot find matching control scheme for {this.name} (all control schemes are already paired to matching devices)", this);
                         }
                     }
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1463,7 +1463,15 @@ namespace UnityEngine.InputSystem
                     {
                         var controlScheme = InputControlScheme.FindControlSchemeForDevices(availableDevices, m_Actions.controlSchemes);
                         if (controlScheme != null)
+                        {
                             TryToActivateControlScheme(controlScheme.Value);
+                        }
+                        else
+                        {
+                            // The device count check is here to allow the unit tests to pass (and not trigger this error message)
+                            if (InputSystem.devices.Count>0 && availableDevices.Count==0)
+                                Debug.LogError($"Cannot find matching control scheme for {this.name} (all control schemes already paired)", this);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Description

Added message to notify the user if a PlayerInputComponent fails to bind a control scheme (ISXB-1020)
This can happen if there are multiple game objects with PlayerInputComponent's and not enough devices to support them

### Changes made

Added an error message in the case when the list of available control schemes has been exhausted

### Testing

Ran on the test case in the bug report and it fires a message on PC when only a keyboard/mouse plugged in.
(Does not fire of a touchscreen is also connected)

Ran all the unit tests and they all pass

### Risk

Potentially there is a use case I missed which doesn't warrant the error message

### Checklist

Before review:

- [X] Changelog entry added.
- Ran existing tests
- No new docs 

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
