### PR TITLE
FIX: CI fixes & regenerated yml for yamato jobs

### DIFF
--- a/.yamato/upm-ci.yml
+++ b/.yamato/upm-ci.yml
@@ -22,6 +22,7 @@
     # really work with them. Move them into the package for when we run upm-ci here.
     - move /Y .\Assets\Samples .\Packages\com.unity.inputsystem
     - move /Y .\Assets\Samples.meta .\Packages\com.unity.inputsystem
+    - npm install upm-ci-utils@stable -g --registry https://artifactory-upload.prd.it.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u %EDITOR_VERSION%
@@ -74,6 +75,7 @@
     # really work with them. Move them into the package for when we run upm-ci here.
     - mv ./Assets/Samples ./Packages/com.unity.inputsystem
     - mv ./Assets/Samples.meta ./Packages/com.unity.inputsystem
+    - npm install upm-ci-utils@stable -g --registry https://artifactory-upload.prd.it.unity3d.com/artifactory/api/npm/upm-npm
     - upm-ci package pack --package-path ./Packages/com.unity.inputsystem/
     # Run upm-ci verification tests as well as tests contained in the package.
     - upm-ci package test --package-path ./Packages/com.unity.inputsystem/ -u $EDITOR_VERSION {% if category.name == "functional" and platform.name == "mac" or platform.name == "linux" %} --enable-code-coverage --code-coverage-options "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem;pathReplacePatterns:@*,,Library/PackageCache,Packages" --extra-utr-arg="--coverage-results-path={{ yamato_source_dir_nix }}/upm-ci~/test-results/CodeCoverage/Package --coverage-upload-options=\"reportsDir:upm-ci~/test-results/CodeCoverage/Package;name:{{platform.name}}_{{editor.version}}_pkg;flags:{{platform.name}}_{{editor.version}}_pkg\"" {% endif %}

--- a/.yamato/wrench/api-validation-jobs.yml
+++ b/.yamato/wrench/api-validation-jobs.yml
@@ -13,14 +13,14 @@ api_validation_-_inputsystem_-_2021_3_-_windows:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/PackageJsonCondersor.py
@@ -51,8 +51,8 @@ api_validation_-_inputsystem_-_2021_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -26,5 +26,5 @@ package_pack_-_inputsystem:
     UPMCI_ACK_LARGE_PACKAGE: 1
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -20,9 +20,12 @@ all_preview_apv_jobs:
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_2_-_macos
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_2_-_ubuntu
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_2_-_windows
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_macos
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_ubuntu
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_windows
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2021.3 manifest (MacOS).
 preview_apv_-_2021_3_-_macos:
@@ -32,14 +35,14 @@ preview_apv_-_2021_3_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2021.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -73,10 +76,10 @@ preview_apv_-_2021_3_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2021.3 manifest (Ubuntu).
 preview_apv_-_2021_3_-_ubuntu:
@@ -86,14 +89,14 @@ preview_apv_-_2021_3_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2021.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -127,10 +130,10 @@ preview_apv_-_2021_3_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2021.3 manifest (Windows).
 preview_apv_-_2021_3_-_windows:
@@ -141,14 +144,14 @@ preview_apv_-_2021_3_-_windows:
     flavor: b1.large
   commands:
   - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2021.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -182,10 +185,10 @@ preview_apv_-_2021_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (MacOS).
 preview_apv_-_2022_3_-_macos:
@@ -195,14 +198,14 @@ preview_apv_-_2022_3_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2022.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -236,10 +239,10 @@ preview_apv_-_2022_3_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (Ubuntu).
 preview_apv_-_2022_3_-_ubuntu:
@@ -249,14 +252,14 @@ preview_apv_-_2022_3_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2022.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -290,10 +293,10 @@ preview_apv_-_2022_3_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 2022.3 manifest (Windows).
 preview_apv_-_2022_3_-_windows:
@@ -304,14 +307,14 @@ preview_apv_-_2022_3_-_windows:
     flavor: b1.large
   commands:
   - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 2022.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=2022.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -345,10 +348,10 @@ preview_apv_-_2022_3_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (MacOS).
 preview_apv_-_6000_0_-_macos:
@@ -358,14 +361,14 @@ preview_apv_-_6000_0_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.0 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.0 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -399,10 +402,10 @@ preview_apv_-_6000_0_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Ubuntu).
 preview_apv_-_6000_0_-_ubuntu:
@@ -412,14 +415,14 @@ preview_apv_-_6000_0_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.0 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.0 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -453,10 +456,10 @@ preview_apv_-_6000_0_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.0 manifest (Windows).
 preview_apv_-_6000_0_-_windows:
@@ -467,14 +470,14 @@ preview_apv_-_6000_0_-_windows:
     flavor: b1.large
   commands:
   - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.0 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.0 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -508,10 +511,10 @@ preview_apv_-_6000_0_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.1 manifest (MacOS).
 preview_apv_-_6000_1_-_macos:
@@ -521,14 +524,14 @@ preview_apv_-_6000_1_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.1 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.1 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -562,10 +565,10 @@ preview_apv_-_6000_1_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.1 manifest (Ubuntu).
 preview_apv_-_6000_1_-_ubuntu:
@@ -575,14 +578,14 @@ preview_apv_-_6000_1_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.1 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.1 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -616,10 +619,10 @@ preview_apv_-_6000_1_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.1 manifest (Windows).
 preview_apv_-_6000_1_-_windows:
@@ -630,14 +633,14 @@ preview_apv_-_6000_1_-_windows:
     flavor: b1.large
   commands:
   - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.1 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.1 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -671,10 +674,10 @@ preview_apv_-_6000_1_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.2 manifest (MacOS).
 preview_apv_-_6000_2_-_macos:
@@ -684,14 +687,14 @@ preview_apv_-_6000_2_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -725,10 +728,10 @@ preview_apv_-_6000_2_-_macos:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.2 manifest (Ubuntu).
 preview_apv_-_6000_2_-_ubuntu:
@@ -738,14 +741,14 @@ preview_apv_-_6000_2_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -779,10 +782,10 @@ preview_apv_-_6000_2_-_ubuntu:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Functional tests for dependents found in the latest 6000.2 manifest (Windows).
 preview_apv_-_6000_2_-_windows:
@@ -793,14 +796,14 @@ preview_apv_-_6000_2_-_windows:
     flavor: b1.large
   commands:
   - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.2 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -834,8 +837,171 @@ preview_apv_-_6000_2_-_windows:
   dependencies:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
+
+# Functional tests for dependents found in the latest 6000.3 manifest (MacOS).
+preview_apv_-_6000_3_-_macos:
+  name: Preview APV - 6000.3 - macos
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 0.12.2.0
+
+# Functional tests for dependents found in the latest 6000.3 manifest (Ubuntu).
+preview_apv_-_6000_3_-_ubuntu:
+  name: Preview APV - 6000.3 - ubuntu
+  agent:
+    image: package-ci/ubuntu-20.04:default
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 0.12.2.0
+
+# Functional tests for dependents found in the latest 6000.3 manifest (Windows).
+preview_apv_-_6000_3_-_windows:
+  name: Preview APV - 6000.3 - windows
+  agent:
+    image: package-ci/win10:default
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.3 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: python PythonScripts/editor_manifest_validator.py --version=6000.3 --wrench-config=.yamato/wrench/wrench_config.json
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -9,7 +9,7 @@ publish_dry_run_inputsystem:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
@@ -34,6 +34,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2021.3-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2021_3_-_ubuntu
     specific_options:
       UTR:
@@ -42,6 +44,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2021.3-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2021_3_-_windows
     specific_options:
       UTR:
@@ -50,6 +54,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2021.3-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_macos
     specific_options:
       UTR:
@@ -58,6 +64,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2022.3-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_ubuntu
     specific_options:
       UTR:
@@ -66,6 +74,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2022.3-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_windows
     specific_options:
       UTR:
@@ -74,6 +84,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2022.3-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_macos
     specific_options:
       UTR:
@@ -82,6 +94,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.0-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_ubuntu
     specific_options:
       UTR:
@@ -90,6 +104,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.0-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_windows
     specific_options:
       UTR:
@@ -98,6 +114,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.0-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_macos
     specific_options:
       UTR:
@@ -106,6 +124,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.1-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_ubuntu
     specific_options:
       UTR:
@@ -114,6 +134,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.1-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_windows
     specific_options:
       UTR:
@@ -122,6 +144,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.1-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_macos
     specific_options:
       UTR:
@@ -130,6 +154,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.2-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_ubuntu
     specific_options:
       UTR:
@@ -138,6 +164,8 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.2-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_windows
     specific_options:
       UTR:
@@ -146,12 +174,44 @@ publish_dry_run_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.2-windows
         unzip: true
+      packages:
+        ignore_artifact: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_3_-_macos
+    specific_options:
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.3-macos
+        unzip: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.3-macos
+        unzip: true
+      packages:
+        ignore_artifact: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_3_-_ubuntu
+    specific_options:
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.3-ubuntu
+        unzip: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.3-ubuntu
+        unzip: true
+      packages:
+        ignore_artifact: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_3_-_windows
+    specific_options:
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.3-windows
+        unzip: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.3-windows
+        unzip: true
+      packages:
+        ignore_artifact: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 
 # Publish  for inputsystem to https://artifactory-slo.bf.unity3d.com/artifactory/api/npm/upm-npm
 publish_inputsystem:
@@ -161,7 +221,7 @@ publish_inputsystem:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
@@ -186,6 +246,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2021.3-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2021_3_-_ubuntu
     specific_options:
       UTR:
@@ -194,6 +256,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2021.3-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2021_3_-_windows
     specific_options:
       UTR:
@@ -202,6 +266,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2021.3-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_macos
     specific_options:
       UTR:
@@ -210,6 +276,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2022.3-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_ubuntu
     specific_options:
       UTR:
@@ -218,6 +286,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2022.3-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_2022_3_-_windows
     specific_options:
       UTR:
@@ -226,6 +296,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-2022.3-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_macos
     specific_options:
       UTR:
@@ -234,6 +306,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.0-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_ubuntu
     specific_options:
       UTR:
@@ -242,6 +316,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.0-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_0_-_windows
     specific_options:
       UTR:
@@ -250,6 +326,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.0-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_macos
     specific_options:
       UTR:
@@ -258,6 +336,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.1-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_ubuntu
     specific_options:
       UTR:
@@ -266,6 +346,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.1-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_1_-_windows
     specific_options:
       UTR:
@@ -274,6 +356,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.1-windows
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_macos
     specific_options:
       UTR:
@@ -282,6 +366,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.2-macos
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_ubuntu
     specific_options:
       UTR:
@@ -290,6 +376,8 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.2-ubuntu
         unzip: true
+      packages:
+        ignore_artifact: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_2_-_windows
     specific_options:
       UTR:
@@ -298,10 +386,42 @@ publish_inputsystem:
       pvp-results:
         location: results/pvp/validate-inputsystem-6000.2-windows
         unzip: true
+      packages:
+        ignore_artifact: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_3_-_macos
+    specific_options:
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.3-macos
+        unzip: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.3-macos
+        unzip: true
+      packages:
+        ignore_artifact: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_3_-_ubuntu
+    specific_options:
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.3-ubuntu
+        unzip: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.3-ubuntu
+        unzip: true
+      packages:
+        ignore_artifact: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_3_-_windows
+    specific_options:
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.3-windows
+        unzip: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.3-windows
+        unzip: true
+      packages:
+        ignore_artifact: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/recipe-regeneration.yml
+++ b/.yamato/wrench/recipe-regeneration.yml
@@ -26,5 +26,5 @@ test_-_wrench_jobs_up_to_date:
     cancel_old_ci: true
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
 

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -9,11 +9,11 @@ validate_-_inputsystem_-_2021_3_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -21,7 +21,7 @@ validate_-_inputsystem_-_2021_3_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -29,8 +29,8 @@ validate_-_inputsystem_-_2021_3_-_macos:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -60,10 +60,10 @@ validate_-_inputsystem_-_2021_3_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -75,11 +75,11 @@ validate_-_inputsystem_-_2021_3_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -87,7 +87,7 @@ validate_-_inputsystem_-_2021_3_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -95,8 +95,8 @@ validate_-_inputsystem_-_2021_3_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -126,10 +126,10 @@ validate_-_inputsystem_-_2021_3_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -141,11 +141,11 @@ validate_-_inputsystem_-_2021_3_-_windows:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2021.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2021.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -153,7 +153,7 @@ validate_-_inputsystem_-_2021_3_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -161,8 +161,8 @@ validate_-_inputsystem_-_2021_3_-_windows:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -192,10 +192,10 @@ validate_-_inputsystem_-_2021_3_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -207,11 +207,11 @@ validate_-_inputsystem_-_2022_3_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2022.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -219,7 +219,7 @@ validate_-_inputsystem_-_2022_3_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -227,8 +227,8 @@ validate_-_inputsystem_-_2022_3_-_macos:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -258,10 +258,10 @@ validate_-_inputsystem_-_2022_3_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -273,11 +273,11 @@ validate_-_inputsystem_-_2022_3_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2022.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -285,7 +285,7 @@ validate_-_inputsystem_-_2022_3_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -293,8 +293,8 @@ validate_-_inputsystem_-_2022_3_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -324,10 +324,10 @@ validate_-_inputsystem_-_2022_3_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -339,11 +339,11 @@ validate_-_inputsystem_-_2022_3_-_windows:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 2022.3 -c Editor --fast
+  - command: unity-downloader-cli -u 2022.3/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -351,7 +351,7 @@ validate_-_inputsystem_-_2022_3_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -359,8 +359,8 @@ validate_-_inputsystem_-_2022_3_-_windows:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -390,10 +390,10 @@ validate_-_inputsystem_-_2022_3_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -405,11 +405,11 @@ validate_-_inputsystem_-_6000_0_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.0 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -417,7 +417,7 @@ validate_-_inputsystem_-_6000_0_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -425,8 +425,8 @@ validate_-_inputsystem_-_6000_0_-_macos:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -456,10 +456,10 @@ validate_-_inputsystem_-_6000_0_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -471,11 +471,11 @@ validate_-_inputsystem_-_6000_0_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.0 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -483,7 +483,7 @@ validate_-_inputsystem_-_6000_0_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -491,8 +491,8 @@ validate_-_inputsystem_-_6000_0_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -522,10 +522,10 @@ validate_-_inputsystem_-_6000_0_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -537,11 +537,11 @@ validate_-_inputsystem_-_6000_0_-_windows:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.0 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.0/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -549,7 +549,7 @@ validate_-_inputsystem_-_6000_0_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -557,8 +557,8 @@ validate_-_inputsystem_-_6000_0_-_windows:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -588,10 +588,10 @@ validate_-_inputsystem_-_6000_0_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -603,11 +603,11 @@ validate_-_inputsystem_-_6000_1_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.1 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -615,7 +615,7 @@ validate_-_inputsystem_-_6000_1_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -623,8 +623,8 @@ validate_-_inputsystem_-_6000_1_-_macos:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -654,10 +654,10 @@ validate_-_inputsystem_-_6000_1_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -669,11 +669,11 @@ validate_-_inputsystem_-_6000_1_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.1 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -681,7 +681,7 @@ validate_-_inputsystem_-_6000_1_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -689,8 +689,8 @@ validate_-_inputsystem_-_6000_1_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -720,10 +720,10 @@ validate_-_inputsystem_-_6000_1_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -735,11 +735,11 @@ validate_-_inputsystem_-_6000_1_-_windows:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.1 -c Editor --fast
+  - command: unity-downloader-cli -u 6000.1/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -747,7 +747,7 @@ validate_-_inputsystem_-_6000_1_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -755,8 +755,8 @@ validate_-_inputsystem_-_6000_1_-_windows:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -786,10 +786,10 @@ validate_-_inputsystem_-_6000_1_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -801,11 +801,11 @@ validate_-_inputsystem_-_6000_2_-_macos:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -813,7 +813,7 @@ validate_-_inputsystem_-_6000_2_-_macos:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -821,8 +821,8 @@ validate_-_inputsystem_-_6000_2_-_macos:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -852,10 +852,10 @@ validate_-_inputsystem_-_6000_2_-_macos:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -867,11 +867,11 @@ validate_-_inputsystem_-_6000_2_-_ubuntu:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -879,7 +879,7 @@ validate_-_inputsystem_-_6000_2_-_ubuntu:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -887,8 +887,8 @@ validate_-_inputsystem_-_6000_2_-_ubuntu:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -918,10 +918,10 @@ validate_-_inputsystem_-_6000_2_-_ubuntu:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 
@@ -933,11 +933,11 @@ validate_-_inputsystem_-_6000_2_-_windows:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-59_594aea2e5eb3a7468ad88458b5c5da2e5e72af0d2267db7b025602fb69e57bd7.zip -o wrench-localapv.zip
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.2 -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.2/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
@@ -945,7 +945,7 @@ validate_-_inputsystem_-_6000_2_-_windows:
     retries: 1
   - command: echo No internal packages to add.
   - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 40
+    timeout: 20
     retries: 0
   - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 5
@@ -953,8 +953,8 @@ validate_-_inputsystem_-_6000_2_-_windows:
   - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
     timeout: 10
     retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}"
-    timeout: 40
+  - command: 'UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
     retries: 1
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -984,10 +984,208 @@ validate_-_inputsystem_-_6000_2_-_windows:
   - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 0.10.43.0
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
   metadata:
     Job Maintainers: '#rm-packageworks'
-    Wrench: 0.10.43.0
+    Wrench: 0.12.2.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.3 - macos (6000.3 - MacOS).
+validate_-_inputsystem_-_6000_3_-_macos:
+  name: Validate - inputsystem - 6000.3 - macos
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 0.12.2.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.3 - ubuntu (6000.3 - Ubuntu).
+validate_-_inputsystem_-_6000_3_-_ubuntu:
+  name: Validate - inputsystem - 6000.3 - ubuntu
+  agent:
+    image: package-ci/ubuntu-20.04:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: 'UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 0.12.2.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.3 - windows (6000.3 - Windows).
+validate_-_inputsystem_-_6000_3_-_windows:
+  name: Validate - inputsystem - 6000.3 - windows
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-2-68_53c92d3b34ce3f4b652c9785dd1530bdc5885f6523465d6969c3be91f9ccaaf1.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: 'UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" '
+    timeout: 20
+    retries: 1
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 0.12.2.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 0.12.2.0
   labels:
   - Packages:inputsystem
 

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -34,7 +34,7 @@
   },
   "publishing_job": ".yamato/wrench/promotion-jobs.yml#publish_inputsystem",
   "branch_pattern": "ReleaseSlash",
-  "wrench_version": "0.10.43.0",
+  "wrench_version": "0.12.2.0",
   "pvp_exemption_path": ".yamato/wrench/pvp-exemptions.json",
   "cs_project_path": "Tools/CI/InputSystem.Cookbook.csproj"
 }

--- a/Tools/CI/InputSystem.Cookbook.csproj
+++ b/Tools/CI/InputSystem.Cookbook.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="0.10.43" />
+      <PackageReference Include="RecipeEngine.Modules.Wrench" Version="0.12.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Description

- Trying to fix Yamato jobs not being up to date with Unity version changes. 
- Upgrading Wrench to 0.12.2.
- add upm-ci-utils install for the new package signing step for the old editor testing jobs


### Testing status & QA
- CI green

### Overall Product Risks

- Complexity: low
- Halo Effect: low


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
