### PR TITLE
NEW: Throw error when extension for inputsystem needed

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -45,6 +45,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Added
 - Added new API `InputSystem.settings.useIMGUIEditorForAssets` that should be used in custom `InputParameterEditor` that use both IMGUI and UI Toolkit.
 - Added ProfilerMakers to `InputAction.Enable()` and `InputActionMap.ResolveBindings()` to enable gathering of profiling data.
+- Added throwing an error message when trying to use the Input System package on console without the extension package installed.
 
 ## [1.11.2] - 2024-10-16
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR
 #if UNITY_2021_1_OR_NEWER
 using System;
-using NUnit.Framework;
 using UnityEditor;
 
 namespace UnityEngine.InputSystem.Editor

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -25,7 +25,6 @@ namespace UnityEngine.InputSystem.Editor
             BuildTarget.StandaloneLinux64,
             BuildTarget.tvOS,
             BuildTarget.LinuxHeadlessSimulation,
-            BuildTarget.PS5,
             BuildTarget.EmbeddedLinux,
             #if UNITY_2022_1_OR_NEWER
             BuildTarget.QNX,

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,3 +1,4 @@
+#if UNITY_2021_1_OR_NEWER
 using System;
 using System.Linq;
 using NUnit.Framework;
@@ -27,9 +28,18 @@ namespace UnityEngine.InputSystem.Editor
             BuildTarget.LinuxHeadlessSimulation,
             BuildTarget.PS5,
             BuildTarget.EmbeddedLinux,
+            #if UNITY_2022_1_OR_NEWER
             BuildTarget.QNX,
+            #endif
+            #if UNITY_2023_3_OR_NEWER
             BuildTarget.VisionOS,
+            #endif
+            #if UNITY_6000_0_OR_NEWER
             BuildTarget.ReservedCFE,
+            #endif
+            #if UNITY_6000_0_7_OR_NEWER
+            BuildTarget.Kepler
+            #endif
             BuildTarget.NoTarget
         };
 
@@ -60,3 +70,4 @@ namespace UnityEngine.InputSystem.Editor
         }
     }
 }
+#endif

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -13,17 +13,18 @@ namespace UnityEngine.InputSystem.Editor
     /// </remarks>
     public class InputSystemPluginControl
     {
-        //At the time of InitializeOnLoad the packages are compiled and registered
-        //InitializeOnLoad on classes (see GXDKSupport) and their static constructors are compiled before methods with InitializeOnLoadMethod attribute (like this one)
-        //Therefore the order of registering platforms from plugins is guaranteed
+        // Input system platform specific classes register with the input system via a class using InitializeOnLoad on static constructors.
+        // Static constructors in classes that are tagged with the InitializeOnLoad attribute are called before methods using the InitializeOnLoadMethod attribute.
+        // So the extra input system packages will be registered before this check which is done in InitializeOnLoadMethod.
         [InitializeOnLoadMethod]
         private static void CheckForExtension()
         {
             ThrowWarningOnMissingPlugin();
         }
 
-        //This static HashSet will be reset OnDomainReload and so it will be emptied and refilled every [InitializeOnLoad]]
-        private static HashSet<BuildTarget> s_targetNoPluginNeeded = new HashSet<BuildTarget>()
+        // This static HashSet will be reset OnDomainReload and so it will be reset every Domain Reload (at the time of InitializeOnLoad).
+        // This is pre-populated with the list of platforms that don't need a extra platform specific input system package to add platform specific functionality.
+        private static HashSet<BuildTarget> s_supportedBuildTargets = new HashSet<BuildTarget>()
         {
             BuildTarget.StandaloneOSX,
             BuildTarget.StandaloneWindows,
@@ -54,7 +55,7 @@ namespace UnityEngine.InputSystem.Editor
         static bool BuildTargetNeedsPlugin()
         {
             BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
-            foreach (var platform in s_targetNoPluginNeeded)
+            foreach (var platform in s_supportedBuildTargets)
             {
                 if (platform == target) return false;
             }
@@ -71,8 +72,7 @@ namespace UnityEngine.InputSystem.Editor
         /// </remarks>
         public static void RegisterPlatform(BuildTarget target)
         {
-            if (EditorUserBuildSettings.activeBuildTarget == target)
-                s_targetNoPluginNeeded.Add(target);
+            s_supportedBuildTargets.Add(target);
         }
 
         private static bool IsPluginInstalled()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -46,19 +46,17 @@ namespace UnityEngine.InputSystem.Editor
             var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
             foreach (var package in registeredPackages)
             {
-                if (package.name.StartsWith(PlugInName)) 
+                if (package.name.StartsWith(PlugInName))
                     return true;
             }
             return false;
-            
-            
         }
 
         private static void ThrowWarningOnMissingPlugin()
         {
-            if(!BuildTargetNeedsPlugin())
+            if (!BuildTargetNeedsPlugin())
                 return;
-            Debug.Assert(IsPluginInstalled(),"Active Input Handling is set to InputSystem, but no Plugin for "+ EditorUserBuildSettings.activeBuildTarget+" was found. Please install the missing InputSystem package extensions.");
+            Debug.Assert(IsPluginInstalled(), "Active Input Handling is set to InputSystem, but no Plugin for " + EditorUserBuildSettings.activeBuildTarget + " was found. Please install the missing InputSystem package extensions.");
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -47,9 +47,9 @@ namespace UnityEngine.InputSystem.Editor
             BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
             foreach (var platform in TargetNoPluginNeeded)
             {
-                if (platform == target) return true;
+                if (platform == target) return false;
             }
-            return false;
+            return true;
         }
 
         private const string PlugInName = "com.unity.inputsystem.";

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -5,7 +5,10 @@ using UnityEditor;
 
 namespace UnityEngine.InputSystem.Editor
 {
-    internal class InputSystemPluginControl
+    /// <summary>
+    /// This class controls all required plugins and extension packages are installed for the InputSystem.
+    /// </summary>
+    public class InputSystemPluginControl
     {
         //At the time of InitializeOnLoad the packages are compiled and registered
         [InitializeOnLoadMethod]
@@ -42,6 +45,8 @@ namespace UnityEngine.InputSystem.Editor
             BuildTarget.NoTarget
         };
 
+        private static bool m_pluginPackageRegistered = false;
+
         static bool BuildTargetNeedsPlugin()
         {
             BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
@@ -54,12 +59,23 @@ namespace UnityEngine.InputSystem.Editor
 
         private const string PlugInName = "com.unity.inputsystem.";
 
+        /// <summary>
+        /// Used to register extensions externally to the InputSystem, this is needed for all Platforms that require a plugin to be installed.
+        /// </summary>
+        public static void RegisterPluginPackage()
+        {
+            m_pluginPackageRegistered = true;
+        }
+
         private static bool IsPluginInstalled()
         {
+            if (!m_pluginPackageRegistered)
+                return true;
             var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
+            var plugInName = PlugInName + EditorUserBuildSettings.activeBuildTarget.ToString().ToLower();
             foreach (var package in registeredPackages)
             {
-                if (package.name.StartsWith(PlugInName))
+                if (package.name.Equals(plugInName))
                     return true;
             }
             return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -5,7 +5,7 @@ using UnityEditor;
 
 namespace UnityEngine.InputSystem.Editor
 {
-    public class InputSystemPluginControl
+    internal class InputSystemPluginControl
     {
         [InitializeOnLoadMethod]
         private static void CheckForExtension()

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using NUnit.Framework;
 using UnityEditor;
@@ -12,7 +13,7 @@ namespace UnityEngine.InputSystem.Editor
             ThrowWarningOnMissingPlugin();
         }
 
-        private static readonly BuildTarget[] targetNoPluginNeeded = new BuildTarget[]
+        private static readonly BuildTarget[] TargetNoPluginNeeded =
         {
             BuildTarget.StandaloneOSX,
             BuildTarget.StandaloneWindows,
@@ -35,26 +36,29 @@ namespace UnityEngine.InputSystem.Editor
         static bool BuildTargetNeedsPlugin()
         {
             BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
-            return !targetNoPluginNeeded.Contains(target);
+            return !TargetNoPluginNeeded.Contains(target);
         }
 
-        private static string plugInName = "com.unity.inputsystem.";
+        private const string PlugInName = "com.unity.inputsystem.";
+
         private static bool IsPluginInstalled()
         {
             var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
             foreach (var package in registeredPackages)
             {
-                if (package.name.StartsWith(plugInName)) //TODO better ??
+                if (package.name.StartsWith(PlugInName)) 
                     return true;
             }
             return false;
+            
+            
         }
 
         private static void ThrowWarningOnMissingPlugin()
         {
-            if (BuildTargetNeedsPlugin() && !IsPluginInstalled())
-                Debug.Log("No plugin installed!");
-            // TODO Assert.
+            if(!BuildTargetNeedsPlugin())
+                return;
+            Debug.Assert(IsPluginInstalled(),"Active Input Handling is set to InputSystem, but no Plugin for "+ EditorUserBuildSettings.activeBuildTarget+" was found. Please install the missing InputSystem package extensions.");
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 #if UNITY_2021_1_OR_NEWER
 using System;
 using NUnit.Framework;
@@ -73,4 +74,5 @@ namespace UnityEngine.InputSystem.Editor
         }
     }
 }
+#endif
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,6 +1,5 @@
 #if UNITY_2021_1_OR_NEWER
 using System;
-using System.Linq;
 using NUnit.Framework;
 using UnityEditor;
 
@@ -46,7 +45,11 @@ namespace UnityEngine.InputSystem.Editor
         static bool BuildTargetNeedsPlugin()
         {
             BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
-            return !TargetNoPluginNeeded.Contains(target);
+            foreach (var platform in TargetNoPluginNeeded)
+            {
+                if (platform == target) return true;
+            }
+            return false;
         }
 
         private const string PlugInName = "com.unity.inputsystem.";

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -14,6 +14,8 @@ namespace UnityEngine.InputSystem.Editor
     public class InputSystemPluginControl
     {
         //At the time of InitializeOnLoad the packages are compiled and registered
+        //InitializeOnLoad on classes (see GXDKSupport) and their static constructors are compiled before methods with InitializeOnLoadMethod attribute (like this one)
+        //Therefore the order of registering platforms from plugins is guaranteed
         [InitializeOnLoadMethod]
         private static void CheckForExtension()
         {
@@ -69,7 +71,7 @@ namespace UnityEngine.InputSystem.Editor
         /// <remarks>
         /// This method is internally called by the InputSystem package extensions to register the PlugIn. This can be called for custom extensions on custom platforms.
         /// </remarks>
-        public static void RegisterPluginPackage()
+        public static void RegisterPlatform(BuildTarget target)
         {
             m_pluginPackageRegistered = true;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -7,6 +7,7 @@ namespace UnityEngine.InputSystem.Editor
 {
     internal class InputSystemPluginControl
     {
+        //At the time of InitializeOnLoad the packages are compiled and registered
         [InitializeOnLoadMethod]
         private static void CheckForExtension()
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 #if UNITY_2021_1_OR_NEWER
 using System;
+using System.Collections.Generic;
 using UnityEditor;
 
 namespace UnityEngine.InputSystem.Editor
@@ -20,10 +21,10 @@ namespace UnityEngine.InputSystem.Editor
         private static void CheckForExtension()
         {
             ThrowWarningOnMissingPlugin();
-            m_pluginPackageRegistered = false;
         }
 
-        private static readonly BuildTarget[] TargetNoPluginNeeded =
+        //This static HashSet will be reset OnDomainReload and so it will be emptied and refilled every [InitializeOnLoad]]
+        private static HashSet<BuildTarget> s_targetNoPluginNeeded = new HashSet<BuildTarget>()
         {
             BuildTarget.StandaloneOSX,
             BuildTarget.StandaloneWindows,
@@ -51,12 +52,10 @@ namespace UnityEngine.InputSystem.Editor
             BuildTarget.NoTarget
         };
 
-        private static bool m_pluginPackageRegistered = false;
-
         static bool BuildTargetNeedsPlugin()
         {
             BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
-            foreach (var platform in TargetNoPluginNeeded)
+            foreach (var platform in s_targetNoPluginNeeded)
             {
                 if (platform == target) return false;
             }
@@ -73,13 +72,12 @@ namespace UnityEngine.InputSystem.Editor
         /// </remarks>
         public static void RegisterPlatform(BuildTarget target)
         {
-            m_pluginPackageRegistered = true;
+            if (EditorUserBuildSettings.activeBuildTarget == target)
+                s_targetNoPluginNeeded.Add(target);
         }
 
         private static bool IsPluginInstalled()
         {
-            if (m_pluginPackageRegistered)
-                return true;
             var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
             var plugInName = PlugInName + EditorUserBuildSettings.activeBuildTarget.ToString().ToLower();
             foreach (var package in registeredPackages)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -8,6 +8,9 @@ namespace UnityEngine.InputSystem.Editor
     /// <summary>
     /// This class controls all required plugins and extension packages are installed for the InputSystem.
     /// </summary>
+    /// <remarks>
+    /// For some platforms, the InputSystem requires additional plugins to be installed. This class checks if the required plugins are installed and throws a warning if they are not.
+    /// </remarks>
     public class InputSystemPluginControl
     {
         //At the time of InitializeOnLoad the packages are compiled and registered
@@ -15,6 +18,7 @@ namespace UnityEngine.InputSystem.Editor
         private static void CheckForExtension()
         {
             ThrowWarningOnMissingPlugin();
+            m_pluginPackageRegistered = false;
         }
 
         private static readonly BuildTarget[] TargetNoPluginNeeded =
@@ -62,6 +66,9 @@ namespace UnityEngine.InputSystem.Editor
         /// <summary>
         /// Used to register extensions externally to the InputSystem, this is needed for all Platforms that require a plugin to be installed.
         /// </summary>
+        /// <remarks>
+        /// This method is internally called by the InputSystem package extensions to register the PlugIn. This can be called for custom extensions on custom platforms.
+        /// </remarks>
         public static void RegisterPluginPackage()
         {
             m_pluginPackageRegistered = true;
@@ -69,7 +76,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private static bool IsPluginInstalled()
         {
-            if (!m_pluginPackageRegistered)
+            if (m_pluginPackageRegistered)
                 return true;
             var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
             var plugInName = PlugInName + EditorUserBuildSettings.activeBuildTarget.ToString().ToLower();

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,5 +1,4 @@
-#if UNITY_EDITOR
-#if UNITY_2021_1_OR_NEWER
+#if ((UNITY_EDITOR && UNITY_2021_1_OR_NEWER) || PACKAGE_DOCS_GENERATION)
 using System;
 using System.Collections.Generic;
 using UnityEditor;
@@ -96,5 +95,4 @@ namespace UnityEngine.InputSystem.Editor
         }
     }
 }
-#endif
 #endif

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+
+namespace UnityEngine.InputSystem.Editor
+{
+    public class InputSystemPluginControl
+    {
+        [InitializeOnLoadMethod]
+        private static void CheckForExtension()
+        {
+            ThrowWarningOnMissingPlugin();
+        }
+
+        private static readonly BuildTarget[] targetNoPluginNeeded = new BuildTarget[]
+        {
+            BuildTarget.StandaloneOSX,
+            BuildTarget.StandaloneWindows,
+            BuildTarget.iOS,
+            BuildTarget.Android,
+            BuildTarget.StandaloneWindows64,
+            BuildTarget.WebGL,
+            BuildTarget.WSAPlayer,
+            BuildTarget.StandaloneLinux64,
+            BuildTarget.tvOS,
+            BuildTarget.LinuxHeadlessSimulation,
+            BuildTarget.PS5,
+            BuildTarget.EmbeddedLinux,
+            BuildTarget.QNX,
+            BuildTarget.VisionOS,
+            BuildTarget.ReservedCFE,
+            BuildTarget.NoTarget
+        };
+
+        static bool BuildTargetNeedsPlugin()
+        {
+            BuildTarget target = EditorUserBuildSettings.activeBuildTarget;
+            return !targetNoPluginNeeded.Contains(target);
+        }
+
+        private static string plugInName = "com.unity.inputsystem.";
+        private static bool IsPluginInstalled()
+        {
+            var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
+            foreach (var package in registeredPackages)
+            {
+                if (package.name.StartsWith(plugInName)) //TODO better ??
+                    return true;
+            }
+            return false;
+        }
+
+        private static void ThrowWarningOnMissingPlugin()
+        {
+            if (BuildTargetNeedsPlugin() && !IsPluginInstalled())
+                Debug.Log("No plugin installed!");
+            // TODO Assert.
+        }
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 409c8128e33f94c378370cd8163fe3b0


### PR DESCRIPTION
### Description

Trying to use Input System package on console without the NDA package installed outputs an error message to the user.
The error is thrown in [OnInitializeLoad] and performs on loading a project, on switching platforms and domain reload.
Link to the related [ticket](https://jira.unity3d.com/browse/ISX-2216).

GXDK extension registeres it self with this [PR](https://github.cds.internal.unity3d.com/unity/com.unity.inputsystem.nda/pull/31).

### Testing status & QA

Manual testing for Switch platform.
Platforms missing: (which should surface this error without the installed Plugin)
-gamecore
-playstation (4&5)
-switch
-xboxone

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
