### PR TITLE
FIX:  Fixed `ArgumentNullException: Value cannot be null.` during the migration of Project-wide Input Actions (ISXB-1105)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,7 +10,11 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
+- Fixed `ArgumentNullException: Value cannot be null.` during the migration of Project-wide Input Actions from `InputManager.asset` to `InputSystem_Actions.inputactions` asset which lead do the lost of the configuration [ISXB-1105](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1105)
 
+### Changed
+- Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086)
 
 ## [1.11.2] - 2024-10-16
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ProjectWideActions/ProjectWideActionsAsset.cs
@@ -17,14 +17,25 @@ namespace UnityEngine.InputSystem.Editor
 
         internal static class ProjectSettingsProjectWideActionsAssetConverter
         {
+            private const string kAssetPathInputManager = "ProjectSettings/InputManager.asset";
+            private const string kAssetNameProjectWideInputActions = "ProjectWideInputActions";
+
             class ProjectSettingsPostprocessor : AssetPostprocessor
             {
+                private static bool migratedInputActionAssets = false;
+
 #if UNITY_2021_2_OR_NEWER
                 private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
 #else
                 private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
 #endif
                 {
+                    if (!migratedInputActionAssets)
+                    {
+                        MoveInputManagerAssetActionsToProjectWideInputActionAsset();
+                        migratedInputActionAssets = true;
+                    }
+
                     if (!Application.isPlaying)
                     {
                         // If the Library folder is deleted, InputSystem will fail to retrieve the assigned Project-wide Asset because this look-up occurs
@@ -34,6 +45,69 @@ namespace UnityEngine.InputSystem.Editor
                             InputSystem.actions = pwaAsset;
                     }
                 }
+            }
+
+            private static void MoveInputManagerAssetActionsToProjectWideInputActionAsset()
+            {
+                var objects = AssetDatabase.LoadAllAssetsAtPath(EditorHelpers.GetPhysicalPath(kAssetPathInputManager));
+                if (objects == null)
+                    return;
+
+                var inputActionsAsset = objects.FirstOrDefault(o => o != null && o.name == kAssetNameProjectWideInputActions) as InputActionAsset;
+                if (inputActionsAsset != default)
+                {
+                    // Found some actions in the InputManager.asset file
+                    //
+                    string path = ProjectWideActionsAsset.kDefaultAssetPath;
+
+                    if (File.Exists(EditorHelpers.GetPhysicalPath(path)))
+                    {
+                        // We already have a path containing inputactions, find a new unique filename
+                        //
+                        //  eg  Assets/InputSystem_Actions.inputactions ->
+                        //      Assets/InputSystem_Actions (1).inputactions ->
+                        //      Assets/InputSystem_Actions (2).inputactions ...
+                        //
+                        string[] files = Directory.GetFiles("Assets", "*.inputactions");
+                        List<string> names = new List<string>();
+                        for (int i = 0; i < files.Length; i++)
+                        {
+                            names.Add(System.IO.Path.GetFileNameWithoutExtension(files[i]));
+                        }
+                        string unique = ObjectNames.GetUniqueName(names.ToArray(), kDefaultAssetName);
+                        path = "Assets/" + unique + ".inputactions";
+                    }
+
+                    var json = inputActionsAsset.ToJson();
+                    InputActionAssetManager.SaveAsset(EditorHelpers.GetPhysicalPath(path), json);
+
+                    Debug.Log($"Migrated Project-wide Input Actions from '{kAssetPathInputManager}' to '{path}' asset");
+
+                    // Update current project-wide settings if needed (don't replace if already set to something else)
+                    //
+                    if (InputSystem.actions == null || InputSystem.actions.name == kAssetNameProjectWideInputActions)
+                    {
+                        InputSystem.actions = (InputActionAsset)AssetDatabase.LoadAssetAtPath(path, typeof(InputActionAsset));
+                        Debug.Log($"Loaded Project-wide Input Actions from '{path}' asset");
+                    }
+                }
+
+                // Handle deleting all InputActionAssets as older 1.8.0 pre release could create more than one project wide input asset in the file
+                foreach (var obj in objects)
+                {
+                    if (obj is InputActionReference)
+                    {
+                        var actionReference = obj as InputActionReference;
+                        AssetDatabase.RemoveObjectFromAsset(obj);
+                        Object.DestroyImmediate(actionReference);
+                    }
+                    else if (obj is InputActionAsset)
+                    {
+                        AssetDatabase.RemoveObjectFromAsset(obj);
+                    }
+                }
+
+                AssetDatabase.SaveAssets();
             }
         }
 


### PR DESCRIPTION
### Description

During the project migration from a pre 1.8.0 you can get an exception and lost your data.

The bug is due to a bug in the editor that fail to deserialize custom ScriptatableObject during the first re-import.
* Added back the migration code
* Added a workarround to detect the deserialize bug, restore the asset and postpone an import.
* Added a loop that deserialize all sub assets, due to an other bug to ensure that no user data are lost
* Changed the migration rule to add less overhead on the import process.

### Testing status & QA
Tested with the issue projects

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

changes without the revert
https://github.com/Unity-Technologies/InputSystem/pull/2037/commits/60569721c21f1cdf1d667c2182bf143aaab6f290

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
