### PR TITLE
CHANGE: add 6.1 to CI & readme for recipe regeneration exception

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -4,6 +4,8 @@ editors:
     disable_tvos_run: true
   - version: 6000.0
     disable_tvos_run: true
+  - version: 6000.1
+    disable_tvos_run: true
   - version: trunk
     disable_tvos_run: true
 

--- a/Tools/CI/README_AFTER_REGENERATION.md
+++ b/Tools/CI/README_AFTER_REGENERATION.md
@@ -1,0 +1,4 @@
+After you regenerate the yamato jobs you need to make the following edit:
+
+In .yamato\wrench\validation-jobs.yml find "validate_-_inputsystem_-_2019_4_-_ubuntu"-job and change
+"image: package-ci/ubuntu-20.04:default" to "image: package-ci/ubuntu-18.04:v4"    


### PR DESCRIPTION
### Description

- 6.1 is now its own version, so we need to add that
- new readme file so we don't forget our 2019.4 special case


### Testing status & QA

CI green.

### Overall Product Risks

None

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
