### PR TITLE
DOCS: Added auto-generated docs for auto-generated code.

### DIFF
--- a/Assets/Samples/InGameHints/InGameHintsActions.cs
+++ b/Assets/Samples/InGameHints/InGameHintsActions.cs
@@ -17,9 +17,73 @@ using UnityEngine.InputSystem.Utilities;
 
 namespace UnityEngine.InputSystem.Samples.InGameHints
 {
+    /// <summary>
+    /// Provides programmatic access to <see cref="InputActionAsset" />, <see cref="InputActionMap" />, <see cref="InputAction" /> and <see cref="InputControlScheme" /> instances defined in asset "Assets/Samples/InGameHints/InGameHintsActions.inputactions".
+    /// </summary>
+    /// <remarks>
+    /// This class is source generated and any manual edits will be discarded if the associated asset is reimported or modified.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// using namespace UnityEngine;
+    /// using UnityEngine.InputSystem;
+    /// 
+    /// // Example of using an InputActionMap named "Player" from a UnityEngine.MonoBehaviour implementing callback interface.
+    /// public class Example : MonoBehaviour, MyActions.IPlayerActions
+    /// {
+    ///     private MyActions_Actions m_Actions;                  // Source code representation of asset.
+    ///     private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
+    /// 
+    ///     void Awake()
+    ///     {
+    ///         m_Actions = new MyActions_Actions();              // Create asset object.
+    ///         m_Player = m_Actions.Player;                      // Extract action map object.
+    ///         m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
+    ///     }
+    /// 
+    ///     void OnDestroy()
+    ///     {
+    ///         m_Actions.Dispose();                              // Destroy asset object.
+    ///     }
+    /// 
+    ///     void OnEnable()
+    ///     {
+    ///         m_Player.Enable();                                // Enable all actions within map.
+    ///     }
+    /// 
+    ///     void OnDisable()
+    ///     {
+    ///         m_Player.Disable();                               // Disable all actions within map.
+    ///     }
+    /// 
+    ///     #region Interface implementation of MyActions.IPlayerActions
+    /// 
+    ///     // Invoked when "Move" action is either started, performed or canceled.
+    ///     public void OnMove(InputAction.CallbackContext context)
+    ///     {
+    ///         Debug.Log($"OnMove: {context.ReadValue&lt;Vector2&gt;()}");
+    ///     }
+    /// 
+    ///     // Invoked when "Attack" action is either started, performed or canceled.
+    ///     public void OnAttack(InputAction.CallbackContext context)
+    ///     {
+    ///         Debug.Log($"OnAttack: {context.ReadValue&lt;float&gt;()}");
+    ///     }
+    /// 
+    ///     #endregion
+    /// }
+    /// </code>
+    /// </example>
     public partial class @InGameHintsActions: IInputActionCollection2, IDisposable
     {
+        /// <summary>
+        /// Provides access to the underlying asset instance.
+        /// </summary>
         public InputActionAsset asset { get; }
+
+        /// <summary>
+        /// Constructs a new instance.
+        /// </summary>
         public @InGameHintsActions()
         {
             asset = InputActionAsset.FromJson(@"{
@@ -277,57 +341,71 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
             UnityEngine.Debug.Assert(!m_Gameplay.enabled, "This will cause a leak and performance issues, InGameHintsActions.Gameplay.Disable() has not been called.");
         }
 
+        /// <summary>
+        /// Destroys this asset and all associated <see cref="InputAction"/> instances.
+        /// </summary>
         public void Dispose()
         {
             UnityEngine.Object.Destroy(asset);
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.bindingMask" />
         public InputBinding? bindingMask
         {
             get => asset.bindingMask;
             set => asset.bindingMask = value;
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.devices" />
         public ReadOnlyArray<InputDevice>? devices
         {
             get => asset.devices;
             set => asset.devices = value;
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.controlSchemes" />
         public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Contains(InputAction)" />
         public bool Contains(InputAction action)
         {
             return asset.Contains(action);
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.GetEnumerator()" />
         public IEnumerator<InputAction> GetEnumerator()
         {
             return asset.GetEnumerator();
         }
 
+        /// <inheritdoc cref="IEnumerable.GetEnumerator()" />
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Enable()" />
         public void Enable()
         {
             asset.Enable();
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Disable()" />
         public void Disable()
         {
             asset.Disable();
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.bindings" />
         public IEnumerable<InputBinding> bindings => asset.bindings;
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.FindAction(string, bool)" />
         public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
         {
             return asset.FindAction(actionNameOrId, throwIfNotFound);
         }
 
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.FindBinding(InputBinding, out InputAction)" />
         public int FindBinding(InputBinding bindingMask, out InputAction action)
         {
             return asset.FindBinding(bindingMask, out action);
@@ -341,20 +419,59 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
         private readonly InputAction m_Gameplay_PickUp;
         private readonly InputAction m_Gameplay_Drop;
         private readonly InputAction m_Gameplay_Throw;
+        /// <summary>
+        /// Provides access to input actions defined in input action map "Gameplay".
+        /// </summary>
         public struct GameplayActions
         {
             private @InGameHintsActions m_Wrapper;
+
+            /// <summary>
+            /// Construct a new instance of the input action map wrapper class.
+            /// </summary>
             public GameplayActions(@InGameHintsActions wrapper) { m_Wrapper = wrapper; }
+            /// <summary>
+            /// Provides access to the underlying input action "Gameplay/Move".
+            /// </summary>
             public InputAction @Move => m_Wrapper.m_Gameplay_Move;
+            /// <summary>
+            /// Provides access to the underlying input action "Gameplay/Look".
+            /// </summary>
             public InputAction @Look => m_Wrapper.m_Gameplay_Look;
+            /// <summary>
+            /// Provides access to the underlying input action "Gameplay/PickUp".
+            /// </summary>
             public InputAction @PickUp => m_Wrapper.m_Gameplay_PickUp;
+            /// <summary>
+            /// Provides access to the underlying input action "Gameplay/Drop".
+            /// </summary>
             public InputAction @Drop => m_Wrapper.m_Gameplay_Drop;
+            /// <summary>
+            /// Provides access to the underlying input action "Gameplay/Throw".
+            /// </summary>
             public InputAction @Throw => m_Wrapper.m_Gameplay_Throw;
+            /// <summary>
+            /// Provides access to the underlying input action map instance.
+            /// </summary>
             public InputActionMap Get() { return m_Wrapper.m_Gameplay; }
+            /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.Enable()" />
             public void Enable() { Get().Enable(); }
+            /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.Disable()" />
             public void Disable() { Get().Disable(); }
+            /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.enabled" />
             public bool enabled => Get().enabled;
+            /// <summary>
+            /// Implicitly converts an <see ref="GameplayActions" /> to an <see ref="InputActionMap" /> instance.
+            /// </summary>
             public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
+            /// <summary>
+            /// Adds <see cref="InputAction.started"/>, <see cref="InputAction.performed"/> and <see cref="InputAction.canceled"/> callbacks provided via <param cref="instance" /> on all input actions contained in this map.
+            /// </summary>
+            /// <param name="instance">Callback instance.</param>
+            /// <remarks>
+            /// If <paramref name="instance" /> is <c>null</c> or <paramref name="instance"/> have already been added this method does nothing.
+            /// </remarks>
+            /// <seealso cref="GameplayActions" />
             public void AddCallbacks(IGameplayActions instance)
             {
                 if (instance == null || m_Wrapper.m_GameplayActionsCallbackInterfaces.Contains(instance)) return;
@@ -376,6 +493,13 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
                 @Throw.canceled += instance.OnThrow;
             }
 
+            /// <summary>
+            /// Removes <see cref="InputAction.started"/>, <see cref="InputAction.performed"/> and <see cref="InputAction.canceled"/> callbacks provided via <param cref="instance" /> on all input actions contained in this map.
+            /// </summary>
+            /// <remarks>
+            /// Calling this method when <paramref name="instance" /> have not previously been registered has no side-effects.
+            /// </remarks>
+            /// <seealso cref="GameplayActions" />
             private void UnregisterCallbacks(IGameplayActions instance)
             {
                 @Move.started -= instance.OnMove;
@@ -395,12 +519,25 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
                 @Throw.canceled -= instance.OnThrow;
             }
 
+            /// <summary>
+            /// Unregisters <param cref="instance" /> and unregisters all input action callbacks via <see cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />.
+            /// </summary>
+            /// <seealso cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />
             public void RemoveCallbacks(IGameplayActions instance)
             {
                 if (m_Wrapper.m_GameplayActionsCallbackInterfaces.Remove(instance))
                     UnregisterCallbacks(instance);
             }
 
+            /// <summary>
+            /// Replaces all existing callback instances and previously registered input action callbacks associated with them with callbacks provided via <param cref="instance" />.
+            /// </summary>
+            /// <remarks>
+            /// If <paramref name="instance" /> is <c>null</c>, calling this method will only unregister all existing callbacks but not register any new callbacks.
+            /// </remarks>
+            /// <seealso cref="GameplayActions.AddCallbacks(IGameplayActions)" />
+            /// <seealso cref="GameplayActions.RemoveCallbacks(IGameplayActions)" />
+            /// <seealso cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />
             public void SetCallbacks(IGameplayActions instance)
             {
                 foreach (var item in m_Wrapper.m_GameplayActionsCallbackInterfaces)
@@ -409,8 +546,15 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
                 AddCallbacks(instance);
             }
         }
+        /// <summary>
+        /// Provides a new <see cref="GameplayActions" /> instance referencing this action map.
+        /// </summary>
         public GameplayActions @Gameplay => new GameplayActions(this);
         private int m_GamepadSchemeIndex = -1;
+        /// <summary>
+        /// Provides access to the input control scheme.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputControlScheme" />
         public InputControlScheme GamepadScheme
         {
             get
@@ -420,6 +564,10 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
             }
         }
         private int m_KeyboardMouseSchemeIndex = -1;
+        /// <summary>
+        /// Provides access to the input control scheme.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputControlScheme" />
         public InputControlScheme KeyboardMouseScheme
         {
             get
@@ -428,12 +576,47 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
                 return asset.controlSchemes[m_KeyboardMouseSchemeIndex];
             }
         }
+        /// <summary>
+        /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "Gameplay" which allows adding and removing callbacks.
+        /// </summary>
+        /// <seealso cref="GameplayActions.AddCallbacks(IGameplayActions)" />
+        /// <seealso cref="GameplayActions.RemoveCallbacks(IGameplayActions)" />
         public interface IGameplayActions
         {
+            /// <summary>
+            /// Method invoked when associated input action "Move" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnMove(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "Look" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnLook(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "PickUp" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnPickUp(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "Drop" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnDrop(InputAction.CallbackContext context);
+            /// <summary>
+            /// Method invoked when associated input action "Throw" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+            /// </summary>
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+            /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
             void OnThrow(InputAction.CallbackContext context);
         }
     }

--- a/Assets/Samples/InGameHints/InGameHintsActions.cs
+++ b/Assets/Samples/InGameHints/InGameHintsActions.cs
@@ -27,49 +27,49 @@ namespace UnityEngine.InputSystem.Samples.InGameHints
     /// <code>
     /// using namespace UnityEngine;
     /// using UnityEngine.InputSystem;
-    /// 
+    ///
     /// // Example of using an InputActionMap named "Player" from a UnityEngine.MonoBehaviour implementing callback interface.
     /// public class Example : MonoBehaviour, MyActions.IPlayerActions
     /// {
     ///     private MyActions_Actions m_Actions;                  // Source code representation of asset.
     ///     private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
-    /// 
+    ///
     ///     void Awake()
     ///     {
     ///         m_Actions = new MyActions_Actions();              // Create asset object.
     ///         m_Player = m_Actions.Player;                      // Extract action map object.
     ///         m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
     ///     }
-    /// 
+    ///
     ///     void OnDestroy()
     ///     {
     ///         m_Actions.Dispose();                              // Destroy asset object.
     ///     }
-    /// 
+    ///
     ///     void OnEnable()
     ///     {
     ///         m_Player.Enable();                                // Enable all actions within map.
     ///     }
-    /// 
+    ///
     ///     void OnDisable()
     ///     {
     ///         m_Player.Disable();                               // Disable all actions within map.
     ///     }
-    /// 
+    ///
     ///     #region Interface implementation of MyActions.IPlayerActions
-    /// 
+    ///
     ///     // Invoked when "Move" action is either started, performed or canceled.
     ///     public void OnMove(InputAction.CallbackContext context)
     ///     {
     ///         Debug.Log($"OnMove: {context.ReadValue&lt;Vector2&gt;()}");
     ///     }
-    /// 
+    ///
     ///     // Invoked when "Attack" action is either started, performed or canceled.
     ///     public void OnAttack(InputAction.CallbackContext context)
     ///     {
     ///         Debug.Log($"OnAttack: {context.ReadValue&lt;float&gt;()}");
     ///     }
-    /// 
+    ///
     ///     #endregion
     /// }
     /// </code>

--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -25,49 +25,49 @@ using UnityEngine.InputSystem.Utilities;
 /// <code>
 /// using namespace UnityEngine;
 /// using UnityEngine.InputSystem;
-/// 
+///
 /// // Example of using an InputActionMap named "Player" from a UnityEngine.MonoBehaviour implementing callback interface.
 /// public class Example : MonoBehaviour, MyActions.IPlayerActions
 /// {
 ///     private MyActions_Actions m_Actions;                  // Source code representation of asset.
 ///     private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
-/// 
+///
 ///     void Awake()
 ///     {
 ///         m_Actions = new MyActions_Actions();              // Create asset object.
 ///         m_Player = m_Actions.Player;                      // Extract action map object.
 ///         m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
 ///     }
-/// 
+///
 ///     void OnDestroy()
 ///     {
 ///         m_Actions.Dispose();                              // Destroy asset object.
 ///     }
-/// 
+///
 ///     void OnEnable()
 ///     {
 ///         m_Player.Enable();                                // Enable all actions within map.
 ///     }
-/// 
+///
 ///     void OnDisable()
 ///     {
 ///         m_Player.Disable();                               // Disable all actions within map.
 ///     }
-/// 
+///
 ///     #region Interface implementation of MyActions.IPlayerActions
-/// 
+///
 ///     // Invoked when "Move" action is either started, performed or canceled.
 ///     public void OnMove(InputAction.CallbackContext context)
 ///     {
 ///         Debug.Log($"OnMove: {context.ReadValue&lt;Vector2&gt;()}");
 ///     }
-/// 
+///
 ///     // Invoked when "Attack" action is either started, performed or canceled.
 ///     public void OnAttack(InputAction.CallbackContext context)
 ///     {
 ///         Debug.Log($"OnAttack: {context.ReadValue&lt;float&gt;()}");
 ///     }
-/// 
+///
 ///     #endregion
 /// }
 /// </code>

--- a/Assets/Samples/SimpleDemo/SimpleControls.cs
+++ b/Assets/Samples/SimpleDemo/SimpleControls.cs
@@ -15,9 +15,73 @@ using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 
+/// <summary>
+/// Provides programmatic access to <see cref="InputActionAsset" />, <see cref="InputActionMap" />, <see cref="InputAction" /> and <see cref="InputControlScheme" /> instances defined in asset "Assets/Samples/SimpleDemo/SimpleControls.inputactions".
+/// </summary>
+/// <remarks>
+/// This class is source generated and any manual edits will be discarded if the associated asset is reimported or modified.
+/// </remarks>
+/// <example>
+/// <code>
+/// using namespace UnityEngine;
+/// using UnityEngine.InputSystem;
+/// 
+/// // Example of using an InputActionMap named "Player" from a UnityEngine.MonoBehaviour implementing callback interface.
+/// public class Example : MonoBehaviour, MyActions.IPlayerActions
+/// {
+///     private MyActions_Actions m_Actions;                  // Source code representation of asset.
+///     private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
+/// 
+///     void Awake()
+///     {
+///         m_Actions = new MyActions_Actions();              // Create asset object.
+///         m_Player = m_Actions.Player;                      // Extract action map object.
+///         m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
+///     }
+/// 
+///     void OnDestroy()
+///     {
+///         m_Actions.Dispose();                              // Destroy asset object.
+///     }
+/// 
+///     void OnEnable()
+///     {
+///         m_Player.Enable();                                // Enable all actions within map.
+///     }
+/// 
+///     void OnDisable()
+///     {
+///         m_Player.Disable();                               // Disable all actions within map.
+///     }
+/// 
+///     #region Interface implementation of MyActions.IPlayerActions
+/// 
+///     // Invoked when "Move" action is either started, performed or canceled.
+///     public void OnMove(InputAction.CallbackContext context)
+///     {
+///         Debug.Log($"OnMove: {context.ReadValue&lt;Vector2&gt;()}");
+///     }
+/// 
+///     // Invoked when "Attack" action is either started, performed or canceled.
+///     public void OnAttack(InputAction.CallbackContext context)
+///     {
+///         Debug.Log($"OnAttack: {context.ReadValue&lt;float&gt;()}");
+///     }
+/// 
+///     #endregion
+/// }
+/// </code>
+/// </example>
 public partial class @SimpleControls: IInputActionCollection2, IDisposable
 {
+    /// <summary>
+    /// Provides access to the underlying asset instance.
+    /// </summary>
     public InputActionAsset asset { get; }
+
+    /// <summary>
+    /// Constructs a new instance.
+    /// </summary>
     public @SimpleControls()
     {
         asset = InputActionAsset.FromJson(@"{
@@ -172,57 +236,71 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
         UnityEngine.Debug.Assert(!m_gameplay.enabled, "This will cause a leak and performance issues, SimpleControls.gameplay.Disable() has not been called.");
     }
 
+    /// <summary>
+    /// Destroys this asset and all associated <see cref="InputAction"/> instances.
+    /// </summary>
     public void Dispose()
     {
         UnityEngine.Object.Destroy(asset);
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.bindingMask" />
     public InputBinding? bindingMask
     {
         get => asset.bindingMask;
         set => asset.bindingMask = value;
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.devices" />
     public ReadOnlyArray<InputDevice>? devices
     {
         get => asset.devices;
         set => asset.devices = value;
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.controlSchemes" />
     public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Contains(InputAction)" />
     public bool Contains(InputAction action)
     {
         return asset.Contains(action);
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.GetEnumerator()" />
     public IEnumerator<InputAction> GetEnumerator()
     {
         return asset.GetEnumerator();
     }
 
+    /// <inheritdoc cref="IEnumerable.GetEnumerator()" />
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Enable()" />
     public void Enable()
     {
         asset.Enable();
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Disable()" />
     public void Disable()
     {
         asset.Disable();
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.bindings" />
     public IEnumerable<InputBinding> bindings => asset.bindings;
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.FindAction(string, bool)" />
     public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
     {
         return asset.FindAction(actionNameOrId, throwIfNotFound);
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.FindBinding(InputBinding, out InputAction)" />
     public int FindBinding(InputBinding bindingMask, out InputAction action)
     {
         return asset.FindBinding(bindingMask, out action);
@@ -234,18 +312,51 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
     private readonly InputAction m_gameplay_fire;
     private readonly InputAction m_gameplay_move;
     private readonly InputAction m_gameplay_look;
+    /// <summary>
+    /// Provides access to input actions defined in input action map "gameplay".
+    /// </summary>
     public struct GameplayActions
     {
         private @SimpleControls m_Wrapper;
+
+        /// <summary>
+        /// Construct a new instance of the input action map wrapper class.
+        /// </summary>
         public GameplayActions(@SimpleControls wrapper) { m_Wrapper = wrapper; }
+        /// <summary>
+        /// Provides access to the underlying input action "gameplay/fire".
+        /// </summary>
         public InputAction @fire => m_Wrapper.m_gameplay_fire;
+        /// <summary>
+        /// Provides access to the underlying input action "gameplay/move".
+        /// </summary>
         public InputAction @move => m_Wrapper.m_gameplay_move;
+        /// <summary>
+        /// Provides access to the underlying input action "gameplay/look".
+        /// </summary>
         public InputAction @look => m_Wrapper.m_gameplay_look;
+        /// <summary>
+        /// Provides access to the underlying input action map instance.
+        /// </summary>
         public InputActionMap Get() { return m_Wrapper.m_gameplay; }
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.Enable()" />
         public void Enable() { Get().Enable(); }
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.Disable()" />
         public void Disable() { Get().Disable(); }
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.enabled" />
         public bool enabled => Get().enabled;
+        /// <summary>
+        /// Implicitly converts an <see ref="GameplayActions" /> to an <see ref="InputActionMap" /> instance.
+        /// </summary>
         public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
+        /// <summary>
+        /// Adds <see cref="InputAction.started"/>, <see cref="InputAction.performed"/> and <see cref="InputAction.canceled"/> callbacks provided via <param cref="instance" /> on all input actions contained in this map.
+        /// </summary>
+        /// <param name="instance">Callback instance.</param>
+        /// <remarks>
+        /// If <paramref name="instance" /> is <c>null</c> or <paramref name="instance"/> have already been added this method does nothing.
+        /// </remarks>
+        /// <seealso cref="GameplayActions" />
         public void AddCallbacks(IGameplayActions instance)
         {
             if (instance == null || m_Wrapper.m_GameplayActionsCallbackInterfaces.Contains(instance)) return;
@@ -261,6 +372,13 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
             @look.canceled += instance.OnLook;
         }
 
+        /// <summary>
+        /// Removes <see cref="InputAction.started"/>, <see cref="InputAction.performed"/> and <see cref="InputAction.canceled"/> callbacks provided via <param cref="instance" /> on all input actions contained in this map.
+        /// </summary>
+        /// <remarks>
+        /// Calling this method when <paramref name="instance" /> have not previously been registered has no side-effects.
+        /// </remarks>
+        /// <seealso cref="GameplayActions" />
         private void UnregisterCallbacks(IGameplayActions instance)
         {
             @fire.started -= instance.OnFire;
@@ -274,12 +392,25 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
             @look.canceled -= instance.OnLook;
         }
 
+        /// <summary>
+        /// Unregisters <param cref="instance" /> and unregisters all input action callbacks via <see cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />.
+        /// </summary>
+        /// <seealso cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />
         public void RemoveCallbacks(IGameplayActions instance)
         {
             if (m_Wrapper.m_GameplayActionsCallbackInterfaces.Remove(instance))
                 UnregisterCallbacks(instance);
         }
 
+        /// <summary>
+        /// Replaces all existing callback instances and previously registered input action callbacks associated with them with callbacks provided via <param cref="instance" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="instance" /> is <c>null</c>, calling this method will only unregister all existing callbacks but not register any new callbacks.
+        /// </remarks>
+        /// <seealso cref="GameplayActions.AddCallbacks(IGameplayActions)" />
+        /// <seealso cref="GameplayActions.RemoveCallbacks(IGameplayActions)" />
+        /// <seealso cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />
         public void SetCallbacks(IGameplayActions instance)
         {
             foreach (var item in m_Wrapper.m_GameplayActionsCallbackInterfaces)
@@ -288,11 +419,37 @@ public partial class @SimpleControls: IInputActionCollection2, IDisposable
             AddCallbacks(instance);
         }
     }
+    /// <summary>
+    /// Provides a new <see cref="GameplayActions" /> instance referencing this action map.
+    /// </summary>
     public GameplayActions @gameplay => new GameplayActions(this);
+    /// <summary>
+    /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "gameplay" which allows adding and removing callbacks.
+    /// </summary>
+    /// <seealso cref="GameplayActions.AddCallbacks(IGameplayActions)" />
+    /// <seealso cref="GameplayActions.RemoveCallbacks(IGameplayActions)" />
     public interface IGameplayActions
     {
+        /// <summary>
+        /// Method invoked when associated input action "fire" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnFire(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "move" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnMove(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "look" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnLook(InputAction.CallbackContext context);
     }
 }

--- a/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
+++ b/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
@@ -25,49 +25,49 @@ using UnityEngine.InputSystem.Utilities;
 /// <code>
 /// using namespace UnityEngine;
 /// using UnityEngine.InputSystem;
-/// 
+///
 /// // Example of using an InputActionMap named "Player" from a UnityEngine.MonoBehaviour implementing callback interface.
 /// public class Example : MonoBehaviour, MyActions.IPlayerActions
 /// {
 ///     private MyActions_Actions m_Actions;                  // Source code representation of asset.
 ///     private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
-/// 
+///
 ///     void Awake()
 ///     {
 ///         m_Actions = new MyActions_Actions();              // Create asset object.
 ///         m_Player = m_Actions.Player;                      // Extract action map object.
 ///         m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
 ///     }
-/// 
+///
 ///     void OnDestroy()
 ///     {
 ///         m_Actions.Dispose();                              // Destroy asset object.
 ///     }
-/// 
+///
 ///     void OnEnable()
 ///     {
 ///         m_Player.Enable();                                // Enable all actions within map.
 ///     }
-/// 
+///
 ///     void OnDisable()
 ///     {
 ///         m_Player.Disable();                               // Disable all actions within map.
 ///     }
-/// 
+///
 ///     #region Interface implementation of MyActions.IPlayerActions
-/// 
+///
 ///     // Invoked when "Move" action is either started, performed or canceled.
 ///     public void OnMove(InputAction.CallbackContext context)
 ///     {
 ///         Debug.Log($"OnMove: {context.ReadValue&lt;Vector2&gt;()}");
 ///     }
-/// 
+///
 ///     // Invoked when "Attack" action is either started, performed or canceled.
 ///     public void OnAttack(InputAction.CallbackContext context)
 ///     {
 ///         Debug.Log($"OnAttack: {context.ReadValue&lt;float&gt;()}");
 ///     }
-/// 
+///
 ///     #endregion
 /// }
 /// </code>

--- a/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
+++ b/Assets/Tests/InputSystem/InputActionCodeGeneratorActions.cs
@@ -15,9 +15,73 @@ using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Utilities;
 
+/// <summary>
+/// Provides programmatic access to <see cref="InputActionAsset" />, <see cref="InputActionMap" />, <see cref="InputAction" /> and <see cref="InputControlScheme" /> instances defined in asset "Assets/Tests/InputSystem/InputActionCodeGeneratorActions.inputactions".
+/// </summary>
+/// <remarks>
+/// This class is source generated and any manual edits will be discarded if the associated asset is reimported or modified.
+/// </remarks>
+/// <example>
+/// <code>
+/// using namespace UnityEngine;
+/// using UnityEngine.InputSystem;
+/// 
+/// // Example of using an InputActionMap named "Player" from a UnityEngine.MonoBehaviour implementing callback interface.
+/// public class Example : MonoBehaviour, MyActions.IPlayerActions
+/// {
+///     private MyActions_Actions m_Actions;                  // Source code representation of asset.
+///     private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
+/// 
+///     void Awake()
+///     {
+///         m_Actions = new MyActions_Actions();              // Create asset object.
+///         m_Player = m_Actions.Player;                      // Extract action map object.
+///         m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
+///     }
+/// 
+///     void OnDestroy()
+///     {
+///         m_Actions.Dispose();                              // Destroy asset object.
+///     }
+/// 
+///     void OnEnable()
+///     {
+///         m_Player.Enable();                                // Enable all actions within map.
+///     }
+/// 
+///     void OnDisable()
+///     {
+///         m_Player.Disable();                               // Disable all actions within map.
+///     }
+/// 
+///     #region Interface implementation of MyActions.IPlayerActions
+/// 
+///     // Invoked when "Move" action is either started, performed or canceled.
+///     public void OnMove(InputAction.CallbackContext context)
+///     {
+///         Debug.Log($"OnMove: {context.ReadValue&lt;Vector2&gt;()}");
+///     }
+/// 
+///     // Invoked when "Attack" action is either started, performed or canceled.
+///     public void OnAttack(InputAction.CallbackContext context)
+///     {
+///         Debug.Log($"OnAttack: {context.ReadValue&lt;float&gt;()}");
+///     }
+/// 
+///     #endregion
+/// }
+/// </code>
+/// </example>
 public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, IDisposable
 {
+    /// <summary>
+    /// Provides access to the underlying asset instance.
+    /// </summary>
     public InputActionAsset asset { get; }
+
+    /// <summary>
+    /// Constructs a new instance.
+    /// </summary>
     public @InputActionCodeGeneratorActions()
     {
         asset = InputActionAsset.FromJson(@"{
@@ -85,57 +149,71 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
         UnityEngine.Debug.Assert(!m_gameplay.enabled, "This will cause a leak and performance issues, InputActionCodeGeneratorActions.gameplay.Disable() has not been called.");
     }
 
+    /// <summary>
+    /// Destroys this asset and all associated <see cref="InputAction"/> instances.
+    /// </summary>
     public void Dispose()
     {
         UnityEngine.Object.Destroy(asset);
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.bindingMask" />
     public InputBinding? bindingMask
     {
         get => asset.bindingMask;
         set => asset.bindingMask = value;
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.devices" />
     public ReadOnlyArray<InputDevice>? devices
     {
         get => asset.devices;
         set => asset.devices = value;
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.controlSchemes" />
     public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Contains(InputAction)" />
     public bool Contains(InputAction action)
     {
         return asset.Contains(action);
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.GetEnumerator()" />
     public IEnumerator<InputAction> GetEnumerator()
     {
         return asset.GetEnumerator();
     }
 
+    /// <inheritdoc cref="IEnumerable.GetEnumerator()" />
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Enable()" />
     public void Enable()
     {
         asset.Enable();
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.Disable()" />
     public void Disable()
     {
         asset.Disable();
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.bindings" />
     public IEnumerable<InputBinding> bindings => asset.bindings;
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.FindAction(string, bool)" />
     public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)
     {
         return asset.FindAction(actionNameOrId, throwIfNotFound);
     }
 
+    /// <inheritdoc cref="UnityEngine.InputSystem.InputActionAsset.FindBinding(InputBinding, out InputAction)" />
     public int FindBinding(InputBinding bindingMask, out InputAction action)
     {
         return asset.FindBinding(bindingMask, out action);
@@ -146,17 +224,47 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
     private List<IGameplayActions> m_GameplayActionsCallbackInterfaces = new List<IGameplayActions>();
     private readonly InputAction m_gameplay_action1;
     private readonly InputAction m_gameplay_action2;
+    /// <summary>
+    /// Provides access to input actions defined in input action map "gameplay".
+    /// </summary>
     public struct GameplayActions
     {
         private @InputActionCodeGeneratorActions m_Wrapper;
+
+        /// <summary>
+        /// Construct a new instance of the input action map wrapper class.
+        /// </summary>
         public GameplayActions(@InputActionCodeGeneratorActions wrapper) { m_Wrapper = wrapper; }
+        /// <summary>
+        /// Provides access to the underlying input action "gameplay/action1".
+        /// </summary>
         public InputAction @action1 => m_Wrapper.m_gameplay_action1;
+        /// <summary>
+        /// Provides access to the underlying input action "gameplay/action2".
+        /// </summary>
         public InputAction @action2 => m_Wrapper.m_gameplay_action2;
+        /// <summary>
+        /// Provides access to the underlying input action map instance.
+        /// </summary>
         public InputActionMap Get() { return m_Wrapper.m_gameplay; }
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.Enable()" />
         public void Enable() { Get().Enable(); }
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.Disable()" />
         public void Disable() { Get().Disable(); }
+        /// <inheritdoc cref="UnityEngine.InputSystem.InputActionMap.enabled" />
         public bool enabled => Get().enabled;
+        /// <summary>
+        /// Implicitly converts an <see ref="GameplayActions" /> to an <see ref="InputActionMap" /> instance.
+        /// </summary>
         public static implicit operator InputActionMap(GameplayActions set) { return set.Get(); }
+        /// <summary>
+        /// Adds <see cref="InputAction.started"/>, <see cref="InputAction.performed"/> and <see cref="InputAction.canceled"/> callbacks provided via <param cref="instance" /> on all input actions contained in this map.
+        /// </summary>
+        /// <param name="instance">Callback instance.</param>
+        /// <remarks>
+        /// If <paramref name="instance" /> is <c>null</c> or <paramref name="instance"/> have already been added this method does nothing.
+        /// </remarks>
+        /// <seealso cref="GameplayActions" />
         public void AddCallbacks(IGameplayActions instance)
         {
             if (instance == null || m_Wrapper.m_GameplayActionsCallbackInterfaces.Contains(instance)) return;
@@ -169,6 +277,13 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
             @action2.canceled += instance.OnAction2;
         }
 
+        /// <summary>
+        /// Removes <see cref="InputAction.started"/>, <see cref="InputAction.performed"/> and <see cref="InputAction.canceled"/> callbacks provided via <param cref="instance" /> on all input actions contained in this map.
+        /// </summary>
+        /// <remarks>
+        /// Calling this method when <paramref name="instance" /> have not previously been registered has no side-effects.
+        /// </remarks>
+        /// <seealso cref="GameplayActions" />
         private void UnregisterCallbacks(IGameplayActions instance)
         {
             @action1.started -= instance.OnAction1;
@@ -179,12 +294,25 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
             @action2.canceled -= instance.OnAction2;
         }
 
+        /// <summary>
+        /// Unregisters <param cref="instance" /> and unregisters all input action callbacks via <see cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />.
+        /// </summary>
+        /// <seealso cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />
         public void RemoveCallbacks(IGameplayActions instance)
         {
             if (m_Wrapper.m_GameplayActionsCallbackInterfaces.Remove(instance))
                 UnregisterCallbacks(instance);
         }
 
+        /// <summary>
+        /// Replaces all existing callback instances and previously registered input action callbacks associated with them with callbacks provided via <param cref="instance" />.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="instance" /> is <c>null</c>, calling this method will only unregister all existing callbacks but not register any new callbacks.
+        /// </remarks>
+        /// <seealso cref="GameplayActions.AddCallbacks(IGameplayActions)" />
+        /// <seealso cref="GameplayActions.RemoveCallbacks(IGameplayActions)" />
+        /// <seealso cref="GameplayActions.UnregisterCallbacks(IGameplayActions)" />
         public void SetCallbacks(IGameplayActions instance)
         {
             foreach (var item in m_Wrapper.m_GameplayActionsCallbackInterfaces)
@@ -193,10 +321,30 @@ public partial class @InputActionCodeGeneratorActions: IInputActionCollection2, 
             AddCallbacks(instance);
         }
     }
+    /// <summary>
+    /// Provides a new <see cref="GameplayActions" /> instance referencing this action map.
+    /// </summary>
     public GameplayActions @gameplay => new GameplayActions(this);
+    /// <summary>
+    /// Interface to implement callback methods for all input action callbacks associated with input actions defined by "gameplay" which allows adding and removing callbacks.
+    /// </summary>
+    /// <seealso cref="GameplayActions.AddCallbacks(IGameplayActions)" />
+    /// <seealso cref="GameplayActions.RemoveCallbacks(IGameplayActions)" />
     public interface IGameplayActions
     {
+        /// <summary>
+        /// Method invoked when associated input action "action1" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnAction1(InputAction.CallbackContext context);
+        /// <summary>
+        /// Method invoked when associated input action "action2" is either <see cref="UnityEngine.InputSystem.InputAction.started" />, <see cref="UnityEngine.InputSystem.InputAction.performed" /> or <see cref="UnityEngine.InputSystem.InputAction.canceled" />.
+        /// </summary>
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.started" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.performed" />
+        /// <seealso cref="UnityEngine.InputSystem.InputAction.canceled" />
         void OnAction2(InputAction.CallbackContext context);
     }
 }

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,7 +17,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed pointerId staying the same when simultaneously releasing and then pressing in the same frame on mobile using touch. [ISXB-1006](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-845)
 - Fixed ISubmitHandler.OnSubmit event processing when operating in Manual Update mode (ISXB-1141)
 - Fixed Rename mode is not entered and name is autocompleted to default when creating a new Action Map on 2022.3. [ISXB-1151](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1151)
-- Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes which registed "Cancel" event on every frame.[ISXB-656](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656)
+- Fixed unexpected control scheme switch when using `OnScreenControl` and pointer based schemes which registed "Cancel" event on every frame.[ISXB-656](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-656).
+- Fixed missing documentation for source generated Input Action Assets. This is now generated as part of the source code generation step when "Generate C# Class" is checked in the importer inspector settings.
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -40,6 +41,54 @@ namespace UnityEngine.InputSystem.Editor
     public static class InputActionCodeGenerator
     {
         private const int kSpacesPerIndentLevel = 4;
+
+        private const string kClassExample = @"using namespace UnityEngine;
+using UnityEngine.InputSystem;
+
+// Example of using an InputActionMap named ""Player"" from a MonoBehavior implementing callback interface.
+public class Example : MonoBehaviour, MyActions.IPlayerActions
+{
+    private MyActions_Actions m_Actions;                  // Source code representation of asset.
+    private MyActions_Actions.PlayerActions m_Player;     // Source code representation of action map.
+
+    void Awake()
+    {
+        m_Actions = new MyActions_Actions();              // Create asset object.
+        m_Player = m_Actions.Player;                      // Extract action map object.
+        m_Player.AddCallbacks(this);                      // Register callback interface IPlayerActions.
+    }
+
+    void OnDestroy()
+    {
+        m_Actions.Dispose();                              // Destroy asset object.
+    }
+
+    void OnEnable()
+    {
+        m_Player.Enable();                                // Enable all actions within map.
+    }
+
+    void OnDisable()
+    {
+        m_Player.Disable();                               // Disable all actions within map.
+    }
+
+    #region Interface implementation of MyActions.IPlayerActions
+
+    // Invoked when ""Move"" action is either started, performed or canceled.
+    public void OnMove(InputAction.CallbackContext context)
+    {
+        Debug.Log($""OnMove: {context.ReadValue<Vector2>()}"");
+    }
+
+    // Invoked when ""Attack"" action is either started, performed or canceled.
+    public void OnAttack(InputAction.CallbackContext context)
+    {
+        Debug.Log($""OnAttack: {context.ReadValue<float>()}"");
+    }
+
+    #endregion
+}";
 
         public struct Options
         {
@@ -94,12 +143,22 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Begin class.
+            writer.DocSummary($"Provides programmatic access to <see cref=\"InputActionAsset\" />, " +
+                "<see cref=\"InputActionMap\" />, <see cref=\"InputAction\" /> and " +
+                "<see cref=\"InputControlScheme\" /> instances defined " +
+                $"in asset \"{options.sourceAssetPath}\".");
+            writer.DocRemarks("This class is source generated and any manual edits will be discarded if the associated asset is reimported or modified.");
+            writer.DocExample(kClassExample);
+
             writer.WriteLine($"public partial class @{options.className}: IInputActionCollection2, IDisposable");
             writer.BeginBlock();
 
+            writer.DocSummary("Provides access to the underlying asset instance.");
             writer.WriteLine($"public InputActionAsset asset {{ get; }}");
+            writer.WriteLine();
 
             // Default constructor.
+            writer.DocSummary("Constructs a new instance.");
             writer.WriteLine($"public @{options.className}()");
             writer.BeginBlock();
             writer.WriteLine($"asset = InputActionAsset.FromJson(@\"{asset.ToJson().Replace("\"", "\"\"")}\");");
@@ -131,12 +190,15 @@ namespace UnityEngine.InputSystem.Editor
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocSummary("Destroys this asset and all associated <see cref=\"InputAction\"/> instances.");
             writer.WriteLine("public void Dispose()");
             writer.BeginBlock();
             writer.WriteLine("UnityEngine.Object.Destroy(asset);");
             writer.EndBlock();
             writer.WriteLine();
 
+            var classNamePrefix = typeof(InputActionAsset).Namespace + "." + nameof(InputActionAsset) + ".";
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.bindingMask));
             writer.WriteLine("public InputBinding? bindingMask");
             writer.BeginBlock();
             writer.WriteLine("get => asset.bindingMask;");
@@ -144,6 +206,7 @@ namespace UnityEngine.InputSystem.Editor
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.devices));
             writer.WriteLine("public ReadOnlyArray<InputDevice>? devices");
             writer.BeginBlock();
             writer.WriteLine("get => asset.devices;");
@@ -151,54 +214,64 @@ namespace UnityEngine.InputSystem.Editor
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.controlSchemes));
             writer.WriteLine("public ReadOnlyArray<InputControlScheme> controlSchemes => asset.controlSchemes;");
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.Contains) + "(InputAction)");
             writer.WriteLine("public bool Contains(InputAction action)");
             writer.BeginBlock();
             writer.WriteLine("return asset.Contains(action);");
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.GetEnumerator) + "()");
             writer.WriteLine("public IEnumerator<InputAction> GetEnumerator()");
             writer.BeginBlock();
             writer.WriteLine("return asset.GetEnumerator();");
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(nameof(IEnumerable) + "." + nameof(IEnumerable.GetEnumerator) + "()");
             writer.WriteLine("IEnumerator IEnumerable.GetEnumerator()");
             writer.BeginBlock();
             writer.WriteLine("return GetEnumerator();");
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.Enable) + "()");
             writer.WriteLine("public void Enable()");
             writer.BeginBlock();
             writer.WriteLine("asset.Enable();");
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.Disable) + "()");
             writer.WriteLine("public void Disable()");
             writer.BeginBlock();
             writer.WriteLine("asset.Disable();");
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.bindings));
             writer.WriteLine("public IEnumerable<InputBinding> bindings => asset.bindings;");
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.FindAction) + "(string, bool)");
             writer.WriteLine("public InputAction FindAction(string actionNameOrId, bool throwIfNotFound = false)");
             writer.BeginBlock();
             writer.WriteLine("return asset.FindAction(actionNameOrId, throwIfNotFound);");
             writer.EndBlock();
             writer.WriteLine();
 
+            writer.DocInherit(classNamePrefix + nameof(InputActionAsset.FindBinding) + "(InputBinding, out InputAction)");
             writer.WriteLine("public int FindBinding(InputBinding bindingMask, out InputAction action)");
             writer.BeginBlock();
             writer.WriteLine("return asset.FindBinding(bindingMask, out action);");
             writer.EndBlock();
 
             // Action map accessors.
+            var inputActionMapClassPrefix = typeof(InputActionMap).Namespace + "." + nameof(InputActionMap) + ".";
             foreach (var map in maps)
             {
                 writer.WriteLine();
@@ -219,34 +292,48 @@ namespace UnityEngine.InputSystem.Editor
                 }
 
                 // Struct wrapping access to action set.
+                writer.DocSummary($"Provides access to input actions defined in input action map \"{map.name}\".");
                 writer.WriteLine($"public struct {mapTypeName}");
                 writer.BeginBlock();
 
-                // Constructor.
                 writer.WriteLine($"private @{options.className} m_Wrapper;");
+                writer.WriteLine();
+
+                // Constructor.
+                writer.DocSummary("Construct a new instance of the input action map wrapper class.");
                 writer.WriteLine($"public {mapTypeName}(@{options.className} wrapper) {{ m_Wrapper = wrapper; }}");
 
                 // Getter for each action.
                 foreach (var action in map.actions)
                 {
                     var actionName = CSharpCodeHelpers.MakeIdentifier(action.name);
+                    writer.DocSummary($"Provides access to the underlying input action \"{mapName}/{actionName}\".");
                     writer.WriteLine(
                         $"public InputAction @{actionName} => m_Wrapper.m_{mapName}_{actionName};");
                 }
 
                 // Action map getter.
+                writer.DocSummary("Provides access to the underlying input action map instance.");
                 writer.WriteLine($"public InputActionMap Get() {{ return m_Wrapper.m_{mapName}; }}");
 
                 // Enable/disable methods.
+                writer.DocInherit(inputActionMapClassPrefix + nameof(InputActionMap.Enable) + "()");
                 writer.WriteLine("public void Enable() { Get().Enable(); }");
+                writer.DocInherit(inputActionMapClassPrefix + nameof(InputActionMap.Disable) + "()");
                 writer.WriteLine("public void Disable() { Get().Disable(); }");
+                writer.DocInherit(inputActionMapClassPrefix + nameof(InputActionMap.enabled));
                 writer.WriteLine("public bool enabled => Get().enabled;");
 
                 // Implicit conversion operator.
+                writer.DocSummary($"Implicitly converts an <see ref=\"{mapTypeName}\" /> to an <see ref=\"InputActionMap\" /> instance.");
                 writer.WriteLine(
                     $"public static implicit operator InputActionMap({mapTypeName} set) {{ return set.Get(); }}");
 
                 // AddCallbacks method.
+                writer.DocSummary("Adds <see cref=\"InputAction.started\"/>, <see cref=\"InputAction.performed\"/> and <see cref=\"InputAction.canceled\"/> callbacks provided via <param cref=\"instance\" /> on all input actions contained in this map.");
+                writer.DocParam("instance", "Callback instance.");
+                writer.DocRemarks("If <paramref name=\"instance\" /> is <c>null</c> or <paramref name=\"instance\"/> have already been added this method does nothing.");
+                writer.DocSeeAlso(mapTypeName);
                 writer.WriteLine($"public void AddCallbacks(I{mapTypeName} instance)");
                 writer.BeginBlock();
 
@@ -268,6 +355,9 @@ namespace UnityEngine.InputSystem.Editor
                 writer.WriteLine();
 
                 // UnregisterCallbacks method.
+                writer.DocSummary("Removes <see cref=\"InputAction.started\"/>, <see cref=\"InputAction.performed\"/> and <see cref=\"InputAction.canceled\"/> callbacks provided via <param cref=\"instance\" /> on all input actions contained in this map.");
+                writer.DocRemarks("Calling this method when <paramref name=\"instance\" /> have not previously been registered has no side-effects.");
+                writer.DocSeeAlso(mapTypeName);
                 writer.WriteLine($"private void UnregisterCallbacks(I{mapTypeName} instance)");
                 writer.BeginBlock();
                 foreach (var action in map.actions)
@@ -283,6 +373,8 @@ namespace UnityEngine.InputSystem.Editor
                 writer.WriteLine();
 
                 // RemoveCallbacks method.
+                writer.DocSummary($"Unregisters <param cref=\"instance\" /> and unregisters all input action callbacks via <see cref=\"{mapTypeName}.UnregisterCallbacks(I{mapTypeName})\" />.");
+                writer.DocSeeAlso($"{mapTypeName}.UnregisterCallbacks(I{mapTypeName})");
                 writer.WriteLine($"public void RemoveCallbacks(I{mapTypeName} instance)");
                 writer.BeginBlock();
                 writer.WriteLine($"if (m_Wrapper.m_{mapTypeName}CallbackInterfaces.Remove(instance))");
@@ -291,9 +383,13 @@ namespace UnityEngine.InputSystem.Editor
                 writer.WriteLine();
 
                 // SetCallbacks method.
+                writer.DocSummary($"Replaces all existing callback instances and previously registered input action callbacks associated with them with callbacks provided via <param cref=\"instance\" />.");
+                writer.DocRemarks($"If <paramref name=\"instance\" /> is <c>null</c>, calling this method will only unregister all existing callbacks but not register any new callbacks.");
+                writer.DocSeeAlso($"{mapTypeName}.AddCallbacks(I{mapTypeName})");
+                writer.DocSeeAlso($"{mapTypeName}.RemoveCallbacks(I{mapTypeName})");
+                writer.DocSeeAlso($"{mapTypeName}.UnregisterCallbacks(I{mapTypeName})");
                 writer.WriteLine($"public void SetCallbacks(I{mapTypeName} instance)");
                 writer.BeginBlock();
-
                 ////REVIEW: this would benefit from having a single callback on InputActions rather than three different endpoints
 
                 writer.WriteLine($"foreach (var item in m_Wrapper.m_{mapTypeName}CallbackInterfaces)");
@@ -306,6 +402,7 @@ namespace UnityEngine.InputSystem.Editor
                 writer.EndBlock();
 
                 // Getter for instance of struct.
+                writer.DocSummary($"Provides a new <see cref=\"{mapTypeName}\" /> instance referencing this action map.");
                 writer.WriteLine($"public {mapTypeName} @{mapName} => new {mapTypeName}(this);");
             }
 
@@ -315,6 +412,8 @@ namespace UnityEngine.InputSystem.Editor
                 var identifier = CSharpCodeHelpers.MakeIdentifier(scheme.name);
 
                 writer.WriteLine($"private int m_{identifier}SchemeIndex = -1;");
+                writer.DocSummary("Provides access to the input control scheme.");
+                writer.DocSeeAlso(typeof(InputControlScheme).Namespace + "." + nameof(InputControlScheme));
                 writer.WriteLine($"public InputControlScheme {identifier}Scheme");
                 writer.BeginBlock();
                 writer.WriteLine("get");
@@ -326,15 +425,23 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             // Generate interfaces.
+            var inputActionClassReference = typeof(InputAction).Namespace + "." + nameof(InputAction) + ".";
             foreach (var map in maps)
             {
                 var typeName = CSharpCodeHelpers.MakeTypeName(map.name);
+                writer.DocSummary($"Interface to implement callback methods for all input action callbacks associated with input actions defined by \"{map.name}\" which allows adding and removing callbacks.");
+                writer.DocSeeAlso($"{typeName}Actions.AddCallbacks(I{typeName}Actions)");
+                writer.DocSeeAlso($"{typeName}Actions.RemoveCallbacks(I{typeName}Actions)");
                 writer.WriteLine($"public interface I{typeName}Actions");
                 writer.BeginBlock();
 
                 foreach (var action in map.actions)
                 {
                     var methodName = CSharpCodeHelpers.MakeTypeName(action.name);
+                    writer.DocSummary($"Method invoked when associated input action \"{action.name}\" is either <see cref=\"UnityEngine.InputSystem.InputAction.started\" />, <see cref=\"UnityEngine.InputSystem.InputAction.performed\" /> or <see cref=\"UnityEngine.InputSystem.InputAction.canceled\" />.");
+                    writer.DocSeeAlso(string.Concat(inputActionClassReference, "started"));
+                    writer.DocSeeAlso(string.Concat(inputActionClassReference, "performed"));
+                    writer.DocSeeAlso(string.Concat(inputActionClassReference, "canceled"));
                     writer.WriteLine($"void On{methodName}(InputAction.CallbackContext context);");
                 }
 
@@ -398,6 +505,65 @@ namespace UnityEngine.InputSystem.Editor
                     for (var n = 0; n < kSpacesPerIndentLevel; ++n)
                         buffer.Append(' ');
                 }
+            }
+
+            public void DocSummary(string text)
+            {
+                DocElement("summary", text);
+            }
+
+            public void DocParam(string paramName, string text)
+            {
+                WriteLine($"/// <param name=\"{paramName}\">{text}</param>");
+            }
+
+            public void DocRemarks(string text)
+            {
+                DocElement("remarks", text);
+            }
+
+            public void DocInherit(string cref)
+            {
+                DocReference("inheritdoc", cref);
+            }
+
+            public void DocSeeAlso(string cref)
+            {
+                DocReference("seealso", cref: cref);
+            }
+
+            public void DocExample(string code)
+            {
+                DocComment("<example>");
+                DocComment("<code>");
+
+                foreach (var line in code.Split('\n'))
+                    DocComment(line.Replace("<", "&lt;").Replace(">", "&gt;"));
+
+                DocComment("</code>");
+                DocComment("</example>");
+            }
+
+            private void DocComment(string text)
+            {
+                WriteLine(string.Concat("/// ", text));
+            }
+
+            private void DocElement(string tag, string text)
+            {
+                DocComment($"<{tag}>");
+                DocComment(text);
+                DocComment($"</{tag}>");
+            }
+
+            private void DocReference(string tag, string cref)
+            {
+                DocInlineElement(tag, "cref", cref);
+            }
+
+            private void DocInlineElement(string tag, string property, string value)
+            {
+                DocComment($"<{tag} {property}=\"{value}\" />");
             }
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -546,7 +546,10 @@ public class Example : MonoBehaviour, MyActions.IPlayerActions
 
             private void DocComment(string text)
             {
-                WriteLine(string.Concat("/// ", text));
+                if (string.IsNullOrEmpty(text))
+                    WriteLine("///");
+                else
+                    WriteLine(string.Concat("/// ", text));
             }
 
             private void DocElement(string tag, string text)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionCodeGenerator.cs
@@ -45,7 +45,7 @@ namespace UnityEngine.InputSystem.Editor
         private const string kClassExample = @"using namespace UnityEngine;
 using UnityEngine.InputSystem;
 
-// Example of using an InputActionMap named ""Player"" from a MonoBehavior implementing callback interface.
+// Example of using an InputActionMap named ""Player"" from a UnityEngine.MonoBehaviour implementing callback interface.
 public class Example : MonoBehaviour, MyActions.IPlayerActions
 {
     private MyActions_Actions m_Actions;                  // Source code representation of asset.


### PR DESCRIPTION
### Description

Added auto-generated docs for auto-generated code based on ticket DOCF-6090 which contains user feedback about generated API surface not being documented. This is basically a bug.

### Testing status & QA

Tested during development by generating source code from Project-wide Actions asset.

### Overall Product Risks

Small, mainly affects code generator and related documentation.

- Complexity: Small
- Halo Effect: Small

### Comments to reviewers

Review for mistakes in generated documentation. Test by generating source code from various assets and verify that documentation is linked and looks correct via e.g. intellisense tooltips in VS and Rider.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
