### PR TITLE
FIX: Change location of the link xml file so that it can persist beyond an editor shutdown.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -36,6 +36,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Action properties edition in the UI Toolkit version of the Input Actions Asset editor. [ISXB-1277](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1277)
 
 ### Changed
+- Changed location of the link xml file (code stripping rules), from a temporary directory to the project Library folder (ISX-2140).
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).
 - Changed `OnScreenControl` to automaticaly switch, in Single Player with autoswitch enabled, to the target device control scheme when the first component is enabled to prevent bad interactions when it start.
 - Changed paremeter `overrideModifiersNeedToBePressedFirst` to obsolete for `ButtonWithOneModifier`, `ButtonWithTwoModifiers`, `OneModifierComposite` and `TwoModifiersComposite` in favour the new `modifiersOrder` parameter which is more explicit.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/BuildPipeline/LinkFileGenerator.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/BuildPipeline/LinkFileGenerator.cs
@@ -77,9 +77,12 @@ namespace UnityEngine.InputSystem.Editor
 
             sb.AppendLine("</linker>");
 
-            var filePathName = Path.Combine(Application.dataPath, "..", "Temp", "InputSystemLink.xml");
-            File.WriteAllText(filePathName, sb.ToString());
-            return filePathName;
+            var linkXmlDirectory = Path.Combine(Application.dataPath, "..", "Library", "InputSystem");
+            var linkXmlFile = Path.Combine(linkXmlDirectory, $"{data.target}Link.xml");
+
+            Directory.CreateDirectory(linkXmlDirectory);
+            File.WriteAllText(linkXmlFile, sb.ToString());
+            return linkXmlFile;
         }
 
         static bool IsTypeUsedViaReflectionByInputSystem(Type type)


### PR DESCRIPTION
### Description
Fixes ISX-2140
Fix location of link xml file. We need a location that is persistent and not cleaned when exiting Unity Editor

### Testing status & QA
Tested locally building an Android IL2CPP variation.

- Complexity: 0
- Halo Effect: 0

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [x] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
