### PR TITLE
NEW: option to manually choose arbitrary editor version for CI jobs

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -68,10 +68,10 @@
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
-    - {{ platform.installscript }} {{ editor.version }}
+    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
     {% endif %}
     # ADBv2 on 2019.4 causes the test runner to not start on initial import when the
     # samples are in the package. Move the samples back into the project.
@@ -101,7 +101,7 @@ build_ios_{{ editor.version }}_{{ category.name }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c iOS -u {{ editor.version }} --fast --wait
+    - unity-downloader-cli -c Editor -c iOS -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_nix }}
@@ -145,7 +145,7 @@ build_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c AppleTV -u {{ editor.version }} --fast --wait
+    - unity-downloader-cli -c Editor -c AppleTV -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_nix }}
@@ -189,7 +189,7 @@ build_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
   commands:
     - {{ utr_install_win }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c Android -u {{ editor.version }} --fast --wait
+    - unity-downloader-cli -c Editor -c Android -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=Android --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --scripting-backend={{ backend.name }} --build-only --repository --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_win }}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -254,8 +254,6 @@ run_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
 
 all_tests:
   name: All Tests
-  variables:
-    EDITOR_REVISION_OVERRIDE: none
   dependencies:
     {% for editor in editors %}
     {% for platform in platforms_win %}
@@ -285,8 +283,6 @@ all_tests:
             
 performance_tests_only:
   name: Performance Tests Only
-  variables:
-    EDITOR_REVISION_OVERRIDE: none
   dependencies:
     {% for editor in editors %}
     {% for platform in platforms_win %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -73,7 +73,7 @@
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
-    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %}
+    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %}
     {% endif %}
     # ADBv2 on 2019.4 causes the test runner to not start on initial import when the
     # samples are in the package. Move the samples back into the project.

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -25,12 +25,12 @@
     - move /Y .\Assets\Samples.meta .\Packages\com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
       {% if platform.name == "win" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" 
       --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_win }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
-    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
+    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
     {% endif %}
     # ADBv2 on 2019.4 causes the test runner to not start on initial import when the
     # samples are in the package. Move the samples back into the project.
@@ -70,7 +70,7 @@
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
     - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %}
@@ -105,7 +105,7 @@ build_ios_{{ editor.version }}_{{ category.name }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c iOS -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} --fast --wait
+    - unity-downloader-cli -c Editor -c iOS -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_nix }}
@@ -153,7 +153,7 @@ build_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c AppleTV -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} --fast --wait
+    - unity-downloader-cli -c Editor -c AppleTV -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_nix }}
@@ -201,7 +201,7 @@ build_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
   commands:
     - {{ utr_install_win }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c Android -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
+    - unity-downloader-cli -c Editor -c Android -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=Android --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --scripting-backend={{ backend.name }} --build-only --repository --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_win }}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -30,7 +30,7 @@
       --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_win }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
-    - {{ platform.installscript }} {{ editor.version }}
+    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
     {% endif %}
     # ADBv2 on 2019.4 causes the test runner to not start on initial import when the
     # samples are in the package. Move the samples back into the project.

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -11,7 +11,7 @@
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   variables:
-    EDITOR_REVISION_OVERRIDE: false
+    EDITOR_REVISION_OVERRIDE:
   commands:
     - {{ utr_install_win }}
     - {{ upm_ci_install }}
@@ -25,7 +25,7 @@
     - move /Y .\Assets\Samples.meta .\Packages\com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == false %} {{ editor.version }} {% else %} EDITOR_REVISION_OVERRIDE {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != nil %} {{ editor.version }} {% else %} EDITOR_REVISION_OVERRIDE {% endif %}
       {% if platform.name == "win" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" 
       --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_win }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -25,7 +25,7 @@
     - move /Y .\Assets\Samples.meta .\Packages\com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != nil %} {{ editor.version }} {% else %} EDITOR_REVISION_OVERRIDE {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
       {% if platform.name == "win" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" 
       --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_win }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -253,7 +253,9 @@ run_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
 {% endfor %} # editors
 
 all_tests:
-  name: All Tests  
+  name: All Tests
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   dependencies:
     {% for editor in editors %}
     {% for platform in platforms_win %}
@@ -283,6 +285,8 @@ all_tests:
             
 performance_tests_only:
   name: Performance Tests Only
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   dependencies:
     {% for editor in editors %}
     {% for platform in platforms_win %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -11,7 +11,7 @@
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   variables:
-    EDITOR_REVISION_OVERRIDE:
+    EDITOR_REVISION_OVERRIDE: none
   commands:
     - {{ utr_install_win }}
     - {{ upm_ci_install }}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -11,7 +11,7 @@
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   variables:
-    EDITOR_REVISION_OVERRIDE: none
+    EDITOR_REVISION_OVERRIDE: 
   commands:
     - {{ utr_install_win }}
     - {{ upm_ci_install }}
@@ -25,12 +25,12 @@
     - move /Y .\Assets\Samples.meta .\Packages\com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == nil %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
       {% if platform.name == "win" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" 
       --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_win }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
-    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE == none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
+    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE == nil %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
     {% endif %}
     # ADBv2 on 2019.4 causes the test runner to not start on initial import when the
     # samples are in the package. Move the samples back into the project.

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -57,7 +57,7 @@
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
   variables:
-    EDITOR_REVISION_OVERRIDE: none
+    EDITOR_REVISION_OVERRIDE: none  
   commands:
     - {{ utr_install_nix }}
     - {{ upm_ci_install }}
@@ -70,10 +70,10 @@
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} {% if platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}
     - {{ unity_downloader_install }}
-    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %}
+    - {{ platform.installscript }} {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %}
     {% endif %}
     # ADBv2 on 2019.4 causes the test runner to not start on initial import when the
     # samples are in the package. Move the samples back into the project.
@@ -105,7 +105,7 @@ build_ios_{{ editor.version }}_{{ category.name }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c iOS -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
+    - unity-downloader-cli -c Editor -c iOS -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} --fast --wait
     - ./utr --suite=playmode {% if category.name == "performance" %} --category=Performance {% endif %} --platform=iOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_nix }}
@@ -153,7 +153,7 @@ build_tvos_{{ editor.version }}:
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
-    - unity-downloader-cli -c Editor -c AppleTV -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} %EDITOR_REVISION_OVERRIDE% {% endif %} --fast --wait
+    - unity-downloader-cli -c Editor -c AppleTV -u {% if EDITOR_REVISION_OVERRIDE != none %} {{ editor.version }} {% else %} $EDITOR_REVISION_OVERRIDE {% endif %} --fast --wait
     - ./utr --suite=playmode --platform=tvOS --editor-location=.Editor --testproject=. --player-save-path=build/players --artifacts_path=build/logs --build-only --report-performance-data --performance-project-id=InputSystem
   after:
     - {{ instabilities_install_nix }}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -10,6 +10,8 @@
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
+  variables:
+    EDITOR_REVISION_OVERRIDE: false
   commands:
     - {{ utr_install_win }}
     - {{ upm_ci_install }}
@@ -23,7 +25,7 @@
     - move /Y .\Assets\Samples.meta .\Packages\com.unity.inputsystem
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
-    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {{ editor.version }} 
+    - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u {% if EDITOR_REVISION_OVERRIDE == false %} {{ editor.version }} {% else %} EDITOR_REVISION_OVERRIDE {% endif %}
       {% if platform.name == "win" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem" 
       --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_win }}/upm-ci~/test-results/CodeCoverage/Package" {% endif %}
     {% if platform.installscript %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -56,6 +56,8 @@
     type: {{ platform.type }}
     image: {{ platform.image }}
     flavor: {{ platform.flavor }}
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   commands:
     - {{ utr_install_nix }}
     - {{ upm_ci_install }}
@@ -98,6 +100,8 @@ build_ios_{{ editor.version }}_{{ category.name }}:
     type: Unity::VM::osx
     image: {{ ios_and_tvos_macos_bokken_image }}
     flavor: b1.large
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
@@ -121,6 +125,8 @@ run_ios_{{ editor.version }}_{{ category.name }}:
       image: {{ ios_and_tvos_macos_bokken_image }}
       model: SE
       flavor: b1.medium
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   skip_checkout: true
   dependencies:
     - .yamato/upm-ci.yml#build_ios_{{ editor.version }}_{{ category.name }}
@@ -142,6 +148,8 @@ build_tvos_{{ editor.version }}:
     type: Unity::VM::osx
     image: {{ ios_and_tvos_macos_bokken_image }}
     flavor: b1.large
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   commands:
     - {{ utr_install_nix }}
     - {{ unity_downloader_install }}
@@ -164,6 +172,8 @@ run_tvos_{{ editor.version }}:
       type: Unity::mobile::appletv
       image: {{ ios_and_tvos_macos_bokken_image }}
       flavor: b1.medium
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   skip_checkout: true
   dependencies:
     - .yamato/upm-ci.yml#build_tvos_{{ editor.version }}
@@ -186,6 +196,8 @@ build_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
       type: Unity::VM
       image: package-ci/win10:default
       flavor: b1.xlarge
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   commands:
     - {{ utr_install_win }}
     - {{ unity_downloader_install }}
@@ -208,6 +220,8 @@ run_android_{{ editor.version }}_{{ backend.name }}_{{ category.name }}:
       type: Unity::mobile::shield
       image: package-ci/win10:default
       flavor: b1.medium
+  variables:
+    EDITOR_REVISION_OVERRIDE: none
   # Skip repository cloning
   skip_checkout: true
   # Set a dependency on the build job


### PR DESCRIPTION
### Description

We can now supply a CI job with a SHA to run that specific unity version with the Input System CI.

### Testing status & QA

*all jobs are green
*jobs that can use the version override are green and work with the override

### Overall Product Risks

- Complexity: low
- Halo Effect: low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
