### PR TITLE
FIX: Add Touch Samples package dependency versions to avoid errors (ISXB-1245)

### DIFF
--- a/Assets/Samples/TouchSamples/TouchSamples.asset
+++ b/Assets/Samples/TouchSamples/TouchSamples.asset
@@ -15,5 +15,5 @@ MonoBehaviour:
   url: https://github.com/Unity-Technologies/InputSystem/releases/download/%VERSION%/TouchSamples-%VERSION%.unitypackage
   packageDeps:
   - com.unity.inputsystem
-  - com.unity.cinemachine
-  - com.unity.probuilder
+  - com.unity.cinemachine@2.10.3
+  - com.unity.probuilder@5.2.3

--- a/ExternalSampleProjects/README.md
+++ b/ExternalSampleProjects/README.md
@@ -1,0 +1,18 @@
+# External Sample Projects
+
+These Samples are self-contained projects because they are too big to be included as a package Sample.
+
+When editing these projects, you need to manually add a few packages for them to work.
+The projects don't contain the packages themselves.
+
+The `InputDeviceTester` needs:
+
+- Input System package (latest version)
+- Unity UI package (2.0.0 version at least)
+- Jetbrains Rider Editor / Visual Studio package for IDE tooling.
+
+The `TouchSamples` need:
+
+- All the same as ´InputDeviceTester`
+- Cinemachine (2.10.3 maximum; 3.x has errors with the project but are easy to fix)
+- Probuilder (5.2.3 version maximum at the moment; 6.x has problems building for iOS and Android)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -16,6 +16,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed GamepadButton.LeftTrigger and GamepadButton.RightTrigger enum values not matching displayed dropdown values in editor when using GamepadButtonPropertyDrawer [ISXB-1270](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1270).
 - Fixed an issue causing InvalidOperationException when entering playmode with domain reload disabled. [ISXB-1208](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1208).
 - Fixed an issue where compiling Addressables with Input System package present would result in failed compilation due to `IInputAnalytic.TryGatherData` not being defined [ISXB-1203](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1203).
+- Pinned Touch Samples sample package dependencies to avoid errors with Cinemachine 3.x and Probuilder 6.x. [ISXB-1245](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1245)
 
 ## [1.12.0] - 2025-01-15
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/DownloadableSample.cs
@@ -72,8 +72,8 @@ internal class DownloadableSampleInspector : Editor
             Rect rect = EditorGUILayout.GetControlRect(true, 20);
 
             GUI.Label(rect, new GUIContent(req), EditorStyles.label);
-            rect.width -= 160;
-            rect.x += 160;
+            rect.width -= 200;
+            rect.x += 200;
             if (add != null || !list.IsCompleted)
             {
                 using (new EditorGUI.DisabledScope(true))


### PR DESCRIPTION


### Description

Change TouchSamples.asset from:
<img width="414" alt="image" src="https://github.com/user-attachments/assets/8f6e31bc-99af-490d-90ee-8b46482817f3" />

To this:
<img width="380" alt="image" src="https://github.com/user-attachments/assets/460c19a1-4927-4194-a673-89d77526b43c" />


Currently, the latest versions of Cinemachine, 3.x, and Probuilder, 6.x have errors when using the Touch Sample assets.
Cinemachine 3.x has a breaking API change.
Probuilder 6.x has a mobile platform compilation error due to a ShaderGraph bug (see https://jira.unity3d.com/browse/UUM-94425)
This change avoids the problem when the Sample is imported through the Samples view of Input System Package Manager window since it shows the Samples dependency and downloads them accordingly.
<img width="1404" alt="image" src="https://github.com/user-attachments/assets/919159a3-4dad-4efa-987c-d25f7ad70bed" />




### Testing status & QA

Tested building for iOS when the Touch Samples uses the latest 5.2.3 version of Probuilder.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

If you import the .unitypackage to a U6 project, U6 will download both 3.x and 6.x versions of Cinemachine and Probuilder, respectively. Which means the problem will remain. Until the Probuilder version is fixed in U6, there's nothing we can easily do to avoid this.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
