### PR TITLE
FIX: Address warnings that happened with Unity 6.4

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue in `RebindingUISample` preventing UI navigation without Keyboard and Mouse present.
 - Fixed an issue in `RebindActionUI` which resulted in active binding not being shown after a scene reload. ISXB-1588.
 - Fixed an issue in `GamepadIconExample` which resulted in icons for left and right triggers not being displayed after a rebind to the exact same controls. ISXB-1593.
+- Fixed the compilation warnings when used with Unity 6.4 (ISX-2349)
 - Fixed an issue where `InputSystemUIInputModule.localMultiPlayerRoot` could not be set to `null` when using `MultiplayerEventSystem`. [ISXB-1610](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1610)
 - Fixed an issue in `Keyboard` where the sub-script operator would return a `null` key control for the deprecated key `Key.IMESelected`. Now, an aliased `KeyControl`mapping to the IMESelected bit is returned for compability reasons. It is still strongly advised to not rely on this key since `IMESelected` bit isn't strictly a key and will be removed from the `Key` enumeration type in a future major revision. [ISXB-1541](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1541).
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,7 +24,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue in `RebindingUISample` preventing UI navigation without Keyboard and Mouse present.
 - Fixed an issue in `RebindActionUI` which resulted in active binding not being shown after a scene reload. ISXB-1588.
 - Fixed an issue in `GamepadIconExample` which resulted in icons for left and right triggers not being displayed after a rebind to the exact same controls. ISXB-1593.
-- Fixed the compilation warnings when used with Unity 6.4 (ISX-2349)
+- Fixed the compilation warnings when used with Unity 6.4 (ISX-2349).
 - Fixed an issue where `InputSystemUIInputModule.localMultiPlayerRoot` could not be set to `null` when using `MultiplayerEventSystem`. [ISXB-1610](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1610)
 - Fixed an issue in `Keyboard` where the sub-script operator would return a `null` key control for the deprecated key `Key.IMESelected`. Now, an aliased `KeyControl`mapping to the IMESelected bit is returned for compability reasons. It is still strongly advised to not rely on this key since `IMESelected` bit isn't strictly a key and will be removed from the `Key` enumeration type in a future major revision. [ISXB-1541](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1541).
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -52,15 +52,17 @@ namespace UnityEngine.InputSystem.Editor
 
             return OpenAsset(EditorUtility.EntityIdToObject(entityId));
         }
+
 #else
         public static bool OpenAsset(int instanceId, int line)
         {
             if (!InputActionImporter.IsInputActionAssetPath(AssetDatabase.GetAssetPath(instanceId)))
                 return false;
-            
+
             return OpenAsset(EditorUtility.InstanceIDToObject(instanceId));
         }
-#endif      
+
+#endif
 
         /// <summary>
         /// Open window if someone clicks on an .inputactions asset or an action inside of it.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/InputActionEditorWindow.cs
@@ -42,28 +42,41 @@ namespace UnityEngine.InputSystem.Editor
             InputActionAssetEditor.RegisterType<InputActionEditorWindow>();
         }
 
+        // Unity 6.4 changed signature of OpenAsset, and now it accepts entity id instead of instance id.
+        [OnOpenAsset]
+#if UNITY_6000_4_OR_NEWER
+        public static bool OpenAsset(EntityId entityId, int line)
+        {
+            if (!InputActionImporter.IsInputActionAssetPath(AssetDatabase.GetAssetPath(entityId)))
+                return false;
+
+            return OpenAsset(EditorUtility.EntityIdToObject(entityId));
+        }
+#else
+        public static bool OpenAsset(int instanceId, int line)
+        {
+            if (!InputActionImporter.IsInputActionAssetPath(AssetDatabase.GetAssetPath(instanceId)))
+                return false;
+            
+            return OpenAsset(EditorUtility.InstanceIDToObject(instanceId));
+        }
+#endif      
+
         /// <summary>
         /// Open window if someone clicks on an .inputactions asset or an action inside of it.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "line", Justification = "line parameter required by OnOpenAsset attribute")]
-        [OnOpenAsset]
-        public static bool OnOpenAsset(int instanceId, int line)
+        private static bool OpenAsset(Object obj)
         {
 #if UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS
             if (!InputSystem.settings.useIMGUIEditorForAssets)
                 return false;
 #endif
-            var path = AssetDatabase.GetAssetPath(instanceId);
-            if (!InputActionImporter.IsInputActionAssetPath(path))
-                return false;
-
             string mapToSelect = null;
             string actionToSelect = null;
 
             // Grab InputActionAsset.
             // NOTE: We defer checking out an asset until we save it. This allows a user to open an .inputactions asset and look at it
             //       without forcing a checkout.
-            var obj = EditorUtility.InstanceIDToObject(instanceId);
             var asset = obj as InputActionAsset;
             if (asset == null)
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -58,15 +58,17 @@ namespace UnityEngine.InputSystem.Editor
 
             return OpenAsset(EditorUtility.EntityIdToObject(entityId));
         }
+
 #else
         public static bool OpenAsset(int instanceId, int line)
         {
             if (!InputActionImporter.IsInputActionAssetPath(AssetDatabase.GetAssetPath(instanceId)))
                 return false;
-            
+
             return OpenAsset(EditorUtility.InstanceIDToObject(instanceId));
         }
-#endif      
+
+#endif
 
         private static bool OpenAsset(Object obj)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -48,18 +48,34 @@ namespace UnityEngine.InputSystem.Editor
             m_Analytics ??= new InputActionsEditorSessionAnalytic(
                 InputActionsEditorSessionAnalytic.Data.Kind.EditorWindow);
 
+        // Unity 6.4 changed signature of OpenAsset, and now it accepts entity id instead of instance id.
         [OnOpenAsset]
+#if UNITY_6000_4_OR_NEWER
+        public static bool OpenAsset(EntityId entityId, int line)
+        {
+            if (!InputActionImporter.IsInputActionAssetPath(AssetDatabase.GetAssetPath(entityId)))
+                return false;
+
+            return OpenAsset(EditorUtility.EntityIdToObject(entityId));
+        }
+#else
         public static bool OpenAsset(int instanceId, int line)
         {
-            if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
-                return false;
             if (!InputActionImporter.IsInputActionAssetPath(AssetDatabase.GetAssetPath(instanceId)))
+                return false;
+            
+            return OpenAsset(EditorUtility.InstanceIDToObject(instanceId));
+        }
+#endif      
+
+        private static bool OpenAsset(Object obj)
+        {
+            if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
                 return false;
 
             // Grab InputActionAsset.
             // NOTE: We defer checking out an asset until we save it. This allows a user to open an .inputactions asset and look at it
             //       without forcing a checkout.
-            var obj = EditorUtility.InstanceIDToObject(instanceId);
             var asset = obj as InputActionAsset;
 
             string actionMapToSelect = null;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3716,7 +3716,7 @@ namespace UnityEngine.InputSystem
             // temporary settings object.
             // NOTE: We access m_Settings directly here to make sure we're not running into asserts
             //       from the settings getter checking it has a valid object.
-            if (HasNativeObject(s_Manager.m_Settings))
+            if (!HasNativeObject(s_Manager.m_Settings))
             {
                 var newSettings = ScriptableObject.CreateInstance<InputSettings>();
                 newSettings.hideFlags = HideFlags.HideAndDontSave;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3592,7 +3592,7 @@ namespace UnityEngine.InputSystem
             }
 
             Debug.Assert(settings != null);
-            Debug.Assert(MiscHelpers.HasNativeObject(settings), "InputSettings has lost its native object");
+            Debug.Assert(HasNativeObject(settings), "InputSettings has lost its native object");
 
             // If native backends for new input system aren't enabled, ask user whether we should
             // enable them (requires restart). We only ask once per session and don't ask when
@@ -3695,6 +3695,16 @@ namespace UnityEngine.InputSystem
             }
         }
 
+        // We have this function to hide away instanceId -> entityId migration that happened in Unity 6.4
+        public static bool HasNativeObject(Object obj)
+        {
+#if UNITY_6000_4_OR_NEWER
+            return EditorUtility.EntityIdToObject(obj.GetEntityId()) != null;
+#else
+            return EditorUtility.InstanceIDToObject(obj.GetInstanceID()) != null;
+#endif
+        }
+
         private static void OnProjectChange()
         {
             ////TODO: use dirty count to find whether settings have actually changed
@@ -3706,7 +3716,7 @@ namespace UnityEngine.InputSystem
             // temporary settings object.
             // NOTE: We access m_Settings directly here to make sure we're not running into asserts
             //       from the settings getter checking it has a valid object.
-            if (MiscHelpers.HasNativeObject(s_Manager.m_Settings))
+            if (HasNativeObject(s_Manager.m_Settings))
             {
                 var newSettings = ScriptableObject.CreateInstance<InputSettings>();
                 newSettings.hideFlags = HideFlags.HideAndDontSave;

--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -3592,8 +3592,7 @@ namespace UnityEngine.InputSystem
             }
 
             Debug.Assert(settings != null);
-            Debug.Assert(EditorUtility.InstanceIDToObject(settings.GetInstanceID()) != null,
-                "InputSettings has lost its native object");
+            Debug.Assert(MiscHelpers.HasNativeObject(settings), "InputSettings has lost its native object");
 
             // If native backends for new input system aren't enabled, ask user whether we should
             // enable them (requires restart). We only ask once per session and don't ask when
@@ -3707,7 +3706,7 @@ namespace UnityEngine.InputSystem
             // temporary settings object.
             // NOTE: We access m_Settings directly here to make sure we're not running into asserts
             //       from the settings getter checking it has a valid object.
-            if (EditorUtility.InstanceIDToObject(s_Manager.m_Settings.GetInstanceID()) == null)
+            if (MiscHelpers.HasNativeObject(s_Manager.m_Settings))
             {
                 var newSettings = ScriptableObject.CreateInstance<InputSettings>();
                 newSettings.hideFlags = HideFlags.HideAndDontSave;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -421,7 +421,11 @@ namespace UnityEngine.InputSystem.XR
 #if UNITY_INPUT_SYSTEM_ENABLE_VR && ENABLE_VR
             if (HasStereoCamera(out var cameraComponent))
             {
+                // The Unity 6.4+ replacement for this call has to be figured later
+                // See https://jira.unity3d.com/browse/XR-7591
+#pragma warning disable CS0618
                 UnityEngine.XR.XRDevice.DisableAutoXRCameraTracking(cameraComponent, true);
+#pragma warning restore CS0618 
             }
 #endif
         }
@@ -458,7 +462,11 @@ namespace UnityEngine.InputSystem.XR
 #if UNITY_INPUT_SYSTEM_ENABLE_VR && ENABLE_VR
             if (HasStereoCamera(out var cameraComponent))
             {
+                // The Unity 6.4+ replacement for this call has to be figured later
+                // See https://jira.unity3d.com/browse/XR-7591
+#pragma warning disable CS0618
                 UnityEngine.XR.XRDevice.DisableAutoXRCameraTracking(cameraComponent, false);
+#pragma warning restore CS0618
             }
 #endif
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XR/TrackedPoseDriver.cs
@@ -425,7 +425,7 @@ namespace UnityEngine.InputSystem.XR
                 // See https://jira.unity3d.com/browse/XR-7591
 #pragma warning disable CS0618
                 UnityEngine.XR.XRDevice.DisableAutoXRCameraTracking(cameraComponent, true);
-#pragma warning restore CS0618 
+#pragma warning restore CS0618
             }
 #endif
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MiscHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MiscHelpers.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using UnityEditor;
 
 namespace UnityEngine.InputSystem.Utilities
 {
@@ -35,6 +36,16 @@ namespace UnityEngine.InputSystem.Utilities
                 else
                     ++index;
             return -1;
+        }
+
+        // We have this function to hide away instanceId -> entityId migration that happened in Unity 6.4
+        public static bool HasNativeObject(Object obj)
+        {
+#if UNITY_6000_4_OR_NEWER
+            return EditorUtility.EntityIdToObject(obj.GetEntityId()) != null;
+#else
+            return EditorUtility.InstanceIDToObject(obj.GetInstanceID()) != null;
+#endif
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MiscHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MiscHelpers.cs
@@ -37,15 +37,5 @@ namespace UnityEngine.InputSystem.Utilities
                     ++index;
             return -1;
         }
-
-        // We have this function to hide away instanceId -> entityId migration that happened in Unity 6.4
-        public static bool HasNativeObject(Object obj)
-        {
-#if UNITY_6000_4_OR_NEWER
-            return EditorUtility.EntityIdToObject(obj.GetEntityId()) != null;
-#else
-            return EditorUtility.InstanceIDToObject(obj.GetInstanceID()) != null;
-#endif
-        }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/MiscHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/MiscHelpers.cs
@@ -1,6 +1,4 @@
 using System.Collections.Generic;
-using UnityEditor;
-
 namespace UnityEngine.InputSystem.Utilities
 {
     internal static class MiscHelpers


### PR DESCRIPTION
### Description

This fixes up the current set of warnings that we get when using the package with Unity 6.4. 
- instanceID is now entityID 
- A new XRModule has to be used instead of the old one (to be addressed still)

Related to https://jira.unity3d.com/browse/ISX-2349

### Testing status & QA

Local testing

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
