### PR TITLE
FIX: Incorrect HID Stick values for LogicalMinimum with negative values (ISXB-1735)

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -317,12 +317,26 @@ internal class HIDTests : CoreTestsFixture
 
     [Test]
     [Category("HID Devices")]
-    public void Devices_CanCreateGenericHID_WithSignedLogicalMinAndMaxSticks()
+
+    // These descriptor values were generated with the Microsoft HID Authoring descriptor tool in
+    // https://github.com/microsoft/hidtools for the expexted values.
+    // Logical min 0, logical max 65535
+    [TestCase(16, new byte[] {0x16, 0x00, 0x00}, new byte[] { 0x27, 0xFF, 0xFF, 0x00, 0x00 }, 0, 65535, 0.01f)]
+    // Logical min -32768, logical max 32767
+    [TestCase(16, new byte[] {0x16, 0x00, 0x80}, new byte[] {0x26, 0xFF, 0x7F}, -32768, 32767, 0.01f)]
+    // Logical min 0, logical max 255
+    [TestCase(8, new byte[] {0x15, 00}, new byte[] {0x26, 0xFF, 0x00}, 0, 255, 0.01f)]
+    // Logical min -128, logical max 127
+    [TestCase(8, new byte[] {0x15, 0x80}, new byte[] {0x25, 0x7F}, -128, 127, 0.01f)]
+    // Logical min -16, logical max 15 (below 8 bit boundary)
+    [TestCase(5, new byte[] {0x15, 0xF0}, new byte[] {0x25, 0x0F}, -16, 15, 0)]
+    // Logical min 0, logical max 31 (below 8 bit boundary)
+    [TestCase(5, new byte[] {0x15, 0x00}, new byte[] {0x25, 0x1F}, 0, 31, 0)]
+    public void Devices_CanParseHIDDescritpor_WithSignedLogicalMinAndMaxSticks(byte reportSizeBits, byte[] logicalMinBytes, byte[] logicalMaxBytes, int logicalMinExpected, int logicalMaxExpected, float errorMargin)
     {
-        // This is a HID report descriptor for a simple device with two analog sticks;
-        // Similar to a user that reported an issue in Discussions:
-        // https://discussions.unity.com/t/input-system-reading-invalid-values-from-hall-effect-keyboards/1684840/3
-        var reportDescriptor = new byte[]
+        // Dynamically create HID report descriptor for two analog sticks with parameterized logical min/max
+
+        var reportDescriptorStart = new byte[]
         {
             0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
             0x09, 0x05,        // Usage (Game Pad)
@@ -330,14 +344,22 @@ internal class HIDTests : CoreTestsFixture
             0x85, 0x01,        //   Report ID (1)
             0x05, 0x01,        //   Usage Page (Generic Desktop Ctrls)
             0x09, 0x30,        //   Usage (X)
-            0x09, 0x31,        //   Usage (Y)
-            0x15, 0x81,        //   Logical Minimum (-127)
-            0x25, 0x7F,        //   Logical Maximum (127)
-            0x75, 0x08,        //   Report Size (8)
-            0x95, 0x02,        //   Report Count (2)
-            0x81, 0x02,        //   Input (Data,Var,Abs)
-            0xC0,              // End Collection
         };
+
+        var reportDescriptorEnd = new byte[]
+        {
+            0x75, reportSizeBits,   //   Report Size (8)
+            0x95, 0x01,             //   Report Count (1)
+            0x81, 0x02,             //   Input (Data,Var,Abs)
+            0xC0,                   //   End Collection
+        };
+
+        // Concatenate to form final descriptor based on test parameters where logical min/max bytes
+        // are inserted in the middle.
+        var reportDescriptor = reportDescriptorStart.Concat(logicalMinBytes).
+            Concat(logicalMaxBytes).
+            Concat(reportDescriptorEnd).
+            ToArray();
 
         // The HID report descriptor is fetched from the device via an IOCTL.
         var deviceId = runtime.AllocateDeviceId();
@@ -350,7 +372,7 @@ internal class HIDTests : CoreTestsFixture
             new InputDeviceDescription
             {
                 interfaceName = HID.kHIDInterface,
-                manufacturer = "TestVendor",
+                manufacturer = "TestLogicalMinMaxParsing",
                 product = "TestHID",
                 capabilities = new HID.HIDDeviceDescriptor
                 {
@@ -365,35 +387,22 @@ internal class HIDTests : CoreTestsFixture
         Assert.That(device, Is.Not.Null);
         Assert.That(device, Is.TypeOf<Joystick>());
 
-        // Stick vector 2 should be centered at (0,0).
+        var parsedDescriptor = JsonUtility.FromJson<HID.HIDDeviceDescriptor>(device.description.capabilities);
+
+        // Check we parsed the values as expected
+        foreach (var element in parsedDescriptor.elements)
+        {
+            if (element.usage == (int)HID.GenericDesktop.X)
+            {
+                Assert.That(element.logicalMin, Is.EqualTo(logicalMinExpected));
+                Assert.That(element.logicalMax, Is.EqualTo(logicalMaxExpected));
+            }
+            else
+                Assert.Fail("Could not find X and Y elements in descriptor");
+        }
+
+        // Stick vector 2 should be centered at (0,0) when initialized
         Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0f, 0f)).Using(Vector2EqualityComparer.Instance));
-
-        // Queue event with stick pushed to bottom. We assume Y axis is inverted by default in HID devices.
-        // See HID.HIDElementDescriptor.DetermineParameters()
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 0, y = 127 });
-        InputSystem.Update();
-
-        Assert.That(device.stick.ReadValue() , Is.EqualTo(new Vector2(0f, -1f)).Using(Vector2EqualityComparer.Instance));
-
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 0, y = -127 });
-        InputSystem.Update();
-
-        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0f, 1f)).Using(Vector2EqualityComparer.Instance));
-
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 127, y = 0 });
-        InputSystem.Update();
-
-        Assert.That(device.stick.ReadValue() , Is.EqualTo(new Vector2(1f, 0f)).Using(Vector2EqualityComparer.Instance));
-
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = -127, y = 0 });
-        InputSystem.Update();
-
-        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(-1f, 0f)).Using(Vector2EqualityComparer.Instance));
-
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 127, y = 127 });
-        InputSystem.Update();
-
-        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0.7071f, -0.7071f)).Using(Vector2EqualityComparer.Instance));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -342,10 +342,14 @@ internal class HIDTests : CoreTestsFixture
     [TestCase(24, new byte[] {0x15, 0x00}, new byte[] {0x27, 0xFF, 0xFF, 0xFF, 0x00}, 0, 16777215)]
     // Logical min -8388608, logical max 8388607 (24 bit)
     [TestCase(24, new byte[] {0x17, 0x00, 0x00, 0x80, 0xFF}, new byte[] {0x27, 0xFF, 0xFF, 0x7F, 0x00}, -8388608, 8388607)]
-    public void Devices_CanParseHIDDescritpor_WithSignedLogicalMinAndMaxSticks(byte reportSizeBits, byte[] logicalMinBytes, byte[] logicalMaxBytes, int logicalMinExpected, int logicalMaxExpected)
-    {
-        // Dynamically create HID report descriptor for two analog sticks with parameterized logical min/max
+    // Logical min -72, logical max -35
+    [TestCase(8, new byte[] {0x15, 0xB8}, new byte[] {0x25, 0xDD}, -72, -35)]
+    // Logical min 30, logical max 78
+    [TestCase(8, new byte[] {0x15, 0x1E}, new byte[] {0x25, 0x4E}, 30, 78)]
 
+    public void Devices_CanParseHIDDescriptor_WithSignedLogicalMinAndMaxValues(byte reportSizeBits, byte[] logicalMinBytes, byte[] logicalMaxBytes, int logicalMinExpected, int logicalMaxExpected)
+    {
+        // Dynamically create HID report descriptor for one X-axis with parameterized logical min/max
         var reportDescriptorStart = new byte[]
         {
             0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
@@ -393,9 +397,8 @@ internal class HIDTests : CoreTestsFixture
 
         InputSystem.Update();
 
-        var device = (Joystick)InputSystem.GetDeviceById(deviceId);
+        var device = InputSystem.GetDeviceById(deviceId);
         Assert.That(device, Is.Not.Null);
-        Assert.That(device, Is.TypeOf<Joystick>());
 
         var parsedDescriptor = JsonUtility.FromJson<HID.HIDDeviceDescriptor>(device.description.capabilities);
 
@@ -408,11 +411,8 @@ internal class HIDTests : CoreTestsFixture
                 Assert.That(element.logicalMax, Is.EqualTo(logicalMaxExpected));
             }
             else
-                Assert.Fail("Could not find X and Y elements in descriptor");
+                Assert.Fail("Could not find X element in descriptor");
         }
-
-        // Stick vector 2 should be centered at (0,0) when initialized
-        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0f, 0f)).Using(Vector2EqualityComparer.Instance));
     }
 
     [Test]

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -317,7 +317,7 @@ internal class HIDTests : CoreTestsFixture
 
     [Test]
     [Category("HID Devices")]
-    public void Devices_CanCrateGenericHID_WithSignedLogicalMinAndMaxSticks()
+    public void Devices_CanCreateGenericHID_WithSignedLogicalMinAndMaxSticks()
     {
         // This is a HID report descriptor for a simple device with two analog sticks;
         // Similar to a user that reported an issue in Discussions:

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -218,27 +218,9 @@ internal class HIDTests : CoreTestsFixture
 
         // The HID report descriptor is fetched from the device via an IOCTL.
         var deviceId = runtime.AllocateDeviceId();
-        unsafe
-        {
-            runtime.SetDeviceCommandCallback(deviceId,
-                (id, commandPtr) =>
-                {
-                    if (commandPtr->type == HID.QueryHIDReportDescriptorSizeDeviceCommandType)
-                        return reportDescriptor.Length;
 
-                    if (commandPtr->type == HID.QueryHIDReportDescriptorDeviceCommandType
-                        && commandPtr->payloadSizeInBytes >= reportDescriptor.Length)
-                    {
-                        fixed(byte* ptr = reportDescriptor)
-                        {
-                            UnsafeUtility.MemCpy(commandPtr->payloadPtr, ptr, reportDescriptor.Length);
-                            return reportDescriptor.Length;
-                        }
-                    }
+        SetDeviceCommandCallbackToReturnReportDescriptor(deviceId, reportDescriptor);
 
-                    return InputDeviceCommand.GenericFailure;
-                });
-        }
         // Report device.
         runtime.ReportNewInputDevice(
             new InputDeviceDescription
@@ -307,6 +289,111 @@ internal class HIDTests : CoreTestsFixture
         Assert.That(hidDescriptor.collections[0].childCount, Is.EqualTo(kNumElements));
 
         ////TODO: check hat switch
+    }
+
+    // This is used to mock out the IOCTL the HID device driver would use to return
+    // the report descriptor and its size.
+    unsafe void SetDeviceCommandCallbackToReturnReportDescriptor(int deviceId, byte[] reportDescriptor)
+    {
+        runtime.SetDeviceCommandCallback(deviceId,
+            (id, commandPtr) =>
+            {
+                if (commandPtr->type == HID.QueryHIDReportDescriptorSizeDeviceCommandType)
+                    return reportDescriptor.Length;
+
+                if (commandPtr->type == HID.QueryHIDReportDescriptorDeviceCommandType
+                    && commandPtr->payloadSizeInBytes >= reportDescriptor.Length)
+                {
+                    fixed(byte* ptr = reportDescriptor)
+                    {
+                        UnsafeUtility.MemCpy(commandPtr->payloadPtr, ptr, reportDescriptor.Length);
+                        return reportDescriptor.Length;
+                    }
+                }
+
+                return InputDeviceCommand.GenericFailure;
+            });
+    }
+
+    [Test]
+    [Category("HID Devices")]
+    public void Devices_CanCrateGenericHID_WithSignedLogicalMinAndMaxSticks()
+    {
+        // This is a HID report descriptor for a simple device with two analog sticks;
+        // Similar to a user that reported an issue in Discussions:
+        // https://discussions.unity.com/t/input-system-reading-invalid-values-from-hall-effect-keyboards/1684840/3
+        var reportDescriptor = new byte[]
+        {
+            0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+            0x09, 0x05,        // Usage (Game Pad)
+            0xA1, 0x01,        // Collection (Application)
+            0x85, 0x01,        //   Report ID (1)
+            0x05, 0x01,        //   Usage Page (Generic Desktop Ctrls)
+            0x09, 0x30,        //   Usage (X)
+            0x09, 0x31,        //   Usage (Y)
+            0x15, 0x81,        //   Logical Minimum (-127)
+            0x25, 0x7F,        //   Logical Maximum (127)
+            0x75, 0x08,        //   Report Size (8)
+            0x95, 0x02,        //   Report Count (2)
+            0x81, 0x02,        //   Input (Data,Var,Abs)
+            0xC0,              // End Collection
+        };
+
+        // The HID report descriptor is fetched from the device via an IOCTL.
+        var deviceId = runtime.AllocateDeviceId();
+
+        // Callback to return the desired report descriptor.
+        SetDeviceCommandCallbackToReturnReportDescriptor(deviceId, reportDescriptor);
+
+        // Report device.
+        runtime.ReportNewInputDevice(
+            new InputDeviceDescription
+            {
+                interfaceName = HID.kHIDInterface,
+                manufacturer = "TestVendor",
+                product = "TestHID",
+                capabilities = new HID.HIDDeviceDescriptor
+                {
+                    vendorId = 0x321,
+                    productId = 0x432
+                }.ToJson()
+            }.ToJson(), deviceId);
+
+        InputSystem.Update();
+
+        var device = (Joystick)InputSystem.GetDeviceById(deviceId);
+        Assert.That(device, Is.Not.Null);
+        Assert.That(device, Is.TypeOf<Joystick>());
+
+        // Stick vector 2 should be centered at (0,0).
+        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0f, 0f)).Using(Vector2EqualityComparer.Instance));
+
+        // Queue event with stick pushed to bottom. We assume Y axis is inverted by default in HID devices.
+        // See HID.HIDElementDescriptor.DetermineParameters()
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 0, y = 127 });
+        InputSystem.Update();
+
+        Assert.That(device.stick.ReadValue() , Is.EqualTo(new Vector2(0f, -1f)).Using(Vector2EqualityComparer.Instance));
+
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 0, y = -127 });
+        InputSystem.Update();
+
+        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0f, 1f)).Using(Vector2EqualityComparer.Instance));
+
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 127, y = 0 });
+        InputSystem.Update();
+
+        Assert.That(device.stick.ReadValue() , Is.EqualTo(new Vector2(1f, 0f)).Using(Vector2EqualityComparer.Instance));
+
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = -127, y = 0 });
+        InputSystem.Update();
+
+        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(-1f, 0f)).Using(Vector2EqualityComparer.Instance));
+
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickByte { reportId = 1, x = 127, y = 127 });
+        InputSystem.Update();
+
+        Assert.That(device.stick.ReadValue(), Is.EqualTo(new Vector2(0.7071f, -0.7071f)).Using(Vector2EqualityComparer.Instance));
     }
 
     [Test]
@@ -1026,11 +1113,21 @@ internal class HIDTests : CoreTestsFixture
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    struct SimpleJoystickLayout : IInputStateTypeInfo
+    struct SimpleJoystickLayoutWithStickUshort : IInputStateTypeInfo
     {
         [FieldOffset(0)] public byte reportId;
         [FieldOffset(1)] public ushort x;
         [FieldOffset(3)] public ushort y;
+
+        public FourCC format => new FourCC('H', 'I', 'D');
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    struct SimpleJoystickLayoutWithStickByte : IInputStateTypeInfo
+    {
+        [FieldOffset(0)] public byte reportId;
+        [FieldOffset(1)] public sbyte x;
+        [FieldOffset(2)] public sbyte y;
 
         public FourCC format => new FourCC('H', 'I', 'D');
     }
@@ -1069,7 +1166,7 @@ internal class HIDTests : CoreTestsFixture
         Assert.That(device, Is.TypeOf<Joystick>());
         Assert.That(device["Stick"], Is.TypeOf<StickControl>());
 
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayout { reportId = 1, x = ushort.MaxValue, y = ushort.MinValue });
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickUshort { reportId = 1, x = ushort.MaxValue, y = ushort.MinValue });
         InputSystem.Update();
 
         Assert.That(device["stick"].ReadValueAsObject(),

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -1122,21 +1122,11 @@ internal class HIDTests : CoreTestsFixture
     }
 
     [StructLayout(LayoutKind.Explicit)]
-    struct SimpleJoystickLayoutWithStickUshort : IInputStateTypeInfo
+    struct SimpleJoystickLayoutWithStick : IInputStateTypeInfo
     {
         [FieldOffset(0)] public byte reportId;
         [FieldOffset(1)] public ushort x;
         [FieldOffset(3)] public ushort y;
-
-        public FourCC format => new FourCC('H', 'I', 'D');
-    }
-
-    [StructLayout(LayoutKind.Explicit)]
-    struct SimpleJoystickLayoutWithStickByte : IInputStateTypeInfo
-    {
-        [FieldOffset(0)] public byte reportId;
-        [FieldOffset(1)] public sbyte x;
-        [FieldOffset(2)] public sbyte y;
 
         public FourCC format => new FourCC('H', 'I', 'D');
     }
@@ -1175,7 +1165,7 @@ internal class HIDTests : CoreTestsFixture
         Assert.That(device, Is.TypeOf<Joystick>());
         Assert.That(device["Stick"], Is.TypeOf<StickControl>());
 
-        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStickUshort { reportId = 1, x = ushort.MaxValue, y = ushort.MinValue });
+        InputSystem.QueueStateEvent(device, new SimpleJoystickLayoutWithStick { reportId = 1, x = ushort.MaxValue, y = ushort.MinValue });
         InputSystem.Update();
 
         Assert.That(device["stick"].ReadValueAsObject(),

--- a/Assets/Tests/InputSystem/Plugins/HIDTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/HIDTests.cs
@@ -298,6 +298,9 @@ internal class HIDTests : CoreTestsFixture
         runtime.SetDeviceCommandCallback(deviceId,
             (id, commandPtr) =>
             {
+                if (commandPtr == null)
+                    return InputDeviceCommand.GenericFailure;
+
                 if (commandPtr->type == HID.QueryHIDReportDescriptorSizeDeviceCommandType)
                     return reportDescriptor.Length;
 
@@ -317,22 +320,29 @@ internal class HIDTests : CoreTestsFixture
 
     [Test]
     [Category("HID Devices")]
-
     // These descriptor values were generated with the Microsoft HID Authoring descriptor tool in
-    // https://github.com/microsoft/hidtools for the expexted values.
+    // https://github.com/microsoft/hidtools for the expected value:
     // Logical min 0, logical max 65535
-    [TestCase(16, new byte[] {0x16, 0x00, 0x00}, new byte[] { 0x27, 0xFF, 0xFF, 0x00, 0x00 }, 0, 65535, 0.01f)]
+    [TestCase(16, new byte[] {0x16, 0x00, 0x00}, new byte[] { 0x27, 0xFF, 0xFF, 0x00, 0x00 }, 0, 65535)]
     // Logical min -32768, logical max 32767
-    [TestCase(16, new byte[] {0x16, 0x00, 0x80}, new byte[] {0x26, 0xFF, 0x7F}, -32768, 32767, 0.01f)]
+    [TestCase(16, new byte[] {0x16, 0x00, 0x80}, new byte[] {0x26, 0xFF, 0x7F}, -32768, 32767)]
     // Logical min 0, logical max 255
-    [TestCase(8, new byte[] {0x15, 00}, new byte[] {0x26, 0xFF, 0x00}, 0, 255, 0.01f)]
+    [TestCase(8, new byte[] {0x15, 00}, new byte[] {0x26, 0xFF, 0x00}, 0, 255)]
     // Logical min -128, logical max 127
-    [TestCase(8, new byte[] {0x15, 0x80}, new byte[] {0x25, 0x7F}, -128, 127, 0.01f)]
+    [TestCase(8, new byte[] {0x15, 0x80}, new byte[] {0x25, 0x7F}, -128, 127)]
     // Logical min -16, logical max 15 (below 8 bit boundary)
-    [TestCase(5, new byte[] {0x15, 0xF0}, new byte[] {0x25, 0x0F}, -16, 15, 0)]
+    [TestCase(5, new byte[] {0x15, 0xF0}, new byte[] {0x25, 0x0F}, -16, 15)]
     // Logical min 0, logical max 31 (below 8 bit boundary)
-    [TestCase(5, new byte[] {0x15, 0x00}, new byte[] {0x25, 0x1F}, 0, 31, 0)]
-    public void Devices_CanParseHIDDescritpor_WithSignedLogicalMinAndMaxSticks(byte reportSizeBits, byte[] logicalMinBytes, byte[] logicalMaxBytes, int logicalMinExpected, int logicalMaxExpected, float errorMargin)
+    [TestCase(5, new byte[] {0x15, 0x00}, new byte[] {0x25, 0x1F}, 0, 31)]
+    // Logical min -4096, logical max 4095 (crosses byte boundary)
+    [TestCase(13, new byte[] {0x16, 0x00, 0xF0}, new byte[] {0x26, 0xFF, 0x0F}, -4096, 4095)]
+    // Logical min 0, logical max 8191 (crosses byte boundary)
+    [TestCase(13, new byte[] {0x15, 0x00}, new byte[] {0x26, 0xFF, 0x1F}, 0, 8191)]
+    // Logical min 0, logical max 16777215 (24 bit)
+    [TestCase(24, new byte[] {0x15, 0x00}, new byte[] {0x27, 0xFF, 0xFF, 0xFF, 0x00}, 0, 16777215)]
+    // Logical min -8388608, logical max 8388607 (24 bit)
+    [TestCase(24, new byte[] {0x17, 0x00, 0x00, 0x80, 0xFF}, new byte[] {0x27, 0xFF, 0xFF, 0x7F, 0x00}, -8388608, 8388607)]
+    public void Devices_CanParseHIDDescritpor_WithSignedLogicalMinAndMaxSticks(byte reportSizeBits, byte[] logicalMinBytes, byte[] logicalMaxBytes, int logicalMinExpected, int logicalMaxExpected)
     {
         // Dynamically create HID report descriptor for two analog sticks with parameterized logical min/max
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,9 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue in `DeltaStateEvent.From` where unsafe code would throw exception or crash if internal pointer `currentStatePtr` was `null`. [ISXB-1637](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1637).
 - Fixed an issue in `InputTestFixture.Set` where attempting to change state of a device not belonging to the test fixture context would result in null pointer exception or crash. [ISXB-1637](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1637).
 - Fixed an issue where input action parameter overrides applied via `InputActionRebindingExtensions.ApplyParameterOverride` would not be applied if the associated binding has the empty string as `InputBinding.name`and the binding mask also has the empty string as name. (ISXB-1721).
+- Fixed HID parsing not handling logical minimum and maximum values correctly when they are negative. This applies for platforms that parse HID descriptors in the package, e.g. macOS at the moment.
+- Fix usage of correct data format for stick axes in HID Layout Builder ([User contribution](https://github.com/Unity-Technologies/InputSystem/pull/2245))
+
 
 ## [1.15.0] - 2025-10-03
 

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -257,7 +257,6 @@ namespace UnityEngine.InputSystem.HID
 
                     // Update the descriptor on the device with the information we got.
                     deviceDescription.capabilities = hidDeviceDescriptor.ToJson();
-                    Debug.Log($"Parsing HID descriptor from JSON for device '{deviceDescription.capabilities}'");
                 }
                 else
                 {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HID.cs
@@ -257,6 +257,7 @@ namespace UnityEngine.InputSystem.HID
 
                     // Update the descriptor on the device with the information we got.
                     deviceDescription.capabilities = hidDeviceDescriptor.ToJson();
+                    Debug.Log($"Parsing HID descriptor from JSON for device '{deviceDescription.capabilities}'");
                 }
                 else
                 {
@@ -385,7 +386,7 @@ namespace UnityEngine.InputSystem.HID
                     var yElementParameters = yElement.DetermineParameters();
 
                     builder.AddControl(stickName + "/x")
-                        .WithFormat(xElement.isSigned ? InputStateBlock.FormatSBit : InputStateBlock.FormatBit)
+                        .WithFormat(xElement.DetermineFormat())
                         .WithByteOffset((uint)(xElement.reportOffsetInBits / 8 - byteOffset))
                         .WithBitOffset((uint)(xElement.reportOffsetInBits % 8))
                         .WithSizeInBits((uint)xElement.reportSizeInBits)
@@ -394,7 +395,7 @@ namespace UnityEngine.InputSystem.HID
                         .WithProcessors(xElement.DetermineProcessors());
 
                     builder.AddControl(stickName + "/y")
-                        .WithFormat(yElement.isSigned ? InputStateBlock.FormatSBit : InputStateBlock.FormatBit)
+                        .WithFormat(yElement.DetermineFormat())
                         .WithByteOffset((uint)(yElement.reportOffsetInBits / 8 - byteOffset))
                         .WithBitOffset((uint)(yElement.reportOffsetInBits % 8))
                         .WithSizeInBits((uint)yElement.reportSizeInBits)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
@@ -277,7 +277,7 @@ namespace UnityEngine.InputSystem.HID
                     return 0;
                 var data1 = *currentPtr;
                 var data2 = *(currentPtr + 1);
-                return (short)(data2 << 8) | data1;
+                return (short)((data2 << 8) | data1);
             }
 
             // Read int.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
@@ -267,7 +267,7 @@ namespace UnityEngine.InputSystem.HID
             {
                 if (currentPtr >= endPtr)
                     return 0;
-                return *currentPtr;
+                return (sbyte)*currentPtr;
             }
 
             // Read short.
@@ -291,7 +291,7 @@ namespace UnityEngine.InputSystem.HID
                 var data3 = *(currentPtr + 2);
                 var data4 = *(currentPtr + 3);
 
-                return (data4 << 24) | (data3 << 24) | (data2 << 8) | data1;
+                return (data4 << 24) | (data3 << 16) | (data2 << 8) | data1;
             }
 
             Debug.Assert(false, "Should not reach here");

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/HID/HIDParser.cs
@@ -277,7 +277,7 @@ namespace UnityEngine.InputSystem.HID
                     return 0;
                 var data1 = *currentPtr;
                 var data2 = *(currentPtr + 1);
-                return (data2 << 8) | data1;
+                return (short)(data2 << 8) | data1;
             }
 
             // Read int.


### PR DESCRIPTION
### Description

This PR addresses the issues encountered when parsing data for devices that have LogicalMinimum values with negative values. Seems we weren't taking 2's complement values into account. Ticket: https://jira.unity3d.com/browse/ISXB-1735

When parsing, we are now casting the bytes read to signed values. It also fixes an error when shifting bits to construct a 4-byte value.

Also includes fixes from user PR #2245 

### Testing status & QA

Tested with a Gamepad stick which has both signed short and byte for LogicalMin/Max of [-127,127] and [-32.768,32.767]

### Overall Product Risks



- Complexity: 0
- Halo Effect: 1

### Comments to reviewers

This is not easy to test without real devices that we don't have a layout for so I at least hope existing devices would still work.

One strategy could be to test this on macOS and comment this line: https://github.com/Unity-Technologies/InputSystem/blob/d1d72d50aa4c9c75e1c4055965e2ba9d9455605e/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs#L3798
Then look if the sticks were well interpreted.

However, this only allows us to verify for devices that send Stick values as a signed short. For signed bytes I don't know of a device besides the ones users have reported in Discussions https://discussions.unity.com/t/input-system-reading-invalid-values-from-hall-effect-keyboards/1684840/3

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
