### PR TITLE
CHANGE: Remove standaloneil2cpp tests on Ubuntu from PR trigger and add them to nightly trigger

### DIFF
--- a/.yamato/input-system-editor-functional-tests.yml
+++ b/.yamato/input-system-editor-functional-tests.yml
@@ -10,7 +10,7 @@ inputsystem-editorfunctionaltests_-_2022_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_2022.3_project;flags:inputsystem_MacOS_2022.3_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_2022.3_project;flags:inputsystem_MacOS_2022.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -28,7 +28,7 @@ inputsystem-editorfunctionaltests_-_2022_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_2022.3_project;flags:inputsystem_Ubuntu_2022.3_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_2022.3_project;flags:inputsystem_Ubuntu_2022.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -47,7 +47,7 @@ inputsystem-editorfunctionaltests_-_2022_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_2022.3_project;flags:inputsystem_Windows_2022.3_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_2022.3_project;flags:inputsystem_Windows_2022.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -65,7 +65,7 @@ inputsystem-editorfunctionaltests_-_6000_0_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.0_project;flags:inputsystem_MacOS_6000.0_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.0_project;flags:inputsystem_MacOS_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -83,7 +83,7 @@ inputsystem-editorfunctionaltests_-_6000_0_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.0_project;flags:inputsystem_Ubuntu_6000.0_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.0_project;flags:inputsystem_Ubuntu_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -102,7 +102,7 @@ inputsystem-editorfunctionaltests_-_6000_0_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.0_project;flags:inputsystem_Windows_6000.0_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.0_project;flags:inputsystem_Windows_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -120,7 +120,7 @@ inputsystem-editorfunctionaltests_-_6000_2_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.2_project;flags:inputsystem_MacOS_6000.2_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.2_project;flags:inputsystem_MacOS_6000.2_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -138,7 +138,7 @@ inputsystem-editorfunctionaltests_-_6000_2_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.2_project;flags:inputsystem_Ubuntu_6000.2_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.2_project;flags:inputsystem_Ubuntu_6000.2_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-editorfunctionaltests_-_6000_2_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.2_project;flags:inputsystem_Windows_6000.2_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.2_project;flags:inputsystem_Windows_6000.2_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -175,7 +175,7 @@ inputsystem-editorfunctionaltests_-_6000_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.3_project;flags:inputsystem_MacOS_6000.3_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.3_project;flags:inputsystem_MacOS_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -193,7 +193,7 @@ inputsystem-editorfunctionaltests_-_6000_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.3_project;flags:inputsystem_Ubuntu_6000.3_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.3_project;flags:inputsystem_Ubuntu_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -212,7 +212,7 @@ inputsystem-editorfunctionaltests_-_6000_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.3_project;flags:inputsystem_Windows_6000.3_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.3_project;flags:inputsystem_Windows_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -230,7 +230,7 @@ inputsystem-editorfunctionaltests_-_6000_4_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.4_project;flags:inputsystem_MacOS_6000.4_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.4_project;flags:inputsystem_MacOS_6000.4_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,7 +248,7 @@ inputsystem-editorfunctionaltests_-_6000_4_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.4_project;flags:inputsystem_Ubuntu_6000.4_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.4_project;flags:inputsystem_Ubuntu_6000.4_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -267,7 +267,7 @@ inputsystem-editorfunctionaltests_-_6000_4_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.4_project;flags:inputsystem_Windows_6000.4_project" --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.4_project;flags:inputsystem_Windows_6000.4_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/input-system-editor-performance-tests.yml
+++ b/.yamato/input-system-editor-performance-tests.yml
@@ -10,7 +10,7 @@ inputsystem-editorperformancetests_-_2022_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -28,7 +28,7 @@ inputsystem-editorperformancetests_-_2022_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -47,7 +47,7 @@ inputsystem-editorperformancetests_-_2022_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -65,7 +65,7 @@ inputsystem-editorperformancetests_-_6000_0_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -83,7 +83,7 @@ inputsystem-editorperformancetests_-_6000_0_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -102,7 +102,7 @@ inputsystem-editorperformancetests_-_6000_0_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -120,7 +120,7 @@ inputsystem-editorperformancetests_-_6000_2_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -138,7 +138,7 @@ inputsystem-editorperformancetests_-_6000_2_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-editorperformancetests_-_6000_2_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -175,7 +175,7 @@ inputsystem-editorperformancetests_-_6000_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -193,7 +193,7 @@ inputsystem-editorperformancetests_-_6000_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -212,7 +212,7 @@ inputsystem-editorperformancetests_-_6000_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -230,7 +230,7 @@ inputsystem-editorperformancetests_-_6000_4_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,7 +248,7 @@ inputsystem-editorperformancetests_-_6000_4_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -267,7 +267,7 @@ inputsystem-editorperformancetests_-_6000_4_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/input-system-mobile-functional-build-jobs.yml
+++ b/.yamato/input-system-mobile-functional-build-jobs.yml
@@ -11,7 +11,7 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -33,7 +33,7 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_mono:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -53,7 +53,7 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -73,7 +73,7 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -95,7 +95,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -117,7 +117,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -137,7 +137,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -179,7 +179,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -201,7 +201,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -221,7 +221,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -241,7 +241,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -263,7 +263,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -285,7 +285,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -305,7 +305,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -327,7 +327,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -349,7 +349,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_il2cpp:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -371,7 +371,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_mono:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -391,7 +391,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -413,7 +413,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -12,7 +12,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -37,7 +37,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -59,7 +59,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -77,7 +77,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -99,7 +99,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -124,7 +124,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -146,7 +146,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -164,7 +164,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -186,7 +186,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -211,7 +211,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -233,7 +233,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -251,7 +251,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -273,7 +273,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -298,7 +298,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -320,7 +320,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -338,7 +338,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -360,7 +360,7 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -385,7 +385,7 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -407,7 +407,7 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -425,7 +425,7 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-performance-build-jobs.yml
+++ b/.yamato/input-system-mobile-performance-build-jobs.yml
@@ -11,7 +11,7 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -33,7 +33,7 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_android_-_mono:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -53,7 +53,7 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -73,7 +73,7 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -95,7 +95,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -117,7 +117,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -137,7 +137,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -179,7 +179,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -201,7 +201,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -221,7 +221,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -241,7 +241,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -263,7 +263,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -285,7 +285,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -305,7 +305,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -327,7 +327,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -349,7 +349,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_il2cpp:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -371,7 +371,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_mono:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -391,7 +391,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=ios
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -413,7 +413,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_tvos:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --artifacts-path=build/logs --platform=tvOS
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -12,7 +12,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -37,7 +37,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -59,7 +59,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -77,7 +77,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -99,7 +99,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -124,7 +124,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -146,7 +146,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -164,7 +164,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -186,7 +186,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -211,7 +211,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -233,7 +233,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -251,7 +251,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -273,7 +273,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -298,7 +298,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -320,7 +320,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -338,7 +338,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -360,7 +360,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -385,7 +385,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=android
+      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -407,7 +407,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=ios
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -425,7 +425,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_tvos:
     type: Unity::mobile::appletv
     flavor: m1.mac
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --artifacts-path=build/test-results --platform=tvOS
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-standalone-functional-tests.yml
+++ b/.yamato/input-system-standalone-functional-tests.yml
@@ -10,7 +10,7 @@ inputsystem-standalonefunctionaltests_-_2022_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -28,7 +28,7 @@ inputsystem-standalonefunctionaltests_-_2022_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -47,7 +47,7 @@ inputsystem-standalonefunctionaltests_-_2022_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -65,7 +65,7 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -83,7 +83,7 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -102,7 +102,7 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -120,7 +120,7 @@ inputsystem-standalonefunctionaltests_-_6000_2_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -138,7 +138,7 @@ inputsystem-standalonefunctionaltests_-_6000_2_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-standalonefunctionaltests_-_6000_2_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -175,7 +175,7 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -193,7 +193,7 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -212,7 +212,7 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -230,7 +230,7 @@ inputsystem-standalonefunctionaltests_-_6000_4_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,7 +248,7 @@ inputsystem-standalonefunctionaltests_-_6000_4_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -267,7 +267,7 @@ inputsystem-standalonefunctionaltests_-_6000_4_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
@@ -10,7 +10,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -28,7 +28,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -47,7 +47,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -65,7 +65,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -83,7 +83,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -102,7 +102,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -120,7 +120,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -138,7 +138,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -175,7 +175,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -193,7 +193,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -212,7 +212,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -230,7 +230,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,7 +248,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -267,7 +267,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
@@ -10,7 +10,7 @@ inputsystem-standaloneil2cppperformancetests_-_2022_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -28,7 +28,7 @@ inputsystem-standaloneil2cppperformancetests_-_2022_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -47,7 +47,7 @@ inputsystem-standaloneil2cppperformancetests_-_2022_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -65,7 +65,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -83,7 +83,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -102,7 +102,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -120,7 +120,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_2_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -138,7 +138,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_2_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_2_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -175,7 +175,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -193,7 +193,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -212,7 +212,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -230,7 +230,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_4_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,7 +248,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_4_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -267,7 +267,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_4_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/input-system-standalone-performance-tests.yml
+++ b/.yamato/input-system-standalone-performance-tests.yml
@@ -10,7 +10,7 @@ inputsystem-standaloneperformancetests_-_2022_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -28,7 +28,7 @@ inputsystem-standaloneperformancetests_-_2022_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -47,7 +47,7 @@ inputsystem-standaloneperformancetests_-_2022_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 2022.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -65,7 +65,7 @@ inputsystem-standaloneperformancetests_-_6000_0_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -83,7 +83,7 @@ inputsystem-standaloneperformancetests_-_6000_0_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -102,7 +102,7 @@ inputsystem-standaloneperformancetests_-_6000_0_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -120,7 +120,7 @@ inputsystem-standaloneperformancetests_-_6000_2_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -138,7 +138,7 @@ inputsystem-standaloneperformancetests_-_6000_2_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -157,7 +157,7 @@ inputsystem-standaloneperformancetests_-_6000_2_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.2/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -175,7 +175,7 @@ inputsystem-standaloneperformancetests_-_6000_3_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -193,7 +193,7 @@ inputsystem-standaloneperformancetests_-_6000_3_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -212,7 +212,7 @@ inputsystem-standaloneperformancetests_-_6000_3_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -230,7 +230,7 @@ inputsystem-standaloneperformancetests_-_6000_4_-_macos:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,7 +248,7 @@ inputsystem-standaloneperformancetests_-_6000_4_-_ubuntu:
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
   artifacts:
@@ -267,7 +267,7 @@ inputsystem-standaloneperformancetests_-_6000_4_-_windows:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --artifacts-path=artifacts
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/triggers.yml
+++ b/.yamato/triggers.yml
@@ -53,19 +53,14 @@ all_functional_tests:
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_4_-_ubuntu
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_4_-_windows
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_macos
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_ubuntu
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_windows
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_macos
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_ubuntu
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_windows
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_macos
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_ubuntu
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_windows
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_macos
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_ubuntu
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_windows
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_macos
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_ubuntu
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_windows
   - path: .yamato/wrench/promotion-jobs.yml#publish_dry_run_inputsystem
   triggers:
@@ -75,29 +70,6 @@ all_functional_tests:
       NOT pull_request.changes.all match "**/*.md"
     cancel_old_ci: true
     cancel_leftover_jobs: Always
-all_mobile_tests:
-  name: All Mobile Tests
-  dependencies:
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_tvos
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_tvos
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_tvos
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_tvos
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_tvos
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_mono
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_2022_3_-_ios
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_0_-_ios
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_mono
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_2_-_ios
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_3_-_ios
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_4_-_ios
 all_performance_tests:
   name: All Performance Tests
   dependencies:
@@ -166,6 +138,15 @@ all_performance_tests:
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_4_-_macos
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_4_-_ubuntu
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_4_-_windows
+nightly_trigger:
+  name: Nightly trigger
+  dependencies:
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_2022_3_-_ubuntu
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_ubuntu
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_2_-_ubuntu
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_ubuntu
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_ubuntu
+  - path: .yamato/triggers.yml#all_performance_tests
   triggers:
     recurring:
     - branch: develop

--- a/Tools/CI/Recipes/EditorFunctionalTests.cs
+++ b/Tools/CI/Recipes/EditorFunctionalTests.cs
@@ -44,6 +44,7 @@ public class EditorFunctionalTests: BaseRecipe
                         $"assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:{yamatoSourceDir}/Packages;\"",
                         $"--coverage-results-path={yamatoSourceDir}/upm-ci~/CodeCoverage",
                         $"--coverage-upload-options=\"reportsDir:upm-ci~/CodeCoverage;name:inputsystem_{platform.System.ToString()}_{unityVersion}_project;flags:inputsystem_{platform.System.ToString()}_{unityVersion}_project\"")
+                    .WithTimeout(3600)
                     .WithArtifacts("artifacts"))
                 ))
             .WithArtifact(new Artifact("artifacts", "artifacts/**/*"))

--- a/Tools/CI/Recipes/EditorPerformanceTests.cs
+++ b/Tools/CI/Recipes/EditorPerformanceTests.cs
@@ -41,6 +41,7 @@ public class EditorPerformanceTests: BaseRecipe
                     .WithRerun(1, true)
                     .WithPerformanceDataReporting(true)
                     .WithPerformanceProject("InputSystem")
+                    .WithTimeout(3600)
                     .WithArtifacts("artifacts"))
                 ))
             .WithArtifact(new Artifact("artifacts", "artifacts/**/*"))

--- a/Tools/CI/Recipes/MobileFunctionalTests.cs
+++ b/Tools/CI/Recipes/MobileFunctionalTests.cs
@@ -35,6 +35,7 @@ public class MobileFunctionalBuildJobs: MobileBaseRecipe
                 .WithRerun(1, true)
                 .WithBuildOnly()
                 .WithPlayerSavePath("build/players")
+                .WithTimeout(3600)
                 .WithArtifacts("build/logs"))
             .WithPlatform(platform);
 
@@ -94,6 +95,7 @@ public class MobileFunctionalTests: MobileBaseRecipe
                 .WithCategory("!Performance")
                 .WithRerun(1)
                 .WithPlayerLoadPath("build/players")
+                .WithTimeout(3600)
                 .WithArtifacts("build/test-results"))
             .WithPlatform(platform);
         

--- a/Tools/CI/Recipes/MobilePerformanceTests.cs
+++ b/Tools/CI/Recipes/MobilePerformanceTests.cs
@@ -37,6 +37,7 @@ public class MobilePerformanceBuildJobs: MobileBaseRecipe
                 .WithPerformanceDataReporting(true)
                 .WithPerformanceProject("InputSystem")
                 .WithPlayerSavePath("build/players")
+                .WithTimeout(3600)
                 .WithArtifacts("build/logs"))
             .WithPlatform(platform);
 
@@ -97,6 +98,7 @@ public class MobilePerformanceTests: MobileBaseRecipe
                 .WithPerformanceDataReporting(true)
                 .WithPerformanceProject("InputSystem")
                 .WithPlayerLoadPath("build/players")
+                .WithTimeout(3600)
                 .WithArtifacts("build/test-results"))
             .WithPlatform(platform);
 

--- a/Tools/CI/Recipes/StandaloneFunctionalTests.cs
+++ b/Tools/CI/Recipes/StandaloneFunctionalTests.cs
@@ -39,6 +39,7 @@ public class StandaloneFunctionalTests: BaseRecipe
                     .WithCategory("!Performance")
                     .WithExtraArgs("--clean-library", "--api-profile=NET_4_6")
                     .WithRerun(1, true)
+                    .WithTimeout(3600)
                     .WithArtifacts("artifacts"))))
             .WithArtifact(new Artifact("artifacts", "artifacts/**/*"))
             .WithInfrastructureInstabilityDetection<WrenchExtensions.CustomScriptInfo>();

--- a/Tools/CI/Recipes/StandaloneIl2CppFunctionalTests.cs
+++ b/Tools/CI/Recipes/StandaloneIl2CppFunctionalTests.cs
@@ -40,6 +40,7 @@ public class StandaloneIl2CppFunctionalTests: BaseRecipe
                     .WithCategory("!Performance")
                     .WithExtraArgs("--clean-library", "--api-profile=NET_4_6")
                     .WithRerun(1, true)
+                    .WithTimeout(3600)
                     .WithArtifacts("artifacts"))))
             .WithArtifact(new Artifact("artifacts", "artifacts/**/*"))
             .WithInfrastructureInstabilityDetection<WrenchExtensions.CustomScriptInfo>();

--- a/Tools/CI/Recipes/StandaloneIl2CppPerformanceTests.cs
+++ b/Tools/CI/Recipes/StandaloneIl2CppPerformanceTests.cs
@@ -42,6 +42,7 @@ public class StandaloneIl2CppPerformanceTests: BaseRecipe
                     .WithRerun(1, true)
                     .WithPerformanceDataReporting(true)
                     .WithPerformanceProject("InputSystem")
+                    .WithTimeout(3600)
                     .WithArtifacts("artifacts"))))
             .WithArtifact(new Artifact("artifacts", "artifacts/**/*"))
             .WithInfrastructureInstabilityDetection<WrenchExtensions.CustomScriptInfo>();

--- a/Tools/CI/Recipes/StandalonePerformanceTests.cs
+++ b/Tools/CI/Recipes/StandalonePerformanceTests.cs
@@ -41,6 +41,7 @@ public class StandalonePerformanceTests: BaseRecipe
                     .WithRerun(1, true)
                     .WithPerformanceDataReporting(true)
                     .WithPerformanceProject("InputSystem")
+                    .WithTimeout(3600)
                     .WithArtifacts("artifacts"))))
             .WithArtifact(new Artifact("artifacts", "artifacts/**/*"))
             .WithInfrastructureInstabilityDetection<WrenchExtensions.CustomScriptInfo>();

--- a/Tools/CI/Recipes/Triggers.cs
+++ b/Tools/CI/Recipes/Triggers.cs
@@ -33,28 +33,31 @@ public class Triggers: RecipeBase
 
     private ISet<IJobBuilder> GetTriggers()
     {
+        var allPerformanceTests = JobBuilder.Create("All Performance Tests")
+            .WithDependencies(allEditorPerformanceTests)
+            .WithDependencies(allStandalonePerformanceTests)
+            .WithDependencies(allStandaloneIl2CppPerformanceTests)
+            .WithDependencies(allMobilePerformanceTests)
+            .WithDependencies(allTvOSPerformanceBuildJobs);
+        
         HashSet<IJobBuilder> builders =
         [
-            JobBuilder.Create("All Mobile Tests")
-                .WithDependencies(allMobileFunctionalTests)
-                .WithDependencies(allTvOSFunctionalBuildJobs),
-            
+            allPerformanceTests,
+
             JobBuilder.Create("All Functional Tests")
                 .WithDependencies(allEditorFunctionalTests)
                 .WithDependencies(allStandaloneFunctionalTests)
-                .WithDependencies(allStandaloneIl2CppFunctionalTests)
+                // Exclude standalone-il2cpp tests on Ubuntu from PR trigger as they are unstable, run them nightly instead.
+                .WithDependencies(allStandaloneIl2CppFunctionalTests.Where(d => !d.JobId.Contains("Ubuntu")) )
                 .WithDependencies(allMobileFunctionalTests)
                 .WithDependencies(allTvOSFunctionalBuildJobs)
                 .WithDependencies(new Dependency("wrench/promotion-jobs", "publish_dry_run_inputsystem"))
                 .WithPullRequestTrigger(pr => pr.ExcludeDraft().And().WithTargetBranch(InputSystemSettings.BranchName).And().WithoutChanges("**/*.md"), true, CancelLeftoverJobs.Always),
-            
-            JobBuilder.Create("All Performance Tests")
-                .WithDependencies(allEditorPerformanceTests)
-                .WithDependencies(allStandalonePerformanceTests)
-                .WithDependencies(allStandaloneIl2CppPerformanceTests)
-                .WithDependencies(allMobilePerformanceTests)
-                .WithDependencies(allTvOSPerformanceBuildJobs)
-                .WithScheduleTrigger(Schedule.RunDaily(InputSystemSettings.BranchName))
+
+            JobBuilder.Create("Nightly trigger")
+                .WithDependencies(allStandaloneIl2CppFunctionalTests.Where(d => d.JobId.Contains("Ubuntu")))
+                .WithDependencies(new Dependency("triggers", "all_performance_tests"))
+                .WithScheduleTrigger(Schedule.RunDaily(InputSystemSettings.BranchName)),
         ];
         return builders;
     }


### PR DESCRIPTION
### Description
Standalone-il2cpp tests on Ubuntu 22 are unstable because Editor can freeze when building the player in this environment.
This PR:
- removed standalone-il2cpp tests on Ubuntu from PR trigger. By doing this, we can have a more stable PR trigger
- added a timeout value `3600 seconds` to UTR command in all test jobs which should be enough. I have checked all the jobs, their run time are all under 30 minutes. After setting the timeout value, a job won't be stuck there for 6 hours.
- added a nightly trigger which run `all performance tests `and `standalone-il2cpp tests on Ubuntu`.


### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 
- Halo Effect: 

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
