### PR TITLE
FIX: Modifying or changing focus on composite bindings in the Input Actions Editor no longer cause a full UI rebuild

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -37,6 +37,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an editor crash caused by input debugger device state window reusing cached state when reconnecting Stadia controller. [ISXB-658](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-658)
 - Fixed an issue where batch jobs would fail with "Error: Error building Player because scripts are compiling" if a source generated .inputactions asset is out of sync with its generated source code (ISXB-1300).
 - Fixed multiple `OnScreenStick` Components that does not work together when using them simultaneously in isolation mode. [ISXB-813](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-813)
+- Fixed an issue in input actions editor window that caused certain fields in custom input composite bindings to require multiple clicks to action / focus. [ISXB-1171](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1171)
 
 ### Changed
 - Changed location of the link xml file (code stripping rules), from a temporary directory to the project Library folder (ISX-2140).

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -176,7 +176,7 @@ namespace UnityEngine.InputSystem.Editor
             DelayFocusLost(element == null);
         }
 
-        private void OnStateChanged(InputActionsEditorState newState)
+        private void OnStateChanged(InputActionsEditorState newState, UIRebuildMode editorRebuildMode)
         {
 #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
             // No action, auto-saved on edit-focus lost

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -237,7 +237,7 @@ namespace UnityEngine.InputSystem.Editor
             m_StateContainer.Initialize(rootVisualElement.Q("action-editor"));
         }
 
-        private void OnStateChanged(InputActionsEditorState newState)
+        private void OnStateChanged(InputActionsEditorState newState, UIRebuildMode editorRebuildMode)
         {
             DirtyInputActionsEditorWindow(newState);
             m_State = newState;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
@@ -7,9 +7,16 @@ using UnityEngine.UIElements;
 
 namespace UnityEngine.InputSystem.Editor
 {
+    // Enum used to dictate if a state change should rebuild the Input Actions editor UI
+    internal enum UIRebuildMode
+    {
+        None,
+        Rebuild,
+    }
+
     internal class StateContainer
     {
-        public event Action<InputActionsEditorState> StateChanged;
+        public event Action<InputActionsEditorState, UIRebuildMode> StateChanged;
 
         private VisualElement m_RootVisualElement;
         private InputActionsEditorState m_State;
@@ -21,7 +28,7 @@ namespace UnityEngine.InputSystem.Editor
             this.assetGUID = assetGUID;
         }
 
-        public void Dispatch(Command command)
+        public void Dispatch(Command command, UIRebuildMode editorRebuildMode = UIRebuildMode.Rebuild)
         {
             if (command == null)
                 throw new ArgumentNullException(nameof(command));
@@ -36,7 +43,7 @@ namespace UnityEngine.InputSystem.Editor
                 // catch exceptions here or the UIToolkit scheduled event will keep firing forever.
                 try
                 {
-                    StateChanged?.Invoke(m_State);
+                    StateChanged?.Invoke(m_State, editorRebuildMode);
                 }
                 catch (Exception e)
                 {
@@ -55,9 +62,9 @@ namespace UnityEngine.InputSystem.Editor
             m_RootVisualElement.Unbind();
             m_RootVisualElement.TrackSerializedObjectValue(m_State.serializedObject, so =>
             {
-                StateChanged?.Invoke(m_State);
+                StateChanged?.Invoke(m_State, UIRebuildMode.Rebuild);
             });
-            StateChanged?.Invoke(m_State);
+            StateChanged?.Invoke(m_State, UIRebuildMode.Rebuild);
             rootVisualElement.Bind(m_State.serializedObject);
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositeBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/CompositeBindingPropertiesView.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.InputSystem.Editor
 
             viewState.parameterListView.onChange = () =>
             {
-                Dispatch(Commands.UpdatePathNameAndValues(viewState.parameterListView.GetParameters(), viewState.selectedBindingPath));
+                Dispatch(Commands.UpdatePathNameAndValues(viewState.parameterListView.GetParameters(), viewState.selectedBindingPath), UIRebuildMode.None);
             };
             viewState.parameterListView.OnDrawVisualElements(rootElement);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ViewBase.cs
@@ -26,8 +26,12 @@ namespace UnityEngine.InputSystem.Editor
             m_ChildViews = new List<IView>();
         }
 
-        protected void OnStateChanged(InputActionsEditorState state)
+        protected void OnStateChanged(InputActionsEditorState state, UIRebuildMode editorRebuildMode)
         {
+            // Return early if rebuilding the editor UI isn't required (ISXB-1171)
+            if (editorRebuildMode == UIRebuildMode.None)
+                return;
+
             UpdateView(state);
         }
 
@@ -70,9 +74,9 @@ namespace UnityEngine.InputSystem.Editor
             view.DestroyView();
         }
 
-        public void Dispatch(Command command)
+        public void Dispatch(Command command, UIRebuildMode editorRebuildMode = UIRebuildMode.Rebuild)
         {
-            stateContainer.Dispatch(command);
+            stateContainer.Dispatch(command, editorRebuildMode);
         }
 
         public abstract void RedrawUI(TViewState viewState);


### PR DESCRIPTION
### Description

Fixes [ISXB-1171](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1171).

The issue was caused by the on change handler causing a full UI rebuild of the editor window when it was not required. The fix required added a new enum which told the UI system if a rebuild was necessary - defaulting to rebuilding since this was the previous default.

### Testing status & QA

This was tested locally using the provided project. The change is localised to the composite binding part of the window and so I don't believe additional QA would be required.

### Overall Product Risks

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

The only concern I have with this solution is - do we know of any instances where changes to the UI *would* require a complete rebuild?

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
