### PR TITLE
FIX: Don't install action trigger hook when notifications set to UnityEvents (case ISXB-711)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -981,7 +981,9 @@ namespace UnityEngine.InputSystem
             }
             if (m_AllMapsHashCode != allMapsHashCode)
             {
-                InstallOnActionTriggeredHook();
+                if (m_NotificationBehavior != PlayerNotifications.InvokeUnityEvents)
+                    InstallOnActionTriggeredHook();
+
                 CacheMessageNames();
                 m_AllMapsHashCode = allMapsHashCode;
             }


### PR DESCRIPTION
### Description

The fix for https://jira.unity3d.com/browse/ISXB-711 (PR https://github.com/Unity-Technologies/InputSystem/pull/2077/) introduced an bug - the action trigger hooks should not be installed when the notification setting is set to use UnityEvents.

This PR addresses that defect - only install the action trigger hooks for SendMessage / BroadcastMessage and CSharp event notification types.


### Testing status & QA

Local tests (SimpleDemo_UsingPlayerInput scene)
Automated tests.

### Overall Product Risks

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

None in particular.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [x] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
