### PR TITLE
FIX: collapsed and expanded treeview state is preserved when saving

### DIFF
--- a/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
+++ b/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
@@ -24,7 +24,7 @@ internal class SelectorsTests
         var actionTwo = actionMap.AddAction("Action2", binding: "<Keyboard>/d");
 
 
-        var treeViewData = Selectors.GetActionsAsTreeViewData(TestData.EditorStateWithAsset(asset).Generate());
+        var treeViewData = Selectors.GetActionsAsTreeViewData(TestData.EditorStateWithAsset(asset).Generate(), new Dictionary<Guid, int>());
 
 
         Assert.That(treeViewData.Count, Is.EqualTo(2));

--- a/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
+++ b/Assets/Tests/InputSystem.Editor/SelectorsTests.cs
@@ -24,7 +24,7 @@ internal class SelectorsTests
         var actionTwo = actionMap.AddAction("Action2", binding: "<Keyboard>/d");
 
 
-        var treeViewData = Selectors.GetActionsAsTreeViewData(TestData.EditorStateWithAsset(asset).Generate(), new Dictionary<Guid, int>());
+        var treeViewData = Selectors.GetActionsAsTreeViewData(TestData.EditorStateWithAsset(asset).Generate());
 
 
         Assert.That(treeViewData.Count, Is.EqualTo(2));

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR && UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using UnityEditor;
 
@@ -92,7 +91,6 @@ namespace UnityEngine.InputSystem.Editor
             int selectedActionIndex = 0,
             int selectedBindingIndex = 0,
             SelectionType selectionType = SelectionType.Action,
-            Dictionary<(string, string), HashSet<int>> expandedBindingIndices = null,
             InputControlScheme selectedControlScheme = default,
             int selectedControlSchemeIndex = -1,
             int selectedDeviceRequirementIndex = -1,
@@ -112,9 +110,6 @@ namespace UnityEngine.InputSystem.Editor
             m_selectedControlSchemeIndex = selectedControlSchemeIndex;
             m_selectedDeviceRequirementIndex = selectedDeviceRequirementIndex;
 
-            m_ExpandedCompositeBindings = expandedBindingIndices == null ?
-                new Dictionary<(string, string), HashSet<int>>() :
-                new Dictionary<(string, string), HashSet<int>>(expandedBindingIndices);
             m_CutElements = cutElements;
         }
 
@@ -201,12 +196,6 @@ namespace UnityEngine.InputSystem.Editor
                 m_ControlScheme = new InputControlScheme();
             }
 
-            // Editor may leave these as null after domain reloads, so recreate them in that case.
-            // If they exist, we attempt to just preserve the same expanded items based on name for now for simplicity.
-            m_ExpandedCompositeBindings = other.m_ExpandedCompositeBindings == null ?
-                new Dictionary<(string, string), HashSet<int>>() :
-                new Dictionary<(string, string), HashSet<int>>(other.m_ExpandedCompositeBindings);
-
             m_CutElements = other.cutElements;
         }
 
@@ -218,7 +207,6 @@ namespace UnityEngine.InputSystem.Editor
             InputControlScheme? selectedControlScheme = null,
             int? selectedControlSchemeIndex = null,
             int? selectedDeviceRequirementIndex = null,
-            Dictionary<(string, string), HashSet<int>> expandedBindingIndices = null,
             List<CutElement> cutElements = null)
         {
             return new InputActionsEditorState(
@@ -228,7 +216,6 @@ namespace UnityEngine.InputSystem.Editor
                 selectedActionIndex ?? this.selectedActionIndex,
                 selectedBindingIndex ?? this.selectedBindingIndex,
                 selectionType ?? this.selectionType,
-                expandedBindingIndices ?? m_ExpandedCompositeBindings,
 
                 // Control schemes
                 selectedControlScheme ?? this.selectedControlScheme,
@@ -248,7 +235,6 @@ namespace UnityEngine.InputSystem.Editor
                 selectedActionIndex,
                 selectedBindingIndex,
                 selectionType,
-                m_ExpandedCompositeBindings,
                 selectedControlScheme,
                 selectedControlSchemeIndex,
                 selectedDeviceRequirementIndex,
@@ -260,39 +246,6 @@ namespace UnityEngine.InputSystem.Editor
             return serializedObject
                 .FindProperty(nameof(InputActionAsset.m_ActionMaps))
                 .FirstOrDefault(p => p.FindPropertyRelative(nameof(InputActionMap.m_Name)).stringValue == actionMapName);
-        }
-
-        public InputActionsEditorState ExpandCompositeBinding(SerializedInputBinding binding)
-        {
-            var key = GetSelectedActionMapAndActionKey();
-
-            var expandedCompositeBindings = new Dictionary<(string, string), HashSet<int>>(m_ExpandedCompositeBindings);
-            if (!expandedCompositeBindings.TryGetValue(key, out var expandedStates))
-            {
-                expandedStates = new HashSet<int>();
-                expandedCompositeBindings.Add(key, expandedStates);
-            }
-
-            expandedStates.Add(binding.indexOfBinding);
-
-            return With(expandedBindingIndices: expandedCompositeBindings);
-        }
-
-        public InputActionsEditorState CollapseCompositeBinding(SerializedInputBinding binding)
-        {
-            var key = GetSelectedActionMapAndActionKey();
-
-            if (m_ExpandedCompositeBindings.ContainsKey(key) == false)
-                throw new InvalidOperationException("Trying to collapse a composite binding tree that was never expanded.");
-
-            // do the dance of C# immutability
-            var oldExpandedCompositeBindings = m_ExpandedCompositeBindings;
-            var expandedCompositeBindings = oldExpandedCompositeBindings.Keys.Where(dictKey => dictKey != key)
-                .ToDictionary(dictKey => dictKey, dictKey => oldExpandedCompositeBindings[dictKey]);
-            var newHashset = new HashSet<int>(m_ExpandedCompositeBindings[key].Where(index => index != binding.indexOfBinding));
-            expandedCompositeBindings.Add(key, newHashset);
-
-            return With(expandedBindingIndices: expandedCompositeBindings);
         }
 
         public InputActionsEditorState SelectAction(string actionName)
@@ -419,47 +372,11 @@ namespace UnityEngine.InputSystem.Editor
             return m_CutElements;
         }
 
-        public ReadOnlyCollection<int> GetOrCreateExpandedState()
-        {
-            return new ReadOnlyCollection<int>(GetOrCreateExpandedStateInternal().ToList());
-        }
-
-        private HashSet<int> GetOrCreateExpandedStateInternal()
-        {
-            var key = GetSelectedActionMapAndActionKey();
-
-            if (m_ExpandedCompositeBindings.TryGetValue(key, out var expandedStates))
-                return expandedStates;
-
-            expandedStates = new HashSet<int>();
-            m_ExpandedCompositeBindings.Add(key, expandedStates);
-            return expandedStates;
-        }
-
-        internal (string, string) GetSelectedActionMapAndActionKey()
-        {
-            var selectedActionMap = GetSelectedActionMap();
-
-            var selectedAction = selectedActionMap
-                .FindPropertyRelative(nameof(InputActionMap.m_Actions))
-                .GetArrayElementAtIndex(selectedActionIndex);
-
-            var key = (
-                selectedActionMap.FindPropertyRelative(nameof(InputActionMap.m_Name)).stringValue,
-                selectedAction.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue
-            );
-            return key;
-        }
-
         private SerializedProperty GetSelectedActionMap()
         {
             return Selectors.GetActionMapAtIndex(serializedObject, selectedActionMapIndex)?.wrappedProperty;
         }
-
-        /// <summary>
-        /// Expanded states for the actions tree view. These are stored per InputActionMap
-        /// </summary>
-        private readonly Dictionary<(string, string), HashSet<int>> m_ExpandedCompositeBindings;
+        
 
         private readonly InputControlScheme m_ControlScheme;
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -376,7 +376,6 @@ namespace UnityEngine.InputSystem.Editor
         {
             return Selectors.GetActionMapAtIndex(serializedObject, selectedActionMapIndex)?.wrappedProperty;
         }
-        
 
         private readonly InputControlScheme m_ControlScheme;
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -26,6 +26,9 @@ namespace UnityEngine.InputSystem.Editor
         private bool m_RenameOnActionAdded;
         private readonly CollectionViewSelectionChangeFilter m_ActionsTreeViewSelectionChangeFilter;
 
+        //save TreeView element id's of individual input actions and bindings to ensure saving of expanded state
+        private Dictionary<Guid, int> m_GuidToTreeViewId;
+
         public ActionsTreeView(VisualElement root, StateContainer stateContainer)
             : base(root, stateContainer)
         {
@@ -35,6 +38,7 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionsTreeView = root.Q<TreeView>("actions-tree-view");
             //assign unique viewDataKey to store treeView states like expanded/collapsed items - make it unique to avoid conflicts with other TreeViews
             m_ActionsTreeView.viewDataKey = $"InputActionTreeView_{stateContainer.assetGUID}";
+            m_GuidToTreeViewId = new Dictionary<Guid, int>();
             m_ActionsTreeView.selectionType = UIElements.SelectionType.Single;
             m_ActionsTreeView.makeItem = () => new InputActionsTreeViewItem();
             m_ActionsTreeView.reorderable = true;
@@ -143,7 +147,7 @@ namespace UnityEngine.InputSystem.Editor
             CreateSelector(Selectors.GetActionsForSelectedActionMap, Selectors.GetActionMapCount,
                 (_, count, state) =>
                 {
-                    var treeData = Selectors.GetActionsAsTreeViewData(state);
+                    var treeData = Selectors.GetActionsAsTreeViewData(state, m_GuidToTreeViewId);
                     return new ViewState
                     {
                         treeViewData = treeData,
@@ -568,7 +572,7 @@ namespace UnityEngine.InputSystem.Editor
 
     internal static partial class Selectors
     {
-        public static List<TreeViewItemData<ActionOrBindingData>> GetActionsAsTreeViewData(InputActionsEditorState state)
+        public static List<TreeViewItemData<ActionOrBindingData>> GetActionsAsTreeViewData(InputActionsEditorState state, Dictionary<Guid, int> idDictionary)
         {
             var actionMapIndex = state.selectedActionMapIndex;
             var controlSchemes = state.serializedObject.FindProperty(nameof(InputActionAsset.m_ControlSchemes));
@@ -587,13 +591,12 @@ namespace UnityEngine.InputSystem.Editor
                 .ToList();
 
             var actionItems = new List<TreeViewItemData<ActionOrBindingData>>();
-            var treeviewItemIDCounter = 0;
             foreach (var action in actions)
             {
                 var actionBindings = bindings.Where(spb => spb.action == action.name).ToList();
                 var bindingItems = new List<TreeViewItemData<ActionOrBindingData>>();
                 var actionId = new Guid(action.id);
-        
+
                 for (var i = 0; i < actionBindings.Count; i++)
                 {
                     var serializedInputBinding = actionBindings[i];
@@ -616,7 +619,7 @@ namespace UnityEngine.InputSystem.Editor
                                 if (isVisible)
                                 {
                                     var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);
-                                    compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
+                                    compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(new Guid(nextBinding.id), idDictionary),
                                         new ActionOrBindingData(isAction: false, name, actionMapIndex, isComposite: false,
                                             isPartOfComposite: true, GetControlLayout(nextBinding.path), bindingIndex: nextBinding.indexOfBinding, isCut: state.IsBindingCut(actionMapIndex, nextBinding.indexOfBinding))));
                                 }
@@ -634,7 +637,7 @@ namespace UnityEngine.InputSystem.Editor
 
                         var shouldCompositeBeVisible = !(compositeItems.Count == 0 && hasHiddenCompositeParts); //hide composite if all parts are hidden
                         if (shouldCompositeBeVisible)
-                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
+                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
                                 new ActionOrBindingData(isAction: false, serializedInputBinding.name, actionMapIndex, isComposite: true, isPartOfComposite: false, action.expectedControlType, bindingIndex: serializedInputBinding.indexOfBinding, isCut: state.IsBindingCut(actionMapIndex, serializedInputBinding.indexOfBinding)),
                                 compositeItems.Count > 0 ? compositeItems : null));
                     }
@@ -642,16 +645,29 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         var isVisible = ShouldBindingBeVisible(serializedInputBinding, state.selectedControlScheme, state.selectedDeviceRequirementIndex);
                         if (isVisible)
-                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
+                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
                                 new ActionOrBindingData(isAction: false, GetHumanReadableBindingName(serializedInputBinding, state.selectedControlScheme, controlSchemes), actionMapIndex,
                                     isComposite: false, isPartOfComposite: false, GetControlLayout(serializedInputBinding.path), bindingIndex: serializedInputBinding.indexOfBinding, isCut: state.IsBindingCut(actionMapIndex, serializedInputBinding.indexOfBinding))));
                     }
                 }
                 var actionIndex = action.wrappedProperty.GetIndexOfArrayElement();
-                actionItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
+                actionItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(actionId, idDictionary),
                     new ActionOrBindingData(isAction: true, action.name, actionMapIndex, isComposite: false, isPartOfComposite: false, action.expectedControlType, actionIndex: actionIndex, isCut: state.IsActionCut(actionMapIndex, actionIndex)), bindingItems.Count > 0 ? bindingItems : null));
             }
             return actionItems;
+        }
+
+        private static int GetIdForGuid(Guid guid, Dictionary<Guid, int> idDictionary)
+        {
+            //This method is used to ensure that the same Guid always gets the same id
+            //We use getHashCode instead of a counter, as we cannot guarantee that the same Guid will always be added in the same order
+            //There is a tiny chance of a collision, but it is it does happen it will only affect the expanded state of the tree view
+            if (!idDictionary.TryGetValue(guid, out var id))
+            {
+                id = guid.GetHashCode(); //idDictionary.Values.Count > 0 ? idDictionary.Values.Max() + 1 : 0;
+                idDictionary.Add(guid, id);
+            }
+            return id;
         }
 
         private static string GetHumanReadableBindingName(SerializedInputBinding serializedInputBinding, InputControlScheme? currentControlScheme, SerializedProperty allControlSchemes)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -659,12 +659,12 @@ namespace UnityEngine.InputSystem.Editor
 
         private static int GetIdForGuid(Guid guid, Dictionary<Guid, int> idDictionary)
         {
-            //This method is used to ensure that the same Guid always gets the same id
-            //We use getHashCode instead of a counter, as we cannot guarantee that the same Guid will always be added in the same order
-            //There is a tiny chance of a collision, but it is it does happen it will only affect the expanded state of the tree view
+            // This method is used to ensure that the same Guid always gets the same id
+            // We use getHashCode instead of a counter, as we cannot guarantee that the same Guid will always be added in the same order
+            // There is a tiny chance of a collision, but it is it does happen it will only affect the expanded state of the tree view
             if (!idDictionary.TryGetValue(guid, out var id))
             {
-                id = guid.GetHashCode(); //idDictionary.Values.Count > 0 ? idDictionary.Values.Max() + 1 : 0;
+                id = guid.GetHashCode();
                 idDictionary.Add(guid, id);
             }
             return id;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -26,9 +26,6 @@ namespace UnityEngine.InputSystem.Editor
         private bool m_RenameOnActionAdded;
         private readonly CollectionViewSelectionChangeFilter m_ActionsTreeViewSelectionChangeFilter;
 
-        //save TreeView element id's of individual input actions and bindings to ensure saving of expanded state
-        private Dictionary<Guid, int> m_GuidToTreeViewId;
-
         public ActionsTreeView(VisualElement root, StateContainer stateContainer)
             : base(root, stateContainer)
         {
@@ -38,7 +35,6 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionsTreeView = root.Q<TreeView>("actions-tree-view");
             //assign unique viewDataKey to store treeView states like expanded/collapsed items - make it unique to avoid conflicts with other TreeViews
             m_ActionsTreeView.viewDataKey = $"InputActionTreeView_{stateContainer.assetGUID}";
-            m_GuidToTreeViewId = new Dictionary<Guid, int>();
             m_ActionsTreeView.selectionType = UIElements.SelectionType.Single;
             m_ActionsTreeView.makeItem = () => new InputActionsTreeViewItem();
             m_ActionsTreeView.reorderable = true;
@@ -147,7 +143,7 @@ namespace UnityEngine.InputSystem.Editor
             CreateSelector(Selectors.GetActionsForSelectedActionMap, Selectors.GetActionMapCount,
                 (_, count, state) =>
                 {
-                    var treeData = Selectors.GetActionsAsTreeViewData(state, m_GuidToTreeViewId);
+                    var treeData = Selectors.GetActionsAsTreeViewData(state);
                     return new ViewState
                     {
                         treeViewData = treeData,
@@ -572,7 +568,7 @@ namespace UnityEngine.InputSystem.Editor
 
     internal static partial class Selectors
     {
-        public static List<TreeViewItemData<ActionOrBindingData>> GetActionsAsTreeViewData(InputActionsEditorState state, Dictionary<Guid, int> idDictionary)
+        public static List<TreeViewItemData<ActionOrBindingData>> GetActionsAsTreeViewData(InputActionsEditorState state)
         {
             var actionMapIndex = state.selectedActionMapIndex;
             var controlSchemes = state.serializedObject.FindProperty(nameof(InputActionAsset.m_ControlSchemes));
@@ -591,12 +587,13 @@ namespace UnityEngine.InputSystem.Editor
                 .ToList();
 
             var actionItems = new List<TreeViewItemData<ActionOrBindingData>>();
+            var treeviewItemIDCounter = 0;
             foreach (var action in actions)
             {
                 var actionBindings = bindings.Where(spb => spb.action == action.name).ToList();
                 var bindingItems = new List<TreeViewItemData<ActionOrBindingData>>();
                 var actionId = new Guid(action.id);
-
+        
                 for (var i = 0; i < actionBindings.Count; i++)
                 {
                     var serializedInputBinding = actionBindings[i];
@@ -619,7 +616,7 @@ namespace UnityEngine.InputSystem.Editor
                                 if (isVisible)
                                 {
                                     var name = GetHumanReadableCompositeName(nextBinding, state.selectedControlScheme, controlSchemes);
-                                    compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(new Guid(nextBinding.id), idDictionary),
+                                    compositeItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
                                         new ActionOrBindingData(isAction: false, name, actionMapIndex, isComposite: false,
                                             isPartOfComposite: true, GetControlLayout(nextBinding.path), bindingIndex: nextBinding.indexOfBinding, isCut: state.IsBindingCut(actionMapIndex, nextBinding.indexOfBinding))));
                                 }
@@ -637,7 +634,7 @@ namespace UnityEngine.InputSystem.Editor
 
                         var shouldCompositeBeVisible = !(compositeItems.Count == 0 && hasHiddenCompositeParts); //hide composite if all parts are hidden
                         if (shouldCompositeBeVisible)
-                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
+                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
                                 new ActionOrBindingData(isAction: false, serializedInputBinding.name, actionMapIndex, isComposite: true, isPartOfComposite: false, action.expectedControlType, bindingIndex: serializedInputBinding.indexOfBinding, isCut: state.IsBindingCut(actionMapIndex, serializedInputBinding.indexOfBinding)),
                                 compositeItems.Count > 0 ? compositeItems : null));
                     }
@@ -645,26 +642,16 @@ namespace UnityEngine.InputSystem.Editor
                     {
                         var isVisible = ShouldBindingBeVisible(serializedInputBinding, state.selectedControlScheme, state.selectedDeviceRequirementIndex);
                         if (isVisible)
-                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(inputBindingId, idDictionary),
+                            bindingItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
                                 new ActionOrBindingData(isAction: false, GetHumanReadableBindingName(serializedInputBinding, state.selectedControlScheme, controlSchemes), actionMapIndex,
                                     isComposite: false, isPartOfComposite: false, GetControlLayout(serializedInputBinding.path), bindingIndex: serializedInputBinding.indexOfBinding, isCut: state.IsBindingCut(actionMapIndex, serializedInputBinding.indexOfBinding))));
                     }
                 }
                 var actionIndex = action.wrappedProperty.GetIndexOfArrayElement();
-                actionItems.Add(new TreeViewItemData<ActionOrBindingData>(GetIdForGuid(actionId, idDictionary),
+                actionItems.Add(new TreeViewItemData<ActionOrBindingData>(treeviewItemIDCounter++,
                     new ActionOrBindingData(isAction: true, action.name, actionMapIndex, isComposite: false, isPartOfComposite: false, action.expectedControlType, actionIndex: actionIndex, isCut: state.IsActionCut(actionMapIndex, actionIndex)), bindingItems.Count > 0 ? bindingItems : null));
             }
             return actionItems;
-        }
-
-        private static int GetIdForGuid(Guid guid, Dictionary<Guid, int> idDictionary)
-        {
-            if (!idDictionary.TryGetValue(guid, out var id))
-            {
-                id = idDictionary.Values.Count > 0 ? idDictionary.Values.Max() + 1 : 0;
-                idDictionary.Add(guid, id);
-            }
-            return id;
         }
 
         private static string GetHumanReadableBindingName(SerializedInputBinding serializedInputBinding, InputControlScheme? currentControlScheme, SerializedProperty allControlSchemes)


### PR DESCRIPTION
### Description

Fix for [ISXB 1164](https://jira.unity3d.com/browse/ISXB-1164)

I've removed (unused) methods related to saving the expanded state of the tree. These might have been an artifact from an earlier implementation, any any case, these were unused.

I changed the guidToId caching mechanism to use guid.GetHashCode() so that we get a deterministic guid->int mapping.


### Testing status & QA

Ran local package tests.

### Overall Product Risks

- Complexity: 0 
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
