### PR TITLE
FIX: Wrong mapping of Xbox Series S|X and Xbox One wireless controllers "View" button on macOS

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,9 @@ however, it has to be formatted properly to pass verification tests.
 - Added the display of the device flag `CanRunInBackground` in device debug view.
 - Added analytics for programmatic `InputAction` setup via `InputActionSetupExtensions` when exiting play-mode.
 
+### Fixed
+- Fixed wrong mapping of Xbox Series S|X and Xbox One wireless controllers "View" button on macOS.[ISXB-385](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-385)
+
 ## [1.11.1] - 2024-09-26
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -111,7 +111,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         public enum Button
         {
             Start = 11,
-            Select = 16,
+            Select = 10,
             LeftThumbstickPress = 13,
             RightThumbstickPress = 14,
             LeftShoulder = 6,


### PR DESCRIPTION
### Description

Fixes [ISXB-385](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-385)

The problem in a nutshell:
<img width="876" alt="image" src="https://github.com/user-attachments/assets/a4fdab28-beca-44c2-85b2-f5460704985c">


### Changes made

Set the correct bit field that maps to the equivalent "Select" button of Xbox controllers, the "View" button.

### Testing

I tested with both Xbox wireless (Bluetooth capable) controllers. Both the Xbox One and Xbox Series S|X models.
It feels like the previous value didn't work for Xbox One wireless controllers so I'm not sure why that value was set in the first place. But maybe I just couldn't test with that device.
If there's a Xbox wireless controller that now doesn't work due to this change, let me know and I'll create a new class and state struct for it.

### Risk

Untested Xbox wireless controllers stop working. 

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".


During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
