### PR TITLE
FIX: Prevent composite parts being pasted into non-composites

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 - Fixed an issue where all action maps were enabled initially for project wide actions, which overrode the PlayerInput action map configuration. [ISXB-920](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-920)
 - Fixed an issue where ButtonStates are not fully updated when switching SingleUnifiedPointer. [ISXB-1356](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1356)
+- Fixed errors when pasting composite parts into non-composites. [ISXB-757](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-757)
 
 ### Changed
 - Changed enum value `Key.IMESelected` to obsolete which was not a real key. Please use the ButtonControl `imeSelected`.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -796,7 +796,7 @@ namespace UnityEngine.InputSystem.Editor
             if (location.item is ActionTreeItemBase dropTarget)
             {
                 // Specific case - Composite parts cannot be dropped into Bindings
-                if (location.item is not CompositeBindingTreeItem && tag == k_PartOfCompositeBindingTag)
+                if (tag == k_PartOfCompositeBindingTag && location.item is not(CompositeBindingTreeItem or PartOfCompositeBindingTreeItem))
                     return;
 
                 if (!dropTarget.GetDropLocation(itemType, location.childIndex, ref array, ref arrayIndex))

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionTreeView.cs
@@ -795,6 +795,10 @@ namespace UnityEngine.InputSystem.Editor
             var itemType = CopyTagToType(tag);
             if (location.item is ActionTreeItemBase dropTarget)
             {
+                // Specific case - Composite parts cannot be dropped into Bindings
+                if (location.item is not CompositeBindingTreeItem && tag == k_PartOfCompositeBindingTag)
+                    return;
+
                 if (!dropTarget.GetDropLocation(itemType, location.childIndex, ref array, ref arrayIndex))
                     return;
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputBindingPropertiesView.cs
@@ -94,12 +94,16 @@ namespace UnityEngine.InputSystem.Editor
                     if (m_CompositeParts == null)
                         InitializeCompositePartProperties();
 
-                    var selectedPart = EditorGUILayout.Popup(s_CompositePartAssignmentLabel, m_SelectedCompositePart,
-                        m_CompositePartOptions);
-                    if (selectedPart != m_SelectedCompositePart)
+                    // If m_CompositeParts still null after InitializeCompositePartProperties something went wrong and we can't select
+                    if (m_CompositeParts != null)
                     {
-                        m_SelectedCompositePart = selectedPart;
-                        OnCompositePartAssignmentChanged();
+                        var selectedPart = EditorGUILayout.Popup(s_CompositePartAssignmentLabel, m_SelectedCompositePart,
+                            m_CompositePartOptions);
+                        if (selectedPart != m_SelectedCompositePart)
+                        {
+                            m_SelectedCompositePart = selectedPart;
+                            OnCompositePartAssignmentChanged();
+                        }
                     }
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Commands/Commands.cs
@@ -266,7 +266,8 @@ namespace UnityEngine.InputSystem.Editor
                         else
                             lastPastedElement = CopyPasteHelper.PasteActionsOrBindingsFromClipboard(state.With(selectedBindingIndex: newIndex >= 0 ? newIndex : state.selectedBindingIndex));
 
-                        lastPastedElement.FindPropertyRelative("m_Action").stringValue = relatedAction.Value.name;
+                        if (lastPastedElement != null)
+                            lastPastedElement.FindPropertyRelative("m_Action").stringValue = relatedAction.Value.name;
                     }
                 }
 


### PR DESCRIPTION
### Description

When attempting to paste a composite part into a non-composite binding both Input Manager and Input System end up throwing errors as it uses a best guess trying to find the closest applicable index it can paste into. When pasting directly into a binding nothing is found, so nothing is pasted, but attempts to return the new selection/last pasted element anyway.

This fix skips returning the new selections when nothing was actually pasted. 

I attempted to look into disabling paste completely in this scenario but `HasPastableClipboardData` is passed the `InputBinding` type and I couldn't find a simple way to distinguish between composites and bindings at this point.

### Testing status & QA

Tested in Input Manager and Input System (old and new UI) and confirmed that there are no longer errors in either.

### Overall Product Risks

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
