### PR TITLE
FIX: MakeEscapedJsonString now null-checks inputs

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
+- Fixed `NullReferenceException` from disconnecting and reconnecting a GXDKGamepad.
+
 ### Added
 - Added the display of the device flag `CanRunInBackground` in device debug view.
 - Added analytics for programmatic `InputAction` setup via `InputActionSetupExtensions` when exiting play-mode.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2562,6 +2562,16 @@ namespace UnityEngine.InputSystem
             // To avoid a very costly escape-skipping character-by-character string comparison in JsonParser.Json.Equals() we
             // reconstruct an escaped string and make an escaped JsonParser.JsonString and use that for the comparison instead.
             //
+
+            if (string.IsNullOrEmpty(theString))
+            {
+                return new JsonParser.JsonString
+                {
+                    text = string.Empty, // text should be an empty string and not null for consistency on property comparisons
+                    hasEscapes = false
+                };
+            }
+
             var builder = new StringBuilder();
             var length = theString.Length;
             var hasEscapes = false;


### PR DESCRIPTION
### Description

Most device decriptor fields are null-checked in ComparePropertyToDeviceDescriptor, however the addition of MakeEscapedJsonString meant that 'capabilities' was not being checked anymore, and so could throw a null-ref exception if a device didn't fill this field.

### Changes made

This change adds a null/empty string check to MakeEscapedJsonString to mirror the old behaviour.
Additionally this'll also now mean any devices with an empty non-null string can skip a minor StringBuilder allocation.

### Testing

Local testing with gamepads to see that the resulting comparisons in ComparePropertyToDeviceDescriptor still work correctly. This was tested between null, empty, and valid json string inputs.

A new unit test has been added too to exercise the null-input path.
Unit tests were also ran.

### Risk

Minor difference in construction of a default JsonString (with a non-null text field).

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
