### PR TITLE
FIX: All InputControls change when modifying one

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -31,6 +31,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed the TreeView compilation warnings when used with Unity 6.2 beta (ISX-2320)
 - Fixed actions being reset when disabling the InputSystemUIInputModule component [ISXB-1493](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1493)
 - Fixed a memory leak when disabling and enabling the InputSystemUIInputModule component at runtime [ISXB-1573](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1573)
+- Fixed all InputControls being changed at once when you change just one by reverting `2a37caac288ac09bc9122234339dc5df8d3a0ca6`, which was an attempt at fixing [ISXB-1221] that introduced this regression [ISXB-1531] (https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1493)
 - Fixed PlayerInput component automatically switching away from the default ActionMap set to 'None'.
 - Fixed a console error being shown when targeting visionOS builds in 2022.3.
 - Fixed a Tap Interaction issue with analog controls. The Tap interaction would keep re-starting after timeout. [ISXB-627](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-627)
@@ -84,6 +85,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue causing InvalidOperationException when entering playmode with domain reload disabled. [ISXB-1208](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1208).
 - Fixed an issue where compiling Addressables with Input System package present would result in failed compilation due to `IInputAnalytic.TryGatherData` not being defined [ISXB-1203](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1203).
 - Pinned Touch Samples sample package dependencies to avoid errors with Cinemachine 3.x and Probuilder 6.x. [ISXB-1245](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1245)
+- Fixed issue where a binding path is sometimes not saved when chosen from the binding path picker. [ISXB-1221](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1221)
 - Fixed an issue where dropdown menu for Path in Input Actions Editor could not be selected from any button position. [ISXB-1309](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1309)
 - Fixed an issue where changing Input System default parameter settings with the editor open would result in changes in the editor. [ISXB-1351](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1351)
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -84,7 +84,6 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue causing InvalidOperationException when entering playmode with domain reload disabled. [ISXB-1208](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1208).
 - Fixed an issue where compiling Addressables with Input System package present would result in failed compilation due to `IInputAnalytic.TryGatherData` not being defined [ISXB-1203](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1203).
 - Pinned Touch Samples sample package dependencies to avoid errors with Cinemachine 3.x and Probuilder 6.x. [ISXB-1245](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1245)
-- Fixed issue where a binding path is sometimes not saved when chosen from the binding path picker. [ISXB-1221](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1221)
 - Fixed an issue where dropdown menu for Path in Input Actions Editor could not be selected from any button position. [ISXB-1309](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1309)
 - Fixed an issue where changing Input System default parameter settings with the editor open would result in changes in the editor. [ISXB-1351](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1351)
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -30,9 +30,8 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (pathProperty == null)
                 throw new ArgumentNullException(nameof(pathProperty));
-            // Update the static pathProperty variable to the most recent serializedProperty.
-            // See comment on pathProperty for more information.
-            s_pathProperty = pathProperty;
+
+            this.pathProperty = pathProperty;
             this.onModified = onModified;
             m_PickerState = pickerState ?? new InputControlPickerState();
             m_PathLabel = label ?? new GUIContent(pathProperty.displayName, pathProperty.GetTooltip());
@@ -40,7 +39,6 @@ namespace UnityEngine.InputSystem.Editor
 
         public void Dispose()
         {
-            s_pathProperty = null;
             m_PickerDropdown?.Dispose();
         }
 
@@ -91,10 +89,10 @@ namespace UnityEngine.InputSystem.Editor
             EditorGUILayout.EndHorizontal();
         }
 
-        //TODO: on next major version remove property argument.
         public void OnGUI(Rect rect, GUIContent label = null, SerializedProperty property = null, Action modifiedCallback = null)
         {
             var pathLabel = label ?? m_PathLabel;
+            var serializedProperty = property ?? pathProperty;
 
             var lineRect = rect;
             var labelRect = lineRect;
@@ -115,7 +113,7 @@ namespace UnityEngine.InputSystem.Editor
             var path = String.Empty;
             try
             {
-                path = pathProperty.stringValue;
+                path = serializedProperty.stringValue;
             }
             catch
             {
@@ -140,8 +138,8 @@ namespace UnityEngine.InputSystem.Editor
                 path = EditorGUI.DelayedTextField(bindingTextRect, path);
                 if (EditorGUI.EndChangeCheck())
                 {
-                    pathProperty.stringValue = path;
-                    pathProperty.serializedObject.ApplyModifiedProperties();
+                    serializedProperty.stringValue = path;
+                    serializedProperty.serializedObject.ApplyModifiedProperties();
                     (modifiedCallback ?? onModified).Invoke();
                 }
             }
@@ -150,9 +148,9 @@ namespace UnityEngine.InputSystem.Editor
                 // Dropdown that shows binding text and allows opening control picker.
                 if (EditorGUI.DropdownButton(bindingTextRect, new GUIContent(displayName), FocusType.Keyboard))
                 {
-                    SetExpectedControlLayoutFromAttribute(pathProperty);
+                    SetExpectedControlLayoutFromAttribute(serializedProperty);
                     ////TODO: for bindings that are part of composites, use the layout information from the [InputControl] attribute on the field
-                    ShowDropdown(bindingTextRect, modifiedCallback ?? onModified);
+                    ShowDropdown(bindingTextRect, serializedProperty, modifiedCallback ?? onModified);
                 }
             }
 
@@ -161,7 +159,7 @@ namespace UnityEngine.InputSystem.Editor
                 EditorStyles.miniButton);
         }
 
-        private void ShowDropdown(Rect rect, Action modifiedCallback)
+        private void ShowDropdown(Rect rect, SerializedProperty serializedProperty, Action modifiedCallback)
         {
             #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(true, false);
@@ -172,12 +170,18 @@ namespace UnityEngine.InputSystem.Editor
                     m_PickerState,
                     path =>
                     {
-                        pathProperty.stringValue = path;
-                        pathProperty.serializedObject.ApplyModifiedProperties();
+                        serializedProperty.stringValue = path;
                         m_PickerState.manualPathEditMode = false;
                         modifiedCallback();
                     });
             }
+
+            m_PickerDropdown.SetPickedCallback(path =>
+            {
+                serializedProperty.stringValue = path;
+                m_PickerState.manualPathEditMode = false;
+                modifiedCallback();
+            });
 
             m_PickerDropdown.SetControlPathsToMatch(m_ControlPathsToMatch);
             m_PickerDropdown.SetExpectedControlLayout(m_ExpectedControlLayout);
@@ -196,16 +200,7 @@ namespace UnityEngine.InputSystem.Editor
                 SetExpectedControlLayout(attribute.layout);
         }
 
-        // This static variable is a hack. Because the editor is rebuilt at unpredictable times with a new serializedObject, we need to keep updating
-        // this variable with most up to date serializedProperty, so that the picker dropdown can access the correct serializedProperty.
-        // The picker dropdown is a separate window and does not have access to the changed serializedObject reference.
-        // This could be removed if the InputControlPathEditor is converted to UITK with a stable, persistent serializedObject backing this editor.
-        // This property will be shared among multiple asset editor windows.
-        private static SerializedProperty s_pathProperty { get; set; }
-
-        // This property will always return the most recent serializedProperty.
-        public SerializedProperty pathProperty { get => s_pathProperty;}
-
+        public SerializedProperty pathProperty { get; }
         public Action onModified { get; }
 
         private GUIContent m_PathLabel;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -58,6 +58,11 @@ namespace UnityEngine.InputSystem.Editor
             Reload();
         }
 
+        public void SetPickedCallback(Action<string> action)
+        {
+            m_OnPickCallback = action;
+        }
+
         protected override void OnDestroy()
         {
             #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputControlPathDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputControlPathDrawer.cs
@@ -44,7 +44,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             EditorGUI.BeginProperty(position, label, property);
-            m_Editor.OnGUI(position, label, property: null, modifiedCallback: () => property.serializedObject.ApplyModifiedProperties());
+            m_Editor.OnGUI(position, label, property, () => property.serializedObject.ApplyModifiedProperties());
             EditorGUI.EndProperty();
         }
     }


### PR DESCRIPTION
This reverts commit 2a37caac288ac09bc9122234339dc5df8d3a0ca6.

### Description

We received a regression from a fix for ISXB-1221 that makes it impossible to have more than one InputControl components at the same time. This is caused by the static variable used internally. We have to roll this back and return back to the drawing board in order to have a better fix for the original case. I'm closing the regression as fixed and reopening ISXB-1221 instead. 

### Testing status & QA

Local testing

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
