### PR TITLE
CHANGE: Expose internals to the input tests package 

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/AssemblyInfo.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/AssemblyInfo.cs
@@ -9,6 +9,9 @@ using UnityEngine.InputSystem;
 [assembly: InternalsVisibleTo("Unity.InputSystem.IntegrationTests")]
 [assembly: InternalsVisibleTo("Unity.InputSystem.ForUI")] // To avoid minor bump
 [assembly: InternalsVisibleTo("Unity.AI.Assistant.Editor")]
+[assembly: InternalsVisibleTo("Unity.Modules.Input.Tests.Editor")]
+[assembly: InternalsVisibleTo("Unity.Modules.Input.Tests.Common")]
+[assembly: InternalsVisibleTo("Unity.Modules.Input.Tests.Playmode")]
 
 namespace UnityEngine.InputSystem
 {


### PR DESCRIPTION
### Description

This change has dependency for this test package PR: https://github.cds.internal.unity3d.com/unity/unity/pull/78036

### Testing status & QA


### Overall Product Risks

- Complexity: 
- Halo Effect: 

### Comments to reviewers


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
