### PR TITLE
FIX: PlayerInput component is redrawn all the time when the notification mode is set to Invoke Unity events

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Input Actions code generation overwriting user files when the names happened to match. [ISXB-1257](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1257)
 - Fixed Input Actions code generation using locale-dependent rules when lowercasing and uppercasing strings. [ISXB-1406]
 - Fixed an issue when providing JoinPlayer with a specific split screen index. [ISXB-897](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-897)
+- Fixed Inspector Window being refreshed all the time when a PlayerInput component is present with Invoke Unity Events nofication mode chosen [ISXB-1448](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1448)
 - Fixed an issue where an action with a name containing a slash "/" could not be found via `InputActionAsset.FindAction(string,bool)`. [ISXB-1306](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1306).
 
 ## [1.14.0] - 2025-03-20

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -417,17 +417,21 @@ namespace UnityEngine.InputSystem.Editor
                 case PlayerNotifications.InvokeUnityEvents:
                 {
                     var playerInput = (PlayerInput)target;
-                    if (playerInput.m_DeviceLostEvent == null)
-                        playerInput.m_DeviceLostEvent = new PlayerInput.DeviceLostEvent();
-                    if (playerInput.m_DeviceRegainedEvent == null)
-                        playerInput.m_DeviceRegainedEvent = new PlayerInput.DeviceRegainedEvent();
-                    if (playerInput.m_ControlsChangedEvent == null)
-                        playerInput.m_ControlsChangedEvent = new PlayerInput.ControlsChangedEvent();
-                    serializedObject.Update();
 
-                    // Force action refresh.
-                    m_ActionAssetInitialized = false;
-                    Refresh();
+                    bool areEventsDirty = (playerInput.m_DeviceLostEvent == null) || (playerInput.m_DeviceRegainedEvent == null) || (playerInput.m_ControlsChangedEvent == null);
+
+                    playerInput.m_DeviceLostEvent ??= new PlayerInput.DeviceLostEvent();
+                    playerInput.m_DeviceRegainedEvent ??= new PlayerInput.DeviceRegainedEvent();
+                    playerInput.m_ControlsChangedEvent ??= new PlayerInput.ControlsChangedEvent();
+
+                    if (areEventsDirty)
+                    {
+                        serializedObject.Update();
+
+                        // Force action refresh.
+                        m_ActionAssetInitialized = false;
+                        Refresh();
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
### Description

A customer noted that if you change the notification mode on a PlayerInput component, that forces refresh of the inspector window every frame (can be observed by watching at the blinking dot at the left top corner).

The reason this happens is `PlayerInputEditor` component has lazy initilization logic in `OnInspectorGUI`

```           
            if (EditorGUI.EndChangeCheck() || !m_ActionAssetInitialized || CheckIfActionAssetChanged())
            {
                OnActionAssetChange();
                actionsWereChanged = true;
            }
```

When we reach this block, `m_ActionAssetInitialized` is always false -- since it's false by default, and it will keep being reset every frame, as you'll see in a bit.

So, we fall inside, set `actionsWereChanged`, and dive into `OnActionAssetChange` where we do all sorts of things, but most importantly, we set `m_ActionAssetInitialized` (unconditionally, in the beginning of the function). 

However, if we keep reading `OnInspectorGUI` further, we see this block

```
            if (EditorGUI.EndChangeCheck() || actionsWereChanged || !m_NotificationBehaviorInitialized)
                OnNotificationBehaviorChange();
```

Recall that `actionsWereChanged` is set in the first block and hasn't been changed yet, so we fall into the if block and call `OnNotificationBehaviorChange` where we have this wonderful final block:

```
case PlayerNotifications.InvokeUnityEvents:
                {
                    var playerInput = (PlayerInput)target;
                    if (playerInput.m_DeviceLostEvent == null)
                        playerInput.m_DeviceLostEvent = new PlayerInput.DeviceLostEvent();
                    if (playerInput.m_DeviceRegainedEvent == null)
                        playerInput.m_DeviceRegainedEvent = new PlayerInput.DeviceRegainedEvent();
                    if (playerInput.m_ControlsChangedEvent == null)
                        playerInput.m_ControlsChangedEvent = new PlayerInput.ControlsChangedEvent();
                    serializedObject.Update();

                    // Force action refresh.
                    m_ActionAssetInitialized = false;
                    Refresh();
```

You can see that we're resetting `m_ActionAssetInitialized` and updating the serializedObject as well. This is precisely what triggers the inspector window update, since the next update we will surely be following exactly the same steps.  

The patch I'm applying aims at minimal impact by not resetting `m_ActionAssetInitialized` when none of the device events need to be recreated any more. This looks safe. 

### Testing status & QA

Local testing, waiting on a QA.

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
