### PR TITLE
FIX: Reenabling the VirtualMouseInput component may lead to NullReferenceException

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Inspector Window being refreshed all the time when a PlayerInput component is present with Invoke Unity Events nofication mode chosen [ISXB-1448](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1448)
 - Fixed an issue where an action with a name containing a slash "/" could not be found via `InputActionAsset.FindAction(string,bool)`. [ISXB-1306](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1306).
 - Fixed Gamepad stick up/down inputs that were not recognized in WebGL. [ISXB-1090](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1090)
+- Fixed reenabling the VirtualMouseInput component may sometimes lead to NullReferenceException. [ISXB-1096](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1096)
 - Fixed PlayerInput component automatically switching away from the default ActionMap set to 'None'.
 - Fixed a console error being shown when targeting visionOS builds in 2022.3.
 - Fixed a Tap Interaction issue with analog controls. The Tap interaction would keep re-starting after timeout. [ISXB-627](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-627)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -872,7 +872,9 @@ namespace UnityEngine.InputSystem
             // Wipe state.
             actionState->phase = toPhase;
             actionState->controlIndex = kInvalidIndex;
-            actionState->bindingIndex = memory.actionBindingIndices[memory.actionBindingIndicesAndCounts[actionIndex]];
+            var idx = memory.actionBindingIndicesAndCounts[actionIndex];
+            var bindingCount = memory.actionBindingIndicesAndCounts[actionIndex] + 1;
+            actionState->bindingIndex = memory.actionBindingIndices != null ? memory.actionBindingIndices[idx] : 0;
             actionState->interactionIndex = kInvalidIndex;
             actionState->startTime = 0;
             actionState->time = 0;
@@ -2879,6 +2881,9 @@ namespace UnityEngine.InputSystem
         internal TValue ApplyProcessors<TValue>(int bindingIndex, TValue value, InputControl<TValue> controlOfType = null)
             where TValue : struct
         {
+            if (totalBindingCount == 0)
+                return value;
+
             var processorCount = bindingStates[bindingIndex].processorCount;
             if (processorCount > 0)
             {
@@ -4139,6 +4144,19 @@ namespace UnityEngine.InputSystem
 
             public ActionMapIndices* mapIndices;
 
+            // This is Anthony's version of block allocation from a blob
+            private byte* AllocFromBlob(ref byte* top, int size)
+            {
+                if (size == 0)
+                    return null;
+                
+                var allocation = top;
+
+                top += size;
+
+                return allocation;
+            }
+
             public void Allocate(int mapCount, int actionCount, int bindingCount, int controlCount, int interactionCount, int compositeCount)
             {
                 Debug.Assert(basePtr == null, "Memory already allocated! Free first!");
@@ -4164,17 +4182,17 @@ namespace UnityEngine.InputSystem
                 // NOTE: This depends on the individual structs being sufficiently aligned in order to not
                 //       cause any misalignment here. TriggerState, InteractionState, and BindingState all
                 //       contain doubles so put them first in memory to make sure they get proper alignment.
-                actionStates = (TriggerState*)ptr; ptr += actionCount * sizeof(TriggerState);
-                interactionStates = (InteractionState*)ptr; ptr += interactionCount * sizeof(InteractionState);
-                bindingStates = (BindingState*)ptr; ptr += bindingCount * sizeof(BindingState);
-                mapIndices = (ActionMapIndices*)ptr; ptr += mapCount * sizeof(ActionMapIndices);
-                controlMagnitudes = (float*)ptr; ptr += controlCount * sizeof(float);
-                compositeMagnitudes = (float*)ptr; ptr += compositeCount * sizeof(float);
-                controlIndexToBindingIndex = (int*)ptr; ptr += controlCount * sizeof(int);
-                controlGroupingAndComplexity = (ushort*)ptr; ptr += controlCount * sizeof(ushort) * 2;
-                actionBindingIndicesAndCounts = (ushort*)ptr; ptr += actionCount * sizeof(ushort) * 2;
-                actionBindingIndices = (ushort*)ptr; ptr += bindingCount * sizeof(ushort);
-                enabledControls = (int*)ptr; ptr += (controlCount + 31) / 32 * sizeof(int);
+                actionStates = (TriggerState*)AllocFromBlob(ref ptr, actionCount * sizeof(TriggerState));
+                interactionStates = (InteractionState*)AllocFromBlob(ref ptr, interactionCount * sizeof(InteractionState));
+                bindingStates = (BindingState*)AllocFromBlob(ref ptr, bindingCount * sizeof(BindingState));
+                mapIndices = (ActionMapIndices*)AllocFromBlob(ref ptr, mapCount * sizeof(ActionMapIndices));
+                controlMagnitudes = (float*)AllocFromBlob(ref ptr, controlCount * sizeof(float));
+                compositeMagnitudes = (float*)AllocFromBlob(ref ptr, compositeCount * sizeof(float));
+                controlIndexToBindingIndex = (int*)AllocFromBlob(ref ptr, controlCount * sizeof(int));
+                controlGroupingAndComplexity = (ushort*)AllocFromBlob(ref ptr, controlCount * sizeof(ushort) * 2);
+                actionBindingIndicesAndCounts = (ushort*)AllocFromBlob(ref ptr, actionCount * sizeof(ushort) * 2);
+                actionBindingIndices = (ushort*)AllocFromBlob(ref ptr, bindingCount * sizeof(ushort));
+                enabledControls = (int*)AllocFromBlob(ref ptr, (controlCount + 31) / 32 * sizeof(int));
             }
 
             public void Dispose()

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -593,7 +593,8 @@ namespace UnityEngine.InputSystem
                 if (newBindingState.isComposite)
                 {
                     var compositeIndex = newBindingState.compositeOrCompositeBindingIndex;
-                    memory.compositeMagnitudes[compositeIndex] = oldState.compositeMagnitudes[compositeIndex];
+                    if (oldState.compositeMagnitudes != null)
+                        memory.compositeMagnitudes[compositeIndex] = oldState.compositeMagnitudes[compositeIndex];
                 }
 
                 var actionIndex = newBindingState.actionIndex;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -4148,7 +4148,7 @@ namespace UnityEngine.InputSystem
             {
                 if (size == 0)
                     return null;
-                
+
                 var allocation = top;
                 top += size;
                 return allocation;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -4143,16 +4143,13 @@ namespace UnityEngine.InputSystem
 
             public ActionMapIndices* mapIndices;
 
-            // This is Anthony's version of block allocation from a blob
-            private byte* AllocFromBlob(ref byte* top, int size)
+            private static byte* AllocFromBlob(ref byte* top, int size)
             {
                 if (size == 0)
                     return null;
                 
                 var allocation = top;
-
                 top += size;
-
                 return allocation;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -873,7 +873,6 @@ namespace UnityEngine.InputSystem
             actionState->phase = toPhase;
             actionState->controlIndex = kInvalidIndex;
             var idx = memory.actionBindingIndicesAndCounts[actionIndex];
-            var bindingCount = memory.actionBindingIndicesAndCounts[actionIndex] + 1;
             actionState->bindingIndex = memory.actionBindingIndices != null ? memory.actionBindingIndices[idx] : 0;
             actionState->interactionIndex = kInvalidIndex;
             actionState->startTime = 0;


### PR DESCRIPTION
### Description

Fixed an exception that happens when you toggle enable/disable a few times on the VirtualMouseInput component. 

This exception is occasionally raised from within `InputActionState.ApplyProcessors` as it tries to read from the processors array that is null in this case. By the normal flow of things, we shouldn't have tried to index into a null array since just a few lines above there is a check that ensures there are more than zero processors before doing this. However, when no bindings are present , `processorCount` will actually be a random value. Let me explain how. 

```        
        internal TValue ApplyProcessors<TValue>(int bindingIndex, TValue value, InputControl<TValue> controlOfType = null)
            where TValue : struct
        {
            var processorCount = bindingStates[bindingIndex].processorCount;
            if (processorCount > 0)
            {
                var processorStartIndex = bindingStates[bindingIndex].processorStartIndex;
                for (var i = 0; i < processorCount; ++i)
                {
                    if (processors[processorStartIndex + i] is InputProcessor<TValue> processor)
                        value = processor.Process(value, controlOfType);
                }
            }

            return value;
        }
```

So in `InputActionState.ApplyProcessors`, we read `processorCount` from the `bindingStates` array using `bindingIndex`. However, when there are no bindings present, `bindingIndex` has a chance to be a fairly large random value if you disable and enable the `VirtualMouseInput` component. Note that `bindingStates` is an unsafe array so nothing prevents from reading out of bounds. How can this`bindingIndex` go wrong?

Moving a bit up the call stack, in `InputAction.ReadValue` we see that `bindingIndex` is taken from `InputActionState.TriggerState`'s bindingIndex field. 

```
        public unsafe TValue ReadValue<TValue>()
            where TValue : struct
        {
            var state = GetOrCreateActionMap().m_State;
            if (state == null)
                return default(TValue);

            var actionStatePtr = &state.actionStates[m_ActionIndexInState];
            return actionStatePtr->phase.IsInProgress()
                ? state.ReadValue<TValue>(actionStatePtr->bindingIndex, actionStatePtr->controlIndex)
                : state.ApplyProcessors(actionStatePtr->bindingIndex, default(TValue));
        }
```

This field is normally correct, however when we disable the `VirtualMouseInput` component there is some interesting logic that tries to restore the binding index to what is stored in the corresponding arrays. It is part of `InputActionState.ResetActionState` method, and the problem here arises from `memory.actionBindingIndices` being an invalid pointer when no bindings are present. This is an unsafe pointer, and it is not null in case the array contains no elements by design of the `UnmanagedMemory` class. Reading from this pointer will get random data that is used after you Enable the `VirtualMouseInput` component. 

```
            actionState->phase = toPhase;
             actionState->controlIndex = kInvalidIndex;
             actionState->bindingIndex = memory.actionBindingIndices[memory.actionBindingIndicesAndCounts[actionIndex]];
             actionState->interactionIndex = kInvalidIndex;
             actionState->startTime = 0;
             actionState->time = 0;
```

Let me pull up some code from `UnmanagedMemory` that I find a bit problematic at the moment:

```
            public int sizeInBytes =>
                mapCount * sizeof(ActionMapIndices) + // mapIndices
                actionCount * sizeof(TriggerState) + // actionStates
                bindingCount * sizeof(BindingState) + // bindingStates
                interactionCount * sizeof(InteractionState) + // interactionStates
                controlCount * sizeof(float) + // controlMagnitudes
                compositeCount * sizeof(float) + // compositeMagnitudes
                controlCount * sizeof(int) + // controlIndexToBindingIndex
                controlCount * sizeof(ushort) * 2 + // controlGrouping
                actionCount * sizeof(ushort) * 2 + // actionBindingIndicesAndCounts
                bindingCount * sizeof(ushort) + // actionBindingIndices
                (controlCount + 31) / 32 * sizeof(int); // enabledControlsArray

               public void Allocate(int mapCount, int actionCount, int bindingCount, int controlCount, int interactionCount, int compositeCount)
             {
                 Debug.Assert(basePtr == null, "Memory already allocated! Free first!");
                 // NOTE: This depends on the individual structs being sufficiently aligned in order to not
                 //       cause any misalignment here. TriggerState, InteractionState, and BindingState all
                 //       contain doubles so put them first in memory to make sure they get proper alignment.
                 actionStates = (TriggerState*)ptr; ptr += actionCount * sizeof(TriggerState);
                 interactionStates = (InteractionState*)ptr; ptr += interactionCount * sizeof(InteractionState);
                 bindingStates = (BindingState*)ptr; ptr += bindingCount * sizeof(BindingState);
                 mapIndices = (ActionMapIndices*)ptr; ptr += mapCount * sizeof(ActionMapIndices);
                 controlMagnitudes = (float*)ptr; ptr += controlCount * sizeof(float);
                 compositeMagnitudes = (float*)ptr; ptr += compositeCount * sizeof(float);
                 controlIndexToBindingIndex = (int*)ptr; ptr += controlCount * sizeof(int);
                 controlGroupingAndComplexity = (ushort*)ptr; ptr += controlCount * sizeof(ushort) * 2;
                 actionBindingIndicesAndCounts = (ushort*)ptr; ptr += actionCount * sizeof(ushort) * 2;
                 actionBindingIndices = (ushort*)ptr; ptr += bindingCount * sizeof(ushort);
                 enabledControls = (int*)ptr; ptr += (controlCount + 31) / 32 * sizeof(int);
             }
```

So essentially this thing makes one allocation to host all the smaller bits of data including the aggregated arrays. However, the problem is that if some array has zero length,  we don't set its pointer to null. Instead, we just shift the current pointer in the blob by how much memory we needed for the previous array. Because of that, some array pointers can be equal (imagine a few empty arrays going in a sequence). Also, especially problematic are the last pointers in the blob -- because if they are zero sized, then they are set to invalid pointer, pointing to the first byte right after the blob. That's precisely the reason why we had random bindingIndex - note how `actionBindingindices` will be set to point to the first byte after the blob in case bindingCount is zero. 

I believe there are a few ways we could attack this problem. 

One, that would aim for minimal footprint is to change just one line in `InputActionState.ApplyProcessors` to also include a check for an empty processors array, like this:

```
if (processorCount > 0 && processors != null)
```

However, in my mind that is slightly unfortunate because it leaves the core issue of having bad bindingIndices around, and it also still leaves us with invalid pointers being around. It's only until next time someone doesn't check for an empty array in the right way. When debugging, it's somewhat uneasy to understand the pointers that look somewhat reasonable are actually pointers to unallocated space. 

Because of that, I thought to propose a change that assigns null to any pointers in the `UnmanagedMemory` class that reflect zero-sized arrays. That way, if someone tries to access them, we get an instant exception that is easy to diagnose. Please advise what you think. 

### Testing status & QA

Local testing

### Overall Product Risks

- Complexity: Medium
- Halo Effect: Medium

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
