### PR TITLE
FIX: Make visionOS a supported build target from 2022.3 (ISXB-1539)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -23,6 +23,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue where an action with a name containing a slash "/" could not be found via `InputActionAsset.FindAction(string,bool)`. [ISXB-1306](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1306).
 - Fixed Gamepad stick up/down inputs that were not recognized in WebGL. [ISXB-1090](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1090)
 - Fixed PlayerInput component automatically switching away from the default ActionMap set to 'None'.
+- Fixed a console error being shown when targeting visionOS builds in 2022.3.
 
 ## [1.14.0] - 2025-03-20
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -40,7 +40,7 @@ namespace UnityEngine.InputSystem.Editor
             #if UNITY_2022_1_OR_NEWER
             BuildTarget.QNX,
             #endif
-            #if UNITY_2023_3_OR_NEWER
+            #if UNITY_2022_3_OR_NEWER
             BuildTarget.VisionOS,
             #endif
             (BuildTarget)49,


### PR DESCRIPTION
### Description

Fix error reported in https://jira.unity3d.com/browse/ISXB-1539

### Testing status & QA

I created a new 2022.3 LTS project (currently at .61f) and saw that the reported error had disappeared.

### Overall Product Risks



- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
