### PR TITLE
FIX: Xbox Controllers on macOS don't detect up-left DPAD presses (ISXB-810)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/XInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XInputTests.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 using System.Runtime.InteropServices;
+using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.HID;
 using UnityEngine.InputSystem.Processors;
 
@@ -208,7 +209,7 @@ internal class XInputTests : CoreTestsFixture
     }
 
 // Disable tests in standalone builds from 2022.1+ see UUM-19622
-#if !UNITY_STANDALONE_OSX || !TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
+// #if !UNITY_STANDALONE_OSX || !TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
     [Test]
     [Category("Devices")]
     public void Devices_SupportXboxWirelessControllerOnOSX()
@@ -242,6 +243,8 @@ internal class XInputTests : CoreTestsFixture
 
         InputSystem.Update();
 
+        Assert.That(gamepad.leftStick.x.IsActuated());
+
         Assert.That(gamepad.leftStick.x.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
         Assert.That(gamepad.leftStick.y.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
         Assert.That(gamepad.leftStick.up.ReadValue(), Is.EqualTo(0.9999).Within(0.001));
@@ -268,10 +271,17 @@ internal class XInputTests : CoreTestsFixture
         AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithButton(XInputControllerWirelessOSXState.Button.Y), gamepad.yButton);
         AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithButton(XInputControllerWirelessOSXState.Button.Y), gamepad.buttonNorth);
 
-        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(5), gamepad.dpad.down);
         AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(1), gamepad.dpad.up);
-        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(7), gamepad.dpad.left);
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(2),  gamepad.dpad.up, gamepad.dpad.right);
         AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(3), gamepad.dpad.right);
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(4), gamepad.dpad.down, gamepad.dpad.right);
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(5), gamepad.dpad.down);
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(6), gamepad.dpad.down, gamepad.dpad.left);
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(7), gamepad.dpad.left);
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(8), gamepad.dpad.up, gamepad.dpad.left);
+        // No Dpad button pressed when the value is 0
+        AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithDpad(0));
+
 
         AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithButton(XInputControllerWirelessOSXState.Button.LeftThumbstickPress), gamepad.leftStickButton);
         AssertButtonPress(gamepad, XInputControllerWirelessOSXState.defaultState.WithButton(XInputControllerWirelessOSXState.Button.RightThumbstickPress), gamepad.rightStickButton);
@@ -306,7 +316,7 @@ internal class XInputTests : CoreTestsFixture
 
 #endif // TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
 
-#endif
+// #endif
 
 
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA

--- a/Assets/Tests/InputSystem/Plugins/XInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/XInputTests.cs
@@ -208,8 +208,6 @@ internal class XInputTests : CoreTestsFixture
         Assert.That(gamepad.startButton.isPressed);
     }
 
-// Disable tests in standalone builds from 2022.1+ see UUM-19622
-// #if !UNITY_STANDALONE_OSX || !TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
     [Test]
     [Category("Devices")]
     public void Devices_SupportXboxWirelessControllerOnOSX()
@@ -315,9 +313,6 @@ internal class XInputTests : CoreTestsFixture
     }
 
 #endif // TEMP_DISABLE_STANDALONE_OSX_XINPUT_TEST
-
-// #endif
-
 
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN || UNITY_WSA
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an analytics event being invoked twice when the Save button in the Actions view was pressed. [ISXB-1378](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1378)
 - Fixed an issue causing a number of errors to be displayed when using `InputTestFixture` in playmode tests with domain reloading disabled on playmode entry. [ISXB-1446](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1446)
 - Fixed issue where user was not prompted to save changes when loading a second input actions asset into an already opened editor. [ISXB-1343](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1343)
+- Fixed an issue on macOS which didn't detect up-left DPAD presses for Xbox controllers. [ISXB-810](https://issuetracker.unity3d.com/issues/macos-d-pad-upper-left-corner-is-not-logged-with-the-xbox-controller)
 
 ## [1.14.0] - 2025-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -149,7 +149,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [InputControl(name = "rightTrigger", format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=0.01560998")]
         [FieldOffset(11)] public ushort rightTrigger;
 
-        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4, defaultState = 8)]
+        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4)]
         [InputControl(name = "dpad/up", format = "BIT", layout = "DiscreteButton", parameters = "minValue=8,maxValue=2,nullValue=0,wrapAtValue=9", bit = 0, sizeInBits = 4)]
         [InputControl(name = "dpad/right", format = "BIT", layout = "DiscreteButton", parameters = "minValue=2,maxValue=4", bit = 0, sizeInBits = 4)]
         [InputControl(name = "dpad/down", format = "BIT", layout = "DiscreteButton", parameters = "minValue=4,maxValue=6", bit = 0, sizeInBits = 4)]
@@ -241,7 +241,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [InputControl(name = "rightTrigger", format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=0.01560998")]
         [FieldOffset(11)] public ushort rightTrigger;
 
-        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4, defaultState = 8)]
+        [InputControl(name = "dpad", format = "BIT", layout = "Dpad", sizeInBits = 4)]
         [InputControl(name = "dpad/up", format = "BIT", layout = "DiscreteButton", parameters = "minValue=8,maxValue=2,nullValue=0,wrapAtValue=9", bit = 0, sizeInBits = 4)]
         [InputControl(name = "dpad/right", format = "BIT", layout = "DiscreteButton", parameters = "minValue=2,maxValue=4", bit = 0, sizeInBits = 4)]
         [InputControl(name = "dpad/down", format = "BIT", layout = "DiscreteButton", parameters = "minValue=4,maxValue=6", bit = 0, sizeInBits = 4)]

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -106,6 +106,7 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
     [StructLayout(LayoutKind.Explicit)]
     internal struct XInputControllerWirelessOSXState : IInputStateTypeInfo
     {
+        const ushort k_StickZeroValue = 32767;
         public static FourCC kFormat => new FourCC('H', 'I', 'D');
 
         public enum Button
@@ -125,20 +126,20 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         private byte padding;
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2S")]
-        [InputControl(name = "leftStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "leftStick/left", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/right", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "leftStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "leftStick/up", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/down", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(1)] public ushort leftStickX;
         [FieldOffset(3)] public ushort leftStickY;
 
         [InputControl(name = "rightStick", layout = "Stick", format = "VC2S")]
-        [InputControl(name = "rightStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "rightStick/left", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/right", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "rightStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "rightStick/up", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/down", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(5)] public ushort rightStickX;
@@ -188,16 +189,17 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public static XInputControllerWirelessOSXState defaultState => new XInputControllerWirelessOSXState
         {
-            rightStickX = 32767,
-            rightStickY = 32767,
-            leftStickX = 32767,
-            leftStickY = 32767
+            rightStickX = k_StickZeroValue,
+            rightStickY = k_StickZeroValue,
+            leftStickX = k_StickZeroValue,
+            leftStickY = k_StickZeroValue
         };
     }
 
     [StructLayout(LayoutKind.Explicit)]
     internal struct XInputControllerWirelessOSXStateV2 : IInputStateTypeInfo
     {
+        const ushort k_StickZeroValue = 32767;
         public static FourCC kFormat => new FourCC('H', 'I', 'D');
 
         public enum Button
@@ -217,20 +219,20 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         private byte padding;
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2S")]
-        [InputControl(name = "leftStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "leftStick/left", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/right", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "leftStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "leftStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "leftStick/up", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "leftStick/down", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(1)] public ushort leftStickX;
         [FieldOffset(3)] public ushort leftStickY;
 
         [InputControl(name = "rightStick", layout = "Stick", format = "VC2S")]
-        [InputControl(name = "rightStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/x", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "rightStick/left", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/right", offset = 0, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1")]
-        [InputControl(name = "rightStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5")]
+        [InputControl(name = "rightStick/y", offset = 2, format = "USHT", parameters = "invert,normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5", defaultState = k_StickZeroValue)]
         [InputControl(name = "rightStick/up", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0,clampMax=0.5,invert")]
         [InputControl(name = "rightStick/down", offset = 2, format = "USHT", parameters = "normalize,normalizeMin=0,normalizeMax=1,normalizeZero=0.5,clamp=1,clampMin=0.5,clampMax=1,invert=false")]
         [FieldOffset(5)] public ushort rightStickX;
@@ -280,10 +282,10 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
 
         public static XInputControllerWirelessOSXStateV2 defaultState => new XInputControllerWirelessOSXStateV2
         {
-            rightStickX = 32767,
-            rightStickY = 32767,
-            leftStickX = 32767,
-            leftStickY = 32767
+            rightStickX = k_StickZeroValue,
+            rightStickY = k_StickZeroValue,
+            leftStickX = k_StickZeroValue,
+            leftStickY = k_StickZeroValue
         };
     }
 }


### PR DESCRIPTION
### Description

Fixes https://jira.unity3d.com/browse/ISXB-810.

Dpad presses for up-left were not being detected with `IsPressed()` function because [we always compare it against their default state first](https://github.com/Unity-Technologies/InputSystem/blob/refs/heads/develop/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlExtensions.cs#L96) to avoid calling the `EvaluateMagnitude()` virtual method.

On Xbox Controllers that I tested with (Xbox One Conteoller, Model 1708, Bluetooth), their default state is 0 for Dpad values. And byte value 8 was being considered as such before, which in fact corresponds to Dpad up-left presses.  This PR fixes that.
 

### Testing status & QA

@stefanunity and @Pauliusd01 could you test this issue all the Xbox controllers you can find, with both Wired and Wireless connections? Just to make sure there are no devices with a different default state for DPAD presses.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

There's a chance that at some point the default DPAD state was 8 but I can't really tell as I haven't used that much Xbox controllers on macOS. 
I did validate that Dualshock 4 uses value 8 as the default state for DPAD.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
