### PR TITLE
FIX: disabling the InputSystemUIInputModule component resets all actions to None

### DIFF
--- a/Assets/Tests/InputSystem.Editor/ProjectWideInputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/ProjectWideInputActionsEditorTests.cs
@@ -236,7 +236,7 @@ internal class ProjectWideInputActionsEditorTests
         }
     }
 
-    [Test(Description = "Verifies that the default asset do not generate any verification errors (Regardless of existing requirements)")]
+    [Test(Description = "Verifies that the default asset does not generate any verification errors (Regardless of existing requirements)")]
     [Category(kTestCategory)]
     public void ProjectWideActions_ShouldSupportAssetVerification_AndHaveNoVerificationErrorsForDefaultAsset()
     {

--- a/Assets/Tests/InputSystem/Plugins/UITests.InputModuleTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.InputModuleTests.cs
@@ -157,6 +157,17 @@ internal partial class UITests
             Assert.IsTrue(callbackCheck.pointerData.fullyExited == true);
         }
 
+        [UnityTest]
+        [Description("Regression test for https://jira.unity3d.com/browse/ISXB-1493")]
+        public IEnumerator DisablingDoesNotResetActions()
+        {
+            m_InputModule.enabled = false;
+
+            yield return null;
+
+            Assert.IsNotNull(m_InputModule.cancel, "Disabling component shouldn't lose its data.");
+        }
+
         public class PointerExitCallbackCheck : MonoBehaviour, IPointerExitHandler
         {
             public PointerEventData pointerData { get; private set; }

--- a/Assets/Tests/InputSystem/Plugins/UITests.InputModuleTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.InputModuleTests.cs
@@ -159,13 +159,19 @@ internal partial class UITests
 
         [UnityTest]
         [Description("Regression test for https://jira.unity3d.com/browse/ISXB-1493")]
-        public IEnumerator DisablingDoesNotResetActions()
+        public IEnumerator DisablingDoesNotResetUserActions()
         {
+            var actions = new DefaultInputActions();
+            m_InputModule.actionsAsset = actions.asset;
+            m_InputModule.cancel = InputActionReference.Create(actions.UI.Cancel);
+
             m_InputModule.enabled = false;
 
             yield return null;
 
             Assert.IsNotNull(m_InputModule.cancel, "Disabling component shouldn't lose its data.");
+
+            actions.Dispose();
         }
 
         public class PointerExitCallbackCheck : MonoBehaviour, IPointerExitHandler

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -29,6 +29,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed reenabling the VirtualMouseInput component may sometimes lead to NullReferenceException. [ISXB-1096](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1096)
 - Fixed the default button press point not being respected in Editor (as well as some other Touchscreen properties). [ISXB-1152](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1152)
 - Fixed actions being reset when disabling the InputSystemUIInputModule component [ISXB-1493](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1493)
+- Fixed a memory leak when disabling and enabling the InputSystemUIInputModule component at runtime [ISXB-1573](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1573)
 - Fixed PlayerInput component automatically switching away from the default ActionMap set to 'None'.
 - Fixed a console error being shown when targeting visionOS builds in 2022.3.
 - Fixed a Tap Interaction issue with analog controls. The Tap interaction would keep re-starting after timeout. [ISXB-627](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-627)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed Gamepad stick up/down inputs that were not recognized in WebGL. [ISXB-1090](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1090)
 - Fixed reenabling the VirtualMouseInput component may sometimes lead to NullReferenceException. [ISXB-1096](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1096)
 - Fixed the default button press point not being respected in Editor (as well as some other Touchscreen properties). [ISXB-1152](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1152)
+- Fixed actions being reset when disabling the InputSystemUIInputModule component [ISXB-1493](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1493)
 - Fixed PlayerInput component automatically switching away from the default ActionMap set to 'None'.
 - Fixed a console error being shown when targeting visionOS builds in 2022.3.
 - Fixed a Tap Interaction issue with analog controls. The Tap interaction would keep re-starting after timeout. [ISXB-627](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-627)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1677,6 +1677,12 @@ namespace UnityEngine.InputSystem.UI
             DisableAllActions();
             UnhookActions();
 
+            // In the case we've been initialialised with default actions, we want to unalloc them
+            if (defaultActions != null && defaultActions.asset == actionsAsset)
+            {
+                UnassignActions();
+            }
+
             base.OnDisable();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1528,6 +1528,17 @@ namespace UnityEngine.InputSystem.UI
             set => SwapAction(ref m_TrackedDevicePositionAction, value, m_ActionsHooked, m_OnTrackedDevicePositionDelegate);
         }
 
+        // We should dispose the static default actions thing because otherwise it will survive domain reloads
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        static void ResetDefaultActions()
+        {
+            if (defaultActions != null)
+            {
+                defaultActions.Dispose();
+                defaultActions = null;
+            }
+        }        
+
         /// <summary>
         /// Assigns default input actions asset and input actions, similar to how defaults are assigned when creating UI module in editor.
         /// Useful for creating <see cref="InputSystemUIInputModule"/> at runtime.
@@ -1665,7 +1676,6 @@ namespace UnityEngine.InputSystem.UI
             InputActionState.s_GlobalState.onActionControlsChanged.RemoveCallback(m_OnControlsChangedDelegate);
             DisableAllActions();
             UnhookActions();
-            UnassignActions();
 
             base.OnDisable();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1677,7 +1677,7 @@ namespace UnityEngine.InputSystem.UI
             DisableAllActions();
             UnhookActions();
 
-            // In the case we've been initialialised with default actions, we want to unalloc them
+            // In the case we've been initialized with default actions, we want to release them
             if (defaultActions != null && defaultActions.asset == actionsAsset)
             {
                 UnassignActions();

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1537,7 +1537,7 @@ namespace UnityEngine.InputSystem.UI
                 defaultActions.Dispose();
                 defaultActions = null;
             }
-        }        
+        }
 
         /// <summary>
         /// Assigns default input actions asset and input actions, similar to how defaults are assigned when creating UI module in editor.


### PR DESCRIPTION
### Description

This PR fixes a problem where disabling the InputSystemUIInputModule component would reset all the actions, even if they had been priorly set by user. 

This started to happen after a fix for another regression landed, where we unassigned all actions from the components OnDisable. I believe this is wrong, since the only thing we really need to be resetting is the default actions asset that shouldn't normally survive re-reentering playmode. 

### Testing status & QA

Local testing, a new regression test, pending a QA pass

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
