### PR TITLE
FIX: Fixed pasting bindings into empty Input Action asset (case ISXB-1180) - take #2

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ContextMenu.cs
@@ -25,6 +25,21 @@ namespace UnityEngine.InputSystem.Editor
         private static readonly string add_Binding_String = "Add Binding";
 
         #region ActionMaps
+        // Determine whether current clipboard contents can can pasted into the ActionMaps view
+        //
+        //  can always paste an ActionMap
+        //  need an existing map to be able to paste an Action
+        //
+        private static bool CanPasteIntoActionMaps(ActionMapsView mapView)
+        {
+            bool haveMap = mapView.GetMapCount() > 0;
+            var copiedType = CopyPasteHelper.GetCopiedClipboardType();
+            bool copyIsMap = copiedType == typeof(InputActionMap);
+            bool copyIsAction = copiedType == typeof(InputAction);
+            bool hasPastableData = (copyIsMap || (copyIsAction && haveMap));
+            return hasPastableData;
+        }
+
         public static void GetContextMenuForActionMapItem(ActionMapsView mapView, InputActionMapsTreeViewItem treeViewItem, int index)
         {
             treeViewItem.OnContextualMenuPopulateEvent = (menuEvent =>
@@ -39,9 +54,15 @@ namespace UnityEngine.InputSystem.Editor
                 menuEvent.menu.AppendAction(copy_String, _ => mapView.CopyItems());
                 menuEvent.menu.AppendAction(cut_String, _ => mapView.CutItems());
 
-                var copiedAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
-                if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
-                    menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copiedAction));
+                if (CanPasteIntoActionMaps(mapView))
+                {
+                    bool copyIsAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
+                    if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
+                        menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copyIsAction));
+                }
+
+                menuEvent.menu.AppendSeparator();
+                menuEvent.menu.AppendAction(add_Action_Map_String, _ => mapView.AddActionMap());
             });
         }
 
@@ -51,11 +72,12 @@ namespace UnityEngine.InputSystem.Editor
         {
             _ = new ContextualMenuManipulator(menuEvent =>
             {
-                var copiedAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
-                if (CopyPasteHelper.HasPastableClipboardData(typeof(InputActionMap)))
-                    menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copiedAction));
-
-                menuEvent.menu.AppendSeparator();
+                if (CanPasteIntoActionMaps(mapView))
+                {
+                    bool copyIsAction = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputAction);
+                    menuEvent.menu.AppendAction(paste_String, _ => mapView.PasteItems(copyIsAction));
+                    menuEvent.menu.AppendSeparator();
+                }
                 menuEvent.menu.AppendAction(add_Action_Map_String, _ => mapView.AddActionMap());
             }) { target = element };
         }
@@ -63,15 +85,47 @@ namespace UnityEngine.InputSystem.Editor
         #endregion
 
         #region Actions
+        // Determine whether current clipboard contents can pasted into the Actions TreeView
+        //
+        //  item selected   => can paste either Action or Binding (depends on selected item context)
+        //  empty view      => can only paste Action
+        //  no selection    => can only paste Action
+        //
+        private static bool CanPasteIntoActions(TreeView treeView)
+        {
+            bool hasPastableData = false;
+            bool selected = treeView.selectedIndex != -1;
+            if (selected)
+            {
+                var item = treeView.GetItemDataForIndex<ActionOrBindingData>(treeView.selectedIndex);
+                var itemType = item.isAction ? typeof(InputAction) : typeof(InputBinding);
+                hasPastableData = CopyPasteHelper.HasPastableClipboardData(itemType);
+            }
+            else
+            {
+                // Cannot paste Binding when no Action is selected or into an empty view
+                bool copyIsBinding = CopyPasteHelper.GetCopiedClipboardType() == typeof(InputBinding);
+                hasPastableData = !copyIsBinding && CopyPasteHelper.HasPastableClipboardData(typeof(InputAction));
+            }
+            return hasPastableData;
+        }
+
         // Add the "Paste" option to all elements in the Action area.
         public static void GetContextMenuForActionListView(ActionsTreeView actionsTreeView, TreeView treeView, VisualElement target)
         {
             _ = new ContextualMenuManipulator(menuEvent =>
             {
-                var item = treeView.GetItemDataForIndex<ActionOrBindingData>(treeView.selectedIndex);
-                var hasPastableData = CopyPasteHelper.HasPastableClipboardData(item.isAction ? typeof(InputAction) : typeof(InputBinding));
-                if (hasPastableData)
-                    menuEvent.menu.AppendAction(paste_String, _ => actionsTreeView.PasteItems());
+                bool haveMap = actionsTreeView.GetMapCount() > 0;
+                if (haveMap)
+                {
+                    bool hasPastableData = CanPasteIntoActions(treeView);
+                    if (hasPastableData)
+                    {
+                        menuEvent.menu.AppendAction(paste_String, _ => actionsTreeView.PasteItems());
+                    }
+                    menuEvent.menu.AppendSeparator();
+                    menuEvent.menu.AppendAction(add_Action_String, _ => actionsTreeView.AddAction());
+                }
             }) { target = target };
         }
 
@@ -81,13 +135,15 @@ namespace UnityEngine.InputSystem.Editor
         {
             _ = new ContextualMenuManipulator(menuEvent =>
             {
-                if (actionsTreeView.GetMapCount() > 0 && (!onlyShowIfTreeIsEmpty || treeView.GetTreeCount() == 0))
+                bool haveMap = actionsTreeView.GetMapCount() > 0;
+                if (haveMap && (!onlyShowIfTreeIsEmpty || treeView.GetTreeCount() == 0))
                 {
-                    var item = treeView.GetItemDataForIndex<ActionOrBindingData>(treeView.selectedIndex);
-                    if (CopyPasteHelper.HasPastableClipboardData(item.isAction ? typeof(InputAction) : typeof(InputBinding)))
+                    bool hasPastableData = CanPasteIntoActions(treeView);
+                    if (hasPastableData)
+                    {
                         menuEvent.menu.AppendAction(paste_String, _ => actionsTreeView.PasteItems());
-
-                    menuEvent.menu.AppendSeparator();
+                        menuEvent.menu.AppendSeparator();
+                    }
                     menuEvent.menu.AppendAction(add_Action_String, _ => actionsTreeView.AddAction());
                 }
             }) { target = target };

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
@@ -265,7 +265,7 @@ namespace UnityEngine.InputSystem.Editor
             else
             {
                 var actionName = Selectors.GetSelectedBinding(s_State)?.wrappedProperty.FindPropertyRelative("m_Action")
-                                 .stringValue;
+                    .stringValue;
 
                 if (s_State.selectionType == SelectionType.Action)
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CopyPasteHelper.cs
@@ -265,9 +265,18 @@ namespace UnityEngine.InputSystem.Editor
             else
             {
                 var actionName = Selectors.GetSelectedBinding(s_State)?.wrappedProperty.FindPropertyRelative("m_Action")
-                    .stringValue;
+                                 .stringValue;
+
                 if (s_State.selectionType == SelectionType.Action)
-                    actionName = PropertyName(Selectors.GetSelectedAction(s_State)?.wrappedProperty);
+                {
+                    SerializedProperty property = Selectors.GetSelectedAction(s_State)?.wrappedProperty;
+                    if (property == null)
+                        return;
+                    actionName = PropertyName(property);
+                }
+                if (actionName == null)
+                    return;
+
                 PasteBindingOrComposite(arrayToInsertInto, block, indexToInsert, actionName);
             }
         }


### PR DESCRIPTION
### Description

Null Reference Exceptions errors could be logged to the console window when pasting items into the Input Actions Editor window.

FIX: Fixed pasting bindings into empty Input Action asset (case ISXB-1180)
FIX: Fixed pasting newly created Action Map when copied from  from Project Settings to new Input Action Asset (case ISXB-1182)

Several issues were addressed:

- Ensure PasteBlocks() deals with invalid selection - when copied type is binding we need to have a valid Action selected to paste into.
- Improved the context menu population in the Input Actions Editor window (Action Maps and Action views):
  o Ensure Paste option is only present in context menu when appropriate.
  o Fix menu separator presence (or absense).
  o Action Maps view: can Paste ActionMap or Action (if a map is present).
  o Actions view: can paste Actions or Bindings depending on selected item context.

### Testing status & QA

Local testing / automated tests.

### Overall Product Risks

Relatively small - only affects the context menu in the Input Actions Editor window.

Complexity: 0
Halo Effect: 0

### Comments to reviewers

None in particular - I tried lots of copy / paste with various selections & no selection made, including after deleting an item previously selected.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
