### PR TITLE
Add extra InputDeviceCharacteristics enum to avoid dependency on XR Module

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/GenericXRDevice.cs
@@ -112,7 +112,6 @@ namespace UnityEngine.InputSystem.XR
         protected override void FinishSetup()
         {
             base.FinishSetup();
-#if UNITY_INPUT_SYSTEM_ENABLE_XR
             var capabilities = description.capabilities;
             var deviceDescriptor = XRDeviceDescriptor.FromJson(capabilities);
 
@@ -123,7 +122,6 @@ namespace UnityEngine.InputSystem.XR
                 else if ((deviceDescriptor.characteristics & InputDeviceCharacteristics.Right) != 0)
                     InputSystem.SetDeviceUsage(this, CommonUsages.RightHand);
             }
-#endif
         }
     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRLayoutBuilder.cs
@@ -88,7 +88,7 @@ namespace UnityEngine.InputSystem.XR
             {
                 return null;
             }
-#if UNITY_INPUT_SYSTEM_ENABLE_XR
+
             if (string.IsNullOrEmpty(matchedLayout))
             {
                 const InputDeviceCharacteristics controllerCharacteristics = InputDeviceCharacteristics.HeldInHand | InputDeviceCharacteristics.Controller;
@@ -97,7 +97,7 @@ namespace UnityEngine.InputSystem.XR
                 else if ((deviceDescriptor.characteristics & controllerCharacteristics) == controllerCharacteristics)
                     matchedLayout = "XRController";
             }
-#endif
+
             string layoutName;
             if (string.IsNullOrEmpty(description.manufacturer))
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.XR;
 
 namespace UnityEngine.InputSystem.XR
 {
@@ -43,6 +42,27 @@ namespace UnityEngine.InputSystem.XR
         Hand,
         Bone,
         Eyes
+    }
+
+    // Sync to InputDeviceCharacteristics in IUnityXRInput.h
+    /// <summary>
+    /// The type of data a <see cref="XRDeviceDescriptor"/> exposes.
+    /// </summary>
+    [Flags]
+    public enum InputDeviceCharacteristics : uint
+    {
+        None = 0,
+        HeadMounted = 1 << 0,
+        Camera = 1 << 1,
+        HeldInHand = 1 << 2,
+        HandTracking = 1 << 3,
+        EyeTracking = 1 << 4,
+        TrackedDevice = 1 << 5,
+        Controller = 1 << 6,
+        TrackingReference = 1 << 7,
+        Left = 1 << 8,
+        Right = 1 << 9,
+        Simulated6DOF = 1 << 10
     }
 
     /// <summary>
@@ -102,12 +122,8 @@ namespace UnityEngine.InputSystem.XR
         /// <summary>
         /// The capabilities of the device, used to help filter and identify devices that server a certain purpose (e.g. controller, or headset, or hardware tracker).
         /// </summary>
-#if UNITY_INPUT_SYSTEM_ENABLE_XR
         public InputDeviceCharacteristics characteristics;
-#else
-        [SerializeField]
-        private uint characteristics;
-#endif
+
         /// <summary>
         /// The underlying deviceId, this can be used with <see cref="UnityEngine.XR.InputDevices"/> to create a device.
         /// </summary>


### PR DESCRIPTION
### Description

Adds the InputDeviceCharacteristics enum into XRSupport so we don't depend on the type coming from the XR Module. 
We already do the same thing [here](https://github.com/Unity-Technologies/InputSystem/blob/develop/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/XRSupport.cs#L30) with the FeatureType enum.
 
### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
