### PR TITLE
FIX: Fixed errors caused by recreation of `DefaultInputActions` instance in `InputSystemProvider`

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where ButtonStates are not fully updated when switching SingleUnifiedPointer. [ISXB-1356](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1356)
 - Fixed errors when pasting composite parts into non-composites. [ISXB-757](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-757)
 - Fixed an issue where updating the InputSystem outside of the dynamic Update would lead to UI input and navigation events get lost. [ISXB-1313](https://issuetracker.unity3d.com/issues/ui-onclick-events-sometimes-do-not-trigger-when-manual-update-is-utilized-with-input-system)
+- Fixed an issue causing a number of errors to be displayed when using `InputTestFixture` in playmode tests with domain reloading disabled on playmode entry [ISXB-1446](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1446)
 
 ### Changed
 - Changed enum value `Key.IMESelected` to obsolete which was not a real key. Please use the ButtonControl `imeSelected`.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputActionAssetVerifier.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/InputForUI/InputActionAssetVerifier.cs
@@ -32,9 +32,23 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
         public void Verify(InputActionAsset asset,
             ProjectWideActionsAsset.IReportInputActionAssetVerificationErrors reporter)
         {
-            // Note that we never cache this to guarantee we have the current configuration.
-            var config = InputSystemProvider.Configuration.GetDefaultConfiguration();
-            Verify(asset, ref config, reporter);
+            // Note:
+            // PWA has initial state check true for "Point" action, DefaultActions do not, does it matter?
+            //
+            // Additionally note that "Submit" and "Cancel" are indirectly expected to be of Button action type.
+            // This is not available in UI configuration, but InputActionRebindingExtensions suggests this.
+            //
+            // Additional "LeftClick" has initial state check set in PWA, but not "MiddleClick" and "RightClick".
+            // Is this intentional? Are requirements different?
+            var context = new Context(asset, reporter, DefaultReportPolicy);
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.PointAction, actionType: InputActionType.PassThrough, expectedControlType: nameof(Vector2));
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.MoveAction, actionType: InputActionType.PassThrough, expectedControlType: nameof(Vector2));
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.SubmitAction, actionType: InputActionType.Button, expectedControlType: "Button");
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.CancelAction, actionType: InputActionType.Button, expectedControlType: "Button");
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.LeftClickAction, actionType: InputActionType.PassThrough, expectedControlType: "Button");
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.MiddleClickAction, actionType: InputActionType.PassThrough, expectedControlType: "Button");
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.RightClickAction, actionType: InputActionType.PassThrough, expectedControlType: "Button");
+            context.Verify(actionNameOrId: InputSystemProvider.Actions.ScrollWheelAction, actionType: InputActionType.PassThrough, expectedControlType: nameof(Vector2));
         }
 
         #endregion
@@ -110,28 +124,6 @@ namespace UnityEngine.InputSystem.Plugins.InputForUI
 
             private HashSet<string> missingPaths; // Avoids generating multiple warnings around missing map
             private ReportPolicy policy;
-        }
-
-        private static void Verify(InputActionAsset asset, ref InputSystemProvider.Configuration config,
-            ProjectWideActionsAsset.IReportInputActionAssetVerificationErrors reporter)
-        {
-            // Note:
-            // PWA has initial state check true for "Point" action, DefaultActions do not, does it matter?
-            //
-            // Additionally note that "Submit" and "Cancel" are indirectly expected to be of Button action type.
-            // This is not available in UI configuration, but InputActionRebindingExtensions suggests this.
-            //
-            // Additional "LeftClick" has initial state check set in PWA, but not "MiddleClick" and "RightClick".
-            // Is this intentional? Are requirements different?
-            var context = new Context(asset, reporter, DefaultReportPolicy);
-            context.Verify(actionNameOrId: config.PointAction, actionType: InputActionType.PassThrough, expectedControlType: nameof(Vector2));
-            context.Verify(actionNameOrId: config.MoveAction, actionType: InputActionType.PassThrough, expectedControlType: nameof(Vector2));
-            context.Verify(actionNameOrId: config.SubmitAction, actionType: InputActionType.Button, expectedControlType: "Button");
-            context.Verify(actionNameOrId: config.CancelAction, actionType: InputActionType.Button, expectedControlType: "Button");
-            context.Verify(actionNameOrId: config.LeftClickAction, actionType: InputActionType.PassThrough, expectedControlType: "Button");
-            context.Verify(actionNameOrId: config.MiddleClickAction, actionType: InputActionType.PassThrough, expectedControlType: "Button");
-            context.Verify(actionNameOrId: config.RightClickAction, actionType: InputActionType.PassThrough, expectedControlType: "Button");
-            context.Verify(actionNameOrId: config.ScrollWheelAction, actionType: InputActionType.PassThrough, expectedControlType: nameof(Vector2));
         }
     }
 }


### PR DESCRIPTION
### Description

Fixes [ISXB-1446](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1446)

Errors similar to the following would be output when running playmode tests when using the `InputTestFixture` (with domain reloads on playmode entry turned off):
```
NullReferenceException: Object reference not set to an instance of an object
UnityEngine.InputSystem.InputActionState+BindingState.get_actionIndex () (at ./Library/PackageCache/com.unity.inputsystem@e2c83221d2dc/InputSystem/Actions/InputActionState.cs:3443)
UnityEngine.InputSystem.InputActionState.ProcessControlStateChange (System.Int32 mapIndex, System.Int32 controlIndex, System.Int32 bindingIndex, System.Double time, UnityEngine.InputSystem.LowLevel.InputEventPtr eventPtr) (at ./Library/PackageCache/com.unity.inputsystem@e2c83221d2dc/InputSystem/Actions/InputActionState.cs:1442)
UnityEngine.InputSystem.InputActionState.UnityEngine.InputSystem.LowLevel.IInputStateChangeMonitor.NotifyControlStateChanged (UnityEngine.InputSystem.InputControl control, System.Double time, UnityEngine.InputSystem.LowLevel.InputEventPtr eventPtr, System.Int64 mapControlAndBindingIndex) (at ./Library/PackageCache/com.unity.inputsystem@e2c83221d2dc/InputSystem/Actions/InputActionState.cs:1343)
UnityEngine.InputSystem.InputManager.FireStateChangeNotifications (System.Int32 deviceIndex, System.Double internalTime, UnityEngine.InputSystem.LowLevel.InputEvent* eventPtr) (at ./Library/PackageCache/com.unity.inputsystem@e2c83221d2dc/InputSystem/InputManagerStateMonitors.cs:394)
UnityEngine.InputSystem.LowLevel.<>c__DisplayClass7_0:<set_onUpdate>b__0(NativeInputUpdateType, NativeInputEventBuffer*)
UnityEngineInternal.Input.NativeInputSystem:NotifyUpdate(NativeInputUpdateType, IntPtr)
```

This was caused by the recreation of a `DefaultInputActions` instance via `InputSystemProvider.OnActionsChange`.

This PR makes some adjustments to `InputSystemProvider` to only create a single `DefaultInputActions` instance that is reused. However, when listening for changes to actions - we still reselect the `InputActionAsset` used on every change.

I also noticed a bunch of things that could be cleaned up in the process and so made some modifications and renames to the class:
- `InputSystemProvider.Configuration` was only holding the `InputActionAsset`, the action strings were constant. Since the `InputActionAsset` reference was removed - it made sense to switch it to being a static class.
- There was a name mismatch between `RegisterNextPreviousAction` & `UnregisterFixedActions` and so `RegisterNextPreviousAction` has been renamed to `RegisterFixedActions`.
- `RegisterFixedActions` & `UnregisterFixedActions` were being called on every action update, this is much more than required so they have been moved to `Initialize` and `Shutdown` respectively.

### Testing status & QA

Tested locally using the project provided by the user.

### Overall Product Risks

- Complexity: 1
- Halo Effect: 1

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
