### PR TITLE
NEW: Add instability detection automation to test jobs

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -83,4 +83,5 @@ test_category:
 instabilities_install_win: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.bat --output run_standalone_instability_detection-latest.bat --retry 5 || exit 0
 instabilities_run_win: run_standalone_instability_detection-latest.bat 0.5.1 || exit 0
 
-instabilities_install_nix: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.sh --output run_standalone_instability_detection-latest.sh --retry 5 || exit 0 
+instabilities_install_nix: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.sh --output run_standalone_instability_detection-latest.sh --retry 5 || exit 0
+instabilities_run_mac: sh ./run_standalone_instability_detection-latest.sh macos 0.5.1 || exit 0

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -73,3 +73,6 @@ ios_and_tvos_macos_bokken_image: package-ci/macos-13:v4.50.0
 test_category: 
   - name: performance
   - name: all
+  
+instabilies_install_win: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.bat --output run_standalone_instability_detection-latest.bat --retry 5 || exit 0
+instabilies_run_win: run_standalone_instability_detection-latest.bat 0.1.6 || exit 0

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -75,4 +75,4 @@ test_category:
   - name: all
   
 instabilies_install_win: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.bat --output run_standalone_instability_detection-latest.bat --retry 5 || exit 0
-instabilies_run_win: run_standalone_instability_detection-latest.bat 0.1.6 || exit 0
+instabilies_run_win: run_standalone_instability_detection-latest.bat 0.5.1 || exit 0

--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -36,15 +36,18 @@ platforms_nix:
     type: Unity::VM::osx
     image: package-ci/macos-13:default
     flavor: m1.mac
+    instabilities_run: sh ./run_standalone_instability_detection-latest.sh macos 0.5.1 || exit 0
   - name: mac_standalone
     type: Unity::VM::osx
     image: package-ci/macos-13:default
     flavor: m1.mac
+    instabilities_run: sh ./run_standalone_instability_detection-latest.sh macos 0.5.1 || exit 0
     runtime: StandaloneOSX
   - name: mac_standalone_il2cpp
     type: Unity::VM::osx
     image: package-ci/macos-13:default
     flavor: m1.mac
+    instabilities_run: sh ./run_standalone_instability_detection-latest.sh macos 0.5.1 || exit 0
     runtime: StandaloneOSX
     scripting-backend: Il2Cpp
     installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP --wait --fast -u
@@ -52,15 +55,18 @@ platforms_nix:
     type: Unity::VM
     image: package-ci/ubuntu-20.04:v4.50.0
     flavor: b1.large
+    instabilities_run: sh ./run_standalone_instability_detection-latest.sh ubuntu 0.5.1 || exit 0
   - name: linux_standalone
     type: Unity::VM
     image: package-ci/ubuntu-20.04:v4.50.0
     flavor: b1.large
+    instabilities_run: sh ./run_standalone_instability_detection-latest.sh ubuntu 0.5.1 || exit 0
     runtime: StandaloneLinux64
   - name: linux_standalone_il2cpp
     type: Unity::VM
     image: package-ci/ubuntu-20.04:v4.50.0
     flavor: b1.large
+    instabilities_run: sh ./run_standalone_instability_detection-latest.sh ubuntu 0.5.1 || exit 0
     runtime: StandaloneLinux64
     scripting-backend: Il2Cpp
     installscript: unity-downloader-cli -c editor -c StandaloneSupport-IL2CPP --wait --fast -u
@@ -74,5 +80,7 @@ test_category:
   - name: performance
   - name: all
   
-instabilies_install_win: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.bat --output run_standalone_instability_detection-latest.bat --retry 5 || exit 0
-instabilies_run_win: run_standalone_instability_detection-latest.bat 0.5.1 || exit 0
+instabilities_install_win: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.bat --output run_standalone_instability_detection-latest.bat --retry 5 || exit 0
+instabilities_run_win: run_standalone_instability_detection-latest.bat 0.5.1 || exit 0
+
+instabilities_install_nix: curl -s https://artifactory.prd.it.unity3d.com/artifactory/automation-and-tooling/infrastructure-instability-detection/standalone/setup/run_standalone_instability_detection-latest.sh --output run_standalone_instability_detection-latest.sh --retry 5 || exit 0 

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -35,8 +35,8 @@
     # Now run our full test suite that sits in Assets/Tests by running UTR on our project.
     - ./utr --testproject . --timeout=1200 --editor-location=.Editor --artifacts_path=upm-ci~/test-results/isolation-com.unity.inputsystem.tests --suite=playmode {% if platform.name == "win" %} --suite=editor {% endif %} {% if category.name == "performance" %} --category=Performance {% endif %} --api-profile=NET_4_6 {% if platform.runtime %} --platform {{ platform.runtime }} {% endif %} {% if platform.scripting-backend %} --scripting-backend {{ platform.scripting-backend }} {% endif %} --report-performance-data --performance-project-id=InputSystem
   after:
-    - {{ instabilies_install_win }}
-    - {{ instabilies_run_win }}  
+    - {{ instabilities_install_win }}
+    - {{ instabilities_run_win }}  
   artifacts:
     UTR_Output.zip:
       paths:
@@ -75,6 +75,9 @@
     - mv ./Packages/com.unity.inputsystem/Samples.meta ./Assets
     # Now run our full test suite that sits in Assets/Tests by running UTR on our project.
     - ./utr --testproject . --timeout=1200 --editor-location=.Editor --artifacts_path=upm-ci~/test-results/isolation-com.unity.inputsystem.tests --suite=playmode {% if platform.name == "mac" %} --suite=editor {% endif %} {% if platform.name == "linux" %} --suite=editor {% endif %} {% if category.name == "performance" %} --category=Performance {% endif %} --api-profile=NET_4_6 {% if platform.runtime %} --platform {{ platform.runtime }} {% endif %} {% if platform.scripting-backend %} --scripting-backend {{ platform.scripting-backend }} {% endif %} --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ platform.instabilities_run }}
   artifacts:
     UTR_Output.zip:
       paths:
@@ -96,6 +99,9 @@ build_ios_{{ editor.version }}_{{ category.name }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ platform.instabilities_run }}
   artifacts:
     players:
         paths:
@@ -117,6 +123,9 @@ run_ios_{{ editor.version }}_{{ category.name }}:
   commands:
     - {{ utr_install_nix }}
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ platform.instabilities_run }}
   artifacts:
     logs:
         paths:
@@ -134,6 +143,9 @@ build_tvos_{{ editor.version }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c AppleTV -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ platform.instabilities_run }}
   artifacts:
     players:
         paths:
@@ -154,6 +166,9 @@ run_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - ./utr --suite=playmode --platform=tvOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ platform.instabilities_run }}
   artifacts:
     logs:
         paths:
@@ -172,6 +187,9 @@ build_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=Android --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --scripting-backend={{ backend.name }} --build-only --repository --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_win }}
+    - {{ instabilities_run_win }}  
   artifacts:
     players:
         paths:
@@ -205,6 +223,9 @@ run_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
     - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
     - if not exist build\test-results mkdir build\test-results
     - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
+  after:
+    - {{ instabilities_install_win }}
+    - {{ instabilities_run_win }}  
   # Set uploadable artifact paths
   artifacts:
     logs:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -34,6 +34,9 @@
     - move /Y .\Packages\com.unity.inputsystem\Samples.meta .\Assets
     # Now run our full test suite that sits in Assets/Tests by running UTR on our project.
     - ./utr --testproject . --timeout=1200 --editor-location=.Editor --artifacts_path=upm-ci~/test-results/isolation-com.unity.inputsystem.tests --suite=playmode {% if platform.name == "win" %} --suite=editor {% endif %} {% if category.name == "performance" %} --category=Performance {% endif %} --api-profile=NET_4_6 {% if platform.runtime %} --platform {{ platform.runtime }} {% endif %} {% if platform.scripting-backend %} --scripting-backend {{ platform.scripting-backend }} {% endif %} --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilies_install_win }}
+    - {{ instabilies_run_win }}  
   artifacts:
     UTR_Output.zip:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -99,6 +99,9 @@ build_ios_{{ editor.version }}_{{ category.name }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ instabilities_run_mac }}
   artifacts:
     players:
         paths:
@@ -120,6 +123,9 @@ run_ios_{{ editor.version }}_{{ category.name }}:
   commands:
     - {{ utr_install_nix }}
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem 
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ instabilities_run_mac }}
   artifacts:
     logs:
         paths:
@@ -137,6 +143,9 @@ build_tvos_{{ editor.version }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c AppleTV -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ instabilities_run_mac }}
   artifacts:
     players:
         paths:
@@ -157,6 +166,9 @@ run_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - ./utr --suite=playmode --platform=tvOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem
+  after:
+    - {{ instabilities_install_nix }}
+    - {{ instabilities_run_mac }}
   artifacts:
     logs:
         paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -99,9 +99,6 @@ build_ios_{{ editor.version }}_{{ category.name }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
-  after:
-    - {{ instabilities_install_nix }}
-    - {{ platform.instabilities_run }}
   artifacts:
     players:
         paths:
@@ -122,10 +119,7 @@ run_ios_{{ editor.version }}_{{ category.name }}:
     - .yamato/upm-ci.yml#build_ios_{{ editor.version }}_{{ category.name }}
   commands:
     - {{ utr_install_nix }}
-    - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem
-  after:
-    - {{ instabilities_install_nix }}
-    - {{ platform.instabilities_run }}
+    - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem 
   artifacts:
     logs:
         paths:
@@ -143,9 +137,6 @@ build_tvos_{{ editor.version }}:
     - {{ unity_downloader_install }}
     - unity-downloader-cli -c Editor -c AppleTV -u {{ editor.version }} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
-  after:
-    - {{ instabilities_install_nix }}
-    - {{ platform.instabilities_run }}
   artifacts:
     players:
         paths:
@@ -166,9 +157,6 @@ run_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - ./utr --suite=playmode --platform=tvOS --player-load-path=build/players --artifacts_path=build/test-results --report-performance-data --performance-project-id=InputSystem
-  after:
-    - {{ instabilities_install_nix }}
-    - {{ platform.instabilities_run }}
   artifacts:
     logs:
         paths:
@@ -222,8 +210,7 @@ run_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
   after:
     - start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
     - if not exist build\test-results mkdir build\test-results
-    - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
-  after:
+    - powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt  
     - {{ instabilities_install_win }}
     - {{ instabilities_run_win }}  
   # Set uploadable artifact paths


### PR DESCRIPTION
### Description

[ISX-2170](https://jira.unity3d.com/browse/ISX-2170) To add the instability detection to all test job runs

### Testing status & QA

All tests jobs continue to run and additional instability info is being added to yamato results tab.

### Overall Product Risks

Jobs take slightly longer for instability detection to run.

- Complexity: low
- Halo Effect: low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
