### PR TITLE
FIX: Fixed "MissingReferenceException" errors when closing an in-game dropdown field

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Multiple interactions could breaks on Composite Binding. [ISXB-619](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-619)
 - Fixed memory leak when the OnScreenStick component was destroyed [ISXB-1070](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1070). Contribution by [LukeUnityDev](https://github.com/LukeUnityDev).
 - Fixed Action Maps contextual menu in Action Editor UI that occasionally displays unrelated items.
+- Fixed "MissingReferenceException" errors when closing an in-game dropdown field [ISXB-1081](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1081).
 
 ### Changed
 - Renamed editor Resources directories to PackageResources to fix package validation warnings.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -473,7 +473,7 @@ namespace UnityEngine.InputSystem.UI
             }
 
             // now issue the enter call up to but not including the common root
-            Transform oldPointerEnter = eventData.pointerEnter?.transform;
+            Transform oldPointerEnter = eventData.pointerEnter ? eventData.pointerEnter.transform : null;
             eventData.pointerEnter = currentPointerTarget;
             if (currentPointerTarget != null)
             {


### PR DESCRIPTION
### Description

When closing a dropdown field the ui module still reference a deleted object and try to use it with a null propagation operator which is not compatible with unity object https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0008.md

### Changes made

Changed the access to use the bool operator check

### Testing

tested with customer project

### Risk

_Please describe the potential risks of your changes for the reviewers._

### Checklist

Before review:

- [ X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
