### PR TITLE
FIX: Input State Window is now force-closed when the device it is inspecting is disconnected

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue with default device selection when adding new Control Scheme.
 - Fixed an issue where action map delegates were not updated when the asset already assigned to the PlayerInput component were changed [ISXB-711](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-711).
 - Fixed Action properties edition in the UI Toolkit version of the Input Actions Asset editor. [ISXB-1277](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1277)
+- Fixed an editor crash caused by input debugger device state window reusing cached state when reconnecting Stadia controller. [ISXB-658](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-658)
 
 ### Changed
 - Added back the InputManager to InputSystem project-wide asset migration code with performance improvement (ISX-2086).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
@@ -125,7 +125,7 @@ namespace UnityEngine.InputSystem.Editor
             if (device.deviceId != m_Control.device.deviceId)
                 return;
 
-            if (change == InputDeviceChange.Removed)            
+            if (change == InputDeviceChange.Removed)
                 Close();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
@@ -113,6 +113,26 @@ namespace UnityEngine.InputSystem.Editor
             PollBuffersFromControl(control, selectBuffer: true);
 
             titleContent = new GUIContent(control.displayName);
+
+            InputSystem.onDeviceChange += OnDeviceChange;
+        }
+
+        private void OnDeviceChange(InputDevice device, InputDeviceChange change)
+        {
+            if (m_Control is null)
+                return;
+
+            if (device.deviceId != m_Control.device.deviceId)
+                return;
+
+            if (change == InputDeviceChange.Removed)            
+                Close();
+        }
+
+        internal void OnDestroy()
+        {
+            if (m_Control != null)
+                InputSystem.onDeviceChange -= OnDeviceChange;
         }
 
         private unsafe void PollBuffersFromControl(InputControl control, bool selectBuffer = false)
@@ -286,6 +306,12 @@ namespace UnityEngine.InputSystem.Editor
         ////TODO: support dumping multiple state side-by-side when comparing
         private void DrawHexDump()
         {
+            if (m_StateBuffers is null)
+                return;
+
+            if (m_StateBuffers[m_SelectedStateBuffer] is null)
+                return;
+
             m_HexDumpScrollPosition = EditorGUILayout.BeginScrollView(m_HexDumpScrollPosition);
 
             var stateBuffer = m_StateBuffers[m_SelectedStateBuffer];


### PR DESCRIPTION
### Description

Fixes [ISXB-658](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-658).

The `InputStateWindow` currently caches a bunch of state. When a device is disconnected, then reconnected, this state is reused. It is possible - likely based on the specifics of the device - that this will cause the window to `memcpy` from or into memory no longer owned by the device or the window leading to an editor crash.

To resolve this, I've used the same strategy used for the Input debugger window; when the device is disconnected - the window is force-closed.

### Testing status & QA

I tested this locally using a Stadia controller, but it would be great to get some wider testing of devices on this before merging. Although I certainly don't see this as high risk.

### Overall Product Risks

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

The changes in `DrawHexDump` were to resolve some spammy null reference exception errors caused by the window. I believe it to be now unlikely that we'd run into a case where null reference exceptions are thrown during the drawing of the window, but there is no harm in doing these checks.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
