### PR TITLE
FIX: Escape the ampersand character from Control Scheme dropdown menu on Windows platform

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed missing documentation for source generated Input Action Assets. This is now generated as part of the source code generation step when "Generate C# Class" is checked in the importer inspector settings.
 - Fixed pasting into an empty map list raising an exception. [ISXB-1150](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1150)
 - Fixed pasting bindings into empty Input Action asset. [ISXB-1180](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1180)
+- Fixed missing '&' symbol in Control Scheme dropdown on Windows platform. [ISXB-1109](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1109)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -138,6 +138,18 @@ namespace UnityEngine.InputSystem.Editor
             m_SaveButton.SetEnabled(InputEditorUserSettings.autoSaveInputActionAssets == false);
         }
 
+        private string SetupControlSchemeName(string name)
+        {
+            //On Windows the '&' is considered an accelerator character and will always be stripped.
+            //Since the ControlScheme menu isn't creating hotkeys, it can be safely assumed that they are meant to be text
+            //so we want to escape the character for MenuItem
+            if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                name = name.Replace("&", "&&");
+            }
+            return name;
+        }
+
         private void SetUpControlSchemesMenu(ViewState viewState)
         {
             m_ControlSchemesToolbar.menu.MenuItems().Clear();
@@ -151,7 +163,7 @@ namespace UnityEngine.InputSystem.Editor
                 m_ControlSchemesToolbar.menu.AppendAction("All Control Schemes", _ => SelectControlScheme(-1),
                     viewState.selectedControlSchemeIndex == -1 ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
                 viewState.controlSchemes.ForEach((scheme, i) =>
-                    m_ControlSchemesToolbar.menu.AppendAction(scheme.name, _ => SelectControlScheme(i),
+                    m_ControlSchemesToolbar.menu.AppendAction(SetupControlSchemeName(scheme.name), _ => SelectControlScheme(i),
                         viewState.selectedControlSchemeIndex == i ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal));
                 m_ControlSchemesToolbar.menu.AppendSeparator();
             }


### PR DESCRIPTION
### Description

On Windows the '&' character is considered an accelerator character and will always be stripped. Since the ControlScheme menu isn't creating hotkeys, it can be safely assumed that they are meant to be text and escape the character for MenuItem.


### Testing status & QA

Local testing / automated tests

### Overall Product Risks

Windows Editor only

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers


### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [X] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [X] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
