### PR TITLE
FIX: Fixed the on hover behaviour of the two plus buttons in the Input Actions Editor window

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,8 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an analytics event being invoked twice when the Save button in the Actions view was pressed. [ISXB-1378](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1378)
 - Fixed an issue causing a number of errors to be displayed when using `InputTestFixture` in playmode tests with domain reloading disabled on playmode entry. [ISXB-1446](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1446)
 - Fixed issue where user was not prompted to save changes when loading a second input actions asset into an already opened editor. [ISXB-1343](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1343)
+- Fixed the on hover behaviour of the two plus buttons in the Input Actions Editor window [ISXB-1327](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1327)
+
 
 ## [1.14.0] - 2025-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -30,12 +30,10 @@
 }
 
 #add-new-action-map-button {
-    background-color: transparent;
     border-width: 0;
 }
 
 #add-new-action-button {
-    background-color: transparent;
     border-width: 0;
 }
 


### PR DESCRIPTION
### Description

This aims to react to a user report where they complain about the two `plus` buttons actually not looking like buttons at all. Since they have no visible border and no background, they don't react to hovering, and neither they react to presses. 

Here it's proposed to correct that by removing the transparent background while keeping the zero border config in, as that is deemed to look a bit better in this particular case.

![b0d463d68c07f0b3ab1e2b0d2d09a4b4](https://github.com/user-attachments/assets/e4ab1824-8b05-43d3-9f3d-0f69e436a3a6)

### Testing status & QA

Only affects UI, no behaviour change at the moment. Tested locally, check the gif above.

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
