### PR TITLE
[ISXB-1610] FIX for 1.4X: Impossibility to set InputSystemUIInputModule.localMultiPlayerRoot to null

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -2766,6 +2766,81 @@ internal partial class UITests : CoreTestsFixture
 
     [UnityTest]
     [Category("UI")]
+    public IEnumerator UI_CanNavigateUI_WithLocalMultiPlayerRoot_Null_UsingGamepads()
+    {
+        // Setup navigation
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var scene = CreateTestUI(makeSelectable: true);
+
+        // Create actions for navigation
+        var asset = ScriptableObject.CreateInstance<InputActionAsset>();
+        var map = asset.AddActionMap("map");
+        var moveAction = map.AddAction("move", type: InputActionType.Value, binding: "<Gamepad>/leftStick");
+        var submitAction = map.AddAction("submit", type: InputActionType.Button, binding: "<Gamepad>/buttonSouth");
+
+        // Assign actions to the UI module
+        scene.uiModule.move = InputActionReference.Create(moveAction);
+        scene.uiModule.submit = InputActionReference.Create(submitAction);
+        map.Enable();
+
+        // Test 1: Assign localMultiPlayerRoot to a value
+        scene.eventSystem.playerRoot = scene.parentGameObject;
+
+        // Initial selection
+        scene.eventSystem.SetSelectedGameObject(scene.leftGameObject);
+        yield return null;
+
+        // Move right
+        Set(gamepad.leftStick, new Vector2(1, 0));
+        yield return null;
+        
+        Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.rightGameObject),"Right navigation did not work when localMultiPlayerRoot was set");
+
+        // Move left
+        Set(gamepad.leftStick, Vector2.zero);
+        yield return null;
+        Set(gamepad.leftStick, new Vector2(-1, 0));
+        yield return null;
+        
+        Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.leftGameObject),"Left navigation did not work when localMultiPlayerRoot was set");
+        
+        // Reset stick position
+        Set(gamepad.leftStick, Vector2.zero);
+        yield return null;
+
+        // Test 2: With localMultiPlayerRoot set to null
+        scene.eventSystem.playerRoot = null;
+
+        // Reset selection
+        scene.eventSystem.SetSelectedGameObject(scene.leftGameObject);
+        yield return null;
+
+        // Move right
+        Set(gamepad.leftStick, new Vector2(1, 0));
+        yield return null;
+        
+        Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.rightGameObject),"Right navigation did not work when localMultiPlayerRoot was null");
+
+        // Move left
+        Set(gamepad.leftStick, Vector2.zero);
+        yield return null;
+        Set(gamepad.leftStick, new Vector2(-1, 0));
+        yield return null;
+
+        Assert.That(scene.eventSystem.currentSelectedGameObject, Is.SameAs(scene.leftGameObject),"Left navigation did not work when localMultiPlayerRoot was null");
+
+        // Submit
+        PressAndRelease(gamepad.buttonSouth);
+        yield return null;
+
+        Assert.That(scene.leftChildReceiver.events, Has.Exactly(1).With.Property("type").EqualTo(EventType.Submit),"Submit event was not received when localMultiPlayerRoot was null");
+
+        // Checking that localMultiPlayerRoot is null
+        Assert.AreEqual(null, scene.uiModule.localMultiPlayerRoot);
+    }
+
+    [UnityTest]
+    [Category("UI")]
     // Check that two players can have separate UI, and that both selections will stay active when
     // clicking on UI with the mouse, using MultiPlayerEventSystem.playerRoot to match UI to the players.
     public IEnumerator UI_CanOperateMultiplayerUIGloballyUsingMouse()

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/MultiplayerEventSystem.cs
@@ -49,8 +49,6 @@ namespace UnityEngine.InputSystem.UI
 
         private void InitializePlayerRoot()
         {
-            if (m_PlayerRoot == null) return;
-
             var inputModule = GetComponent<InputSystemUIInputModule>();
             if (inputModule != null)
                 inputModule.localMultiPlayerRoot = m_PlayerRoot;


### PR DESCRIPTION
### Description

Case ISXB-1610] (https://jira.unity3d.com/browse/ISXB-1610) 

This PR removes the null check in MultiplayerEventSystem.InitializePlayerRoot() that prevented setting InputSystemUIInputModule.localMultiPlayerRoot to null. We found that the check was introduced in [PR #1547](https://github.com/Unity-Technologies/InputSystem/pull/1547), but no specific reason was provided

Since localMultiPlayerRoot is already safely used (e.g., in IsMoveAllowed() via its own null check), we have removed the null check.

### Testing status & QA

Added a UnityTest to validate that setting InputSystemUIInputModule.localMultiPlayerRoot to null allows full UI navigation as expected.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: low
- Halo Effect: low

### Comments to reviewers

As localMultiPlayerRoot is having its own null check, we have removed the PlayerRoot null check in InitializePlayerRoot().

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
