### PR TITLE
FIX: "ArgumentNullException: Value cannot be null." when deleting a newly created input action (ISXB-1405)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
+- Fixed an issue where removing a newly created action in the Asset Editor would cause an exception. [UUM-95693](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-95693)
+
 ## [1.13.0] - 2025-02-05
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -152,12 +152,17 @@ namespace UnityEngine.InputSystem.Editor
             return actionMap.FindPropertyRelative(nameof(InputActionMap.m_Actions)).GetArrayElementAtIndex(actionIndex);
         }
 
-        public static SerializedInputAction GetActionInMap(InputActionsEditorState state, int mapIndex, string name)
+        public static SerializedInputAction? GetActionInMap(InputActionsEditorState state, int mapIndex, string name)
         {
-            return new SerializedInputAction(state.serializedObject
+            SerializedProperty property = state.serializedObject
                 ?.FindProperty(nameof(InputActionAsset.m_ActionMaps))?.GetArrayElementAtIndex(mapIndex)
                 ?.FindPropertyRelative(nameof(InputActionMap.m_Actions))
-                ?.FirstOrDefault(p => p.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue == name));
+                ?.FirstOrDefault(p => p.FindPropertyRelative(nameof(InputAction.m_Name)).stringValue == name);
+
+            // If the action is not found, return null.
+            if (property == null)
+                return null;
+            return new SerializedInputAction(property);
         }
 
         public static SerializedInputBinding GetCompositeOrBindingInMap(SerializedProperty actionMap, int bindingIndex)


### PR DESCRIPTION
### Description

Fixes https://jira.unity3d.com/browse/ISXB-1405.

The problem ocurred when creating a new action and deleting it before finishing "renaming it". The delete triggers a focus change which calls the event to "rename" the action. 
Since at this stage, the action is in "renaming mode" (`m_IsEditing` == `true`) and the action was deleted, the search for that action serialized property would return "null". That case was not being considered before.

### Testing status & QA

Local testing on macOS trying to replicate the problem.
Creating new actions with a name and removing them also works.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

I'd only ask to do some more exploratory work around renaming and creating actions in both Project Settings > Input System and a standalone Asset Editor view.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
