### PR TITLE
FIX: Fixed multiple `OnScreenStick` Components that does not work together when using them simultaneously in isolation mode (ISXB-813)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -435,7 +435,7 @@ internal class OnScreenTests : CoreTestsFixture
         stickLeftTransform.sizeDelta = new Vector2(100, 100);
         stickLeft.controlPath = "<Gamepad>/leftStick";
         stickLeftGO.SetActive(true);
-        
+
         var stickRightGO = new GameObject("StickRight");
         stickRightGO.SetActive(false);
         var stickRightTransform = stickRightGO.AddComponent<RectTransform>();
@@ -506,7 +506,7 @@ internal class OnScreenTests : CoreTestsFixture
         InputSystem.Update(); // Button is feeding events when responding to UI events.
 
         Assert.That(Gamepad.all[0].buttonSouth.isPressed, Is.False);
-        
+
         // Touch the right stick and drag it downwards
         BeginTouch(2, new Vector2(550, 150));
         yield return null;
@@ -519,7 +519,7 @@ internal class OnScreenTests : CoreTestsFixture
 
         Assert.That(Gamepad.all[0].leftStick.ReadValue(), Is.EqualTo(new Vector2(0, 1)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Gamepad.all[0].rightStick.ReadValue(), Is.EqualTo(new Vector2(0, -1)).Using(Vector2EqualityComparer.Instance));
-        
+
         // Release finger one and move second and ensure that it still works
         EndTouch(1, new Vector2(550, 200));
         MoveTouch(2, new Vector2(600, 150));
@@ -529,7 +529,7 @@ internal class OnScreenTests : CoreTestsFixture
 
         Assert.That(Gamepad.all[0].leftStick.ReadValue(), Is.EqualTo(new Vector2(0, 0)).Using(Vector2EqualityComparer.Instance));
         Assert.That(Gamepad.all[0].rightStick.ReadValue(), Is.EqualTo(new Vector2(1, 0)).Using(Vector2EqualityComparer.Instance));
-        
+
         // Release finger two
         EndTouch(2, new Vector2(600, 150));
         yield return null;
@@ -565,7 +565,7 @@ internal class OnScreenTests : CoreTestsFixture
         {
             uiTestScene.uiInputModule.actionsAsset.actionMaps[0].LazyResolveBindings(true);
         };
-        
+
         // Ensure that the OnScreenStick component has been started
         yield return null;
 

--- a/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/OnScreenTests.cs
@@ -395,7 +395,7 @@ internal class OnScreenTests : CoreTestsFixture
     // https://fogbugz.unity3d.com/f/cases/1271942
     [UnityTest]
     [Category("Devices")]
-    public IEnumerator Devices_CanHaveOnScreenJoystickControls()
+    public IEnumerator Devices_CanHaveOnScreenJoystickControls([Values(false, true)] bool useInIsolation)
     {
         foreach (var c in Camera.allCameras)
             Object.Destroy(c.gameObject);
@@ -422,18 +422,33 @@ internal class OnScreenTests : CoreTestsFixture
         canvasGO.AddComponent<GraphicRaycaster>();
         canvas.renderMode = RenderMode.ScreenSpaceOverlay;
 
-        var stickGO = new GameObject("Stick");
-        stickGO.SetActive(false);
-        var stickTransform = stickGO.AddComponent<RectTransform>();
-        var stick = stickGO.AddComponent<OnScreenStick>();
-        stickGO.AddComponent<Image>();
-        stickTransform.SetParent(canvasTransform);
-        stickTransform.anchorMin = new Vector2(0, 0);
-        stickTransform.anchorMax = new Vector2(0, 0);
-        stickTransform.anchoredPosition = new Vector2(100, 100);
-        stickTransform.sizeDelta = new Vector2(100, 100);
-        stick.controlPath = "<Gamepad>/leftStick";
-        stickGO.SetActive(true);
+        var stickLeftGO = new GameObject("StickLeft");
+        stickLeftGO.SetActive(false);
+        var stickLeftTransform = stickLeftGO.AddComponent<RectTransform>();
+        var stickLeft = stickLeftGO.AddComponent<OnScreenStick>();
+        stickLeft.useIsolatedInputActions = useInIsolation;
+        stickLeftGO.AddComponent<Image>();
+        stickLeftTransform.SetParent(canvasTransform);
+        stickLeftTransform.anchorMin = new Vector2(0, 0);
+        stickLeftTransform.anchorMax = new Vector2(0, 0);
+        stickLeftTransform.anchoredPosition = new Vector2(100, 100);
+        stickLeftTransform.sizeDelta = new Vector2(100, 100);
+        stickLeft.controlPath = "<Gamepad>/leftStick";
+        stickLeftGO.SetActive(true);
+        
+        var stickRightGO = new GameObject("StickRight");
+        stickRightGO.SetActive(false);
+        var stickRightTransform = stickRightGO.AddComponent<RectTransform>();
+        var stickRight = stickRightGO.AddComponent<OnScreenStick>();
+        stickRight.useIsolatedInputActions = useInIsolation;
+        stickRightGO.AddComponent<Image>();
+        stickRightTransform.SetParent(canvasTransform);
+        stickRightTransform.anchorMin = new Vector2(0, 0);
+        stickRightTransform.anchorMax = new Vector2(0, 0);
+        stickRightTransform.anchoredPosition = new Vector2(500, 100);
+        stickRightTransform.sizeDelta = new Vector2(100, 100);
+        stickRight.controlPath = "<Gamepad>/rightStick";
+        stickRightGO.SetActive(true);
 
         var buttonGO = new GameObject("Button");
         buttonGO.SetActive(false);
@@ -464,7 +479,7 @@ internal class OnScreenTests : CoreTestsFixture
 
         Assert.That(player.devices, Is.EquivalentTo(new[] { Gamepad.all[0] }));
 
-        // Touch the stick and drag it upwards.
+        // Touch the Left stick and drag it upwards.
         BeginTouch(1, new Vector2(150, 150));
         yield return null;
         eventSystem.Update();
@@ -491,6 +506,38 @@ internal class OnScreenTests : CoreTestsFixture
         InputSystem.Update(); // Button is feeding events when responding to UI events.
 
         Assert.That(Gamepad.all[0].buttonSouth.isPressed, Is.False);
+        
+        // Touch the right stick and drag it downwards
+        BeginTouch(2, new Vector2(550, 150));
+        yield return null;
+        eventSystem.Update();
+        Assert.That(eventSystem.IsPointerOverGameObject(), Is.True);
+        MoveTouch(2, new Vector2(550, 50));
+        yield return null;
+        eventSystem.Update();
+        InputSystem.Update(); // Stick is feeding events when responding to UI events.
+
+        Assert.That(Gamepad.all[0].leftStick.ReadValue(), Is.EqualTo(new Vector2(0, 1)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Gamepad.all[0].rightStick.ReadValue(), Is.EqualTo(new Vector2(0, -1)).Using(Vector2EqualityComparer.Instance));
+        
+        // Release finger one and move second and ensure that it still works
+        EndTouch(1, new Vector2(550, 200));
+        MoveTouch(2, new Vector2(600, 150));
+        yield return null;
+        eventSystem.Update();
+        InputSystem.Update(); // Stick is feeding events when responding to UI events.
+
+        Assert.That(Gamepad.all[0].leftStick.ReadValue(), Is.EqualTo(new Vector2(0, 0)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Gamepad.all[0].rightStick.ReadValue(), Is.EqualTo(new Vector2(1, 0)).Using(Vector2EqualityComparer.Instance));
+        
+        // Release finger two
+        EndTouch(2, new Vector2(600, 150));
+        yield return null;
+        eventSystem.Update();
+        InputSystem.Update(); // Stick is feeding events when responding to UI events.
+
+        Assert.That(Gamepad.all[0].leftStick.ReadValue(), Is.EqualTo(new Vector2(0, 0)).Using(Vector2EqualityComparer.Instance));
+        Assert.That(Gamepad.all[0].rightStick.ReadValue(), Is.EqualTo(new Vector2(0, 0)).Using(Vector2EqualityComparer.Instance));
     }
 
     [UnityTest]
@@ -518,6 +565,9 @@ internal class OnScreenTests : CoreTestsFixture
         {
             uiTestScene.uiInputModule.actionsAsset.actionMaps[0].LazyResolveBindings(true);
         };
+        
+        // Ensure that the OnScreenStick component has been started
+        yield return null;
 
         yield return uiTestScene.PressAndDrag(image, new Vector2(50, 50));
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue with default device selection when adding new Control Scheme.
 - Fixed an issue where action map delegates were not updated when the asset already assigned to the PlayerInput component were changed [ISXB-711](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-711).
 - Fixed Action properties edition in the UI Toolkit version of the Input Actions Asset editor. [ISXB-1277](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1277)
+- Fixed multiple `OnScreenStick` Components that does not work together when using them simultaneously in isolation mode. [ISXB-813](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-813)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -243,7 +243,7 @@ namespace UnityEngine.InputSystem.OnScreen
             {
                 screenPosition = pointer.position.ReadValue();
             }
-            
+
             m_PointerEventData.position = screenPosition;
             EventSystem.current.RaycastAll(m_PointerEventData, m_RaycastResults);
             if (m_RaycastResults.Count == 0)
@@ -267,11 +267,11 @@ namespace UnityEngine.InputSystem.OnScreen
                 m_TouchControl = touchControl;
                 m_PointerMoveAction.ApplyBindingOverride($"{touchControl.path}/position", path: "<Touchscreen>/touch*/position");
             }
-           
+
             m_PointerMoveAction.performed += OnPointerMove;
             m_IsIsolationActive = true;
         }
-        
+
         private void OnPointerChanged(InputAction.CallbackContext ctx)
         {
             if (ctx.control.IsPressed())
@@ -285,8 +285,8 @@ namespace UnityEngine.InputSystem.OnScreen
             // only pointer devices are allowed
             Debug.Assert(ctx.control?.device is Pointer);
             Vector2 screenPosition;
-           
-            // If it's a finger take the value from the finger that initiated the change            
+
+            // If it's a finger take the value from the finger that initiated the change
             if (m_TouchControl != null)
             {
                 // if the finger is up ignore the move
@@ -307,15 +307,15 @@ namespace UnityEngine.InputSystem.OnScreen
         private void OnPointerUp(InputAction.CallbackContext ctx)
         {
             if (!m_IsIsolationActive) return;
-            
+
             // if it's a finger ensure that is the one that get released
             if (m_TouchControl != null)
             {
                 if (m_TouchControl.isInProgress) return;
-                m_PointerMoveAction.ApplyBindingOverride(null, path: "<Touchscreen>/touch*/position");    
+                m_PointerMoveAction.ApplyBindingOverride(null, path: "<Touchscreen>/touch*/position");
                 m_TouchControl = null;
             }
-            
+
             EndInteraction();
             m_PointerMoveAction.performed -= OnPointerMove;
             m_IsIsolationActive = false;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -6,6 +6,7 @@ using UnityEngine.Serialization;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.UI;
+using UnityEngine.InputSystem.Controls;
 
 #if UNITY_EDITOR
 using UnityEditor;
@@ -91,7 +92,10 @@ namespace UnityEngine.InputSystem.OnScreen
                 if (m_PointerDownAction == null || m_PointerDownAction.bindings.Count == 0)
                 {
                     if (m_PointerDownAction == null)
-                        m_PointerDownAction = new InputAction();
+                        m_PointerDownAction = new InputAction(type: InputActionType.PassThrough);
+                    // ensure PassThrough mode
+                    else if (m_PointerDownAction.m_Type != InputActionType.PassThrough)
+                        m_PointerDownAction.m_Type = InputActionType.PassThrough;
 
                     #if UNITY_EDITOR
                     InputExitPlayModeAnalytic.suppress = true;
@@ -121,8 +125,7 @@ namespace UnityEngine.InputSystem.OnScreen
                     #endif
                 }
 
-                m_PointerDownAction.started += OnPointerDown;
-                m_PointerDownAction.canceled += OnPointerUp;
+                m_PointerDownAction.performed += OnPointerChanged;
                 m_PointerDownAction.Enable();
                 m_PointerMoveAction.Enable();
             }
@@ -154,8 +157,7 @@ namespace UnityEngine.InputSystem.OnScreen
         {
             if (m_UseIsolatedInputActions)
             {
-                m_PointerDownAction.started -= OnPointerDown;
-                m_PointerDownAction.canceled -= OnPointerUp;
+                m_PointerDownAction.performed -= OnPointerChanged;
             }
         }
 
@@ -227,12 +229,21 @@ namespace UnityEngine.InputSystem.OnScreen
 
         private void OnPointerDown(InputAction.CallbackContext ctx)
         {
+            if (m_IsIsolationActive) { return; }
             Debug.Assert(EventSystem.current != null);
 
             var screenPosition = Vector2.zero;
-            if (ctx.control?.device is Pointer pointer)
+            TouchControl touchControl = null;
+            if (ctx.control?.parent is TouchControl touch)
+            {
+                touchControl = touch;
+                screenPosition = touch.position.ReadValue();
+            }
+            else if (ctx.control?.device is Pointer pointer)
+            {
                 screenPosition = pointer.position.ReadValue();
-
+            }
+            
             m_PointerEventData.position = screenPosition;
             EventSystem.current.RaycastAll(m_PointerEventData, m_RaycastResults);
             if (m_RaycastResults.Count == 0)
@@ -251,23 +262,63 @@ namespace UnityEngine.InputSystem.OnScreen
                 return;
 
             BeginInteraction(screenPosition, GetCameraFromCanvas());
+            if (touchControl != null)
+            {
+                m_TouchControl = touchControl;
+                m_PointerMoveAction.ApplyBindingOverride($"{touchControl.path}/position", path: "<Touchscreen>/touch*/position");
+            }
+           
             m_PointerMoveAction.performed += OnPointerMove;
+            m_IsIsolationActive = true;
+        }
+        
+        private void OnPointerChanged(InputAction.CallbackContext ctx)
+        {
+            if (ctx.control.IsPressed())
+                OnPointerDown(ctx);
+            else
+                OnPointerUp(ctx);
         }
 
         private void OnPointerMove(InputAction.CallbackContext ctx)
         {
             // only pointer devices are allowed
             Debug.Assert(ctx.control?.device is Pointer);
-
-            var screenPosition = ((Pointer)ctx.control.device).position.ReadValue();
+            Vector2 screenPosition;
+           
+            // If it's a finger take the value from the finger that initiated the change            
+            if (m_TouchControl != null)
+            {
+                // if the finger is up ignore the move
+                if (m_TouchControl.isInProgress == false)
+                {
+                    return;
+                }
+                screenPosition = m_TouchControl.position.ReadValue();
+            }
+            else
+            {
+                screenPosition = ((Pointer)ctx.control.device).position.ReadValue();
+            }
 
             MoveStick(screenPosition, GetCameraFromCanvas());
         }
 
         private void OnPointerUp(InputAction.CallbackContext ctx)
         {
+            if (!m_IsIsolationActive) return;
+            
+            // if it's a finger ensure that is the one that get released
+            if (m_TouchControl != null)
+            {
+                if (m_TouchControl.isInProgress) return;
+                m_PointerMoveAction.ApplyBindingOverride(null, path: "<Touchscreen>/touch*/position");    
+                m_TouchControl = null;
+            }
+            
             EndInteraction();
             m_PointerMoveAction.performed -= OnPointerMove;
+            m_IsIsolationActive = false;
         }
 
         private Camera GetCameraFromCanvas()
@@ -430,6 +481,10 @@ namespace UnityEngine.InputSystem.OnScreen
         private List<RaycastResult> m_RaycastResults;
         [NonSerialized]
         private PointerEventData m_PointerEventData;
+        [NonSerialized]
+        private TouchControl m_TouchControl;
+        [NonSerialized]
+        private bool m_IsIsolationActive;
 
         protected override string controlPathInternal
         {


### PR DESCRIPTION
### Description

When multiple OnScreenStick is used at the same time, in isolation mode, it doesn't distinguish which finger drive the components and will be not functional. 

To fix that I added, when it come from a touch event a track of which finger triggered it and only use information from it.
I also switched the pointerdown tracking to bypass to be able to track any pointer down/up instead of only the First down and last Up.

### Testing status & QA

Added tests
tested on android with the customer project.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [X ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ X] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
