### PR TITLE
DOCS: Update Gamepad documentation

### DIFF
--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests.meta
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0f26b555bfc14351a9f8ec342fd6ae8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/DocCodeSamples.asmdef
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/DocCodeSamples.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "Unity.InputSystem.DocCodeSamples",
+    "rootNamespace": "",
+    "references": [
+        "GUID:75469ad4d38634e559750d17036d5f7c"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/DocCodeSamples.asmdef.meta
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/DocCodeSamples.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41b01d3964f844d8b43923c18b3a9a6f
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadExample.cs
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadExample.cs
@@ -1,50 +1,53 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-internal class GamepadExample : MonoBehaviour
+namespace DocCodeSamples.Tests
 {
-    void Start()
+    internal class GamepadExample : MonoBehaviour
     {
-        // Print all connected gamepads
-        Debug.Log(string.Join("\n", Gamepad.all));
-    }
-
-    void Update()
-    {
-        var gamepad = Gamepad.current;
-
-        // No gamepad connected.
-        if (gamepad == null)
+        void Start()
         {
-            return;
+            // Print all connected gamepads
+            Debug.Log(string.Join("\n", Gamepad.all));
         }
 
-        // Check if "Button North" was pressed this frame
-        if (gamepad.buttonNorth.wasPressedThisFrame)
+        void Update()
         {
-            Debug.Log("Button North was pressed");
-        }
+            var gamepad = Gamepad.current;
 
-        // Check if the button control is being continuously actuated and read its value
-        if (gamepad.rightTrigger.IsActuated())
-        {
-            Debug.Log("Right trigger value: " + gamepad.rightTrigger.ReadValue());
-        }
+            // No gamepad connected.
+            if (gamepad == null)
+            {
+                return;
+            }
 
-        // Read left stick value and perform some code based on the value
-        Vector2 move = gamepad.leftStick.ReadValue();
-        {
-            // Do 'move' code here
-        }
+            // Check if "Button North" was pressed this frame
+            if (gamepad.buttonNorth.wasPressedThisFrame)
+            {
+                Debug.Log("Button North was pressed");
+            }
 
-        // Creating haptic feedback while "Button South" is pressed and stopping it when released.
-        if (gamepad.buttonSouth.wasPressedThisFrame)
-        {
-            gamepad.SetMotorSpeeds(0.2f, 1.0f);
-        }
-        else if (gamepad.buttonSouth.wasReleasedThisFrame)
-        {
-            gamepad.ResetHaptics();
+            // Check if the button control is being continuously actuated and read its value
+            if (gamepad.rightTrigger.IsActuated())
+            {
+                Debug.Log("Right trigger value: " + gamepad.rightTrigger.ReadValue());
+            }
+
+            // Read left stick value and perform some code based on the value
+            Vector2 move = gamepad.leftStick.ReadValue();
+            {
+                // Use the Vector2 move for the game logic here
+            }
+
+            // Creating haptic feedback while "Button South" is pressed and stopping it when released.
+            if (gamepad.buttonSouth.wasPressedThisFrame)
+            {
+                gamepad.SetMotorSpeeds(0.2f, 1.0f);
+            }
+            else if (gamepad.buttonSouth.wasReleasedThisFrame)
+            {
+                gamepad.ResetHaptics();
+            }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadExample.cs
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadExample.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+internal class GamepadExample : MonoBehaviour
+{
+    void Start()
+    {
+        // Print all connected gamepads
+        Debug.Log(string.Join("\n", Gamepad.all));
+    }
+
+    void Update()
+    {
+        var gamepad = Gamepad.current;
+
+        // No gamepad connected.
+        if (gamepad == null)
+        {
+            return;
+        }
+
+        // Check if "Button North" was pressed this frame
+        if (gamepad.buttonNorth.wasPressedThisFrame)
+        {
+            Debug.Log("Button North was pressed");
+        }
+
+        // Check if the button control is being continuously actuated and read its value
+        if (gamepad.rightTrigger.IsActuated())
+        {
+            Debug.Log("Right trigger value: " + gamepad.rightTrigger.ReadValue());
+        }
+
+        // Read left stick value and perform some code based on the value
+        Vector2 move = gamepad.leftStick.ReadValue();
+        {
+            // Do 'move' code here
+        }
+
+        // Creating haptic feedback while "Button South" is pressed and stopping it when released.
+        if (gamepad.buttonSouth.wasPressedThisFrame)
+        {
+            gamepad.SetMotorSpeeds(0.2f, 1.0f);
+        }
+        else if (gamepad.buttonSouth.wasReleasedThisFrame)
+        {
+            gamepad.ResetHaptics();
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadExample.cs.meta
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadExample.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 898672c95e554f2fb492125d78b11af2
+timeCreated: 1733401360

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadHapticsExample.cs
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadHapticsExample.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+internal class GamepadHapticsExample : MonoBehaviour
+{
+    bool hapticsArePaused = false;
+
+    void Update()
+    {
+        var gamepad = Gamepad.current;
+
+        // No gamepad connected, no need to continue.
+        if (gamepad == null)
+            return;
+
+        float leftTrigger = gamepad.leftTrigger.ReadValue();
+        float rightTrigger = gamepad.rightTrigger.ReadValue();
+
+        // Only set motor speeds if haptics were not paused and if trigger is actuated.
+        // Both triggers must be actuated past 0.2f to start haptics.
+        if (!hapticsArePaused &&
+            (gamepad.leftTrigger.IsActuated() || gamepad.rightTrigger.IsActuated()))
+            gamepad.SetMotorSpeeds(
+                leftTrigger < 0.2f ? 0.0f : leftTrigger,
+                rightTrigger < 0.2f ? 0.0f : rightTrigger);
+
+        // Toggle haptics "playback" when "Button South" is pressed.
+        // Notice that if you release the triggers after pausing,
+        // and press the button again, haptics will resume.
+        if (gamepad.buttonSouth.wasPressedThisFrame)
+        {
+            if (hapticsArePaused)
+                gamepad.ResumeHaptics();
+            else
+                gamepad.PauseHaptics();
+
+            hapticsArePaused = !hapticsArePaused;
+        }
+
+        // Notice that if you release the triggers after pausing,
+        // and press the Start button, haptics will be reset.
+        if (gamepad.startButton.wasPressedThisFrame)
+            gamepad.ResetHaptics();
+    }
+}

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadHapticsExample.cs
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadHapticsExample.cs
@@ -1,45 +1,48 @@
 using UnityEngine;
 using UnityEngine.InputSystem;
 
-internal class GamepadHapticsExample : MonoBehaviour
+namespace DocCodeSamples.Tests
 {
-    bool hapticsArePaused = false;
-
-    void Update()
+    internal class GamepadHapticsExample : MonoBehaviour
     {
-        var gamepad = Gamepad.current;
+        bool hapticsArePaused = false;
 
-        // No gamepad connected, no need to continue.
-        if (gamepad == null)
-            return;
-
-        float leftTrigger = gamepad.leftTrigger.ReadValue();
-        float rightTrigger = gamepad.rightTrigger.ReadValue();
-
-        // Only set motor speeds if haptics were not paused and if trigger is actuated.
-        // Both triggers must be actuated past 0.2f to start haptics.
-        if (!hapticsArePaused &&
-            (gamepad.leftTrigger.IsActuated() || gamepad.rightTrigger.IsActuated()))
-            gamepad.SetMotorSpeeds(
-                leftTrigger < 0.2f ? 0.0f : leftTrigger,
-                rightTrigger < 0.2f ? 0.0f : rightTrigger);
-
-        // Toggle haptics "playback" when "Button South" is pressed.
-        // Notice that if you release the triggers after pausing,
-        // and press the button again, haptics will resume.
-        if (gamepad.buttonSouth.wasPressedThisFrame)
+        void Update()
         {
-            if (hapticsArePaused)
-                gamepad.ResumeHaptics();
-            else
-                gamepad.PauseHaptics();
+            var gamepad = Gamepad.current;
 
-            hapticsArePaused = !hapticsArePaused;
+            // No gamepad connected, no need to continue.
+            if (gamepad == null)
+                return;
+
+            float leftTrigger = gamepad.leftTrigger.ReadValue();
+            float rightTrigger = gamepad.rightTrigger.ReadValue();
+
+            // Only set motor speeds if haptics were not paused and if trigger is actuated.
+            // Both triggers must be actuated past 0.2f to start haptics.
+            if (!hapticsArePaused &&
+                (gamepad.leftTrigger.IsActuated() || gamepad.rightTrigger.IsActuated()))
+                gamepad.SetMotorSpeeds(
+                    leftTrigger < 0.2f ? 0.0f : leftTrigger,
+                    rightTrigger < 0.2f ? 0.0f : rightTrigger);
+
+            // Toggle haptics "playback" when "Button South" is pressed.
+            // Notice that if you release the triggers after pausing,
+            // and press the button again, haptics will resume.
+            if (gamepad.buttonSouth.wasPressedThisFrame)
+            {
+                if (hapticsArePaused)
+                    gamepad.ResumeHaptics();
+                else
+                    gamepad.PauseHaptics();
+
+                hapticsArePaused = !hapticsArePaused;
+            }
+
+            // Notice that if you release the triggers after pausing,
+            // and press the Start button, haptics will be reset.
+            if (gamepad.startButton.wasPressedThisFrame)
+                gamepad.ResetHaptics();
         }
-
-        // Notice that if you release the triggers after pausing,
-        // and press the Start button, haptics will be reset.
-        if (gamepad.startButton.wasPressedThisFrame)
-            gamepad.ResetHaptics();
     }
 }

--- a/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadHapticsExample.cs.meta
+++ b/Packages/com.unity.inputsystem/DocCodeSamples.Tests/GamepadHapticsExample.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3bbc200178984676a2dcb977a2fe3bae
+timeCreated: 1733400387

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -707,10 +707,10 @@ namespace UnityEngine.InputSystem
 
         /// <inheritdoc cref="InputDevice.OnAdded"/>
         /// <summary>
-        /// Called when the gamepad is added to the system.
+        /// Called when a gamepad is added to the system.
         /// </summary>
         /// <remarks>
-        /// It will also add the gamepad to the list of <see cref="all"/> gamepads.
+        /// Override this method if you want to do additional processing when a gamepad becomes connected. After this method is called, the gamepad is automatically added to the list of <see cref="all"/> gamepads.
         /// </remarks>
         protected override void OnAdded()
         {
@@ -722,7 +722,7 @@ namespace UnityEngine.InputSystem
         /// Called when the gamepad is removed from the system.
         /// </summary>
         /// <remarks>
-        /// It will also remove the gamepad from the list of <see cref="all"/> gamepads.
+        /// Override this method if you want to do additional processing when a gamepad becomes disconnected. After this method is called, the gamepad is automatically removed from the list of <see cref="all"/> gamepads.
         /// </remarks>
         protected override void OnRemoved()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -142,7 +142,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// Right stick position.
         /// </summary>
-        /// <remarks>Each axis from -1 to 1 with 0 being center position.</remarks>
+        /// <remarks>Each axis goes from -1 to 1 with 0 being center position.</remarks>
         /// <seealso cref="Gamepad.rightStick"/>
         [InputControl(layout = "Stick", usage = "Secondary2DMotion", processors = "stickDeadzone", displayName = "Right Stick", shortDisplayName = "RS")]
         [FieldOffset(12)]

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -398,59 +398,7 @@ namespace UnityEngine.InputSystem
     /// generic <see cref="Joystick"/> or as just a plain <see cref="HID.HID"/> instead.
     /// </remarks>
     /// <example>
-    /// <code>
-    ///
-    /// using UnityEngine;
-    /// using UnityEngine.InputSystem;
-    ///
-    /// public class Example : MonoBehaviour
-    /// {
-    ///     void Start()
-    ///     {
-    ///         // Print all connected gamepads
-    ///         Debug.Log(string.Join("\n", Gamepad.all));
-    ///     }
-    ///
-    ///     void Update()
-    ///     {
-    ///         var gamepad = Gamepad.current;
-    ///
-    ///         // No gamepad connected.
-    ///         if (gamepad == null)
-    ///         {
-    ///             return;
-    ///         }
-    ///
-    ///         // Check if "Button North" was pressed this frame
-    ///         if (gamepad.buttonNorth.wasPressedThisFrame)
-    ///         {
-    ///             Debug.Log("Button North was pressed");
-    ///         }
-    ///
-    ///         // Check if the button control is being continuously actuated and read its value
-    ///         if (gamepad.rightTrigger.IsActuated())
-    ///         {
-    ///             Debug.Log("Right trigger value: " + gamepad.rightTrigger.ReadValue());
-    ///         }
-    ///
-    ///         // Read left stick value and perform some code based on the value
-    ///         Vector2 move = gamepad.leftStick.ReadValue();
-    ///         {
-    ///             // Do 'move' code here
-    ///         }
-    ///
-    ///         // Creating haptic feedback while "Button South" is pressed and stopping it when released.
-    ///         if (gamepad.buttonSouth.wasPressedThisFrame)
-    ///         {
-    ///             gamepad.SetMotorSpeeds(0.2f, 1.0f);
-    ///
-    ///         } else if (gamepad.buttonSouth.wasReleasedThisFrame)
-    ///         {
-    ///             gamepad.ResetHaptics();
-    ///         }
-    ///     }
-    /// }
-    /// </code>
+    /// <code source="../../DocCodeSamples.Tests/GamepadExample.cs" />
     /// </example>
     /// <seealso cref="all"/>
     /// <seealso cref="current"/>
@@ -751,11 +699,11 @@ namespace UnityEngine.InputSystem
             current = this;
         }
 
+        /// <inheritdoc cref="InputDevice.OnAdded"/>
         /// <summary>
         /// Called when the gamepad is added to the system.
         /// </summary>
         /// <remarks>
-        /// <inheritdoc cref="InputDevice.OnAdded()"/>
         /// It will also add the gamepad to the list of <see cref="all"/> gamepads.
         /// </remarks>
         protected override void OnAdded()
@@ -763,11 +711,11 @@ namespace UnityEngine.InputSystem
             ArrayHelpers.AppendWithCapacity(ref s_Gamepads, ref s_GamepadCount, this);
         }
 
+        /// <inheritdoc cref="InputDevice.OnRemoved"/>
         /// <summary>
         /// Called when the gamepad is removed from the system.
         /// </summary>
         /// <remarks>
-        /// <inheritdoc cref="InputDevice.OnRemoved()"/>
         /// It will also remove the gamepad from the list of <see cref="all"/> gamepads.
         /// </remarks>
         protected override void OnRemoved()
@@ -788,15 +736,16 @@ namespace UnityEngine.InputSystem
 
         /// <summary>
         /// Pause rumble effects on the gamepad.
-        /// <inheritdoc cref="DualMotorRumble.PauseHaptics"/>
         /// </summary>
         /// <remarks>
-        /// Resume with <see cref="ResumeHaptics"/>.
-        /// <inheritdoc cref="DualMotorRumble.PauseHaptics"/>
+        /// It will pause rumble effects and save the current motor speeds.
+        /// Resume from those speeds with <see cref="ResumeHaptics"/>.
+        /// Some devices such as <see cref="DualShock.DualSenseGamepadHID"/> and
+        /// <see cref="DualShock.DualShock4GamepadHID"/> can also set the LED color when this method is called.
         /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
         /// <example>
-        /// <inheritdoc cref="SetMotorSpeeds"/>
+        /// <code source="../../DocCodeSamples.Tests/GamepadHapticsExample.cs"/>
         /// </example>
         public virtual void PauseHaptics()
         {
@@ -804,14 +753,17 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Resume rumble affects on the gamepad that have been paused with <see cref="PauseHaptics"/>.
+        /// Resume rumble effects on the gamepad.
         /// </summary>
         /// <remarks>
-        /// <inheritdoc cref="DualMotorRumble.ResumeHaptics"/>
+        /// It will resume rumble effects from the previously set motor speeds, such as motor speeds saved when
+        /// calling <see cref="PauseHaptics"/>.
+        /// Some devices such as <see cref="DualShock.DualSenseGamepadHID"/> and
+        /// <see cref="DualShock.DualShock4GamepadHID"/> can also set the LED color when this method is called.
         /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
         /// <example>
-        /// <inheritdoc cref="SetMotorSpeeds"/>
+        /// <code source="../../DocCodeSamples.Tests/GamepadHapticsExample.cs"/>
         /// </example>
         public virtual void ResumeHaptics()
         {
@@ -819,14 +771,15 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Reset rumble effects on the gamepad.
+        /// Resets rumble effects on the gamepad by setting motor speeds to 0.
         /// </summary>
         /// <remarks>
-        /// <inheritdoc cref="DualMotorRumble.ResetHaptics"/>
+        /// Some devices such as <see cref="DualShock.DualSenseGamepadHID"/> and
+        /// <see cref="DualShock.DualShock4GamepadHID"/> can also set the LED color when this method is called.
         /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
         /// <example>
-        /// <inheritdoc cref="SetMotorSpeeds"/>
+        /// <code source="../../DocCodeSamples.Tests/GamepadHapticsExample.cs"/>
         /// </example>
         public virtual void ResetHaptics()
         {
@@ -835,53 +788,7 @@ namespace UnityEngine.InputSystem
 
         /// <inheritdoc />
         /// <example>
-        /// <code>
-        /// using UnityEngine;
-        /// using UnityEngine.InputSystem;
-        ///
-        /// public class GamepadHapticsExample : MonoBehaviour
-        /// {
-        ///     bool hapticsArePaused = false;
-        ///
-        ///     void Update() {
-        ///         var gamepad = Gamepad.current;
-        ///
-        ///         // No gamepad connected, no need to continue.
-        ///         if (gamepad == null)
-        ///             return;
-        ///
-        ///         float leftTrigger = gamepad.leftTrigger.ReadValue();
-        ///         float rightTrigger = gamepad.rightTrigger.ReadValue();
-        ///
-        ///         // Only set motor speeds if haptics were not paused and if trigger is actuated.
-        ///         // Both triggers must be actuated past 0.2f to start haptics.
-        ///         if (!hapticsArePaused &amp;&amp;
-        ///             (gamepad.leftTrigger.IsActuated() || gamepad.rightTrigger.IsActuated()))
-        ///             gamepad.SetMotorSpeeds(
-        ///                 leftTrigger &lt; 0.2f ? 0.0f : leftTrigger,
-        ///                 rightTrigger &lt; 0.2f ? 0.0f : rightTrigger);
-        ///
-        ///         // Toggle haptics "playback" when "Button South" is pressed.
-        ///         // Notice that if you release the triggers after pausing,
-        ///         // and press the button again, haptics will resume.
-        ///         if (gamepad.buttonSouth.wasPressedThisFrame)
-        ///         {
-        ///             if (hapticsArePaused)
-        ///                 gamepad.ResumeHaptics();
-        ///             else
-        ///                 gamepad.PauseHaptics();
-        ///
-        ///             hapticsArePaused = !hapticsArePaused;
-        ///         }
-        ///
-        ///         // Notice that if you release the triggers after pausing,
-        ///         // and press the Start button, haptics will be reset.
-        ///         if (gamepad.startButton.wasPressedThisFrame)
-        ///             gamepad.ResetHaptics();
-        ///     }
-        /// }
-        ///
-        /// </code>
+        /// <code source="../../DocCodeSamples.Tests/GamepadHapticsExample.cs"/>
         /// </example>
         public virtual void SetMotorSpeeds(float lowFrequency, float highFrequency)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -131,18 +131,18 @@ namespace UnityEngine.InputSystem.LowLevel
         public uint buttons;
 
         /// <summary>
-        /// Left stick position.
+        /// A 2D vector representing the current position of the left stick on a gamepad.
         /// </summary>
-        /// <remarks>Each axis goes from -1 to 1 with 0 being center position.</remarks>
+        /// <remarks>Each axis of the 2D vector's range goes from -1 to 1. 0 represents the stick in its center position, and -1 or 1 represents the the stick pushed to its extent in each direction along the axis.</remarks>
         /// <seealso cref="Gamepad.leftStick"/>
         [InputControl(layout = "Stick", usage = "Primary2DMotion", processors = "stickDeadzone", displayName = "Left Stick", shortDisplayName = "LS")]
         [FieldOffset(4)]
         public Vector2 leftStick;
 
         /// <summary>
-        /// Right stick position.
+        /// A 2D vector representing the current position of the right stick on a gamepad.
         /// </summary>
-        /// <remarks>Each axis goes from -1 to 1 with 0 being center position.</remarks>
+        /// <remarks>Each axis of the 2D vector's range goes from -1 to 1. 0 represents the stick in its center position, and -1 or 1 represents the the stick pushed to its extent in each direction along the axis.</remarks>
         /// <seealso cref="Gamepad.rightStick"/>
         [InputControl(layout = "Stick", usage = "Secondary2DMotion", processors = "stickDeadzone", displayName = "Right Stick", shortDisplayName = "RS")]
         [FieldOffset(12)]
@@ -151,18 +151,18 @@ namespace UnityEngine.InputSystem.LowLevel
         ////REVIEW: should left and right trigger get deadzones?
 
         /// <summary>
-        /// Position of the left trigger.
+        /// The current position of the left trigger on a gamepad.
         /// </summary>
-        /// <remarks>Goes from 0 (not pressed) to 1 (fully pressed).</remarks>
+        /// <remarks>The value's range goes from 0 to 1, where 0 represents the trigger not pressed at all, and 1 represents the trigger in its fully pressed position.</remarks>
         /// <seealso cref="Gamepad.leftTrigger"/>
         [InputControl(layout = "Button", format = "FLT", usage = "SecondaryTrigger", displayName = "Left Trigger", shortDisplayName = "LT")]
         [FieldOffset(20)]
         public float leftTrigger;
 
         /// <summary>
-        /// Position of the right trigger.
+        /// The current position of the right trigger on a gamepad.
         /// </summary>
-        /// <remarks>Goes from 0 (not pressed) to 1 (fully pressed).</remarks>
+        /// <remarks>The value's range goes from 0 to 1, where 0 represents the trigger not pressed at all, and 1 represents the trigger in its fully pressed position.</remarks>
         /// <seealso cref="Gamepad.rightTrigger"/>
         [InputControl(layout = "Button", format = "FLT", usage = "SecondaryTrigger", displayName = "Right Trigger", shortDisplayName = "RT")]
         [FieldOffset(24)]

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -102,7 +102,6 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// Button bit mask.
         /// </summary>
-        /// <value>Button bit mask.</value>
         /// <seealso cref="GamepadButton"/>
         /// <seealso cref="Gamepad.buttonSouth"/>
         /// <seealso cref="Gamepad.buttonNorth"/>
@@ -132,20 +131,18 @@ namespace UnityEngine.InputSystem.LowLevel
         public uint buttons;
 
         /// <summary>
-        /// Left stick position. Each axis goes from -1 to 1 with
-        /// 0 being center position.
+        /// Left stick position.
         /// </summary>
-        /// <value>Left stick position.</value>
+        /// <remarks>Each axis goes from -1 to 1 with 0 being center position.</remarks>
         /// <seealso cref="Gamepad.leftStick"/>
         [InputControl(layout = "Stick", usage = "Primary2DMotion", processors = "stickDeadzone", displayName = "Left Stick", shortDisplayName = "LS")]
         [FieldOffset(4)]
         public Vector2 leftStick;
 
         /// <summary>
-        /// Right stick position. Each axis from -1 to 1 with
-        /// 0 being center position.
+        /// Right stick position.
         /// </summary>
-        /// <value>Right stick position.</value>
+        /// <remarks>Each axis from -1 to 1 with 0 being center position.</remarks>
         /// <seealso cref="Gamepad.rightStick"/>
         [InputControl(layout = "Stick", usage = "Secondary2DMotion", processors = "stickDeadzone", displayName = "Right Stick", shortDisplayName = "RS")]
         [FieldOffset(12)]
@@ -154,18 +151,18 @@ namespace UnityEngine.InputSystem.LowLevel
         ////REVIEW: should left and right trigger get deadzones?
 
         /// <summary>
-        /// Position of the left trigger. Goes from 0 (not pressed) to 1 (fully pressed).
+        /// Position of the left trigger.
         /// </summary>
-        /// <value>Position of left trigger.</value>
+        /// <remarks>Goes from 0 (not pressed) to 1 (fully pressed).</remarks>
         /// <seealso cref="Gamepad.leftTrigger"/>
         [InputControl(layout = "Button", format = "FLT", usage = "SecondaryTrigger", displayName = "Left Trigger", shortDisplayName = "LT")]
         [FieldOffset(20)]
         public float leftTrigger;
 
         /// <summary>
-        /// Position of the right trigger. Goes from 0 (not pressed) to 1 (fully pressed).
+        /// Position of the right trigger.
         /// </summary>
-        /// <value>Position of right trigger.</value>
+        /// <remarks>Goes from 0 (not pressed) to 1 (fully pressed).</remarks>
         /// <seealso cref="Gamepad.rightTrigger"/>
         [InputControl(layout = "Button", format = "FLT", usage = "SecondaryTrigger", displayName = "Right Trigger", shortDisplayName = "RT")]
         [FieldOffset(24)]
@@ -174,7 +171,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// State format tag for GamepadState.
         /// </summary>
-        /// <value>Returns "GPAD".</value>
+        /// <remarks>Returns "GPAD".</remarks>
         public FourCC format => Format;
 
         /// <summary>
@@ -402,106 +399,146 @@ namespace UnityEngine.InputSystem
     ///
     /// <example>
     /// <code>
-    /// // Show all gamepads in the system.
-    /// Debug.Log(string.Join("\n", Gamepad.all));
     ///
-    /// // Check whether the X button on the current gamepad is pressed.
-    /// if (Gamepad.current.xButton.wasPressedThisFrame)
-    ///     Debug.Log("Pressed");
+    /// using UnityEngine;
+    /// using UnityEngine.InputSystem;
     ///
-    /// // Rumble the left motor on the current gamepad slightly.
-    /// Gamepad.current.SetMotorSpeeds(0.2f, 0.
+    /// public class Example : MonoBehaviour
+    /// {
+    ///     void Start()
+    ///     {
+    ///         // Print all connected gamepads
+    ///         Debug.Log(string.Join("\n", Gamepad.all));
+    ///     }
+    ///
+    ///     void Update()
+    ///     {
+    ///         var gamepad = Gamepad.current;
+    ///
+    ///         // No gamepad connected.
+    ///         if (gamepad == null)
+    ///         {
+    ///             return;
+    ///         }
+    ///
+    ///         // Check if "Button North" was pressed this frame
+    ///         if (gamepad.buttonNorth.wasPressedThisFrame)
+    ///         {
+    ///             Debug.Log("Button North was pressed");
+    ///         }
+    ///
+    ///         // Check if the button control is being continuously actuated and read its value
+    ///         if (gamepad.rightTrigger.IsActuated())
+    ///         {
+    ///             Debug.Log("Right trigger value: " + gamepad.rightTrigger.ReadValue());
+    ///         }
+    ///
+    ///         // Read left stick value and perform some code based on the value
+    ///         Vector2 move = gamepad.leftStick.ReadValue();
+    ///         {
+    ///             // Do 'move' code here
+    ///         }
+    ///
+    ///         // Creating haptic feedback while "Button South" is pressed and stopping it when released.
+    ///         if (gamepad.buttonSouth.wasPressedThisFrame)
+    ///         {
+    ///             gamepad.SetMotorSpeeds(0.2f, 1.0f);
+    ///
+    ///         } else if (gamepad.buttonSouth.wasReleasedThisFrame)
+    ///         {
+    ///             gamepad.ResetHaptics();
+    ///         }
+    ///     }
+    /// }
     /// </code>
     /// </example>
     /// </remarks>
+    /// <seealso cref="all"/>
+    /// <seealso cref="current"/>
+    /// <seealso cref="GamepadState"/>
+    /// <seealso cref="InputDevice"/>
+    /// <seealso cref="SetMotorSpeeds"/>
+    /// <seealso cref="ButtonControl.wasPressedThisFrame"/>
     [InputControlLayout(stateType = typeof(GamepadState), isGenericTypeOfDevice = true)]
     public class Gamepad : InputDevice, IDualMotorRumble
     {
         /// <summary>
         /// The left face button of the gamepad.
         /// </summary>
-        /// <value>Control representing the X/Square face button.</value>
         /// <remarks>
-        /// On an Xbox controller, this is the X button and on the PS4 controller, this is the
-        /// square button.
+        /// Control representing the X/Square face button.
+        /// On an Xbox controller, this is the <see cref="xButton"/> and on the PS4 controller, this is the
+        /// <see cref="squareButton"/>.
         /// </remarks>
-        /// <seealso cref="xButton"/>
-        /// <seealso cref="squareButton"/>
         public ButtonControl buttonWest { get; protected set; }
 
         /// <summary>
         /// The top face button of the gamepad.
         /// </summary>
-        /// <value>Control representing the Y/Triangle face button.</value>
         /// <remarks>
-        /// On an Xbox controller, this is the Y button and on the PS4 controller, this is the
-        /// triangle button.
+        /// Control representing the Y/Triangle face button.
+        /// On an Xbox controller, this is the <see cref="yButton"/> and on the PS4 controller, this is the
+        /// <see cref="triangleButton"/>.
         /// </remarks>
-        /// <seealso cref="yButton"/>
-        /// <seealso cref="triangleButton"/>
         public ButtonControl buttonNorth { get; protected set; }
 
         /// <summary>
         /// The bottom face button of the gamepad.
         /// </summary>
-        /// <value>Control representing the A/Cross face button.</value>
         /// <remarks>
-        /// On an Xbox controller, this is the A button and on the PS4 controller, this is the
-        /// cross button.
+        /// Control representing the A/Cross face button.
+        /// On an Xbox controller, this is the <see cref="aButton"/> and on the PS4 controller, this is the
+        /// <see cref="crossButton"/>.
         /// </remarks>
-        /// <seealso cref="aButton"/>
-        /// <seealso cref="crossButton"/>
         public ButtonControl buttonSouth { get; protected set; }
 
         /// <summary>
         /// The right face button of the gamepad.
         /// </summary>
-        /// <value>Control representing the B/Circle face button.</value>
         /// <remarks>
-        /// On an Xbox controller, this is the B button and on the PS4 controller, this is the
-        /// circle button.
+        /// Control representing the B/Circle face button.
+        /// On an Xbox controller, this is the <see cref="bButton"/> and on the PS4 controller, this is the
+        /// <see cref="circleButton"/>.
         /// </remarks>
-        /// <seealso cref="bButton"/>
-        /// <seealso cref="circleButton"/>
         public ButtonControl buttonEast { get; protected set; }
 
         /// <summary>
         /// The button that gets triggered when <see cref="leftStick"/> is pressed down.
         /// </summary>
-        /// <value>Control representing a click with the left stick.</value>
+        /// <remarks>Control representing a click with the left stick.</remarks>
         public ButtonControl leftStickButton { get; protected set; }
 
         /// <summary>
         /// The button that gets triggered when <see cref="rightStick"/> is pressed down.
         /// </summary>
-        /// <value>Control representing a click with the right stick.</value>
+        /// <remarks>Control representing a click with the right stick.</remarks>
         public ButtonControl rightStickButton { get; protected set; }
 
         /// <summary>
         /// The right button in the middle section of the gamepad (called "menu" on Xbox
         /// controllers and "options" on PS4 controllers).
         /// </summary>
-        /// <value>Control representing the right button in midsection.</value>
+        /// <remarks>Control representing the right button in midsection.</remarks>
         public ButtonControl startButton { get; protected set; }
 
         /// <summary>
         /// The left button in the middle section of the gamepad (called "view" on Xbox
         /// controllers and "share" on PS4 controllers).
         /// </summary>
-        /// <value>Control representing the left button in midsection.</value>
+        /// <remarks>Control representing the left button in midsection.</remarks>
         public ButtonControl selectButton { get; protected set; }
 
         /// <summary>
         /// The 4-way directional pad on the gamepad.
         /// </summary>
-        /// <value>Control representing the d-pad.</value>
+        /// <remarks>Control representing the d-pad.</remarks>
         public DpadControl dpad { get; protected set; }
 
         /// <summary>
         /// The left shoulder/bumper button that sits on top of <see cref="leftTrigger"/>.
         /// </summary>
-        /// <value>Control representing the left shoulder button.</value>
         /// <remarks>
+        /// Control representing the left shoulder button.
         /// On Xbox controllers, this is usually called "left bumper" whereas on PS4
         /// controllers, this button is referred to as "L1".
         /// </remarks>
@@ -510,8 +547,8 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// The right shoulder/bumper button that sits on top of <see cref="rightTrigger"/>.
         /// </summary>
-        /// <value>Control representing the right shoulder button.</value>
         /// <remarks>
+        /// Control representing the right shoulder button.
         /// On Xbox controllers, this is usually called "right bumper" whereas on PS4
         /// controllers, this button is referred to as "R1".
         /// </remarks>
@@ -520,20 +557,19 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// The left thumbstick on the gamepad.
         /// </summary>
-        /// <value>Control representing the left thumbstick.</value>
+        /// <remarks>Control representing the left thumbstick.</remarks>
         public StickControl leftStick { get; protected set; }
 
         /// <summary>
         /// The right thumbstick on the gamepad.
         /// </summary>
-        /// <value>Control representing the right thumbstick.</value>
+        /// <remarks>Control representing the right thumbstick.</remarks>
         public StickControl rightStick { get; protected set; }
 
         /// <summary>
         /// The left trigger button sitting below <see cref="leftShoulder"/>.
         /// </summary>
-        /// <value>Control representing the left trigger button.</value>
-        /// <remarks>
+        /// <remarks>Control representing the left trigger button.
         /// On PS4 controllers, this button is referred to as "L2".
         /// </remarks>
         public ButtonControl leftTrigger { get; protected set; }
@@ -541,8 +577,7 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// The right trigger button sitting below <see cref="rightShoulder"/>.
         /// </summary>
-        /// <value>Control representing the right trigger button.</value>
-        /// <remarks>
+        /// <remarks>Control representing the right trigger button.
         /// On PS4 controllers, this button is referred to as "R2".
         /// </remarks>
         public ButtonControl rightTrigger { get; protected set; }
@@ -550,49 +585,41 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Same as <see cref="buttonSouth"/>. Xbox-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonSouth"/>.</value>
         public ButtonControl aButton => buttonSouth;
 
         /// <summary>
         /// Same as <see cref="buttonEast"/>. Xbox-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonEast"/>.</value>
         public ButtonControl bButton => buttonEast;
 
         /// <summary>
         /// Same as <see cref="buttonWest"/> Xbox-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonWest"/>.</value>
         public ButtonControl xButton => buttonWest;
 
         /// <summary>
         /// Same as <see cref="buttonNorth"/>. Xbox-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonNorth"/>.</value>
         public ButtonControl yButton => buttonNorth;
 
         /// <summary>
         /// Same as <see cref="buttonNorth"/>. PS4-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonNorth"/>.</value>
         public ButtonControl triangleButton => buttonNorth;
 
         /// <summary>
         /// Same as <see cref="buttonWest"/>. PS4-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonWest"/>.</value>
         public ButtonControl squareButton => buttonWest;
 
         /// <summary>
         /// Same as <see cref="buttonEast"/>. PS4-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonEast"/>.</value>
         public ButtonControl circleButton => buttonEast;
 
         /// <summary>
         /// Same as <see cref="buttonSouth"/>. PS4-style alias.
         /// </summary>
-        /// <value>Same as <see cref="buttonSouth"/>.</value>
         public ButtonControl crossButton => buttonSouth;
 
         /// <summary>
@@ -637,28 +664,29 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// When added, a device is automatically made current (see <see cref="InputDevice.MakeCurrent"/>), so
         /// when connecting a gamepad, it will also become current. After that, it will only become current again
-        /// when input change on non-noisy controls (see <see cref="InputControl.noisy"/>) is received.
+        /// when input change on non-noisy controls (see <see cref="InputControl.noisy"/>) is received. It will also
+        /// be available once <see cref="all"/> is queried.
         ///
         /// For local multiplayer scenarios (or whenever there are multiple gamepads that need to be usable
         /// in a concurrent fashion), it is not recommended to rely on this property. Instead, it is recommended
         /// to use <see cref="PlayerInput"/> or <see cref="Users.InputUser"/>.
         /// </remarks>
-        /// <seealso cref="InputDevice.MakeCurrent"/>
-        /// <seealso cref="all"/>
         public static Gamepad current { get; private set; }
 
         /// <summary>
         /// A list of gamepads currently connected to the system.
         /// </summary>
-        /// <value>All currently connected gamepads.</value>
         /// <remarks>
+        /// Returns all currently connected gamepads.
+        ///
         /// Does not cause GC allocation.
         ///
         /// Do <em>not</em> hold on to the value returned by this getter but rather query it whenever
         /// you need it. Whenever the gamepad setup changes, the value returned by this getter
         /// is invalidated.
+        ///
+        /// Alternately, if you want a single gamepad, you can use <see cref="current"/> for example.
         /// </remarks>
-        /// <seealso cref="current"/>
         public new static ReadOnlyArray<Gamepad> all => new ReadOnlyArray<Gamepad>(s_Gamepads, 0, s_GamepadCount);
 
         /// <inheritdoc />
@@ -695,7 +723,29 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <remarks>
         /// This is called automatically by the system when there is input on a gamepad.
+        ///
+        /// More remarks are available in <see cref="InputDevice.MakeCurrent()"/> when it comes to devices with
+        /// <see cref="InputControl.noisy"/> controls.
         /// </remarks>
+        /// <example>
+        /// <code>
+        /// using System;
+        /// using UnityEngine;
+        /// using UnityEngine.InputSystem;
+        ///
+        /// public class MakeCurrentGamepadExample : MonoBehaviour
+        /// {
+        ///     void Update()
+        ///     {
+        ///         /// Make the first Gamepad always the current one
+        ///         if (Gamepad.all.Count > 0)
+        ///         {
+        ///             Gamepad.all[0].MakeCurrent();
+        ///         }
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
         public override void MakeCurrent()
         {
             base.MakeCurrent();
@@ -705,6 +755,10 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Called when the gamepad is added to the system.
         /// </summary>
+        /// <remarks>
+        /// <inheritdoc cref="InputDevice.OnAdded()"/>
+        /// It will also add the gamepad to the list of <see cref="all"/> gamepads.
+        /// </remarks>
         protected override void OnAdded()
         {
             ArrayHelpers.AppendWithCapacity(ref s_Gamepads, ref s_GamepadCount, this);
@@ -713,6 +767,10 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Called when the gamepad is removed from the system.
         /// </summary>
+        /// <remarks>
+        /// <inheritdoc cref="InputDevice.OnRemoved()"/>
+        /// It will also remove the gamepad from the list of <see cref="all"/> gamepads.
+        /// </remarks>
         protected override void OnRemoved()
         {
             if (current == this)
@@ -730,9 +788,19 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Pause rumble effects on the gamepad. Resume with <see cref="ResumeHaptics"/>.
+        /// Pause rumble effects on the gamepad.
+        /// <inheritdoc cref="DualMotorRumble.PauseHaptics"/>
         /// </summary>
+        /// <remarks>
+        /// Resume with <see cref="ResumeHaptics"/>.
+        /// <inheritdoc cref="DualMotorRumble.PauseHaptics"/>
+        /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
+        /// <example>
+        /// <code>
+        /// <inheritdoc cref="SetMotorSpeeds"/>
+        /// </code>
+        /// </example>
         public virtual void PauseHaptics()
         {
             m_Rumble.PauseHaptics(this);
@@ -741,23 +809,87 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Resume rumble affects on the gamepad that have been paused with <see cref="PauseHaptics"/>.
         /// </summary>
+        /// <remarks>
+        /// <inheritdoc cref="DualMotorRumble.ResumeHaptics"/>
+        /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
+        /// <example>
+        /// <code>
+        /// <inheritdoc cref="SetMotorSpeeds"/>
+        /// </code>
+        /// </example>
         public virtual void ResumeHaptics()
         {
             m_Rumble.ResumeHaptics(this);
         }
 
         /// <summary>
-        /// Reset rumble effects on the gamepad. Puts the gamepad rumble motors back into their
-        /// default state.
+        /// Reset rumble effects on the gamepad.
         /// </summary>
+        /// <remarks>
+        /// <inheritdoc cref="DualMotorRumble.ResetHaptics"/>
+        /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
+        /// <example>
+        /// <code>
+        /// <inheritdoc cref="SetMotorSpeeds"/>
+        /// </code>
+        /// </example>
         public virtual void ResetHaptics()
         {
             m_Rumble.ResetHaptics(this);
         }
 
         /// <inheritdoc />
+        /// <example>
+        /// <code>
+        /// using UnityEngine;
+        /// using UnityEngine.InputSystem;
+        ///
+        /// public class GamepadHapticsExample : MonoBehaviour
+        /// {
+        ///     bool hapticsArePaused = false;
+        ///
+        ///     void Update() {
+        ///         var gamepad = Gamepad.current;
+        ///
+        ///         // No gamepad connected, no need to continue.
+        ///         if (gamepad == null)
+        ///             return;
+        ///
+        ///         float leftTrigger = gamepad.leftTrigger.ReadValue();
+        ///         float rightTrigger = gamepad.rightTrigger.ReadValue();
+        ///
+        ///         // Only set motor speeds if haptics were not paused and if trigger is actuated.
+        ///         // Both triggers must be actuated past 0.2f to start haptics.
+        ///         if (!hapticsArePaused &amp;&amp;
+        ///             (gamepad.leftTrigger.IsActuated() || gamepad.rightTrigger.IsActuated()))
+        ///             gamepad.SetMotorSpeeds(
+        ///                 leftTrigger &lt; 0.2f ? 0.0f : leftTrigger,
+        ///                 rightTrigger &lt; 0.2f ? 0.0f : rightTrigger);
+        ///
+        ///         // Toggle haptics "playback" when "Button South" is pressed.
+        ///         // Notice that if you release the triggers after pausing,
+        ///         // and press the button again, haptics will resume.
+        ///         if (gamepad.buttonSouth.wasPressedThisFrame)
+        ///         {
+        ///             if (hapticsArePaused)
+        ///                 gamepad.ResumeHaptics();
+        ///             else
+        ///                 gamepad.PauseHaptics();
+        ///
+        ///             hapticsArePaused = !hapticsArePaused;
+        ///         }
+        ///
+        ///         // Notice that if you release the triggers after pausing,
+        ///         // and press the Start button, haptics will be reset.
+        ///         if (gamepad.startButton.wasPressedThisFrame)
+        ///             gamepad.ResetHaptics();
+        ///     }
+        /// }
+        ///
+        /// </code>
+        /// </example>
         public virtual void SetMotorSpeeds(float lowFrequency, float highFrequency)
         {
             m_Rumble.SetMotorSpeeds(this, lowFrequency, highFrequency);

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -171,7 +171,7 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// State format tag for GamepadState.
         /// </summary>
-        /// <remarks>Returns "GPAD".</remarks>
+        /// <remarks> Holds the format tag for GamepadState ("GPAD")</remarks>
         public FourCC format => Format;
 
         /// <summary>
@@ -396,7 +396,7 @@ namespace UnityEngine.InputSystem
     /// to be mapped correctly and consistently. If, based on the set of supported devices available
     /// to the input system, this cannot be guaranteed, a given device is usually represented as a
     /// generic <see cref="Joystick"/> or as just a plain <see cref="HID.HID"/> instead.
-    ///
+    /// </remarks>
     /// <example>
     /// <code>
     ///
@@ -452,7 +452,6 @@ namespace UnityEngine.InputSystem
     /// }
     /// </code>
     /// </example>
-    /// </remarks>
     /// <seealso cref="all"/>
     /// <seealso cref="current"/>
     /// <seealso cref="GamepadState"/>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -142,7 +142,9 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// A 2D vector representing the current position of the right stick on a gamepad.
         /// </summary>
-        /// <remarks>Each axis of the 2D vector's range goes from -1 to 1. 0 represents the stick in its center position, and -1 or 1 represents the the stick pushed to its extent in each direction along the axis.</remarks>
+        /// <remarks>Each axis of the 2D vector's range goes from -1 to 1.
+        /// 0 represents the stick in its center position.
+        /// -1 or 1 represents the stick pushed to its extent in each direction along the axis.</remarks>
         /// <seealso cref="Gamepad.rightStick"/>
         [InputControl(layout = "Stick", usage = "Secondary2DMotion", processors = "stickDeadzone", displayName = "Right Stick", shortDisplayName = "RS")]
         [FieldOffset(12)]
@@ -153,7 +155,9 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// The current position of the left trigger on a gamepad.
         /// </summary>
-        /// <remarks>The value's range goes from 0 to 1, where 0 represents the trigger not pressed at all, and 1 represents the trigger in its fully pressed position.</remarks>
+        /// <remarks>The value's range goes from 0 to 1.
+        /// 0 represents the trigger in its neutral position.
+        /// 1 represents the trigger in its fully pressed position.</remarks>
         /// <seealso cref="Gamepad.leftTrigger"/>
         [InputControl(layout = "Button", format = "FLT", usage = "SecondaryTrigger", displayName = "Left Trigger", shortDisplayName = "LT")]
         [FieldOffset(20)]
@@ -162,7 +166,9 @@ namespace UnityEngine.InputSystem.LowLevel
         /// <summary>
         /// The current position of the right trigger on a gamepad.
         /// </summary>
-        /// <remarks>The value's range goes from 0 to 1, where 0 represents the trigger not pressed at all, and 1 represents the trigger in its fully pressed position.</remarks>
+        /// <remarks>The value's range goes from 0 to 1.
+        /// 0 represents the trigger in its neutral position.
+        /// 1 represents the trigger in its fully pressed position.</remarks>
         /// <seealso cref="Gamepad.rightTrigger"/>
         [InputControl(layout = "Button", format = "FLT", usage = "SecondaryTrigger", displayName = "Right Trigger", shortDisplayName = "RT")]
         [FieldOffset(24)]
@@ -632,7 +638,7 @@ namespace UnityEngine.InputSystem
         /// you need it. Whenever the gamepad setup changes, the value returned by this getter
         /// is invalidated.
         ///
-        /// Alternately, if you want a single gamepad, you can use <see cref="current"/> for example.
+        /// Alternately, for querying a single gamepad, you can use <see cref="current"/> for example.
         /// </remarks>
         public new static ReadOnlyArray<Gamepad> all => new ReadOnlyArray<Gamepad>(s_Gamepads, 0, s_GamepadCount);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Gamepad.cs
@@ -796,9 +796,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
         /// <example>
-        /// <code>
         /// <inheritdoc cref="SetMotorSpeeds"/>
-        /// </code>
         /// </example>
         public virtual void PauseHaptics()
         {
@@ -813,9 +811,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
         /// <example>
-        /// <code>
         /// <inheritdoc cref="SetMotorSpeeds"/>
-        /// </code>
         /// </example>
         public virtual void ResumeHaptics()
         {
@@ -830,9 +826,7 @@ namespace UnityEngine.InputSystem
         /// </remarks>
         /// <seealso cref="IDualMotorRumble"/>
         /// <example>
-        /// <code>
         /// <inheritdoc cref="SetMotorSpeeds"/>
-        /// </code>
         /// </example>
         public virtual void ResetHaptics()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Haptics/DualMotorRumble.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Haptics/DualMotorRumble.cs
@@ -39,7 +39,7 @@ namespace UnityEngine.InputSystem.Haptics
             || !Mathf.Approximately(highFrequencyMotorSpeed, 0f);
 
         /// <summary>
-        /// Reset motor speeds to zero.
+        /// Stops haptics by setting motor speeds to zero.
         /// </summary>
         /// <remarks>
         /// Sets both motor speeds to zero while retaining the current values for <see cref="lowFrequencyMotorSpeed"/>

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Haptics/DualMotorRumble.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Haptics/DualMotorRumble.cs
@@ -39,9 +39,13 @@ namespace UnityEngine.InputSystem.Haptics
             || !Mathf.Approximately(highFrequencyMotorSpeed, 0f);
 
         /// <summary>
-        /// Reset motor speeds to zero but retain current values for <see cref="lowFrequencyMotorSpeed"/>
-        /// and <see cref="highFrequencyMotorSpeed"/>.
+        /// Reset motor speeds to zero.
         /// </summary>
+        /// <remarks>
+        /// Sets both motor speeds to zero while retaining the current values for <see cref="lowFrequencyMotorSpeed"/>
+        /// and <see cref="highFrequencyMotorSpeed"/>.
+        /// It will only send the command if <see cref="isRumbling"/> is true.
+        /// </remarks>
         /// <param name="device">Device to send command to.</param>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         public void PauseHaptics(InputDevice device)
@@ -60,6 +64,9 @@ namespace UnityEngine.InputSystem.Haptics
         /// Resume haptics by setting motor speeds to the current values of <see cref="lowFrequencyMotorSpeed"/>
         /// and <see cref="highFrequencyMotorSpeed"/>.
         /// </summary>
+        /// <remarks>
+        /// It will only set motor speeds if <see cref="isRumbling"/> is true
+        /// </remarks>
         /// <param name="device">Device to send command to.</param>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         public void ResumeHaptics(InputDevice device)
@@ -74,9 +81,12 @@ namespace UnityEngine.InputSystem.Haptics
         }
 
         /// <summary>
-        /// Reset haptics by setting both <see cref="lowFrequencyMotorSpeed"/> and <see cref="highFrequencyMotorSpeed"/>
-        /// to zero.
+        /// Reset haptics by setting motor speeds to zero.
         /// </summary>
+        /// <remarks>
+        /// Sets <see cref="lowFrequencyMotorSpeed"/> and <see cref="highFrequencyMotorSpeed"/> to zero.
+        /// It will only set motor speeds if <see cref="isRumbling"/> is true.
+        /// </remarks>
         /// <param name="device">Device to send command to.</param>
         /// <exception cref="ArgumentNullException"><paramref name="device"/> is null.</exception>
         public void ResetHaptics(InputDevice device)


### PR DESCRIPTION
### Description

## Documentation fixes
Updates Gamepad documentation based on Unity Package API Quality Standards by addressing Score Explanation issues:
- Fix related links for all, buttonEast, buttonNorth, buttonSouth, buttonWest, current
- Removed value tag for aButton, all, bButton, buttonEast, buttonNorth, buttonSouth, buttonWest, circleButton, crossButton, current, dpad, leftShoulder, leftStick, leftStickButton, leftTrigger, rightShoulder, rightStick, rightStickButton, rightTrigger, selectButton, squareButton, startButton, triangleButton, xButton, yButton.
- Fixed insufficient remarks length (threshold is 120) on MakeCurrent()
- Added related links (required for this API type) to Gamepad class
- Added  code samples (required for this API type) each for MakeCurrent(), PauseHaptics(), ResetHaptics(), ResumeHaptics(), SetMotorSpeeds(float, float)
  - ❌ Decided not to add examples to FinishSetup(),  OnAdded(), OnRemoved() since they are protected methods.
- Added remarks  for OnAdded(), OnRemoved(), PauseHaptics(), ResetHaptics(), ResumeHaptics()
- Expanded code samples (required for this API type) for Gamepad class.

## Reusability of code examples improvement

This PR follows the approach mentioned in https://docs.unity.com/internal/content-ops/en-us/documentation/content-model/code-snippets-examples.

Many packages such as the Localization and Entities packages follow this convention. I'm throwing the first rock for our package :D 

Also, see the [Slack thread](https://unity.slack.com/archives/C08100WBU92/p1733326529294579) for more insights in this approach, so that I could fix PVP problems.

I'm open for deeper improvements in follow-up PRs but this seems like a good way forward for now.
Let me know your thoughts. 

### Testing status & QA

Docs build on my machine.

### Overall Product Risks

None

- Complexity: Minimal
- Halo Effect: Minimal

### Comments to reviewers

Please let me know of any inconsistencies and improvements I should do.
Also, let me know if the approach to reuse code samples in the folder `DocCodeSamples` is ok.
### Checklist

Before review:

- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
