### PR TITLE
FIX: Modify logic to get active player settings object to work with build profiles (ISXB-1430)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,6 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Fixed
+- Fixed a problem with the logic to get the active player settings object that cause an infinit reimport loop. [ISXB-1430](https://jira.unity3d.com/browse/ISXB-1430)
 - Fixed an issue where removing a newly created action in the Asset Editor would cause an exception. [UUM-95693](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-95693)
 - Fixed arrow key navigation of Input Actions after Action rename. [ISXB-1024](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1024)
 - Fixed gamepad navigation in UI Toolkit TextField when using InputSystemUIInputModule. [UUM-77364](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-77364)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/EditorPlayerSettingHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/EditorPlayerSettingHelpers.cs
@@ -164,11 +164,21 @@ namespace UnityEngine.InputSystem.Editor
             // this will be replaced by a call to an API in the editor instead of using reflection once it is available
             var buildProfileType = typeof(BuildProfile);
             var globalPlayerSettingsField = buildProfileType.GetField("s_GlobalPlayerSettings", BindingFlags.Static | BindingFlags.NonPublic);
+            if (globalPlayerSettingsField == null)
+            {
+                Debug.LogError($"Could not find global player settings field in build profile when trying to get property {name}. Please try to update the Input System package.");
+                return null;
+            }
             var playerSettings = (PlayerSettings)globalPlayerSettingsField.GetValue(null);
             var activeBuildProfile = BuildProfile.GetActiveBuildProfile();
             if (activeBuildProfile != null)
             {
                 var playerSettingsOverrideField = buildProfileType.GetField("m_PlayerSettings", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (playerSettingsOverrideField == null)
+                {
+                    Debug.LogError($"Could not find player settings override field in build profile when trying to get property {name}. Please try to update the Input System package.");
+                    return null;
+                }
                 var playerSettingsOverride = (PlayerSettings)playerSettingsOverrideField.GetValue(activeBuildProfile);
                 if (playerSettingsOverride != null)
                     playerSettings = playerSettingsOverride;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/EditorPlayerSettingHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/EditorPlayerSettingHelpers.cs
@@ -3,6 +3,11 @@ using System;
 using System.Linq;
 using UnityEditor;
 
+#if UNITY_6000_0_OR_NEWER
+using System.Reflection;
+using UnityEditor.Build.Profile;
+#endif
+
 namespace UnityEngine.InputSystem.Editor
 {
     internal static class EditorPlayerSettingHelpers
@@ -154,7 +159,23 @@ namespace UnityEngine.InputSystem.Editor
 
         private static SerializedProperty GetPropertyOrNull(string name)
         {
+#if UNITY_6000_0_OR_NEWER
+            // HOTFIX: the code below works around an issue causing an infinite reimport loop
+            // this will be replaced by a call to an API in the editor instead of using reflection once it is available
+            var buildProfileType = typeof(BuildProfile);
+            var globalPlayerSettingsField = buildProfileType.GetField("s_GlobalPlayerSettings", BindingFlags.Static | BindingFlags.NonPublic);
+            var playerSettings = (PlayerSettings)globalPlayerSettingsField.GetValue(null);
+            var activeBuildProfile = BuildProfile.GetActiveBuildProfile();
+            if (activeBuildProfile != null)
+            {
+                var playerSettingsOverrideField = buildProfileType.GetField("m_PlayerSettings", BindingFlags.Instance | BindingFlags.NonPublic);
+                var playerSettingsOverride = (PlayerSettings)playerSettingsOverrideField.GetValue(activeBuildProfile);
+                if (playerSettingsOverride != null)
+                    playerSettings = playerSettingsOverride;
+            }
+#else
             var playerSettings = Resources.FindObjectsOfTypeAll<PlayerSettings>().FirstOrDefault();
+#endif
             if (playerSettings == null)
                 return null;
             var playerSettingsObject = new SerializedObject(playerSettings);


### PR DESCRIPTION
### Description

This PR fixes [ISXB-1430](https://jira.unity3d.com/browse/ISXB-1430) by introducing a workaround to properly determine the currently active PlayerSettings. Previously a list of all exisiting PlayerSettings objects was fetched and the first one was assumed to be the active one. 

### Testing status & QA

Verified locally that the infinit reimport loop no longer occurs with the provided reproducer project.

### Overall Product Risks

- Complexity: 1
- Halo Effect: 1

### Comments to reviewers

None.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
