### PR TITLE
FIX: Fix a 6000.2 build automation instability

### DIFF
--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -691,7 +691,7 @@ preview_apv_-_6000_2_-_macos:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -745,7 +745,7 @@ preview_apv_-_6000_2_-_ubuntu:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -800,7 +800,7 @@ preview_apv_-_6000_2_-_windows:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -805,7 +805,7 @@ validate_-_inputsystem_-_6000_2_-_macos:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -871,7 +871,7 @@ validate_-_inputsystem_-_6000_2_-_ubuntu:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -937,7 +937,7 @@ validate_-_inputsystem_-_6000_2_-_windows:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor


### PR DESCRIPTION
### Description

While working on another case I noticed that sometimes our automation would fail if it happens to pick up a Unity beta version that hasn't yet finished being built apparently. To fix that, I was suggested to add a --wait flag everywhere 6.2 is used. That's precisely what happens here.

### Testing status & QA

This only affects automations. 

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
