### PR TITLE
FIX: PointerEventData.pointerId is the same when simultaneously releasing and then pressing with another finger (ISXB-845)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1719,7 +1719,6 @@ internal partial class UITests : CoreTestsFixture
 
         scene.leftChildReceiver.events.Clear();
 
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
 
@@ -1730,8 +1729,8 @@ internal partial class UITests : CoreTestsFixture
 
         var pointerIdTouch1 = ExtendedPointerEventData.MakePointerIdForTouch(touchScreen.deviceId, 1);
         var pointerIdTouch2 = ExtendedPointerEventData.MakePointerIdForTouch(touchScreen.deviceId, 2);
+        var pointerIdTouch3 = ExtendedPointerEventData.MakePointerIdForTouch(touchScreen.deviceId, 3);
 
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
 
@@ -1749,7 +1748,9 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch1).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
+
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
+        Assert.That(scene.uiModule.m_PointerStates.length, Is.EqualTo(1));
 
         scene.leftChildReceiver.events.Clear();
         scene.rightChildReceiver.events.Clear();
@@ -1758,12 +1759,15 @@ internal partial class UITests : CoreTestsFixture
         var secondPosition = scene.From640x480ToScreen(350, 200);
         EndTouch(1, firstPosition);
         BeginTouch(2, secondPosition);
+        BeginTouch(3, secondPosition);
+        MoveTouch(2, secondPosition);
         yield return null;
 
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.True);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(3), Is.True);
 
+        // Pointer 1
         Assert.That(scene.leftChildReceiver.events,
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerUp).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
@@ -1772,6 +1776,7 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
 
+        // Pointer 2
         Assert.That(scene.rightChildReceiver.events,
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerEnter).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
@@ -1788,16 +1793,44 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
 
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerMove).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+
+        // Pointer 3
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerEnter).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerDown).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+
+        Assert.That(scene.uiModule.m_PointerStates.length, Is.EqualTo(3));
+
         scene.leftChildReceiver.events.Clear();
         scene.rightChildReceiver.events.Clear();
 
         // End second touch.
         EndTouch(2, secondPosition);
+        EndTouch(3, secondPosition);
         yield return null;
 
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.True);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(3), Is.True);
 
         Assert.That(scene.leftChildReceiver.events,
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerExit).And
@@ -1815,15 +1848,25 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
 
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerUp).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+
+        Assert.That(scene.uiModule.m_PointerStates.length, Is.EqualTo(2));
+
         scene.leftChildReceiver.events.Clear();
         scene.rightChildReceiver.events.Clear();
 
         // Next frame
         yield return null;
 
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
+        Assert.That(scene.eventSystem.IsPointerOverGameObject(3), Is.False);
 
         Assert.That(scene.leftChildReceiver.events, Is.Empty);
         Assert.That(scene.rightChildReceiver.events,
@@ -1833,6 +1876,16 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerExit).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch3).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+
+        Assert.That(scene.uiModule.m_PointerStates.length, Is.Zero);
     }
 
     // https://fogbugz.unity3d.com/f/cases/1190150/
@@ -1866,8 +1919,6 @@ internal partial class UITests : CoreTestsFixture
 
             Assert.That(scene.uiModule.m_CurrentPointerType, Is.EqualTo(UIPointerType.Touch));
             Assert.That(scene.uiModule.m_PointerIds.length, Is.EqualTo(1));
-            Assert.That(scene.uiModule.m_PointerTouchControls.length, Is.EqualTo(1));
-            Assert.That(scene.uiModule.m_PointerTouchControls[0], Is.SameAs(Touchscreen.current.touches[0]));
             Assert.That(scene.leftChildReceiver.events,
                 EventSequence(
                     AllEvents("pointerType", UIPointerType.Touch),
@@ -1891,8 +1942,6 @@ internal partial class UITests : CoreTestsFixture
 
             Assert.That(scene.uiModule.m_CurrentPointerType, Is.EqualTo(UIPointerType.Touch));
             Assert.That(scene.uiModule.m_PointerIds.length, Is.EqualTo(1));
-            Assert.That(scene.uiModule.m_PointerTouchControls.length, Is.EqualTo(1));
-            Assert.That(scene.uiModule.m_PointerTouchControls[0], Is.SameAs(Touchscreen.current.touches[0]));
             Assert.That(scene.leftChildReceiver.events,
                 EventSequence(
                     AllEvents("pointerType", UIPointerType.Touch),
@@ -1909,7 +1958,6 @@ internal partial class UITests : CoreTestsFixture
 
             Assert.That(scene.uiModule.m_CurrentPointerType, Is.EqualTo(UIPointerType.None));
             Assert.That(scene.uiModule.m_PointerIds.length, Is.Zero);
-            Assert.That(scene.uiModule.m_PointerTouchControls.length, Is.Zero);
             Assert.That(scene.leftChildReceiver.events,
                 EventSequence(
                     AllEvents("pointerType", UIPointerType.Touch),

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1729,6 +1729,9 @@ internal partial class UITests : CoreTestsFixture
         BeginTouch(1, firstPosition);
         yield return null;
 
+        var pointerIdTouch1 = ExtendedPointerEventData.MakePointerIdForTouch(touchScreen.deviceId, 1);
+        var pointerIdTouch2 = ExtendedPointerEventData.MakePointerIdForTouch(touchScreen.deviceId, 2);
+
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
@@ -1738,12 +1741,14 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerEnter).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 1).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch1).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
         Assert.That(scene.leftChildReceiver.events,
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerDown).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 1).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch1).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
@@ -1766,6 +1771,7 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerUp).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 1).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch1).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
 
@@ -1773,6 +1779,7 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerEnter).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
 
@@ -1780,6 +1787,7 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerDown).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
 
@@ -1799,6 +1807,7 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerExit).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 1).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch1).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
 
@@ -1806,6 +1815,7 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerUp).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
 
@@ -1825,6 +1835,7 @@ internal partial class UITests : CoreTestsFixture
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerExit).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.touchId == 2).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
     }

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1720,7 +1720,6 @@ internal partial class UITests : CoreTestsFixture
         scene.leftChildReceiver.events.Clear();
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.False);
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
 
@@ -1733,7 +1732,6 @@ internal partial class UITests : CoreTestsFixture
         var pointerIdTouch2 = ExtendedPointerEventData.MakePointerIdForTouch(touchScreen.deviceId, 2);
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
 
@@ -1763,7 +1761,6 @@ internal partial class UITests : CoreTestsFixture
         yield return null;
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.True);
 
@@ -1799,7 +1796,6 @@ internal partial class UITests : CoreTestsFixture
         yield return null;
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.True);
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.True);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.True);
 
@@ -1826,7 +1822,6 @@ internal partial class UITests : CoreTestsFixture
         yield return null;
 
         Assert.That(scene.eventSystem.IsPointerOverGameObject(), Is.False);
-        Assert.That(scene.eventSystem.IsPointerOverGameObject(touchScreen.deviceId), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(1), Is.False);
         Assert.That(scene.eventSystem.IsPointerOverGameObject(2), Is.False);
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,7 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed an issue causing the Action context menu to not show on right click when right clicking an action in the Input Action Editor [ISXB-1134](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1134).
-- Fixed `ArgumentN- Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch. [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
+- Fixed `ArgumentNullException: Value cannot be null.` during the migration of Project-wide Input Actions from `InputManager.asset` to `InputSystem_Actions.inputactions` asset which lead do the lost of the configuration [ISXB-1105](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1105)
 - Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch. [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
 
 ### Changed

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,7 +12,8 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 - Fixed an issue causing the Action context menu to not show on right click when right clicking an action in the Input Action Editor [ISXB-1134](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1134).
-- Fixed `ArgumentNullException: Value cannot be null.` during the migration of Project-wide Input Actions from `InputManager.asset` to `InputSystem_Actions.inputactions` asset which lead do the lost of the configuration [ISXB-1105](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1105)
+- Fixed `ArgumentN- Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch. [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
+- Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch. [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -27,7 +27,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "AnalyticsResult" errors on consoles [ISXB-1107]
 - Fixed wrong `Display Index` value for touchscreen events.[ISXB-1101](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1101)
 - Fixed event handling when using Fixed Update processing where WasPressedThisFrame could appear to true for consecutive frames [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1006)
-- Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
 
 ### Added
 - Added the display of the device flag `CanRunInBackground` in device debug view.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -26,6 +26,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed "AnalyticsResult" errors on consoles [ISXB-1107]
 - Fixed wrong `Display Index` value for touchscreen events.[ISXB-1101](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1101)
 - Fixed event handling when using Fixed Update processing where WasPressedThisFrame could appear to true for consecutive frames [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1006)
+- Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
 
 ### Added
 - Added the display of the device flag `CanRunInBackground` in device debug view.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1746,8 +1746,7 @@ namespace UnityEngine.InputSystem.UI
                 ref var pointerState = ref GetPointerStateForIndex(touchControlIndex);
 
                 if (!(pointerTouchControl is TouchControl) ||
-                    (pointerTouchControl is TouchControl &&
-                     pointerState.eventData.touchId == ((TouchControl)pointerTouchControl).touchId.value))
+                    (pointerState.eventData.touchId == ((TouchControl)pointerTouchControl).touchId.value))
                 {
                     // For touches, we cache a reference to the control of a pointer so that we don't
                     // have to continuously do ReadValue() on the touch ID control.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1729,21 +1729,6 @@ namespace UnityEngine.InputSystem.UI
             // Determine the pointer (and touch) ID. We default the pointer ID to the device
             // ID of the InputDevice.
             var controlParent = control.parent;
-            // NOTE: m_PointerTouchControls stores references to TouchControl instances. e.g. this means that "touch0"
-            // in the same frame can have different touchId values.
-            var touchControlIndex = m_PointerTouchControls.IndexOfReference(controlParent);
-            if (touchControlIndex != -1)
-            {
-                // Pointers are deallocated in the frame after their release (unpressed), which means the pointer state
-                // and the m_PointerTouchControls entry is only removed in the next frame
-                // (see UI_TouchPointersAreKeptForOneFrameAfterRelease).
-                // To accomodate for cases when touch is released and pressed in the same frame, the pointer
-                // state touchId needs to be checked against the cached touch control touchId (in m_PointerTouchControls)
-                // This is because the pointer state of the released touch (unpressed) still exists.
-                // If touchIDs are different, a new pointer should be allocated. Otherwise, a cached reference will
-                // be used.
-                var pointerTouchControl = m_PointerTouchControls[touchControlIndex];
-                ref var pointerState = ref GetPointerStateForIndex(touchControlIndex);
 
                 if (!(pointerTouchControl is TouchControl) ||
                     (pointerState.eventData.touchId == ((TouchControl)pointerTouchControl).touchId.value))

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1789,18 +1789,15 @@ namespace UnityEngine.InputSystem.UI
             // NOTE: This is a linear search but m_PointerIds is only IDs and the number of concurrent pointers
             //       should be very low at any one point (in fact, we don't generally expect to have more than one
             //       which is why we are using InlinedArrays).
-            if (touchId == 0) // Not necessary for touches; see above.
+            for (var i = 0; i < m_PointerIds.length; i++)
             {
-                for (var i = 0; i < m_PointerIds.length; i++)
+                if (m_PointerIds[i] == pointerId)
                 {
-                    if (m_PointerIds[i] == pointerId)
-                    {
-                        // Existing entry found. Make it the current pointer.
-                        m_CurrentPointerId = pointerId;
-                        m_CurrentPointerIndex = i;
-                        m_CurrentPointerType = m_PointerStates[i].pointerType;
-                        return i;
-                    }
+                    // Existing entry found. Make it the current pointer.
+                    m_CurrentPointerId = pointerId;
+                    m_CurrentPointerIndex = i;
+                    m_CurrentPointerType = m_PointerStates[i].pointerType;
+                    return i;
                 }
             }
 
@@ -1946,7 +1943,6 @@ namespace UnityEngine.InputSystem.UI
 
             // Allocate state.
             m_PointerIds.AppendWithCapacity(pointerId);
-            m_PointerTouchControls.AppendWithCapacity(touchControl);
             return m_PointerStates.AppendWithCapacity(new PointerModel(eventData));
         }
 
@@ -1991,7 +1987,6 @@ namespace UnityEngine.InputSystem.UI
             // Remove. Note that we may change the order of pointers here. This can save us needless copying
             // and m_CurrentPointerIndex should be the only index we get around for longer.
             m_PointerIds.RemoveAtByMovingTailWithCapacity(index);
-            m_PointerTouchControls.RemoveAtByMovingTailWithCapacity(index);
             m_PointerStates.RemoveAtByMovingTailWithCapacity(index);
             Debug.Assert(m_PointerIds.length == m_PointerStates.length, "Pointer ID array should match state array in length");
 
@@ -2491,7 +2486,6 @@ namespace UnityEngine.InputSystem.UI
         [NonSerialized] private int m_CurrentPointerIndex = -1;
         [NonSerialized] internal UIPointerType m_CurrentPointerType = UIPointerType.None;
         internal InlinedArray<int> m_PointerIds; // Index in this array maps to index in m_PointerStates. Separated out to make searching more efficient (we do a linear search).
-        internal InlinedArray<InputControl> m_PointerTouchControls;
         internal InlinedArray<PointerModel> m_PointerStates;
 
         // Navigation-type input.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1721,27 +1721,9 @@ namespace UnityEngine.InputSystem.UI
             ////REVIEW: Any way we can cut down on the hops all over memory that we're doing here?
             var device = control.device;
 
-            ////TODO: We're repeatedly inspecting the control setup here. Do this once and only redo it if the control setup changes.
-
-            ////REVIEW: It seems wrong that we are picking up an input here that is *NOT* reflected in our actions. We just end
-            ////        up reading a touchId control implicitly instead of allowing actions to deliver IDs to us. On the other hand,
-            ////        making that setup explicit in actions may be quite awkward and not nearly as robust.
             // Determine the pointer (and touch) ID. We default the pointer ID to the device
             // ID of the InputDevice.
             var controlParent = control.parent;
-
-                if (!(pointerTouchControl is TouchControl) ||
-                    (pointerState.eventData.touchId == ((TouchControl)pointerTouchControl).touchId.value))
-                {
-                    // For touches, we cache a reference to the control of a pointer so that we don't
-                    // have to continuously do ReadValue() on the touch ID control.
-                    m_CurrentPointerId = m_PointerIds[touchControlIndex];
-                    m_CurrentPointerIndex = touchControlIndex;
-                    m_CurrentPointerType = UIPointerType.Touch;
-                    return touchControlIndex;
-                }
-            }
-
             var pointerId = device.deviceId;
             var touchId = 0;
             var touchPosition = Vector2.zero;


### PR DESCRIPTION
### Description

Fix for https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845

A new pointer was not being created when we released and pressed a finger in the same frame, even though a new touchId was being produced by the native side.

This PR fixes that by looking into pointerIds instead of cached pointer controls. The cached pointer controls wouldn't reflect the control with the correct touchId when we release and press a touch control in the same frame.

### Testing status & QA

Please test the bug project with and without this PR on a mobile device (Android or iOS)

For example, to reproduce the issue (more instructions in the bug report):
1. Press and hold with one finger on the left panel (left panel is green)
2. Quickly release the finger and press it with another on the right panel
3. The right will not stay green. This means OnPointerDown wasn't called for this pointer ❌

With the PR, in this example, step 3 should show the right panel green ✅

### Overall Product Risks

Low

- Complexity: Low
- Halo Effect: Low


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
