### PR TITLE
CHANGE: Skip running functional tests for doc only changes

### DIFF
--- a/.yamato/analyze.yml
+++ b/.yamato/analyze.yml
@@ -17,10 +17,7 @@ code_analyser:
     - upm-ci project test --project-path Tools/CodeAnalyzerTestProject -u 2021.3
   triggers:
     cancel_old_ci: true
-    pull_requests:
-      - targets:
-          only:
-            - "develop"
+    expression: pull_request.(target eq "develop" AND NOT changes.all match "**/*.md")
   artifacts:
     UTR_Output.zip:
       paths:

--- a/.yamato/format.yml
+++ b/.yamato/format.yml
@@ -12,7 +12,4 @@ check_formatting:
     - perl unity-meta/Tools/Format/format.pl Assets Packages --dry-run
   triggers:
     cancel_old_ci: true
-    pull_requests:
-      - targets:
-          only:
-            - "develop"
+    expression: pull_request.(target eq "develop" AND NOT changes.all match "**/*.md")

--- a/.yamato/test-samples.yml
+++ b/.yamato/test-samples.yml
@@ -14,10 +14,7 @@ test_sample_projects_{{ editor.version }}:
     - Editor=.Editor/Unity.app/Contents/MacOS/Unity Method=DryRun sh ExternalSampleProjects/publish.sh 
   triggers:
     cancel_old_ci: true
-    pull_requests:
-      - targets:
-          only:
-            - "develop"
+    expression: pull_request.(target eq "develop" AND NOT changes.all match "**/*.md")
   artifacts:
     UTR_Output.zip:
       paths:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -271,6 +271,7 @@ all_tests:
     {% for platform in platforms_win %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}_functional
     {% endfor %}
+    {% unless editor == "2021.3" %}
     {% for platform in platforms_nix %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}_functional
     {% endfor %}
@@ -283,6 +284,7 @@ all_tests:
     {% else %}
     - .yamato/upm-ci.yml#run_tvos_{{ editor.version }}_functional
     {% endif %}
+    {% endunless %}
     {% endfor %}
     - .yamato/wrench/promotion-jobs.yml#publish_dry_run_inputsystem
   triggers:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -287,10 +287,19 @@ all_tests:
     - .yamato/wrench/promotion-jobs.yml#publish_dry_run_inputsystem
   triggers:
     cancel_old_ci: true
-    pull_requests:
-      - targets:
-          only:
-            - "develop"
+    expression: pull_request.(target eq "develop" AND NOT push.changes.all match "**/*.md")
+
+tests_for_doc_changes:
+  name: Tests for Documentation Changes
+  dependencies:
+    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2021_3_-_windows
+    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_windows
+    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_windows
+    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_windows
+    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_windows
+  triggers:
+    cancel_old_ci: true
+    expression: pull_request.(target eq "develop" AND push.changes.all match "**/*.md")
             
 performance_tests_only:
   name: All Performance Tests

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -271,7 +271,7 @@ all_tests:
     {% for platform in platforms_win %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}_functional
     {% endfor %}
-    {% unless editor == "2021.3" %}
+    {% unless editor.version == "2021.3" %}
     {% for platform in platforms_nix %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}_functional
     {% endfor %}

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -293,9 +293,7 @@ tests_for_doc_changes:
   name: Tests for Documentation Changes
   dependencies:
     - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2021_3_-_windows
-    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_windows
     - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_windows
-    - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_windows
     - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_windows
   triggers:
     cancel_old_ci: true

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -271,7 +271,6 @@ all_tests:
     {% for platform in platforms_win %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}_functional
     {% endfor %}
-    {% unless editor.version == "2021.3" %}
     {% for platform in platforms_nix %}
     - .yamato/upm-ci.yml#{{ platform.name }}_{{ editor.version }}_functional
     {% endfor %}
@@ -284,7 +283,6 @@ all_tests:
     {% else %}
     - .yamato/upm-ci.yml#run_tvos_{{ editor.version }}_functional
     {% endif %}
-    {% endunless %}
     {% endfor %}
     - .yamato/wrench/promotion-jobs.yml#publish_dry_run_inputsystem
   triggers:

--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -287,7 +287,7 @@ all_tests:
     - .yamato/wrench/promotion-jobs.yml#publish_dry_run_inputsystem
   triggers:
     cancel_old_ci: true
-    expression: pull_request.(target eq "develop" AND NOT push.changes.all match "**/*.md")
+    expression: pull_request.(target eq "develop" AND NOT changes.all match "**/*.md")
 
 tests_for_doc_changes:
   name: Tests for Documentation Changes
@@ -297,7 +297,7 @@ tests_for_doc_changes:
     - .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_windows
   triggers:
     cancel_old_ci: true
-    expression: pull_request.(target eq "develop" AND push.changes.all match "**/*.md")
+    expression: pull_request.(target eq "develop" AND changes.all match "**/*.md")
             
 performance_tests_only:
   name: All Performance Tests

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -15,3 +15,4 @@ Notes:
   4) Fixes, changes, and additions need to be documented in [CHANGELOG](Packages/com.unity.inputsystem/CHANGELOG.md).
   5) Breaking API changes can only be introduced in new major versions.
 * The more a PR deviates from these requirements, the more work we have to do on our side to incorporate your changes. Give your PR a leg up by making it easy on us :)
+

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -15,4 +15,3 @@ Notes:
   4) Fixes, changes, and additions need to be documented in [CHANGELOG](Packages/com.unity.inputsystem/CHANGELOG.md).
   5) Breaking API changes can only be introduced in new major versions.
 * The more a PR deviates from these requirements, the more work we have to do on our side to incorporate your changes. Give your PR a leg up by making it easy on us :)
-


### PR DESCRIPTION
### Description

This PR:
- skips `All Functional Tests` trigger if a PR only changes `.md` files
- adds a new trigger ` Tests for Documentation Changes` for PRs which only change `.md` files

JIRA ticket: [ISX-2317](https://jira.unity3d.com/browse/ISX-2317) Review CI and source of instabilities

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
