### PR TITLE
Fix attempt for ISXB-1066 where we still process a hold interaction despite having a more dominant interaction

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -60,6 +60,113 @@ partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_WithMultipleBindingsAndMultipleInteractions_Works()
+    {
+        InputSystem.settings.defaultButtonPressPoint = 0.5f;
+
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+
+        var action = new InputAction(interactions: "tap,hold(duration=2)");
+        action.AddBinding("<Keyboard>/w");
+        action.AddBinding("<Keyboard>/a");
+        action.Enable();
+
+        IInputInteraction performedInteraction = null;
+        IInputInteraction canceledInteraction = null;
+        action.performed += ctx =>
+        {
+            performedInteraction = ctx.interaction;
+        };
+        action.canceled += ctx =>
+        {
+            canceledInteraction = ctx.interaction;
+        };
+
+        // PressRelease AW trigger a tap
+        currentTime = 0;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A, Key.W));
+        InputSystem.Update();
+
+        // nothing triggered
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.Null);
+
+        currentTime = 0.01;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState());
+        InputSystem.Update();
+
+        // tap should be triggered
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.TypeOf(typeof(TapInteraction)));
+        performedInteraction = null;
+
+        // Should be no other remaining events
+        currentTime = 10;
+        InputSystem.Update();
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.Null);
+
+
+
+        // PressRelease AW trigger a tap
+        currentTime = 11;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A, Key.W));
+        InputSystem.Update();
+
+        // nothing triggered
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.Null);
+
+        currentTime = 11.01;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A));
+        InputSystem.Update();
+
+        currentTime = 11.02;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState());
+        InputSystem.Update();
+
+        // tap should be triggered
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.TypeOf(typeof(TapInteraction)));
+        performedInteraction = null;
+
+        // Should be no other remaining events
+        currentTime = 20;
+        InputSystem.Update();
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.Null);
+
+        // PressRelease AW trigger a tap
+        currentTime = 21;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.A, Key.W));
+        InputSystem.Update();
+
+        // nothing triggered
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.Null);
+
+        currentTime = 21.01;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState(Key.W));
+        InputSystem.Update();
+
+        currentTime = 21.02;
+        InputSystem.QueueStateEvent(keyboard, new KeyboardState());
+        InputSystem.Update();
+
+        // tap should be triggered
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.TypeOf(typeof(TapInteraction)));
+        performedInteraction = null;
+
+        // Should be no other remaining events
+        currentTime = 30;
+        InputSystem.Update();
+        Assert.That(canceledInteraction, Is.Null);
+        Assert.That(performedInteraction, Is.Null);
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_WhenShortcutsDisabled_AllConflictingActionsTrigger()
     {
         var keyboard = InputSystem.AddDevice<Keyboard>();

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -10,6 +10,7 @@ using Unity.Profiling;
 using UnityEngine.InputSystem.Utilities;
 
 using ProfilerMarker = Unity.Profiling.ProfilerMarker;
+using UnityEngine.InputSystem.Interactions;
 
 ////TODO: now that we can bind to controls by display name, we need to re-resolve controls when those change (e.g. when the keyboard layout changes)
 
@@ -1510,6 +1511,8 @@ namespace UnityEngine.InputSystem
                         }
                     }
 
+                    var previousTrigger = trigger;
+                    var previousBindingStatePtr = bindingStatePtr;
                     // Check if we have multiple concurrent actuations on the same action. This may lead us
                     // to ignore certain inputs (e.g. when we get an input of lesser magnitude while already having
                     // one of higher magnitude) or may even lead us to switch to processing a different binding
@@ -1528,6 +1531,11 @@ namespace UnityEngine.InputSystem
                     if (interactionCount > 0 && !bindingStatePtr->isPartOfComposite)
                     {
                         ProcessInteractions(ref trigger, bindingStatePtr->interactionStartIndex, interactionCount);
+                        // We still need to process hold interactions. If we don't, then we risk having a danling hold which triggers after all buttons are unpressed. 
+                        if (previousBindingStatePtr != bindingStatePtr)
+                        {
+                            ProcessHoldInteractions(ref previousTrigger, previousBindingStatePtr->interactionStartIndex, previousBindingStatePtr->interactionCount);
+                        }
                     }
                     else if (!haveInteractionsOnComposite && !isConflictingInput)
                     {
@@ -2039,6 +2047,32 @@ namespace UnityEngine.InputSystem
                 var index = interactionStartIndex + i;
                 var state = interactionStates[index];
                 var interaction = interactions[index];
+
+                context.m_TriggerState.phase = state.phase;
+                context.m_TriggerState.startTime = state.startTime;
+                context.m_TriggerState.interactionIndex = index;
+
+                interaction.Process(ref context);
+            }
+        }
+
+        private void ProcessHoldInteractions(ref TriggerState trigger, int interactionStartIndex, int interactionCount)
+        {
+            var context = new InputInteractionContext
+            {
+                m_State = this,
+                m_TriggerState = trigger
+            };
+
+            for (var i = 0; i < interactionCount; ++i)
+            {
+                var index = interactionStartIndex + i;
+                var state = interactionStates[index];
+                var interaction = interactions[index];
+                if (interaction is not HoldInteraction)
+                {
+                    continue;
+                }
 
                 context.m_TriggerState.phase = state.phase;
                 context.m_TriggerState.startTime = state.startTime;


### PR DESCRIPTION
### Description
Issue stems from having one of the interaction release early, causing the other to become the dominant interaction, then said other interaction releases. When the first is released, the second takes over and the hold interaction is never processed, leaving it to trigger despite both buttons being released. 

Proposed solution is to still process the first interaction to ensure the hold is released. 

### Testing status & QA
Test case provided under the name
Actions_WithMultipleBindingsAndMultipleInteractions_Works

### Overall Product Risks

It fixes the issue but may create a different one. 

For instance, if we have two buttons, A and W, bound to the same action, we can do

Press A & W
Release A
Press A
Release W

Since both holds were released, no hold will be triggered. 

### Comments to reviewers

Current state of the fix is rough, PR mostly to open up to discussion if solution is viable. 

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
