### PR TITLE
FIX: An infinite loop in `InputSystemUIInputModule` was causing an editor / player hang

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where batch jobs would fail with "Error: Error building Player because scripts are compiling" if a source generated .inputactions asset is out of sync with its generated source code (ISXB-1300).
 - Fixed multiple `OnScreenStick` Components that does not work together when using them simultaneously in isolation mode. [ISXB-813](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-813)
 - Fixed an issue in input actions editor window that caused certain fields in custom input composite bindings to require multiple clicks to action / focus. [ISXB-1171](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1171)
+- Fixed an editor/player hang in `InputSystemUIInputModule` due to an infinite loop. This was caused by the assumption that `RemovePointerAtIndex` would _always_ successfully remove the pointer, which is not the case with touch based pointers. [ISXB-1258](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1258)
 
 ### Changed
 - Changed location of the link xml file (code stripping rules), from a temporary directory to the project Library folder (ISX-2140).


### PR DESCRIPTION
### Description

Fixes [ISXB-1258](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1258)

This was caused by the assumption that `RemovePointerAtIndex` would _always_ successfully remove the pointer, which is not the case with touch based pointers.

The following code highlights the issue:
```cs
private void PurgeStalePointers()
{
    for (var i = 0; i < m_PointerStates.length; ++i)
    {
        ref var state = ref GetPointerStateForIndex(i);
        var device = state.eventData.device;
        if (!device.added || // Check if device was removed altogether.
            (!HaveControlForDevice(device, point) &&
             !HaveControlForDevice(device, trackedDevicePosition) &&
             !HaveControlForDevice(device, trackedDeviceOrientation)))
        {
            SendPointerExitEventsAndRemovePointer(i);
            --i;
        }
    }
```

If `SendPointerExitEventsAndRemovePointer` fails to remove the pointer from the list; decrementing `i` is incorrect and will lead to attempting to remove the pointer at the same index again, which will fail and we'll loop ad infinitum.

### Testing status & QA

I've tested this locally on a Windows 11 touch-enabled machine (laptop), but it would be great to get some testing across mobile devices (including Switch) to ensure no additional issues were introduced.

### Overall Product Risks

- Complexity: 0
- Halo Effect: 1

### Comments to reviewers

The only remaining concern I have with this solution is with the `OnDisable` code. The first thing we call in `OnDisable` for the Input system UI module is `ResetPointers` - how important is it that the pointers are all 100% reset here? If it is an absolute must, we could always add a _force_ flag as a parameter to the `SendPointerExitEventsAndRemovePointer` method.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
