### PR TITLE
FIX:  Action Maps contextual menu in Action Editor UI that could display unrelated items.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed Multiple interactions could breaks on Composite Binding. [ISXB-619](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-619)
 - Fixed memory leak when the OnScreenStick component was destroyed [ISXB-1070](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1070). Contribution by [LukeUnityDev](https://github.com/LukeUnityDev).
+- Fixed Action Maps contextual menu in Action Editor UI that could display unrelated items.
 
 ### Changed
 - Renamed editor Resources directories to PackageResources to fix package validation warnings.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,7 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed Multiple interactions could breaks on Composite Binding. [ISXB-619](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-619)
 - Fixed memory leak when the OnScreenStick component was destroyed [ISXB-1070](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1070). Contribution by [LukeUnityDev](https://github.com/LukeUnityDev).
-- Fixed Action Maps contextual menu in Action Editor UI that could display unrelated items.
+- Fixed Action Maps contextual menu in Action Editor UI that occasionally displays unrelated items.
 
 ### Changed
 - Renamed editor Resources directories to PackageResources to fix package validation warnings.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -27,9 +27,8 @@ namespace UnityEngine.InputSystem.Editor
         #region ActionMaps
         public static void GetContextMenuForActionMapItem(ActionMapsView mapView, InputActionMapsTreeViewItem treeViewItem, int index)
         {
-            var manipulator = new ContextualMenuManipulator(menuEvent =>
+            treeViewItem.OnContextualMenuPopulateEvent = (menuEvent =>
             {
-                //menuEvent.menu.ClearItems();
                 // TODO: AddAction should enable m_RenameOnActionAdded
                 menuEvent.menu.AppendAction(add_Action_String, _ => mapView.Dispatch(Commands.AddAction()));
                 menuEvent.menu.AppendSeparator();
@@ -43,8 +42,7 @@ namespace UnityEngine.InputSystem.Editor
                 var copiedAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
                 if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
                     menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copiedAction));
-            }) { target = treeViewItem };
-            treeViewItem.contextualMenuManipulator = manipulator;
+            });
         }
 
         // Add "Add Action Map" option to empty space under the ListView. Matches with old IMGUI style (ISX-1519).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -27,8 +27,9 @@ namespace UnityEngine.InputSystem.Editor
         #region ActionMaps
         public static void GetContextMenuForActionMapItem(ActionMapsView mapView, InputActionMapsTreeViewItem treeViewItem, int index)
         {
-            _ = new ContextualMenuManipulator(menuEvent =>
+            var manipulator = new ContextualMenuManipulator(menuEvent =>
             {
+                //menuEvent.menu.ClearItems();
                 // TODO: AddAction should enable m_RenameOnActionAdded
                 menuEvent.menu.AppendAction(add_Action_String, _ => mapView.Dispatch(Commands.AddAction()));
                 menuEvent.menu.AppendSeparator();
@@ -43,6 +44,7 @@ namespace UnityEngine.InputSystem.Editor
                 if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
                     menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copiedAction));
             }) { target = treeViewItem };
+            treeViewItem.contextualMenuManipulator = manipulator;
         }
 
         // Add "Add Action Map" option to empty space under the ListView. Matches with old IMGUI style (ISX-1519).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
@@ -18,6 +18,8 @@ namespace UnityEngine.InputSystem.Editor
         private const string kRenameTextField = "rename-text-field";
         public event EventCallback<string> EditTextFinished;
 
+        internal ContextualMenuManipulator contextualMenuManipulator;
+
         // for testing purposes to know if the item is focused to accept input
         internal bool IsFocused { get; private set; } = false;
 
@@ -87,6 +89,11 @@ namespace UnityEngine.InputSystem.Editor
                 m_IsEditing = false;
             }
             EditTextFinished = null;
+            if (contextualMenuManipulator != null)
+            {
+                contextualMenuManipulator.target = null;
+                contextualMenuManipulator = null;
+            }
         }
 
         public void FocusOnRenameTextField()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionMapsTreeViewItem.cs
@@ -1,6 +1,7 @@
 // UITK TreeView is not supported in earlier versions
 // Therefore the UITK version of the InputActionAsset Editor is not available on earlier Editor versions either.
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+using System;
 using System.Threading.Tasks;
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;
@@ -17,8 +18,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private const string kRenameTextField = "rename-text-field";
         public event EventCallback<string> EditTextFinished;
-
-        internal ContextualMenuManipulator contextualMenuManipulator;
+        public Action<ContextualMenuPopulateEvent> OnContextualMenuPopulateEvent;
 
         // for testing purposes to know if the item is focused to accept input
         internal bool IsFocused { get; private set; } = false;
@@ -43,6 +43,11 @@ namespace UnityEngine.InputSystem.Editor
             RegisterCallback<MouseDownEvent>(OnMouseDownEventForRename);
             renameTextfield.RegisterCallback<FocusInEvent>(e => IsFocused = true);
             renameTextfield.RegisterCallback<FocusOutEvent>(e => { OnEditTextFinished(); IsFocused = false; });
+            _ = new ContextualMenuManipulator(menuBuilder =>
+            {
+                OnContextualMenuPopulateEvent?.Invoke(menuBuilder);
+            })
+            { target = this };
         }
 
         public Label label => this.Q<Label>();
@@ -89,11 +94,6 @@ namespace UnityEngine.InputSystem.Editor
                 m_IsEditing = false;
             }
             EditTextFinished = null;
-            if (contextualMenuManipulator != null)
-            {
-                contextualMenuManipulator.target = null;
-                contextualMenuManipulator = null;
-            }
         }
 
         public void FocusOnRenameTextField()


### PR DESCRIPTION
### Description

Contextual menu of Action maps contain wrong entries

![Screenshot 2024-09-18 135055](https://github.com/user-attachments/assets/8eed1056-c08b-4d01-a36a-747f13ff0f3a)

### Changes made

Fixed the contextual registration that registered on each item without unregistering.



### Testing

local testing
![Screenshot 2024-09-18 151847](https://github.com/user-attachments/assets/042c54cc-7880-4002-b9e2-503a370cdb7b)

### Risk


_Please describe the potential risks of your changes for the reviewers._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
