### PR TITLE
FIX: Use the invariant culture for capitalization when generating code

### DIFF
--- a/Assets/Editor/AddScenesToBuild.cs
+++ b/Assets/Editor/AddScenesToBuild.cs
@@ -66,7 +66,7 @@ public class AddScenesToBuild : EditorWindow
         // Check if the path or any part of it contains any of the excluded folder names
         foreach (string folder in excludedFolders)
         {
-            if (path.ToLower().Contains(folder.ToLower()))
+            if (path.Contains(folder, StringComparison.InvariantCultureIgnoreCase))
             {
                 return true;
             }

--- a/Assets/Editor/AddScenesToBuild.cs
+++ b/Assets/Editor/AddScenesToBuild.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
+using System;
 
 [InitializeOnLoad]
 public class AddScenesToBuild : EditorWindow

--- a/Assets/Tests/InputSystem.Editor/InputActionAssetManagerTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionAssetManagerTests.cs
@@ -142,6 +142,7 @@ class InputActionAssetManagerEditorTests
 
     [Test]
     [Category("Editor")]
+    [Description("A regression test for ISXB-1406")]
     public void Editor_InputActionAssetManager_ActionsCodeGeneration_TypeNamesAreNotAffectedByCultureChange()
     {
         var culture = Thread.CurrentThread.CurrentCulture;

--- a/Assets/Tests/InputSystem.Editor/InputActionAssetManagerTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionAssetManagerTests.cs
@@ -1,12 +1,15 @@
 #if UNITY_EDITOR
 
 using System;
+using System.Globalization;
 using System.IO;
+using System.Threading;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Editor;
+using UnityEngine.InputSystem.Utilities;
 
 class InputActionAssetManagerEditorTests
 {
@@ -135,6 +138,20 @@ class InputActionAssetManagerEditorTests
             // Expecting SaveChangesToAsset to throw when asset no longer exist
             Assert.Throws<Exception>(() => inputActionAssetManager.SaveChangesToAsset());
         }
+    }
+
+    [Test]
+    [Category("Editor")]
+    public void Editor_InputActionAssetManager_ActionsCodeGeneration_TypeNamesAreNotAffectedByCultureChange()
+    {
+        var culture = Thread.CurrentThread.CurrentCulture;
+        Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("tr-TR");
+        
+        var name = CSharpCodeHelpers.MakeTypeName("info");
+
+        Thread.CurrentThread.CurrentCulture = culture;
+
+        Assert.AreEqual('I', name[0], "Unexpected first letter in a type name.");
     }
 }
 

--- a/Assets/Tests/InputSystem.Editor/InputActionAssetManagerTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionAssetManagerTests.cs
@@ -146,7 +146,7 @@ class InputActionAssetManagerEditorTests
     {
         var culture = Thread.CurrentThread.CurrentCulture;
         Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("tr-TR");
-        
+
         var name = CSharpCodeHelpers.MakeTypeName("info");
 
         Thread.CurrentThread.CurrentCulture = culture;

--- a/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/GamepadISX.cs
+++ b/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/GamepadISX.cs
@@ -109,9 +109,9 @@ public class GamepadISX : MonoBehaviour
         if (String.IsNullOrEmpty(str))
             return null;
         else if (str.Length == 1)
-            return str.ToUpper();
+            return str.ToUpperInvariant();
         else
-            return char.ToUpper(str[0]) + str.Substring(1);
+            return char.ToUpperInvariant(str[0]) + str.Substring(1);
     }
 
     protected void ShowMessage(string msg)

--- a/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/PenISX.cs
+++ b/ExternalSampleProjects/InputDeviceTester/Assets/InputDeviceTester/Scripts/Input/PenISX.cs
@@ -190,9 +190,9 @@ public class PenISX : MonoBehaviour
         if (String.IsNullOrEmpty(str))
             return null;
         else if (str.Length == 1)
-            return str.ToUpper();
+            return str.ToUpperInvariant();
         else
-            return char.ToUpper(str[0]) + str.Substring(1);
+            return char.ToUpperInvariant(str[0]) + str.Substring(1);
     }
 
     private void ShowMessage(string msg)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed the on hover behaviour of the two plus buttons in the Input Actions Editor window [ISXB-1327](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1327)
 - Fixed an issue on macOS which didn't detect up-left DPAD presses for Xbox controllers. [ISXB-810](https://issuetracker.unity3d.com/issues/macos-d-pad-upper-left-corner-is-not-logged-with-the-xbox-controller)
 - Fixed Input Actions code generation overwriting user files when the names happened to match. [ISXB-1257](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1257)
+- Fixed Input Actions code generation using locale-dependent rules when lowercasing and uppercasing strings. [ISXB-1406](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1406)
 - Fixed an issue when providing JoinPlayer with a specific split screen index. [ISXB-897](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-897)
 - Fixed an issue where an action with a name containing a slash "/" could not be found via `InputActionAsset.FindAction(string,bool)`. [ISXB-1306](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1306).
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,7 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed the on hover behaviour of the two plus buttons in the Input Actions Editor window [ISXB-1327](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1327)
 - Fixed an issue on macOS which didn't detect up-left DPAD presses for Xbox controllers. [ISXB-810](https://issuetracker.unity3d.com/issues/macos-d-pad-upper-left-corner-is-not-logged-with-the-xbox-controller)
 - Fixed Input Actions code generation overwriting user files when the names happened to match. [ISXB-1257](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1257)
-- Fixed Input Actions code generation using locale-dependent rules when lowercasing and uppercasing strings. [ISXB-1406](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1406)
+- Fixed Input Actions code generation using locale-dependent rules when lowercasing and uppercasing strings. [ISXB-1406]
 - Fixed an issue when providing JoinPlayer with a specific split screen index. [ISXB-897](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-897)
 - Fixed an issue where an action with a name containing a slash "/" could not be found via `InputActionAsset.FindAction(string,bool)`. [ISXB-1306](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1306).
 

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlLayout.cs
@@ -1673,7 +1673,7 @@ namespace UnityEngine.InputSystem.Layouts
                 // Before render behavior.
                 if (!string.IsNullOrEmpty(beforeRender))
                 {
-                    var beforeRenderLowerCase = beforeRender.ToLower();
+                    var beforeRenderLowerCase = beforeRender.ToLowerInvariant();
                     if (beforeRenderLowerCase == "ignore")
                         layout.m_UpdateBeforeRender = false;
                     else if (beforeRenderLowerCase == "update")
@@ -1685,7 +1685,7 @@ namespace UnityEngine.InputSystem.Layouts
                 // CanRunInBackground flag.
                 if (!string.IsNullOrEmpty(runInBackground))
                 {
-                    var runInBackgroundLowerCase = runInBackground.ToLower();
+                    var runInBackgroundLowerCase = runInBackground.ToLowerInvariant();
                     if (runInBackgroundLowerCase == "enabled")
                         layout.canRunInBackground = true;
                     else if (runInBackgroundLowerCase == "disabled")

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControlPath.cs
@@ -559,7 +559,7 @@ namespace UnityEngine.InputSystem
                         return true; // Wildcard at end of string so rest is matched.
 
                     ++posInStr;
-                    nextChar = char.ToLower(str[posInStr], CultureInfo.InvariantCulture);
+                    nextChar = char.ToLowerInvariant(str[posInStr]);
 
                     while (posInMatchTo < matchToLength && matchToLowerCase[posInMatchTo] != nextChar)
                         ++posInMatchTo;
@@ -567,7 +567,7 @@ namespace UnityEngine.InputSystem
                     if (posInMatchTo == matchToLength)
                         return false; // Matched all the way to end of matchTo but there's more in str after the wildcard.
                 }
-                else if (char.ToLower(nextChar, CultureInfo.InvariantCulture) != matchToLowerCase[posInMatchTo])
+                else if (char.ToLowerInvariant(nextChar) != matchToLowerCase[posInMatchTo])
                 {
                     return false;
                 }
@@ -1156,7 +1156,7 @@ namespace UnityEngine.InputSystem
                 }
 
                 var charInComponent = component[indexInComponent];
-                if (charInComponent == nextCharInPath || char.ToLower(charInComponent, CultureInfo.InvariantCulture) == char.ToLower(nextCharInPath, CultureInfo.InvariantCulture))
+                if (charInComponent == nextCharInPath || char.ToLowerInvariant(charInComponent) == char.ToLowerInvariant(nextCharInPath))
                 {
                     ++indexInComponent;
                     ++indexInPath;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
@@ -77,17 +77,18 @@ namespace UnityEngine.InputSystem.Controls
                     return;
                 }
 
-                var textInfo = CultureInfo.InvariantCulture.TextInfo;
                 // We need to lower case first because ToTitleCase preserves upper casing.
                 // For example on Swedish Windows layout right shift display name is "HÖGER SKIFT".
                 // Just passing it to ToTitleCase won't change anything. But passing "höger skift" will return "Höger Skift".
-                var keyNameLowerCase = textInfo.ToLower(rawKeyName);
+                var keyNameLowerCase =  rawKeyName.ToLowerInvariant();
+                
                 if (string.IsNullOrEmpty(keyNameLowerCase))
                 {
                     displayName = rawKeyName;
                     return;
                 }
 
+                var textInfo = CultureInfo.InvariantCulture.TextInfo;
                 displayName = textInfo.ToTitleCase(keyNameLowerCase);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/KeyControl.cs
@@ -81,7 +81,7 @@ namespace UnityEngine.InputSystem.Controls
                 // For example on Swedish Windows layout right shift display name is "HÖGER SKIFT".
                 // Just passing it to ToTitleCase won't change anything. But passing "höger skift" will return "Höger Skift".
                 var keyNameLowerCase =  rawKeyName.ToLowerInvariant();
-                
+
                 if (string.IsNullOrEmpty(keyNameLowerCase))
                 {
                     displayName = rawKeyName;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -236,8 +236,8 @@ namespace UnityEngine.InputSystem.Editor
                 var directory = Path.GetDirectoryName(assetPath);
                 wrapperFilePath = Path.Combine(directory, wrapperFilePath);
             }
-            else if (!wrapperFilePath.ToLower().StartsWith("assets/") &&
-                     !wrapperFilePath.ToLower().StartsWith("assets\\"))
+            else if (!wrapperFilePath.StartsWith("assets/", StringComparison.InvariantCultureIgnoreCase) &&
+                     !wrapperFilePath.StartsWith("assets\\", StringComparison.InvariantCultureIgnoreCase))
             {
                 // User-specified file in Assets/ folder.
                 wrapperFilePath = Path.Combine("Assets", wrapperFilePath);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -210,7 +210,7 @@ namespace UnityEngine.InputSystem.Editor
                 m_GetDefaultValue = getDefaultValue;
                 m_ToggleLabel = EditorGUIUtility.TrTextContent("Default",
                     defaultComesFromInputSettings
-                    ? $"If enabled, the default {label.ToLower()} configured globally in the input settings is used. See Edit >> Project Settings... >> Input (NEW)."
+                    ? $"If enabled, the default {label.ToLowerInvariant()} configured globally in the input settings is used. See Edit >> Project Settings... >> Input (NEW)."
                     : "If enabled, the default value is used.");
                 m_ValueLabel = EditorGUIUtility.TrTextContent(label, tooltip);
                 if (defaultComesFromInputSettings)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -73,10 +73,10 @@ namespace UnityEngine.InputSystem.Editor
         private static bool IsPluginInstalled()
         {
             var registeredPackages = UnityEditor.PackageManager.PackageInfo.GetAllRegisteredPackages();
-            var plugInName = PlugInName + EditorUserBuildSettings.activeBuildTarget.ToString().ToLower();
+            var plugInName = PlugInName + EditorUserBuildSettings.activeBuildTarget.ToString();
             foreach (var package in registeredPackages)
             {
-                if (package.name.Equals(plugInName))
+                if (package.name.Equals(plugInName, StringComparison.InvariantCultureIgnoreCase))
                     return true;
             }
             return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownDataSource.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownDataSource.cs
@@ -80,7 +80,7 @@ namespace UnityEngine.InputSystem.Editor
             if (searchTree == null)
             {
                 // Support multiple search words separated by spaces.
-                var searchWords = searchString.ToLower().Split(' ');
+                var searchWords = searchString.ToLowerInvariant().Split(' ');
 
                 // We keep two lists. Matches that matches the start of an item always get first priority.
                 var matchesStart = new List<AdvancedDropdownItem>();
@@ -88,7 +88,7 @@ namespace UnityEngine.InputSystem.Editor
 
                 foreach (var e in m_SearchableElements)
                 {
-                    var name = e.searchableName.ToLower().Replace(" ", "");
+                    var name = e.searchableName.ToLowerInvariant().Replace(" ", "");
                     AddMatchItem(e, name, searchWords, matchesStart, matchesWithin);
                 }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
@@ -217,7 +217,7 @@ namespace UnityEngine.InputSystem.XR
                 if (inheritedLayout != null)
                     featureName = ConvertPotentialAliasToName(inheritedLayout, featureName);
 
-                featureName = featureName.ToLower();
+                featureName = featureName.ToLowerInvariant();
 
                 if (IsSubControl(featureName))
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/CSharpCodeHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/CSharpCodeHelpers.cs
@@ -85,7 +85,7 @@ namespace UnityEngine.InputSystem.Utilities
         {
             var symbolName = MakeIdentifier(name, suffix);
             if (char.IsLower(symbolName[0]))
-                symbolName = char.ToUpper(symbolName[0]) + symbolName.Substring(1);
+                symbolName = char.ToUpperInvariant(symbolName[0]) + symbolName.Substring(1);
             return symbolName;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
@@ -171,26 +171,22 @@ namespace UnityEngine.InputSystem.Utilities
 
         public static bool operator==(InternedString a, string b)
         {
-            return string.Compare(a.m_StringLowerCase, b.ToLower(CultureInfo.InvariantCulture),
-                StringComparison.InvariantCultureIgnoreCase) == 0;
+            return string.Compare(a.m_StringLowerCase, b, StringComparison.InvariantCultureIgnoreCase) == 0;
         }
 
         public static bool operator!=(InternedString a, string b)
         {
-            return string.Compare(a.m_StringLowerCase, b.ToLower(CultureInfo.InvariantCulture),
-                StringComparison.InvariantCultureIgnoreCase) != 0;
+            return string.Compare(a.m_StringLowerCase, b, StringComparison.InvariantCultureIgnoreCase) != 0;
         }
 
         public static bool operator==(string a, InternedString b)
         {
-            return string.Compare(a.ToLower(CultureInfo.InvariantCulture), b.m_StringLowerCase,
-                StringComparison.InvariantCultureIgnoreCase) == 0;
+            return string.Compare(a, b.m_StringLowerCase, StringComparison.InvariantCultureIgnoreCase) == 0;
         }
 
         public static bool operator!=(string a, InternedString b)
         {
-            return string.Compare(a.ToLower(CultureInfo.InvariantCulture), b.m_StringLowerCase,
-                StringComparison.InvariantCultureIgnoreCase) != 0;
+            return string.Compare(a, b.m_StringLowerCase, StringComparison.InvariantCultureIgnoreCase) != 0;
         }
 
         public static bool operator<(InternedString left, InternedString right)

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/StringHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/StringHelpers.cs
@@ -327,7 +327,6 @@ namespace UnityEngine.InputSystem.Utilities
                 return baseName;
 
             var name = baseName;
-            var nameLowerCase = name.ToLower();
             var nameIsUnique = false;
             var namesTried = 1;
 
@@ -351,10 +350,9 @@ namespace UnityEngine.InputSystem.Utilities
                 foreach (var existing in existingSet)
                 {
                     var existingName = getNameFunc(existing);
-                    if (existingName.ToLower() == nameLowerCase)
+                    if (existingName.Equals(name, StringComparison.InvariantCultureIgnoreCase))
                     {
                         name = $"{baseName}{namesTried}";
-                        nameLowerCase = name.ToLower();
                         nameIsUnique = false;
                         ++namesTried;
                         break;


### PR DESCRIPTION
### Description

A customer with the Turkish locale set, noticed that when we're generating function names for Input Actions, we're using the wrong function. This way, the "info" input action results in Onİnfo method name (notice the dot above the I, it's apparently how the capital for i looks like in Turkish). 

### Testing status & QA

Pending a QA pass, local testing by dev, a new regression test added

### Overall Product Risks

- Complexity: Medium
- Halo Effect: Medium

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
