### PR TITLE
CHANGE: ignore InputActionsEditorTests.CanCreateActionMap until instability is fixed

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
@@ -71,6 +71,7 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
     }
 
     [UnityTest]
+    [Ignore("Instability, see ISXB-1284")]
     public IEnumerator CanCreateActionMap()
     {
         var button = m_Window.rootVisualElement.Q<Button>("add-new-action-map-button");

--- a/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
@@ -148,6 +148,7 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
     }
 
     [UnityTest]
+    [Ignore("Instability, see ISXB-1284")]
     public IEnumerator CanDeleteActionMap()
     {
         var actionMapsContainer = m_Window.rootVisualElement.Q("action-maps-container");


### PR DESCRIPTION
### Description

See title

### Testing status & QA

green CI

### Overall Product Risks

Lowering test coverage.

- Complexity: low
- Halo Effect: low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
