### PR TITLE
FIX: Re-focus Action after RedrawUI

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
@@ -63,7 +63,7 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
         return WaitUntil(() =>
         {
             var actionItems = m_Window.rootVisualElement.Q("actions-container").Query<InputActionsTreeViewItem>().ToList();
-            if (actionItems.Count > index && actionItems[index].IsFocused == isActive)
+            if (actionItems.Count > index && actionItems[index].IsTextFieldFocused == isActive)
             {
                 return true;
             }
@@ -211,7 +211,7 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
         // Click twice to start the rename
         SimulateClickOn(actionItem[1]);
         // If the item is already focused, don't click again
-        if (!actionItem[1].IsFocused)
+        if (!actionItem[1].IsTextFieldFocused)
         {
             SimulateClickOn(actionItem[1]);
         }

--- a/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
@@ -21,9 +21,12 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
     {
         base.OneTimeSetUp();
         m_Asset = AssetDatabaseUtils.CreateAsset<InputActionAsset>();
-        m_Asset.AddActionMap("First Name");
+        var actionMap = m_Asset.AddActionMap("First Name");
         m_Asset.AddActionMap("Second Name");
         m_Asset.AddActionMap("Third Name");
+
+        actionMap.AddAction("Action One");
+        actionMap.AddAction("Action Two");
     }
 
     public override void OneTimeTearDown()
@@ -53,6 +56,19 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
             }
             return false;
         }, $"WaitForActionMapRename {index} {isActive}", timeoutSecs);
+    }
+
+    IEnumerator WaitForActionRename(int index, bool isActive, double timeoutSecs = 5.0)
+    {
+        return WaitUntil(() =>
+        {
+            var actionItems = m_Window.rootVisualElement.Q("actions-container").Query<InputActionsTreeViewItem>().ToList();
+            if (actionItems.Count > index && actionItems[index].IsFocused == isActive)
+            {
+                return true;
+            }
+            return false;
+        }, $"WaitForActionRename {index} {isActive}", timeoutSecs);
     }
 
     #endregion
@@ -172,6 +188,52 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
         Assert.That(m_Window.currentAssetInEditor.actionMaps.Count, Is.EqualTo(2));
         Assert.That(m_Window.currentAssetInEditor.actionMaps[0].name, Is.EqualTo("First Name"));
         Assert.That(m_Window.currentAssetInEditor.actionMaps[1].name, Is.EqualTo("Third Name"));
+    }
+
+    [UnityTest]
+    public IEnumerator CanRenameAction()
+    {
+        var actionContainer = m_Window.rootVisualElement.Q("actions-container");
+        var actionItem = actionContainer.Query<InputActionsTreeViewItem>().ToList();
+        Assume.That(actionItem[1].Q<Label>("name").text, Is.EqualTo("Action Two"));
+
+        m_Window.rootVisualElement.Q<TreeView>("actions-tree-view").Focus();
+        m_Window.rootVisualElement.Q<TreeView>("actions-tree-view").selectedIndex = 1;
+
+        // Selection change triggers a state change, wait for the scheduler to process the frame
+        yield return WaitForSchedulerLoop();
+        yield return WaitForNotDirty();
+        yield return WaitForFocus(m_Window.rootVisualElement.Q<TreeView>("actions-tree-view"));
+
+        // Re-fetch the actions since the UI may have refreshed.
+        actionItem = actionContainer.Query<InputActionsTreeViewItem>().ToList();
+
+        // Click twice to start the rename
+        SimulateClickOn(actionItem[1]);
+        // If the item is already focused, don't click again
+        if (!actionItem[1].IsFocused)
+        {
+            SimulateClickOn(actionItem[1]);
+        }
+
+        yield return WaitForActionRename(1, isActive: true);
+
+        // Rename the action
+        SimulateTypingText("New Name");
+
+        // Wait for rename to end
+        yield return WaitForActionRename(1, isActive: false);
+
+        // Check on the UI side
+        actionContainer = m_Window.rootVisualElement.Q("actions-container");
+        Assume.That(actionContainer, Is.Not.Null);
+        actionItem = actionContainer.Query<InputActionsTreeViewItem>().ToList();
+        Assert.That(actionItem, Is.Not.Null);
+        Assert.That(actionItem.Count, Is.EqualTo(2));
+        Assert.That(actionItem[1].Q<Label>("name").text, Is.EqualTo("New Name"));
+
+        // Check on the asset side
+        Assert.That(m_Window.currentAssetInEditor.actionMaps[0].actions[1].name, Is.EqualTo("New Name"));
     }
 }
 #endif

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -20,6 +20,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes which registed "Cancel" event on every frame.[ISXB-656](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656).
 - Fixed an issue with The "Add Control Scheme..." popup window so that it now persists until any changes are explicitly Saved or Cancelled [case ISXB-1131](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1131).
 - Fixed missing documentation for source generated Input Action Assets. This is now generated as part of the source code generation step when "Generate C# Class" is checked in the importer inspector settings.
+- Fixed arrow key navigation of Input Actions after Action rename. [ISXB-1024](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1024)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -24,6 +24,7 @@ namespace UnityEngine.InputSystem.Editor
         private readonly ScrollView m_PropertiesScrollview;
 
         private bool m_RenameOnActionAdded;
+        private bool m_FocusOnRenameActionFinish;
         private readonly CollectionViewSelectionChangeFilter m_ActionsTreeViewSelectionChangeFilter;
 
         //save TreeView element id's of individual input actions and bindings to ensure saving of expanded state
@@ -215,6 +216,8 @@ namespace UnityEngine.InputSystem.Editor
 
             // Don't want to show action properties if there's no actions.
             m_PropertiesScrollview.visible = m_ActionsTreeView.GetTreeCount() > 0;
+            
+            FinishActionRename(viewState.newElementID);
         }
 
         private void OnDraggedItem(DragPerformEvent evt)
@@ -307,6 +310,17 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionsTreeView.ScrollToItem(index);
             m_ActionsTreeView.GetRootElementForIndex(index)?.Q<InputActionsTreeViewItem>()?.FocusOnRenameTextField();
         }
+        
+        private void FinishActionRename(int id)
+        {
+            if (!m_FocusOnRenameActionFinish || id == -1)
+                return;
+            m_ActionsTreeView.ScrollToItemById(id);
+            var treeViewItem = m_ActionsTreeView.GetRootElementForId(id)?.Q<InputActionsTreeViewItem>();
+            treeViewItem?.FocusOnRenameFinish();
+
+            m_FocusOnRenameActionFinish = false;
+        }
 
         internal void AddAction()
         {
@@ -369,6 +383,8 @@ namespace UnityEngine.InputSystem.Editor
                 Dispatch(Commands.ChangeActionName(data.actionMapIndex, data.name, newName));
             else if (data.isComposite)
                 Dispatch(Commands.ChangeCompositeName(data.actionMapIndex, data.bindingIndex, newName));
+
+            m_FocusOnRenameActionFinish = true;
         }
 
         internal int GetMapCount()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -216,7 +216,7 @@ namespace UnityEngine.InputSystem.Editor
 
             // Don't want to show action properties if there's no actions.
             m_PropertiesScrollview.visible = m_ActionsTreeView.GetTreeCount() > 0;
-            
+
             FinishActionRename(viewState.newElementID);
         }
 
@@ -310,7 +310,7 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionsTreeView.ScrollToItem(index);
             m_ActionsTreeView.GetRootElementForIndex(index)?.Q<InputActionsTreeViewItem>()?.FocusOnRenameTextField();
         }
-        
+
         private void FinishActionRename(int id)
         {
             if (!m_FocusOnRenameActionFinish || id == -1)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -17,6 +17,9 @@ namespace UnityEngine.InputSystem.Editor
         private const string kRenameTextField = "rename-text-field";
         public event EventCallback<string> EditTextFinished;
 
+        // for testing purposes to know if the item is focused to accept input
+        internal bool IsFocused { get; private set; } = false;
+
         private bool m_IsEditing;
         private static InputActionsTreeViewItem s_EditingItem = null;
 
@@ -34,9 +37,13 @@ namespace UnityEngine.InputSystem.Editor
             renameTextfield.selectAllOnFocus = true;
             renameTextfield.selectAllOnMouseUp = false;
 
-
             RegisterCallback<MouseDownEvent>(OnMouseDownEventForRename);
-            renameTextfield.RegisterCallback<FocusOutEvent>(e => OnEditTextFinished());
+            renameTextfield.RegisterCallback<FocusInEvent>(e => IsFocused = true);
+            renameTextfield.RegisterCallback<FocusOutEvent>(e =>
+            {
+                OnEditTextFinished();
+                IsFocused = false;
+            });
         }
 
         public Label label => this.Q<Label>();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -105,7 +105,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             s_EditingItem?.OnEditTextFinished();
         }
-        
+
         public void FocusOnRenameFinish()
         {
             if (m_IsEditing)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -18,7 +18,7 @@ namespace UnityEngine.InputSystem.Editor
         public event EventCallback<string> EditTextFinished;
 
         // for testing purposes to know if the item is focused to accept input
-        internal bool IsFocused { get; private set; } = false;
+        internal bool IsTextFieldFocused { get; private set; } = false;
 
         private bool m_IsEditing;
         private static InputActionsTreeViewItem s_EditingItem = null;
@@ -38,11 +38,11 @@ namespace UnityEngine.InputSystem.Editor
             renameTextfield.selectAllOnMouseUp = false;
 
             RegisterCallback<MouseDownEvent>(OnMouseDownEventForRename);
-            renameTextfield.RegisterCallback<FocusInEvent>(e => IsFocused = true);
+            renameTextfield.RegisterCallback<FocusInEvent>(e => IsTextFieldFocused = true);
             renameTextfield.RegisterCallback<FocusOutEvent>(e =>
             {
                 OnEditTextFinished();
-                IsFocused = false;
+                IsTextFieldFocused = false;
             });
         }
 
@@ -116,6 +116,7 @@ namespace UnityEngine.InputSystem.Editor
             //Everything else has already been taken restored in OnEditTextFinished() but this has to happen after
             //listView/treeView reclaims the focus in RedrawUI
             label.Q<Label>().Focus();
+            IsTextFieldFocused = false;
         }
 
         async void DelayCall()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsTreeViewItem.cs
@@ -105,6 +105,18 @@ namespace UnityEngine.InputSystem.Editor
         {
             s_EditingItem?.OnEditTextFinished();
         }
+        
+        public void FocusOnRenameFinish()
+        {
+            if (m_IsEditing)
+                return;
+
+            //FocusOnRenameTextField() changes the focus to the renameTextfield explicitly, the focus needs to
+            //get moved again using a similar workaround when finished editing text
+            //Everything else has already been taken restored in OnEditTextFinished() but this has to happen after
+            //listView/treeView reclaims the focus in RedrawUI
+            label.Q<Label>().Focus();
+        }
 
         async void DelayCall()
         {


### PR DESCRIPTION
### Description

FocusOnRenameTextField() changes the focus to the renameTextfield explicitly, this moves the focus back again using a similar workaround when finished editing text.

### Testing status & QA

Tested locally on 6000. Added new CanRenameAction test.

### Overall Product Risks

- Complexity: Low
- Halo Effect: None

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [X] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.