### PR TITLE
FIX: Update icon scaling in Input Actions window

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed missing documentation for source generated Input Action Assets. This is now generated as part of the source code generation step when "Generate C# Class" is checked in the importer inspector settings.
 - Fixed pasting into an empty map list raising an exception. [ISXB-1150](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1150)
 - Fixed pasting bindings into empty Input Action asset. [ISXB-1180](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1180)
+- Fixed icon scaling in Input Actions window.
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/GUIHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/GUIHelpers.cs
@@ -43,7 +43,7 @@ namespace UnityEngine.InputSystem.Editor
         public static Texture2D LoadIcon(string name)
         {
             var skinPrefix = EditorGUIUtility.isProSkin ? "d_" : "";
-            var scale = Mathf.Clamp((int)EditorGUIUtility.pixelsPerPoint, 0, 4);
+            var scale = Mathf.Clamp(Mathf.CeilToInt(EditorGUIUtility.pixelsPerPoint), 0, 4);
             var scalePostFix = scale > 1 ? $"@{scale}x" : "";
             if (name.IndexOfAny(Path.GetInvalidFileNameChars()) > -1)
                 name = string.Join("_", name.Split(Path.GetInvalidFileNameChars()));


### PR DESCRIPTION
### Description

In **GUIHelpers.LoadIcon()** pixelsPerPoint is being cast from float to int in order to calculate scale. Using a simple cast truncates the floating point number resulting in the scale being rounded to 1 for any value from 1-1.99 and the default 1x icon being used. Any scale above 1.0 should ideally be using 2x icon and the icons will appear more clearly in Input Actions if the integer value is rounded up be default.


### Testing status & QA

Local testing

### Overall Product Risks

Value rounding for a value already clamped

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers


### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [X] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
