### PR TITLE
FIX: Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes (ISXB-656)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -365,6 +365,33 @@ internal class OnScreenTests : CoreTestsFixture
         Assert.That(InputSystem.devices, Has.None.InstanceOf<Keyboard>());
     }
 
+    [Test]
+    [Category("Devices")]
+    public void Devices_DisablingLastOnScreenControlDoesReportActiveControl()
+    {
+        var gameObject = new GameObject();
+
+        Assert.That(OnScreenControl.HasAnyActive, Is.False);
+        
+        var buttonA = gameObject.AddComponent<OnScreenButton>();
+
+        Assert.That(OnScreenControl.HasAnyActive, Is.True);
+
+        var buttonB = gameObject.AddComponent<OnScreenButton>();
+        buttonA.controlPath = "/<Keyboard>/a";
+        buttonB.controlPath = "/<Keyboard>/b";
+        
+        Assert.That(OnScreenControl.HasAnyActive, Is.True);
+
+        buttonA.enabled = false;
+
+        Assert.That(OnScreenControl.HasAnyActive, Is.True);
+
+        buttonB.enabled = false;
+
+        Assert.That(OnScreenControl.HasAnyActive, Is.False);
+    }
+
     // https://fogbugz.unity3d.com/f/cases/1271942
     [UnityTest]
     [Category("Devices")]

--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -372,7 +372,7 @@ internal class OnScreenTests : CoreTestsFixture
         var gameObject = new GameObject();
 
         Assert.That(OnScreenControl.HasAnyActive, Is.False);
-        
+
         var buttonA = gameObject.AddComponent<OnScreenButton>();
 
         Assert.That(OnScreenControl.HasAnyActive, Is.True);
@@ -380,7 +380,7 @@ internal class OnScreenTests : CoreTestsFixture
         var buttonB = gameObject.AddComponent<OnScreenButton>();
         buttonA.controlPath = "/<Keyboard>/a";
         buttonB.controlPath = "/<Keyboard>/b";
-        
+
         Assert.That(OnScreenControl.HasAnyActive, Is.True);
 
         buttonA.enabled = false;

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -17,6 +17,7 @@ using UnityEngine.TestTools.Constraints;
 using Object = UnityEngine.Object;
 using Gyroscope = UnityEngine.InputSystem.Gyroscope;
 using Is = UnityEngine.TestTools.Constraints.Is;
+using UnityEngine.InputSystem.OnScreen;
 
 /// <summary>
 /// Tests for <see cref="PlayerInput"/> and <see cref="PlayerInputManager"/>.
@@ -661,6 +662,66 @@ internal class PlayerInputTests : CoreTestsFixture
             new Message("OnControlsChanged", playerInput), // Control scheme switch.
             new Message("OnFire", 1f)
         }));
+    }
+
+    [Test]
+    [Category("PlayerInput")]
+    public void PlayerInput_AutoSwitchControlSchemesInSinglePlayerWithOnScreenControl_AutoSwitchToTargetDeviceAndIgnoreMouse()
+    {
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        var mouse = InputSystem.AddDevice<Mouse>();
+       
+        var go = new GameObject();
+
+        var onScreenButton = go.AddComponent<OnScreenButton>();
+        onScreenButton.enabled = false;
+        onScreenButton.controlPath = "<Gamepad>/buttonSouth";
+
+        var listener = go.AddComponent<MessageListener>();
+        var playerInput = go.AddComponent<PlayerInput>();
+        playerInput.defaultControlScheme = "Keyboard&Mouse";
+        playerInput.defaultActionMap = "gameplay";
+        playerInput.actions = InputActionAsset.FromJson(kActions);
+        listener.messages.Clear();
+
+        Assert.That(playerInput.devices, Is.EquivalentTo(new InputDevice[] { keyboard, mouse }));
+
+        // enable the OnScreenButton, it should switch to Gamepad
+        onScreenButton.enabled = true;
+        var gamepad = onScreenButton.control.device;
+        Assert.That(gamepad, Is.TypeOf<Gamepad>());
+        Assert.That(playerInput.devices, Is.EquivalentTo(new InputDevice[] { gamepad }));
+        Assert.That(playerInput.user.controlScheme, Is.Not.Null);
+        Assert.That(playerInput.user.controlScheme.Value.name, Is.EqualTo("Gamepad"));
+
+        // Perform mouse move and click. to try to switch to Keyboard&Mouse scheme
+        Move(mouse.position, new Vector2(0.123f, 0.234f));
+        Click(mouse.leftButton);
+        Move(mouse.position, new Vector2(100f, 100f));
+        InputSystem.Update();
+
+        // The controlScheme shouldn't have changed
+        Assert.That(playerInput.devices, Is.EquivalentTo(new[] { gamepad }));
+        Assert.That(playerInput.user.controlScheme, Is.Not.Null);
+        Assert.That(playerInput.user.controlScheme.Value.name, Is.EqualTo("Gamepad"));
+
+
+        // Perform mouse move and click. to try to switch to Keyboard&Mouse scheme
+        Move(mouse.position, new Vector2(0.123f, 0.234f));
+        Click(mouse.leftButton);
+        Move(mouse.position, new Vector2(100f, 100f));
+
+        // disabling the OnScreenButton to ensure that it will now switch to Keyboard&Mouse as expected
+        onScreenButton.enabled = false;
+
+        // Perform mouse move and click. to try to switch to Keyboard&Mouse scheme
+        Move(mouse.position, new Vector2(0.123f, 0.234f));
+        Click(mouse.leftButton);
+        Move(mouse.position, new Vector2(100f, 100f));
+
+        Assert.That(playerInput.devices, Is.EquivalentTo(new InputDevice[] { keyboard, mouse }));
+        Assert.That(playerInput.user.controlScheme, Is.Not.Null);
+        Assert.That(playerInput.user.controlScheme.Value.name, Is.EqualTo("Keyboard&Mouse"));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -670,7 +670,7 @@ internal class PlayerInputTests : CoreTestsFixture
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();
         var mouse = InputSystem.AddDevice<Mouse>();
-       
+
         var go = new GameObject();
 
         var onScreenButton = go.AddComponent<OnScreenButton>();

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -677,12 +677,10 @@ internal class PlayerInputTests : CoreTestsFixture
         onScreenButton.enabled = false;
         onScreenButton.controlPath = "<Gamepad>/buttonSouth";
 
-        var listener = go.AddComponent<MessageListener>();
         var playerInput = go.AddComponent<PlayerInput>();
         playerInput.defaultControlScheme = "Keyboard&Mouse";
         playerInput.defaultActionMap = "gameplay";
         playerInput.actions = InputActionAsset.FromJson(kActions);
-        listener.messages.Clear();
 
         Assert.That(playerInput.devices, Is.EquivalentTo(new InputDevice[] { keyboard, mouse }));
 
@@ -704,12 +702,6 @@ internal class PlayerInputTests : CoreTestsFixture
         Assert.That(playerInput.devices, Is.EquivalentTo(new[] { gamepad }));
         Assert.That(playerInput.user.controlScheme, Is.Not.Null);
         Assert.That(playerInput.user.controlScheme.Value.name, Is.EqualTo("Gamepad"));
-
-
-        // Perform mouse move and click. to try to switch to Keyboard&Mouse scheme
-        Move(mouse.position, new Vector2(0.123f, 0.234f));
-        Click(mouse.leftButton);
-        Move(mouse.position, new Vector2(100f, 100f));
 
         // disabling the OnScreenButton to ensure that it will now switch to Keyboard&Mouse as expected
         onScreenButton.enabled = false;

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -2590,9 +2590,9 @@ internal partial class UITests : CoreTestsFixture
         Assert.Fail();
     }
 
-    [UnityTest]
+    [Test]
     [Category("UI")]
-    public IEnumerator UI_ClickDraggingMouseDoesNotAllocateGCMemory()
+    public void UI_ClickDraggingMouseDoesNotAllocateGCMemory()
     {
         var mouse = InputSystem.AddDevice<Mouse>();
 
@@ -2630,9 +2630,8 @@ internal partial class UITests : CoreTestsFixture
         Release(mouse.leftButton);
         scene.eventSystem.InvokeUpdate();
 
-        // Waiting for a frame to ensure that everythings was updated.
-        // Linux seems to require it when this test is run along a "brunch" of other tests.
-        yield return null;
+        // Process all queued UI events to ensure that next events will not make the events list capacity growing
+        UnityEngine.InputForUI.EventProvider.NotifyUpdate();
 
         var kProfilerRegion = "UI_ClickDraggingDoesNotAllocateGCMemory";
 

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -2590,9 +2590,9 @@ internal partial class UITests : CoreTestsFixture
         Assert.Fail();
     }
 
-    [Test]
+    [UnityTest]
     [Category("UI")]
-    public void UI_ClickDraggingMouseDoesNotAllocateGCMemory()
+    public IEnumerator UI_ClickDraggingMouseDoesNotAllocateGCMemory()
     {
         var mouse = InputSystem.AddDevice<Mouse>();
 
@@ -2629,6 +2629,10 @@ internal partial class UITests : CoreTestsFixture
         scene.eventSystem.InvokeUpdate();
         Release(mouse.leftButton);
         scene.eventSystem.InvokeUpdate();
+
+        // Waiting for a frame to ensure that everythings was updated.
+        // Linux seems to require it when this test is run along a "brunch" of other tests.
+        yield return null;
 
         var kProfilerRegion = "UI_ClickDraggingDoesNotAllocateGCMemory";
 

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -2630,8 +2630,10 @@ internal partial class UITests : CoreTestsFixture
         Release(mouse.leftButton);
         scene.eventSystem.InvokeUpdate();
 
+#if UNITY_2023_2_OR_NEWER // UnityEngine.InputForUI Module unavailable in earlier releases
         // Process all queued UI events to ensure that next events will not make the events list capacity growing
         UnityEngine.InputForUI.EventProvider.NotifyUpdate();
+#endif
 
         var kProfilerRegion = "UI_ClickDraggingDoesNotAllocateGCMemory";
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,9 +17,11 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch. [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
 - Fixed ISubmitHandler.OnSubmit event processing when operating in Manual Update mode (ISXB-1141)
 - Fixed Rename mode is not entered and name is autocompleted to default when creating a new Action Map on 2022.3. [ISXB-1151](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1151)
+- Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes which registed "Cancel" event on every frame.[ISXB-656](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086)
+- Changed `OnScreenControl` to automaticaly switch, in Single Player with autoswitch enabled, to the target device control scheme when the first component is enabled to prevent bad interactions when it start.
 
 ## [1.11.2] - 2024-10-16
 
@@ -30,13 +32,11 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "AnalyticsResult" errors on consoles [ISXB-1107]
 - Fixed wrong `Display Index` value for touchscreen events.[ISXB-1101](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1101)
 - Fixed event handling when using Fixed Update processing where WasPressedThisFrame could appear to true for consecutive frames [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1006)
+- Removed a redundant warning when using fallback code to parse a HID descriptor. (UUM-71260)
 
 ### Added
 - Added the display of the device flag `CanRunInBackground` in device debug view.
 - Added analytics for programmatic `InputAction` setup via `InputActionSetupExtensions` when exiting play-mode.
-
-### Fixed
-- Removed a redundant warning when using fallback code to parse a HID descriptor. (UUM-71260)
 
 ### Changed
 - Removed the InputManager to InputSystem project-wide asset migration code for performance improvement (ISX-2086)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
@@ -2,6 +2,7 @@ using System;
 using Unity.Collections;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
 
 ////REVIEW: should we make this ExecuteInEditMode?
@@ -34,6 +35,14 @@ namespace UnityEngine.InputSystem.OnScreen
     /// types of device layouts (e.g. one control references 'buttonWest' on
     /// a gamepad and another references 'leftButton' on a mouse), then a device
     /// is created for each type referenced by the setup.
+    /// 
+    /// The <see cref="OnScreenControl"/> works by simulating events from the device specified in the <see cref="OnScreenControl.controlPath"/>
+    /// property. Some parts of the Input System, such as the <see cref="PlayerInput"/> component, can be set up to
+    /// auto-switch <see cref="PlayerInput.neverAutoSwitchControlSchemes"/> to a new device when input from them is detected.
+    /// When a device is switched, any currently running inputs from the previously active device are cancelled.
+    ///
+    /// To avoid this situation, you need to ensure, depending on your case, that the Mouse, Pen, Touchsceen and/or XRController devices are not used in a concurent 
+    /// control schemes of the simulated device.
     /// </remarks>
     public abstract class OnScreenControl : MonoBehaviour
     {
@@ -208,13 +217,46 @@ namespace UnityEngine.InputSystem.OnScreen
             InputSystem.QueueEvent(m_InputEventPtr);
         }
 
+
+        // Used by PlayerInput auto switch for scheme to prevent using Pointer device. 
+        internal static bool HasAnyActive => s_nbActiveInstances != 0;
+        private static int s_nbActiveInstances = 0;
+
         protected virtual void OnEnable()
         {
+            ++s_nbActiveInstances;
             SetupInputControl();
+            if (m_Control == null)
+                return;
+            // if we are in single player and if it the first active switch to the target device.
+            if (s_nbActiveInstances == 1 &&
+                PlayerInput.isSinglePlayer)
+            {
+                var firstPlayer = PlayerInput.GetPlayerByIndex(0);
+                if (firstPlayer?.neverAutoSwitchControlSchemes == false)
+                {
+                    var devices = firstPlayer.devices;
+                    bool deviceFound = false;
+                    // skip is the device is already part of the current scheme
+                    foreach (var device in devices)
+                    {
+                        if (m_Control.device.deviceId == device.deviceId)
+                        {
+                            deviceFound = true;
+                            break;
+                        }
+                    }
+                    if (!deviceFound)
+                    {
+                        firstPlayer.SwitchCurrentControlScheme(m_Control.device);
+                    }
+                }
+            }
         }
 
         protected virtual void OnDisable()
         {
+            --s_nbActiveInstances;
             if (m_Control == null)
                 return;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenControl.cs
@@ -35,13 +35,13 @@ namespace UnityEngine.InputSystem.OnScreen
     /// types of device layouts (e.g. one control references 'buttonWest' on
     /// a gamepad and another references 'leftButton' on a mouse), then a device
     /// is created for each type referenced by the setup.
-    /// 
+    ///
     /// The <see cref="OnScreenControl"/> works by simulating events from the device specified in the <see cref="OnScreenControl.controlPath"/>
     /// property. Some parts of the Input System, such as the <see cref="PlayerInput"/> component, can be set up to
     /// auto-switch <see cref="PlayerInput.neverAutoSwitchControlSchemes"/> to a new device when input from them is detected.
     /// When a device is switched, any currently running inputs from the previously active device are cancelled.
     ///
-    /// To avoid this situation, you need to ensure, depending on your case, that the Mouse, Pen, Touchsceen and/or XRController devices are not used in a concurent 
+    /// To avoid this situation, you need to ensure, depending on your case, that the Mouse, Pen, Touchsceen and/or XRController devices are not used in a concurent
     /// control schemes of the simulated device.
     /// </remarks>
     public abstract class OnScreenControl : MonoBehaviour
@@ -217,8 +217,7 @@ namespace UnityEngine.InputSystem.OnScreen
             InputSystem.QueueEvent(m_InputEventPtr);
         }
 
-
-        // Used by PlayerInput auto switch for scheme to prevent using Pointer device. 
+        // Used by PlayerInput auto switch for scheme to prevent using Pointer device.
         internal static bool HasAnyActive => s_nbActiveInstances != 0;
         private static int s_nbActiveInstances = 0;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -25,12 +25,12 @@ namespace UnityEngine.InputSystem.OnScreen
     /// property. Some parts of the Input System, such as the <see cref="PlayerInput"/> component, can be set up to
     /// auto-switch <see cref="PlayerInput.neverAutoSwitchControlSchemes"/> to a new device when input from them is detected.
     /// When a device is switched, any currently running inputs from the previously active device are cancelled.
-    /// In the case of <see cref="OnScreenStick"/>, this can mean that the <see cref="IPointerUpHandler.OnPointerUp"/> method will be called 
+    /// In the case of <see cref="OnScreenStick"/>, this can mean that the <see cref="IPointerUpHandler.OnPointerUp"/> method will be called
     /// and the stick will jump back to center, even though the pointer input has not physically been released.
     ///
     /// To avoid this situation, set the <see cref="useIsolatedInputActions"/> property to true. This will create a set of local
     /// Input Actions to drive the stick that are not cancelled when device switching occurs.
-    /// You might also need to ensure, depending on your case, that the Mouse, Pen, Touchsceen and/or XRController devices are not used in a concurent 
+    /// You might also need to ensure, depending on your case, that the Mouse, Pen, Touchsceen and/or XRController devices are not used in a concurent
     /// control schemes of the simulated device.
     /// </remarks>
     [AddComponentMenu("Input/On-Screen Stick")]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -23,13 +23,15 @@ namespace UnityEngine.InputSystem.OnScreen
     /// <remarks>
     /// The <see cref="OnScreenStick"/> works by simulating events from the device specified in the <see cref="OnScreenControl.controlPath"/>
     /// property. Some parts of the Input System, such as the <see cref="PlayerInput"/> component, can be set up to
-    /// auto-switch to a new device when input from them is detected. When a device is switched, any currently running
-    /// inputs from the previously active device are cancelled. In the case of <see cref="OnScreenStick"/>, this can mean that the
-    /// <see cref="IPointerUpHandler.OnPointerUp"/> method will be called and the stick will jump back to center, even though
-    /// the pointer input has not physically been released.
+    /// auto-switch <see cref="PlayerInput.neverAutoSwitchControlSchemes"/> to a new device when input from them is detected.
+    /// When a device is switched, any currently running inputs from the previously active device are cancelled.
+    /// In the case of <see cref="OnScreenStick"/>, this can mean that the <see cref="IPointerUpHandler.OnPointerUp"/> method will be called 
+    /// and the stick will jump back to center, even though the pointer input has not physically been released.
     ///
     /// To avoid this situation, set the <see cref="useIsolatedInputActions"/> property to true. This will create a set of local
     /// Input Actions to drive the stick that are not cancelled when device switching occurs.
+    /// You might also need to ensure, depending on your case, that the Mouse, Pen, Touchsceen and/or XRController devices are not used in a concurent 
+    /// control schemes of the simulated device.
     /// </remarks>
     [AddComponentMenu("Input/On-Screen Stick")]
     [HelpURL(InputSystem.kDocUrl + "/manual/OnScreen.html#on-screen-sticks")]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -1869,7 +1869,7 @@ namespace UnityEngine.InputSystem
             // Early out if the device isn't usable with any of our control schemes.
             var actions = all[0].actions;
             // Skip Pointer device if any OnScreenControl is active since they will use it to generate device event
-            return actions != null && (!OnScreenControl.HasAnyActive || device is not Pointer) && actions.IsUsableWithDevice(device);
+            return actions != null && (!OnScreenControl.HasAnyActive || !(device is Pointer)) && actions.IsUsableWithDevice(device);
         }
 
         private void OnUnpairedDeviceUsed(InputControl control, InputEventPtr eventPtr)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -4,6 +4,7 @@ using UnityEngine.Events;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Utilities;
+using UnityEngine.InputSystem.OnScreen;
 
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
@@ -1867,7 +1868,8 @@ namespace UnityEngine.InputSystem
         {
             // Early out if the device isn't usable with any of our control schemes.
             var actions = all[0].actions;
-            return actions != null && actions.IsUsableWithDevice(device);
+            // Skip Pointer device if any OnScreenControl is active since they will use it to generate device event
+            return actions != null && (!OnScreenControl.HasAnyActive || device is not Pointer) && actions.IsUsableWithDevice(device);
         }
 
         private void OnUnpairedDeviceUsed(InputControl control, InputEventPtr eventPtr)


### PR DESCRIPTION
### Description

When using an OnScreenControl with default Control scheme with a Move Action it will trigger a Cancel event on every frame since if will autoswitch back to pointer device when the user made an input and the OnScreenControl will switch back to the emulated one.

[ISXB-656 The "Cancel" event is registered every frame when the Move action is used](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656)

### Changes made

Added an instance counter to OnScreenControl to know if there is an active one.
Added a check in player autoswitch filter to prevent switching to pointer scheme when using an OnScreenControl
Changed OnScreenControl to automatically switch to a scheme that use the emulated device to prevent some remaining interaction when is was previously using a pointer.

### Testing

added test and tested on customer project

### Risk

I added the auto switch to target device in the OnScreenControl but I'm not sure if it's the right condition.
For now it's only on the first control if it's not part of the current player device.
But it may be better to just move aways from pointer devices in all case 🤔.
(or remove that part of the change)

### Checklist

Before review:

- [X ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [X ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [X ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
