### PR TITLE
FIX: Analytics errors on consoles by reverting changes from #1991

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed touch pointers being released twice causing an index out of bounds error. [ISXB-687](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-687)
 - Fixed `NullReferenceException` from disconnecting and reconnecting a GXDKGamepad.
+- Fixed "AnalyticsResult" errors on consoles [ISXB-1107]
 
 ### Added
 - Added the display of the device flag `CanRunInBackground` in device debug view.

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -393,6 +393,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public void SendAnalytic(InputAnalytics.IInputAnalytic analytic)
         {
+        #if ENABLE_CLOUD_SERVICES_ANALYTICS
             #if (UNITY_EDITOR)
                 #if (UNITY_2023_2_OR_NEWER)
             EditorAnalytics.SendAnalytic(analytic);
@@ -404,7 +405,7 @@ namespace UnityEngine.InputSystem.LowLevel
             EditorAnalytics.SendEventWithLimit(info.Name, analytic);
                     #endif // UNITY_INPUT_SYSTEM_ENABLE_ANALYTICS || UNITY_2023_1_OR_NEWER
                 #endif // UNITY_2023_2_OR_NEWER
-            #elif (ENABLE_CLOUD_SERVICES_ANALYTICS) // Implicitly: !UNITY_EDITOR && UNITY_ANALYTICS
+            #elif (UNITY_ANALYTICS) // Implicitly: !UNITY_EDITOR
             var info = analytic.info;
             Analytics.Analytics.RegisterEvent(info.Name, info.MaxEventsPerHour, info.MaxNumberOfElements, InputAnalytics.kVendorKey);
             if (analytic.TryGatherData(out var data, out var error))
@@ -412,6 +413,7 @@ namespace UnityEngine.InputSystem.LowLevel
             else
                 Debug.Log(error);     // Non fatal
             #endif //UNITY_EDITOR
+        #endif //ENABLE_CLOUD_SERVICES_ANALYTICS
         }
 
         #endif // UNITY_ANALYTICS || UNITY_EDITOR


### PR DESCRIPTION
### Description

This PR reverts changes from here: https://github.com/Unity-Technologies/InputSystem/pull/1991
As they've caused analytics errors on 22.3. For more context please check the latest #devs-input thread on slack

### Testing done

Will check building the Xbox Platform on a VM as well as Input System basics

### To Reviewers

Please try to build and run projects on your platforms on the 22.3 and U6 Editors.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
