### PR TITLE
DOCS: Improves DOCF-5483.

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/UISupport.md
+++ b/Packages/com.unity.inputsystem/Documentation~/UISupport.md
@@ -32,6 +32,7 @@ The three main UI solutions are **UI Toolkit**, **Unity UI**, and **IMGUI**. The
 
 - From Unity 2023.2 and onwards, the UI actions defined in the default [project-wide actions](./ProjectWideActions.md) directly map to UI Toolkit input. You do not need to use the UI Input Module component.</br></br>
 - In versions of Unity prior to 2023.2, you must use the UI Input Module component to define which actions are passed through from the Input System to the UI.
+- Refer to UI Toolkit [Runtime UI event system and input handling](https://docs.unity3d.com/Manual/UIE-Runtime-Event-System.html) for more information on how to configure UI Toolkit input.
 
 **For [**Unity UI**](https://docs.unity3d.com/Packages/com.unity.ugui@latest), also known as "uGUI" (a GameObject and Component style UI solution):**
 


### PR DESCRIPTION
### Description

Adds a link in Input System's "UI Support" documentation to the UI Toolkit manual page that contains more explanations on input handling. This should end up effectively addressing the problem of lack of clarity and scarcity of information mentioned in the [DOCF-5483](https://jira.unity3d.com/browse/DOCF-5483) jira task.

### Testing status & QA

No testing. This is documentation only. That being said, I'll defer to Ben Pitt to verify that the documentation changes are showing properly.

### Overall Product Risks

- Complexity: minimal
- Halo Effect: minimal

### Comments to reviewers

Documentation only. No new entry, just a small improvement on an existing manual page. Do I need to add an entry to the changelog?

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
