### PR TITLE
FIX: InputControl is not updated from the first time [ISXB-1221]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ Due to package verification, the latest version below is the unpublished version
 however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
+- Fixed InputControl picker not updating correctly when the Input Actions Window was dirty. [ISXB-1221](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1221)
 
 ### Added
 - Exposed MediaPlayPause, MediaRewind, MediaForward keys on Keyboard.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -217,7 +217,7 @@ namespace UnityEngine.InputSystem.Editor
         /// <summary>
         /// This property is only set from this class in order to communicate that we're showing the dropdown at the moment
         /// It's employed to skip auto-saving, because that complicates updating the internal SerializedProperties.
-        /// Unfortunately, we can't use IMGUIDropdownVisible from the setings provider because of the early-out logic in there. 
+        /// Unfortunately, we can't use IMGUIDropdownVisible from the setings provider because of the early-out logic in there.
         /// </summary>
         public static bool IsShowingDropdown { get; private set; }
     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -161,9 +161,11 @@ namespace UnityEngine.InputSystem.Editor
 
         private void ShowDropdown(Rect rect, SerializedProperty serializedProperty, Action modifiedCallback)
         {
-            #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
+#if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             InputActionsEditorSettingsProvider.SetIMGUIDropdownVisible(true, false);
-            #endif
+#endif
+            IsShowingDropdown = true;
+
             if (m_PickerDropdown == null)
             {
                 m_PickerDropdown = new InputControlPickerDropdown(
@@ -187,6 +189,8 @@ namespace UnityEngine.InputSystem.Editor
             m_PickerDropdown.SetExpectedControlLayout(m_ExpectedControlLayout);
 
             m_PickerDropdown.Show(rect);
+
+            IsShowingDropdown = false;
         }
 
         private void SetExpectedControlLayoutFromAttribute(SerializedProperty property)
@@ -209,6 +213,13 @@ namespace UnityEngine.InputSystem.Editor
 
         private InputControlPickerDropdown m_PickerDropdown;
         private readonly InputControlPickerState m_PickerState;
+
+        /// <summary>
+        /// This property is only set from this class in order to communicate that we're showing the dropdown at the moment
+        /// It's employed to skip auto-saving, because that complicates updating the internal SerializedProperties.
+        /// Unfortunately, we can't use IMGUIDropdownVisible from the setings provider because of the early-out logic in there. 
+        /// </summary>
+        public static bool IsShowingDropdown { get; private set; }
     }
 }
  #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -219,7 +219,7 @@ namespace UnityEngine.InputSystem.Editor
         /// It's employed to skip auto-saving, because that complicates updating the internal SerializedProperties.
         /// Unfortunately, we can't use IMGUIDropdownVisible from the setings provider because of the early-out logic in there.
         /// </summary>
-        public static bool IsShowingDropdown { get; private set; }
+        internal static bool IsShowingDropdown { get; private set; }
     }
 }
  #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -206,12 +206,9 @@ namespace UnityEngine.InputSystem.Editor
         private GUIContent m_PathLabel;
         private string m_ExpectedControlLayout;
         private string[] m_ControlPathsToMatch;
-        private InputControlScheme[] m_ControlSchemes;
-        private bool m_NeedToClearProgressBar;
 
         private InputControlPickerDropdown m_PickerDropdown;
         private readonly InputControlPickerState m_PickerState;
-        private InputActionRebindingExtensions.RebindingOperation m_RebindingOperation;
     }
 }
  #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -17,7 +17,6 @@ namespace UnityEngine.InputSystem.Editor
         [SerializeField] InputActionsEditorState m_State;
         VisualElement m_RootVisualElement;
         private bool m_HasEditFocus;
-        private bool m_IgnoreActionChangedCallback;
         private bool m_IsActivated;
         private static bool m_IMGUIDropdownVisible;
         StateContainer m_StateContainer;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -344,7 +344,12 @@ namespace UnityEngine.InputSystem.Editor
             // Auto-save triggers on focus-lost instead of on every change
             #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
             if (InputEditorUserSettings.autoSaveInputActionAssets && m_IsDirty)
-                Save(isAutoSave: true);
+                // We'd like to avoid saving in case the focus was lost due to the drop-down window being spawned.
+                // This code should be cleaned up once we migrate the InputControl stuff from ImGUI completely.
+                // Since at that point it stops being a separate window that steals focus.
+                // (See case ISXB-1221)
+                if (!InputControlPathEditor.IsShowingDropdown)
+                    Save(isAutoSave: true);
             #endif
 
             analytics.RegisterEditorFocusOut();


### PR DESCRIPTION
### Description

This aims fixing the problem where the InputControl picker won't apply the selected item every second time basically (only when auto-save was on). To be technically precise, it wasn't applying the selected item every time when the input actions window was dirty, which normally happens in two cases:
- you add a new input action, the window is marked dirty, and then if you try to select a new binding it won't be set
- you set a new binding, that marks the window dirty, and then you try selecting the binding another time, that won't work

The root cause for these issues is that our input picker drop-down menu is technically a separate EditorWindow that steals focus from the input actions window as it's open. This was unfortunate  because the input actions window subscribes to focus loss in order to save changes and reload all the state as it does so. Practically, if the input actions window was dirty, you click on the picker, that changes focus and triggers auto-save right there. It re-creates all the backing for the window, but the picker uses SerializedProperties, it doesn't talk to data directly. Because of that, when the new assets are loaded as part of auto-save, it won't pick the right data up.

Hereby we propose to address that by avoiding auto-save at that sensitive moment in time while we're opening the drop-down thing for the input control picker. 

### Testing status & QA

Local testing, QA pending

### Overall Product Risks

- Complexity:  Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
