### PR TITLE
FIX: The "Add Control Scheme..." popup now requires explicit Save/Close user action (case ISXB-1131)

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,5 +1,5 @@
 editors:
-  - version: 2021.3
+  - version: 2021.3.45f
   - version: 2022.3
     disable_tvos_run: true
   - version: 6000.0

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,7 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed ISubmitHandler.OnSubmit event processing when operating in Manual Update mode (ISXB-1141)
 - Fixed Rename mode is not entered and name is autocompleted to default when creating a new Action Map on 2022.3. [ISXB-1151](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1151)
 - Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes which registed "Cancel" event on every frame.[ISXB-656](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656)
-- Fixed an issue with The "Add Control Scheme..." popup window so that it now persists until any changes are explicitly Saved or Cancelled [case ISXB-1131](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1131))
+- Fixed an issue with The "Add Control Scheme..." popup window so that it now persists until any changes are explicitly Saved or Cancelled [case ISXB-1131](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1131)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed ISubmitHandler.OnSubmit event processing when operating in Manual Update mode (ISXB-1141)
 - Fixed Rename mode is not entered and name is autocompleted to default when creating a new Action Map on 2022.3. [ISXB-1151](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1151)
 - Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes which registed "Cancel" event on every frame.[ISXB-656](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656)
+- Fixed an issue with The "Add Control Scheme..." popup window so that it now persists until any changes are explicitly Saved or Cancelled [case ISXB-1131](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1131))
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ControlSchemesView.cs
@@ -63,7 +63,6 @@ namespace UnityEngine.InputSystem.Editor
             m_ModalWindow.Add(popupWindow);
             root.Add(m_ModalWindow);
             m_ModalWindow.StretchToParentSize();
-            m_ModalWindow.RegisterCallback<ClickEvent>(evt => CloseView());
             popupWindow.RegisterCallback<ClickEvent>(evt => evt.StopPropagation());
 
             m_ListView = controlSchemeVisualElement.Q<MultiColumnListView>(kControlSchemesListView);


### PR DESCRIPTION
### Description

Previously clicking outside the popup window (anywhere in the editor) would close the popup window.

This would leave a new blank (unnamed, orphaned) control scheme populating the UI - this was confusing.

Now this popup will persist until the user explicitly chooses to Save or Cancel.


### Testing status & QA

Manually testing the UI using the reproduction steps provided.
Local and automated testing.

### Overall Product Risks

- Complexity: minimal - it's single line change (deletion)
- Halo Effect: minimal - just affects the behaviour of this popup window

### Comments to reviewers

This issue manifested when the Input System started using the newer UIToolkit implementation of its UI.

It was a result of fixing [another issue](https://jira.unity3d.com/browse/ISX-1892) in [this PR](https://github.com/Unity-Technologies/InputSystem/pull/1874).

[Discussions ](https://unity.slack.com/archives/C04RDRXRJ1L/p1730823258485409)with @Pauliusd01 and @lyndon-unity led to this choice of behaviour change of this popup window:

- it's the least surprising for the user
- it avoids losing any unsaved changes without the user explicitly making a choice.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [x] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
