### PR TITLE
FIX: commit missing files from Wrech tooling setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ Tools/CI/[Oo]bj
 .Editor
 .bin
 .download
+
+!Tools/CI/InputSystem.Cookbook.csproj
+!Tools/CI/InputSystem-recipes.sln

--- a/Tools/CI/InputSystem-recipes.sln
+++ b/Tools/CI/InputSystem-recipes.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputSystem.Cookbook", "InputSystem.Cookbook.csproj", "{A5A71435-C891-4C78-989C-2713DAA7B3B8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A5A71435-C891-4C78-989C-2713DAA7B3B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5A71435-C891-4C78-989C-2713DAA7B3B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5A71435-C891-4C78-989C-2713DAA7B3B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5A71435-C891-4C78-989C-2713DAA7B3B8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/Tools/CI/InputSystem.Cookbook.csproj
+++ b/Tools/CI/InputSystem.Cookbook.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="0.10.27" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Description

See title, files need to be checked in but fell through due to our gitignore rules.


### Testing status & QA

Files are now commited.

### Overall Product Risks

None

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
