### PR TITLE
FIX: Fixed potential crash on Mac when using stale references to deleted InputDevice objects (case ISXB-606)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed Multiple interactions could breaks on Composite Binding. [ISXB-619](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-619)
 - Fixed memory leak when the OnScreenStick component was destroyed [ISXB-1070](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1070). Contribution by [LukeUnityDev](https://github.com/LukeUnityDev).
+- Fixed potential crash on Mac when using stale references to deleted InputDevice objects [ISXB-606](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-606).
 
 ### Changed
 - Renamed editor Resources directories to PackageResources to fix package validation warnings.

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1242,7 +1242,7 @@ namespace UnityEngine.InputSystem
                 // InputStateBuffers.Get{Front,Back}Buffer() now check for the requested index being
                 // in-bounds and return null if not - check that here to avoid null derefence later.
                 //
-                if (currentStatePtr is null)
+                if (currentStatePtr == null)
                 {
                     return ref m_UnprocessedCachedValue;
                 }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -1232,6 +1232,20 @@ namespace UnityEngine.InputSystem
                 if (InputUpdate.s_LatestUpdateType.IsEditorUpdate())
                     return ref ReadUnprocessedStateInEditor();
 #endif
+                // Case ISXB-606
+                // If an object reference has the underlying object deleted then a device can go
+                // away which means that the underlying state buffers will have been resized.
+                //
+                // The currentStatePtr accessor uses GetDeviceIndex() to index into the state
+                // buffers but this index can then be out of bounds.
+                //
+                // InputStateBuffers.Get{Front,Back}Buffer() now check for the requested index being
+                // in-bounds and return null if not - check that here to avoid null derefence later.
+                //
+                if (currentStatePtr is null)
+                {
+                    return ref m_UnprocessedCachedValue;
+                }
 
                 if (
                     // if feature is disabled we re-evaluate every call

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -60,27 +60,34 @@ namespace UnityEngine.InputSystem.LowLevel
             // buffer and [deviceIndex*2+1] is back buffer. Each device
             // has its buffers swapped individually with SwapDeviceBuffers().
             public void** deviceToBufferMapping;
+            public int deviceCount;
 
             public bool valid => deviceToBufferMapping != null;
 
             public void SetFrontBuffer(int deviceIndex, void* ptr)
             {
-                deviceToBufferMapping[deviceIndex * 2] = ptr;
+                if (deviceIndex < deviceCount)
+                    deviceToBufferMapping[deviceIndex * 2] = ptr;
             }
 
             public void SetBackBuffer(int deviceIndex, void* ptr)
             {
-                deviceToBufferMapping[deviceIndex * 2 + 1] = ptr;
+                if (deviceIndex < deviceCount)
+                    deviceToBufferMapping[deviceIndex * 2 + 1] = ptr;
             }
 
             public void* GetFrontBuffer(int deviceIndex)
             {
-                return deviceToBufferMapping[deviceIndex * 2];
+                if (deviceIndex < deviceCount)
+                    return deviceToBufferMapping[deviceIndex * 2];
+                return null;
             }
 
             public void* GetBackBuffer(int deviceIndex)
             {
-                return deviceToBufferMapping[deviceIndex * 2 + 1];
+                if (deviceIndex < deviceCount)
+                    return deviceToBufferMapping[deviceIndex * 2 + 1];
+                return null;
             }
 
             public void SwapBuffers(int deviceIndex)
@@ -197,7 +204,11 @@ namespace UnityEngine.InputSystem.LowLevel
             var mappings = (void**)(bufferPtr + sizePerBuffer * 2);  // Put mapping table at end.
             bufferPtr += sizePerBuffer * 2 + mappingTableSizePerBuffer;
 
-            var buffers = new DoubleBuffers {deviceToBufferMapping = mappings};
+            var buffers = new DoubleBuffers
+            {
+                deviceToBufferMapping = mappings,
+                deviceCount = deviceCount
+            };
 
             for (var i = 0; i < deviceCount; ++i)
             {


### PR DESCRIPTION

### Description

A user reported that the Editor sometimes crashed on Mac when running (their) tests in the Editor's TestRunner window

This PR addresses the root cause of the problem: stale object references were resulting in the input system accessing somewhat random memory addresses to read device state.

Some random memory address access can cause the Mac OS kernel to terminate the application instead of returning an exception to the process (this does not appear to happen on Windows).

### Changes made

Added **deviceIndex** checks when accessing **InputStateBuffers**.**DoubleBuffers** front and back buffers to avoid reading random memory.


### Testing

Local testing of the user's supplied reproduction project.

### Risk

Minimal risks - these changes prevent access to essentially random memory addresses when reading device state.

### Checklist


- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
