### PR TITLE
FIX: add com.unity.polyspatial.extensions to DependantsToIgnoreInPreviewApv

### DIFF
--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -21,6 +21,7 @@
       ],
       "dependantsToIgnoreInPreviewApv": {
         "6000.3": [
+          "com.unity.polyspatial",
           "com.unity.polyspatial.extensions"
         ]
       }

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -22,7 +22,9 @@
       "dependantsToIgnoreInPreviewApv": {
         "6000.3": [
           "com.unity.polyspatial",
-          "com.unity.polyspatial.extensions"
+          "com.unity.polyspatial.extensions",
+          "com.unity.polyspatial.visionos",
+          "com.unity.xr.visionos"
         ]
       }
     }

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -24,6 +24,7 @@
           "com.unity.polyspatial",
           "com.unity.polyspatial.extensions",
           "com.unity.polyspatial.visionos",
+          "com.unity.polyspatial.xr",
           "com.unity.xr.visionos"
         ]
       }

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -19,7 +19,11 @@
       "coverageCommands": [
         "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:ASSEMBLY_NAME;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:YAMATO_SOURCE_DIR/Packages;"
       ],
-      "dependantsToIgnoreInPreviewApv": {}
+      "dependantsToIgnoreInPreviewApv": {
+        "6000.3": [
+          "com.unity.polyspatial.extensions"
+        ]
+      }
     }
   },
   "releasing_packages": [

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -73,8 +73,10 @@ public class InputSystemSettings : AnnotatedSettingsBase
                 new Editor("6000.3",  ""),
                 new HashSet<string>()
                 {
+                    "com.unity.polyspatial",
+                    "com.unity.polyspatial.visionos",
                     "com.unity.polyspatial.extensions",
-                    "com.unity.polyspatial"
+                    "com.unity.xr.visionos"
                 }
             }
         };

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -76,7 +76,8 @@ public class InputSystemSettings : AnnotatedSettingsBase
                     "com.unity.polyspatial",
                     "com.unity.polyspatial.visionos",
                     "com.unity.polyspatial.extensions",
-                    "com.unity.xr.visionos"
+                    "com.unity.polyspatial.xr",
+                    "com.unity.xr.visionos" 
                 }
             }
         };

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -4,6 +4,7 @@ using RecipeEngine.Api.Settings;
 using RecipeEngine.Modules.Wrench.Models;
 using RecipeEngine.Modules.Wrench.Settings;
 using RecipeEngine.Platforms;
+using RecipeEngine.Unity.Abstractions.Editors;
 
 namespace InputSystem.Cookbook.Settings;
 
@@ -64,6 +65,18 @@ public class InputSystemSettings : AnnotatedSettingsBase
         
         // change default images as per Dictionary above.
         Wrench.Packages["com.unity.inputsystem"].EditorPlatforms = ImageOverrides;
+        
+        // ignore packages listed below in PreviewAPV
+        Wrench.Packages["com.unity.inputsystem"].DependantsToIgnoreInPreviewApv = new Dictionary<Editor, ISet<string>>()
+        {
+            {
+                new Editor("6000.3",  ""),
+                new HashSet<string>()
+                {
+                    "com.unity.polyspatial.extensions"
+                }
+            }
+        };
         
         Wrench.PvpProfilesToCheck = new HashSet<string>() { "supported" };
     }

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -73,7 +73,8 @@ public class InputSystemSettings : AnnotatedSettingsBase
                 new Editor("6000.3",  ""),
                 new HashSet<string>()
                 {
-                    "com.unity.polyspatial.extensions"
+                    "com.unity.polyspatial.extensions",
+                    "com.unity.polyspatial"
                 }
             }
         };


### PR DESCRIPTION
### Description

A preview version of com.unity.polyspatial.extensions currently throws compile errors. Adding it to a list of package to ignore during our own APV as advised by RM.


### Testing status & QA

- green CI hopefully :)
- 
### Overall Product Risks
Low.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
