### PR TITLE
Fix issue: New Input System - All mouse buttons have the same pointer Id

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -343,6 +343,8 @@ namespace UnityEngine.InputSystem.UI
 
             ////REVIEW: for touch, we only need the left button; should we skip right and middle button processing? then we also don't need to copy to/from the event
 
+            var pointerId = eventData.pointerId;
+
             // Left mouse button. Movement and scrolling is processed with event set left button.
             eventData.button = PointerEventData.InputButton.Left;
             state.leftButton.CopyPressStateTo(eventData);
@@ -358,7 +360,11 @@ namespace UnityEngine.InputSystem.UI
             // However, after that, early out at this point when there's no changes to the pointer state (except
             // for tracked pointers as the tracking origin may have moved).
             if (!state.changedThisFrame && (xrTrackingOrigin == null || state.pointerType != UIPointerType.Tracked))
+            {
+                // Restore the original pointerId
+                eventData.pointerId = pointerId;
                 return;
+            }
 
             ProcessPointerButton(ref state.leftButton, eventData);
             ProcessPointerButtonDrag(ref state.leftButton, eventData);
@@ -379,6 +385,9 @@ namespace UnityEngine.InputSystem.UI
 
             ProcessPointerButton(ref state.middleButton, eventData);
             ProcessPointerButtonDrag(ref state.middleButton, eventData);
+
+            // Restore the original pointerId
+            eventData.pointerId = pointerId;
         }
 
         // if we are using a MultiplayerEventSystem, ignore any transforms

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -346,6 +346,7 @@ namespace UnityEngine.InputSystem.UI
             // Left mouse button. Movement and scrolling is processed with event set left button.
             eventData.button = PointerEventData.InputButton.Left;
             state.leftButton.CopyPressStateTo(eventData);
+            eventData.pointerId = PointerInputModule.kMouseLeftId;
 
             // Unlike StandaloneInputModule, we process moves before processing buttons. This way
             // UI elements get pointer enters/exits before they get button ups/downs and clicks.
@@ -366,6 +367,7 @@ namespace UnityEngine.InputSystem.UI
             // Right mouse button.
             eventData.button = PointerEventData.InputButton.Right;
             state.rightButton.CopyPressStateTo(eventData);
+            eventData.pointerId = PointerInputModule.kMouseRightId;
 
             ProcessPointerButton(ref state.rightButton, eventData);
             ProcessPointerButtonDrag(ref state.rightButton, eventData);
@@ -373,6 +375,7 @@ namespace UnityEngine.InputSystem.UI
             // Middle mouse button.
             eventData.button = PointerEventData.InputButton.Middle;
             state.middleButton.CopyPressStateTo(eventData);
+            eventData.pointerId = PointerInputModule.kMouseMiddleId;
 
             ProcessPointerButton(ref state.middleButton, eventData);
             ProcessPointerButtonDrag(ref state.middleButton, eventData);


### PR DESCRIPTION
### Description

Fixes the following bug: https://unity3d.atlassian.net/servicedesk/customer/portal/2/IN-90349

When using the IPointerDownHandler (OnPointerDown method) with the New Input System, the eventData.pointerId for any mouse button is always the same, corresponding to the mouse's deviceId.

According to the [documentation for Unity 2018](https://docs.unity3d.com/2018.1/Documentation/ScriptReference/EventSystems.PointerEventData-pointerId.html):
> When using a mouse the pointerId returns -1, -2, or -3. These are the left, right and center mouse buttons respectively.

I mention the 2018 because the [documentation on the standalone Unity UI package](https://docs.unity3d.com/Packages/com.unity.ugui@3.0/api/UnityEngine.EventSystems.PointerEventData.html) is lacking the values for the mouse buttons.

### Testing status & QA

Tested locally.

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

Note that `m_CurrentPointerId` is set and checked against the value `-1`, which is the same value that should be used for the left mouse button, but in the case of the `m_CurrentPointerId` it means "none". This is not a problem in the current fix, as it only changes the `eventData` object being passed to the event listeners, so the `m_CurrentPointerId` will still contain the original `pointerId`, which would be the mouse's `deviceId` .

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
