### PR TITLE
FIX: CI Failure due to hard coded path to the Assembly changing

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -3398,7 +3398,7 @@ partial class CoreTests
     {
         var codeProvider = CodeDomProvider.CreateProvider("CSharp");
         var cp = new CompilerParameters { CompilerOptions = options };
-        cp.ReferencedAssemblies.Add($"{EditorApplication.applicationContentsPath}/Managed/UnityEngine/UnityEngine.CoreModule.dll");
+        cp.ReferencedAssemblies.Add(typeof(UnityEngine.Vector2).Assembly.Location);
         cp.ReferencedAssemblies.Add("Library/ScriptAssemblies/Unity.InputSystem.dll");
 #if UNITY_2022_1_OR_NEWER
         // Currently there is are cross-references to netstandard, e.g. System.IEquatable<UnityEngine.Vector2>, System.IFormattable


### PR DESCRIPTION
### Description

Fixes a failure on CI on the CoreTests.Editor_CanGenerateCodeForInputDeviceLayout
That test compiles a script and references the UnityEngine.CoreModule.dll, the failure was happening due to the dll path changing on trunk. Instead of hardcoding the path, we can use the type that we are referencing in the generated script where its assembly is located.


### Testing status & QA

Tested locally that the tests pass, waiting for results on CI

### Overall Product Risks

Changes in test infrastructure, no risk for the product.

- Complexity:  0
- Halo Effect: 0

### Comments to reviewers



### Checklist

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
