### PR TITLE
FIX: Pen touch input triggers UI/Click action two times (ISXB-1456)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1460,33 +1460,73 @@ internal partial class UITests : CoreTestsFixture
         scene.leftChildReceiver.events.Clear();
         scene.rightChildReceiver.events.Clear();
 
-        // Test if creating Pointer events from different devices at the same time results in only one event
-        BeginTouch(0, firstPosition, screen: touch1, queueEventOnly: true);
-        Press(mouse1.leftButton);
+        // End previous touches that started so that we can do a cleanup from the last test.
+        EndTouch(1, secondPosition, screen: touch1);
         yield return null;
-        EndTouch(0, firstPosition, screen: touch1, queueEventOnly: true);
+        EndTouch(1, firstPosition, screen: touch2);
+        yield return null;
+        // Set a mouse position without any clicks to "emulate" a real movement before a button press.
+        Set(mouse1.position, secondPosition + new Vector2(-10, 0));
+        yield return null;
+
+        scene.leftChildReceiver.events.Clear();
+        scene.rightChildReceiver.events.Clear();
+
+        // Test a press and release from both a Mouse and Touchscreen at the same time
+        // This is to simulate some platforms that always send Mouse/Pen and Touches (e.g. Android).
+        // Also, this mostly assets the expected behavior for the options SingleMouseOrPenButMultiTouchAndTrack.
+        var touchId = 2;
+        BeginTouch(touchId, secondPosition, screen: touch1, queueEventOnly: true);
+        Set(mouse1.position, secondPosition, queueEventOnly: true);
+        Press(mouse1.leftButton);
+
+        yield return null;
+
+        EndTouch(touchId, secondPosition, screen: touch1, queueEventOnly: true);
         Release(mouse1.leftButton);
         yield return null;
 
+        Func<UICallbackReceiver.Event, bool> eventDeviceCondition = null;
+        var expectedCount = 0;
         switch (pointerBehavior)
         {
-            case UIPointerBehavior.SingleUnifiedPointer:
-                //// Getting "Drop" event even if using only one type of input device for Press/Release.
-                //// E.g. the following test would also produce only a Drop event:
-                ////     Press(mouse1.leftButton);
-                ////     yield return null;
-                ////     Release(mouse1.leftButton);
-                ////     yield return null;
-                break;
             case UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack:
-            case UIPointerBehavior.AllPointersAsIs:
-                // Single pointer click on the left object
-                Assert.That(scene.leftChildReceiver.events,
-                    Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerClick).And
-                        .Matches((UICallbackReceiver.Event e) => e.pointerData.device == mouse1).And
-                        .Matches((UICallbackReceiver.Event e) => e.pointerData.position == firstPosition));
+                // Expects only mouse events for PointerClick, PointerDown, and PointerUp
+                eventDeviceCondition = (e) => e.pointerData.device == mouse1;
+                expectedCount = 1;
+                // Make sure that the touch does not generate a UI events.
+                Assert.That(scene.rightChildReceiver.events, Has.None.Matches((UICallbackReceiver.Event e) =>
+                    e.pointerData != null && e.pointerData.device == touch1));
                 break;
+
+            case UIPointerBehavior.SingleUnifiedPointer:
+                // Expects only single UI events with touch source since they are the first events in the queue
+                eventDeviceCondition = (e) => e.pointerData.device == touch1;
+                expectedCount = 1;
+                break;
+
+            case UIPointerBehavior.AllPointersAsIs:
+                // Expects both pointer devices to generate PointerClick, PointerDown, and PointerUp events
+                eventDeviceCondition = (e) => e.pointerData.device == mouse1 || e.pointerData.device == touch1;
+                expectedCount = 2;
+                break;
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(pointerBehavior), pointerBehavior, null);
         }
+
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(expectedCount).With.Property("type").EqualTo(EventType.PointerClick).And
+                .Matches((UICallbackReceiver.Event e) => eventDeviceCondition(e)).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(expectedCount).With.Property("type").EqualTo(EventType.PointerDown).And
+                .Matches((UICallbackReceiver.Event e) => eventDeviceCondition(e)).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
+        Assert.That(scene.rightChildReceiver.events,
+            Has.Exactly(expectedCount).With.Property("type").EqualTo(EventType.PointerUp).And
+                .Matches((UICallbackReceiver.Event e) => eventDeviceCondition(e)).And
+                .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
     }
 
     [UnityTest]

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1531,6 +1531,65 @@ internal partial class UITests : CoreTestsFixture
 
     [UnityTest]
     [Category("UI")]
+    [Description("Tests that disabling the UI module during a Button click event works correctly with touch pointers." +
+        "ISXB-687")]
+    public IEnumerator UI_DisablingEventSystemOnClickEventWorksWithTouchPointersWorks()
+    {
+        var touch = InputSystem.AddDevice<Touchscreen>();
+        var scene = CreateTestUI();
+
+        var actions = ScriptableObject.CreateInstance<InputActionAsset>();
+        var uiActions = actions.AddActionMap("UI");
+        var pointAction = uiActions.AddAction("point", type: InputActionType.PassThrough);
+        var clickAction = uiActions.AddAction("click", type: InputActionType.PassThrough);
+
+        pointAction.AddBinding("<Touchscreen>/touch*/position");
+        clickAction.AddBinding("<Touchscreen>/touch*/press");
+
+        pointAction.Enable();
+        clickAction.Enable();
+
+        scene.uiModule.point = InputActionReference.Create(pointAction);
+        scene.uiModule.pointerBehavior = UIPointerBehavior.SingleMouseOrPenButMultiTouchAndTrack;
+        scene.uiModule.leftClick = InputActionReference.Create(clickAction);
+
+        // Turn left object into a button.
+        var button = scene.leftGameObject.AddComponent<MyButton>();
+        var clicked = false;
+
+        // Add a listener to the button to disable the UI module when clicked.
+        // This calls InputSystemUIInputModule.OnDisable() which will reset the pointer data during
+        // InputSystemUIInputModule.Process() and ProcessPointer(). It will allow us to test that removing
+        // a pointer once the UI module is disabled (all pointers are removed) works correctly.
+        button.onClick.AddListener(() =>
+        {
+            clicked = true;
+            scene.uiModule.enabled = false; // Disable the UI module to test pointer reset.
+        });
+
+        yield return null;
+
+        var firstPosition = scene.From640x480ToScreen(100, 100);
+
+        // This will allocate a pointer for the touch and set the first touch position and press
+        BeginTouch(1, firstPosition, screen: touch);
+        yield return null;
+
+        Assert.That(clicked, Is.False, "Button was clicked when it should not have been yet.");
+        Assert.That(scene.uiModule.m_PointerStates.length, Is.EqualTo(1),
+            "A pointer states was not allocated for the touch pointer.");
+
+        // Release the touch to make sure we have a Click event that calls the button listener.
+        EndTouch(1, firstPosition, screen: touch);
+        yield return null;
+
+        Assert.That(clicked, Is.True, "Button was not clicked when it should have been.");
+        Assert.That(scene.uiModule.m_PointerStates.length, Is.EqualTo(0),
+            "Pointer states were not cleared when the UI module was disabled after a click event.");
+    }
+
+    [UnityTest]
+    [Category("UI")]
     public IEnumerator UI_CanDriveUIFromMultipleTouches()
     {
         var touchScreen = InputSystem.AddDevice<Touchscreen>();

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -1533,7 +1533,7 @@ internal partial class UITests : CoreTestsFixture
     [Category("UI")]
     [Description("Tests that disabling the UI module during a Button click event works correctly with touch pointers." +
         "ISXB-687")]
-    public IEnumerator UI_DisablingEventSystemOnClickEventWorksWithTouchPointersWorks()
+    public IEnumerator UI_DisablingEventSystemOnClickEventWorksWithTouchPointers()
     {
         var touch = InputSystem.AddDevice<Touchscreen>();
         var scene = CreateTestUI();

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
+- Fixed an issue where using Pen devices on Android tablets would result in double clicks for UI interactions. [ISXB-1456](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1456)
+
 
 
 ## [1.14.1] - 2025-07-10

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -2077,14 +2077,6 @@ namespace UnityEngine.InputSystem.UI
 
             Debug.Assert(m_PointerStates[index].eventData.pointerEnter == null, "Pointer should have exited all objects before being removed");
 
-            // // We don't want to release touch pointers on the same frame they are released (unpressed). They get cleaned up one frame later in Process()
-            // ref var state = ref GetPointerStateForIndex(index);
-            // if (state.pointerType == UIPointerType.Touch && (state.leftButton.isPressed || state.leftButton.wasReleasedThisFrame))
-            // {
-            //     // The pointer was not removed
-            //     return false;
-            // }
-
             // Retain event data so that we can reuse the event the next time we allocate a PointerModel record.
             var eventData = m_PointerStates[index].eventData;
             Debug.Assert(eventData != null, "Pointer state should have an event instance!");
@@ -2355,18 +2347,6 @@ namespace UnityEngine.InputSystem.UI
                     // We have input on a mouse or pen. Kill all touch and tracked pointers we may have.
                     for (var i = 0; i < m_PointerStates.length; ++i)
                     {
-                        // ref var state = ref GetPointerStateForIndex(i);
-                        // // Touch pointers need to get forced to no longer be pressed otherwise they will not get released in subsequent frames.
-                        // if (m_PointerStates[i].pointerType == UIPointerType.Touch)
-                        // {
-                        //     state.leftButton.isPressed = false;
-                        // }
-                        // if (m_PointerStates[i].pointerType != UIPointerType.MouseOrPen && m_PointerStates[i].pointerType != UIPointerType.Touch || (m_PointerStates[i].pointerType == UIPointerType.Touch && !state.leftButton.isPressed && !state.leftButton.wasReleasedThisFrame))
-                        // {
-                        //     if (SendPointerExitEventsAndRemovePointer(i))
-                        //         --i;
-                        // }
-
                         if (m_PointerStates[i].pointerType != UIPointerType.MouseOrPen)
                         {
                             if (SendPointerExitEventsAndRemovePointer(i))

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -2070,7 +2070,7 @@ namespace UnityEngine.InputSystem.UI
 
         private bool RemovePointerAtIndex(int index)
         {
-            // Pointers can have be reset before (e.g. when calling OnDisable) which would make m_PointerStates
+            // Pointers might have been reset before (e.g. when calling OnDisable) which would make m_PointerStates
             // empty (ISXB-687).
             if (m_PointerStates.length == 0)
                 return false;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -2070,6 +2070,11 @@ namespace UnityEngine.InputSystem.UI
 
         private bool RemovePointerAtIndex(int index)
         {
+            // Pointers can have be reset before (e.g. when calling OnDisable) which would make m_PointerStates
+            // empty (ISXB-687).
+            if (m_PointerStates.length == 0)
+                return false;
+
             Debug.Assert(m_PointerStates[index].eventData.pointerEnter == null, "Pointer should have exited all objects before being removed");
 
             // // We don't want to release touch pointers on the same frame they are released (unpressed). They get cleaned up one frame later in Process()
@@ -2458,8 +2463,8 @@ namespace UnityEngine.InputSystem.UI
                     //       stays true for the touch in the frame of release (see UI_TouchPointersAreKeptForOneFrameAfterRelease).
                     if (state.pointerType == UIPointerType.Touch && !state.leftButton.isPressed && !state.leftButton.wasReleasedThisFrame)
                     {
-                        RemovePointerAtIndex(i);
-                        --i;
+                        if (RemovePointerAtIndex(i))
+                            --i;
                         continue;
                     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -2072,13 +2072,13 @@ namespace UnityEngine.InputSystem.UI
         {
             Debug.Assert(m_PointerStates[index].eventData.pointerEnter == null, "Pointer should have exited all objects before being removed");
 
-            // We don't want to release touch pointers on the same frame they are released (unpressed). They get cleaned up one frame later in Process()
-            ref var state = ref GetPointerStateForIndex(index);
-            if (state.pointerType == UIPointerType.Touch && (state.leftButton.isPressed || state.leftButton.wasReleasedThisFrame))
-            {
-                // The pointer was not removed
-                return false;
-            }
+            // // We don't want to release touch pointers on the same frame they are released (unpressed). They get cleaned up one frame later in Process()
+            // ref var state = ref GetPointerStateForIndex(index);
+            // if (state.pointerType == UIPointerType.Touch && (state.leftButton.isPressed || state.leftButton.wasReleasedThisFrame))
+            // {
+            //     // The pointer was not removed
+            //     return false;
+            // }
 
             // Retain event data so that we can reuse the event the next time we allocate a PointerModel record.
             var eventData = m_PointerStates[index].eventData;
@@ -2350,13 +2350,19 @@ namespace UnityEngine.InputSystem.UI
                     // We have input on a mouse or pen. Kill all touch and tracked pointers we may have.
                     for (var i = 0; i < m_PointerStates.length; ++i)
                     {
-                        ref var state = ref GetPointerStateForIndex(i);
-                        // Touch pointers need to get forced to no longer be pressed otherwise they will not get released in subsequent frames.
-                        if (m_PointerStates[i].pointerType == UIPointerType.Touch)
-                        {
-                            state.leftButton.isPressed = false;
-                        }
-                        if (m_PointerStates[i].pointerType != UIPointerType.MouseOrPen && m_PointerStates[i].pointerType != UIPointerType.Touch || (m_PointerStates[i].pointerType == UIPointerType.Touch && !state.leftButton.isPressed && !state.leftButton.wasReleasedThisFrame))
+                        // ref var state = ref GetPointerStateForIndex(i);
+                        // // Touch pointers need to get forced to no longer be pressed otherwise they will not get released in subsequent frames.
+                        // if (m_PointerStates[i].pointerType == UIPointerType.Touch)
+                        // {
+                        //     state.leftButton.isPressed = false;
+                        // }
+                        // if (m_PointerStates[i].pointerType != UIPointerType.MouseOrPen && m_PointerStates[i].pointerType != UIPointerType.Touch || (m_PointerStates[i].pointerType == UIPointerType.Touch && !state.leftButton.isPressed && !state.leftButton.wasReleasedThisFrame))
+                        // {
+                        //     if (SendPointerExitEventsAndRemovePointer(i))
+                        //         --i;
+                        // }
+
+                        if (m_PointerStates[i].pointerType != UIPointerType.MouseOrPen)
                         {
                             if (SendPointerExitEventsAndRemovePointer(i))
                                 --i;


### PR DESCRIPTION
### Description

This fixes [ISXB-1546](https://jira.unity3d.com/browse/ISXB-1546) by reverting the changes from #1982, which introduced a regression while addressing [ISXB-687](https://jira.unity3d.com/browse/ISXB-687). Additionally, new tests have been added to prevent future regressions in this area.

The fix for [ISXB-687](https://jira.unity3d.com/browse/ISXB-687) now checks whether the pointer state list contains the pointer before attempting removal. 
Previously, users could set up a button listener event that could call `InputSystemUIInputModule.OnDisable()`, which would reset the pointer state during `InputSystemUIInputModule.Process()`. This would lead to attempts to remove pointer states that were removed during the reset.


### Testing status & QA

Tested ISXB-1546 with a Samsung tablet with an active Pen. It would be ideal if @Pauliusd01 or some CQA could test this on device to make sure I didn't miss something.

Tested ISXB-687 reproduction steps which now don't raise an error.

Additionally, If you copy `UITest.cs` changes from this PR into `develop`, the tests should fail.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 1

### Comments to reviewers

Make sure to replicate steps from the Jira tickets and make sure they now work as expected.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] ~Docs for new/changed API's.~
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
