### PR TITLE
FIX: Tap Interaction is performed after it times out (ISXB-627)

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions_Interactions.cs
@@ -671,6 +671,78 @@ internal partial class CoreTests
 
     [Test]
     [Category("Actions")]
+    public void Actions_CanPerformTapInteractionWithAnalogControls()
+    {
+        ResetTime();
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+
+        var action = new InputAction(binding: "<Gamepad>/leftTrigger", type: InputActionType.Button,
+            interactions: "tap(duration=0.2)");
+
+        // This is the default value, which makes the release point to be 0.75 * 0.5 = 0.375.
+        InputSystem.settings.defaultButtonPressPoint = 0.5f;
+
+        action.Enable();
+
+        currentTime = 0f;
+
+        using (var trace = new InputActionTrace())
+        {
+            trace.SubscribeTo(action);
+
+            currentTime = 0.1f;
+            Set(gamepad.leftTrigger, 0.3f);
+            currentTime = 0.2f;
+            Set(gamepad.leftTrigger, 0.54f);
+
+            Assert.That(trace,
+                Started<TapInteraction>(action, value: 0.54f, time: 0.2f));
+            trace.Clear();
+
+            // Assert that a timeout will ocurr and a canceled event will be triggered.
+            currentTime = 0.5f;
+            Set(gamepad.leftTrigger, 0.9f);
+            Assert.That(trace,
+                Canceled<TapInteraction>(action));
+            trace.Clear();
+
+            // Maintain a value above the press point for a while to assess that a start event is not triggered.
+            // This was the case where the tap interaction was previously re-starting.
+            currentTime = 1.2f;
+            Set(gamepad.leftTrigger, 0.52f);
+
+            Assert.That(trace, Is.Empty);
+
+            // Go below the release point so check that no cancel event is triggered, since it didn't start.
+            // This was the case where the tap interaction was previously re-starting and then would cancel after
+            // timeout.
+            currentTime = 1.5f;
+            Set(gamepad.leftTrigger, 0.2f);
+
+            Assert.That(trace, Is.Empty);
+
+            // Go above the press point again and check that a start event is triggered.
+            currentTime = 2.0f;
+            Set(gamepad.leftTrigger, 0.6f);
+
+            Assert.That(trace,
+                Started<TapInteraction>(action));
+            trace.Clear();
+
+            currentTime = 2.10f;
+            Set(gamepad.leftTrigger, 0.4f);
+
+            // Check that the tap is performed.
+            currentTime = 2.15f;
+            Set(gamepad.leftTrigger, 0.2f);
+            Assert.That(trace,
+                Performed<TapInteraction>(action));
+        }
+    }
+
+    [Test]
+    [Category("Actions")]
     public void Actions_CanPerformDoubleTapInteraction()
     {
         var gamepad = InputSystem.AddDevice<Gamepad>();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Gamepad stick up/down inputs that were not recognized in WebGL. [ISXB-1090](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1090)
 - Fixed PlayerInput component automatically switching away from the default ActionMap set to 'None'.
 - Fixed a console error being shown when targeting visionOS builds in 2022.3.
+- Fixed a Tap Interaction issue with analog controls. The Tap interaction would keep re-starting after timeout. [ISXB-627](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-627)
 
 ## [1.14.0] - 2025-03-20
 


### PR DESCRIPTION
### Description

Fixes an issue surfaced by https://jira.unity3d.com/browse/ISXB-627

Tap interaction for analog controls such as Gamepad sticks and triggers would keep getting restarted and canceled once above the press point. And could potentially get `performed` after it's first timeout.

Now, once the Tap Interactions timer expires, it can only be "restarted" once if goes below the release point. 

### Testing status & QA

I added a automated test to confirm the behavior and validated it with the ISX-627 project (adapted) as well.


### Overall Product Risks


- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

⚠️ The ISXB-627 bug repro doesn't work properly from 1.14 forward since it uses PlayerInput, and there are some issues with the project setup. I recommend editing that project.
Or alternatively, creating a project with an InputActionAsset that has 2 different actions for a Gamepad trigger: one with a Hold interaction and one with a Tap interaction and see that the problem doesn't reproduce.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
