### PR TITLE
FIX: Accept API updates in Samples publish script

### DIFF
--- a/ExternalSampleProjects/publish.sh
+++ b/ExternalSampleProjects/publish.sh
@@ -5,12 +5,12 @@ do
     ln -s ../../Packages ${Sample}Packages
     cp ExternalSampleProjects/ExternalSamplesUtility.cs ${Sample}Assets/ExternalSamplesUtility/Editor/
     cp -r ${Sample}ProjectSettings ${Sample}ProjectSettingsBackup
-    ${Editor} -batchmode -projectPath $Sample -executeMethod ExternalSamplesUtility.${Method} -logFile upm-ci~/${Sample}Editor.log
+    ${Editor} -accept-apiupdate -batchmode -projectPath $Sample -executeMethod ExternalSamplesUtility.${Method} -logFile upm-ci~/${Sample}Editor.log
     status=$?
     echo Editor returned $status
     rm ${Sample}Assets/ExternalSamplesUtility/Editor/ExternalSamplesUtility.cs
-    rm ${Sample}Packages
-    rm -r ${Sample}ProjectSettings
+    rm -rf ${Sample}Packages
+    rm -rf ${Sample}ProjectSettings
     mv ${Sample}ProjectSettingsBackup ${Sample}ProjectSettings
     if [ $? -eq $status ]; then
         echo Ok


### PR DESCRIPTION
### Description

6.2 introduces some API changes and obsoleted some APIs used in Touch Samples. The file `publish.sh` needed to be updated to accept scripting updates automatically. Similar to what one would do when opening the Editor, to avoid having console errors.
![image](https://github.com/user-attachments/assets/4f125c45-fd0d-4c8e-b1fa-16ec19079df9)


### Testing status & QA

Local test on macOS. The script only works out of the box in a Unix environment.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

If CI passes it should be enough for approval.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
