### PR TITLE
FIX: Avoid problems with CI and reimports

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue with default device selection when adding new Control Scheme.
 - Fixed an issue where action map delegates were not updated when the asset already assigned to the PlayerInput component were changed [ISXB-711](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-711).
 - Fixed Action properties edition in the UI Toolkit version of the Input Actions Asset editor. [ISXB-1277](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1277)
+- Fixed an issue where batch jobs would fail with "Error: Error building Player because scripts are compiling" if a source generated .inputactions asset is out of sync with its generated source code. (ISXB-1300).
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,7 +34,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue with default device selection when adding new Control Scheme.
 - Fixed an issue where action map delegates were not updated when the asset already assigned to the PlayerInput component were changed [ISXB-711](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-711).
 - Fixed Action properties edition in the UI Toolkit version of the Input Actions Asset editor. [ISXB-1277](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1277)
-- Fixed an issue where batch jobs would fail with "Error: Error building Player because scripts are compiling" if a source generated .inputactions asset is out of sync with its generated source code. (ISXB-1300).
+- Fixed an issue where batch jobs would fail with "Error: Error building Player because scripts are compiling" if a source generated .inputactions asset is out of sync with its generated source code (ISXB-1300).
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -256,22 +256,12 @@ namespace UnityEngine.InputSystem.Editor
 
             if (InputActionCodeGenerator.GenerateWrapperCode(wrapperFilePath, asset, options))
             {
-                // When we generate the wrapper code cs file during asset import, we cannot call ImportAsset on that directly because
-                // script assets have to be imported before all other assets, and are not allowed to be added to the import queue during
-                // asset import. So instead we register a callback to trigger a delayed asset refresh which should then pick up the
-                // changed/added script, and trigger a new import.
-                if (++_importedAssetsSinceLastRefresh == 1)
-                    EditorApplication.update += AssetDatabase.Refresh;
+                // This isn't ideal and may have side effects, but we cannot avoid compiling again.
+                // Previously we attempted to run a EditorApplication.delayCall += AssetDatabase.Refresh
+                // but this would lead to "error: Error building Player because scripts are compiling" in CI.
+                // Previous comment here warned against not being able to reimport here directly, but it seems it's ok.
+                AssetDatabase.ImportAsset(wrapperFilePath);
             }
-        }
-
-        private static int _importedAssetsSinceLastRefresh = 0;
-
-        private void RefreshGeneratedAssets()
-        {
-            EditorApplication.update -= RefreshGeneratedAssets;
-            _importedAssetsSinceLastRefresh = 0;
-            AssetDatabase.Refresh();
         }
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -260,8 +260,18 @@ namespace UnityEngine.InputSystem.Editor
                 // script assets have to be imported before all other assets, and are not allowed to be added to the import queue during
                 // asset import. So instead we register a callback to trigger a delayed asset refresh which should then pick up the
                 // changed/added script, and trigger a new import.
-                EditorApplication.delayCall += AssetDatabase.Refresh;
+                if (++_importedAssetsSinceLastRefresh == 1)
+                    EditorApplication.update += AssetDatabase.Refresh;
             }
+        }
+
+        private static int _importedAssetsSinceLastRefresh = 0;
+
+        private void RefreshGeneratedAssets()
+        {
+            EditorApplication.update -= RefreshGeneratedAssets;
+            _importedAssetsSinceLastRefresh = 0;
+            AssetDatabase.Refresh();
         }
 
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS


### PR DESCRIPTION
### Description

FIX: Solves problem with CI and reimports issues by `EditorApplication.delayCall` which leads to CI build errors "Error: Scripts are compiling" when attempting to run a batch mode project via UTR when source code associated with an .inputactions asset is out of sync due to asset or code generator update.

### Testing status & QA

Have tested various ways to go around the problem `EditorApplication.update`, `AssetDatabase.ImportAsset` etc but went with `AssetDatabase.ImportAsset` which is a solution that goes straight against what previous inline comment suggested. Discussed solution with Asset Database team and no solution is good since this should use a source generator (Roslyn) for this kind of feature, but cannot be reliably setup in current Unity version. Hence this solution.

Recommendation for testing is to also ensure this solution works with regular editor use (non-batch mode). Also proven by the following PR which has intentionally outdated test source asset and sample source asset: https://github.com/Unity-Technologies/InputSystem/pull/2060 

The linked PR should be closed if/when this lands.

### Overall Product Risks

- Complexity: Small to medium
- Halo Effect: Medium due to many corner cases and unknown side effects

### Comments to reviewers

Focus on corner cases and potential race conditions.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
