### PR TITLE
FIX: Use android-execution image for Test runs

### DIFF
--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -10,9 +10,10 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -35,9 +36,10 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -97,9 +99,10 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -122,9 +125,10 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -184,9 +188,10 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -209,9 +214,10 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -271,9 +277,10 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -296,9 +303,10 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -358,9 +366,10 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -383,9 +392,10 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results

--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -4,7 +4,7 @@
 inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalTests - 2022.3 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -29,7 +29,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_il2cpp:
 inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_mono:
   name: InputSystem-MobileFunctionalTests - 2022.3 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -91,7 +91,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_tvos:
 inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalTests - 6000.0 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -116,7 +116,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp:
 inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono:
   name: InputSystem-MobileFunctionalTests - 6000.0 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -178,7 +178,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_tvos:
 inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalTests - 6000.2 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -203,7 +203,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_il2cpp:
 inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_mono:
   name: InputSystem-MobileFunctionalTests - 6000.2 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -265,7 +265,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_tvos:
 inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalTests - 6000.3 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -290,7 +290,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp:
 inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono:
   name: InputSystem-MobileFunctionalTests - 6000.3 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -352,7 +352,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_tvos:
 inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalTests - 6000.4 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -377,7 +377,7 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp:
 inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono:
   name: InputSystem-MobileFunctionalTests - 6000.4 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -10,10 +10,10 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -36,10 +36,10 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -99,10 +99,10 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -125,10 +125,10 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -188,10 +188,10 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -214,10 +214,10 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -277,10 +277,10 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -303,10 +303,10 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -366,10 +366,10 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results
@@ -392,10 +392,10 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
   after:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: if not exist build\test-results mkdir build\test-results

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -4,7 +4,7 @@
 inputsystem-mobileperformancetests_-_2022_3_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceTests - 2022.3 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -29,7 +29,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_il2cpp:
 inputsystem-mobileperformancetests_-_2022_3_-_android_-_mono:
   name: InputSystem-MobilePerformanceTests - 2022.3 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -91,7 +91,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_tvos:
 inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceTests - 6000.0 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -116,7 +116,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp:
 inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono:
   name: InputSystem-MobilePerformanceTests - 6000.0 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -178,7 +178,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_tvos:
 inputsystem-mobileperformancetests_-_6000_2_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceTests - 6000.2 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -203,7 +203,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_il2cpp:
 inputsystem-mobileperformancetests_-_6000_2_-_android_-_mono:
   name: InputSystem-MobilePerformanceTests - 6000.2 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -265,7 +265,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_tvos:
 inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceTests - 6000.3 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -290,7 +290,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp:
 inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono:
   name: InputSystem-MobilePerformanceTests - 6000.3 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -352,7 +352,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_tvos:
 inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceTests - 6000.4 - Android - il2cpp
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:
@@ -377,7 +377,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
 inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
   name: InputSystem-MobilePerformanceTests - 6000.4 - Android - mono
   agent:
-    image: package-ci/win10:default
+    image: mobile/android-execution-base:v2.3785910
     type: Unity::mobile::shield
     flavor: b1.xlarge
   commands:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -10,6 +10,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -35,6 +36,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -97,6 +99,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -122,6 +125,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -184,6 +188,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -209,6 +214,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -271,6 +277,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -296,6 +303,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -358,6 +366,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
@@ -383,6 +392,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
   commands:
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
   - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output UnifiedTestRunner.exe
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner.exe --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android

--- a/.yamato/mobile_config.json
+++ b/.yamato/mobile_config.json
@@ -32,7 +32,7 @@
         },
         "run": {
             "type": "Unity::mobile::shield",
-            "image": "package-ci/win10:default",
+            "image": "mobile/android-execution-base:v2.3785910",
             "flavor": "b1.xlarge"
         }
     }

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -1,5 +1,6 @@
 using RecipeEngine.Api.Jobs;
 using RecipeEngine.Api.Platforms;
+using RecipeEngine.Modules.UnifiedTestRunner;
 using RecipeEngine.Platforms;
 using RecipeEngine.Unity.Abstractions.Packages;
 
@@ -35,7 +36,7 @@ public abstract class MobileBaseRecipe: BaseRecipe
 
         return builders;
     }
-    
+
     // Produces jobs for Android platform with different scripting backends.
     IEnumerable<IJobBuilder> ProduceJobsForAndroid(Package package, Platform platform, string unityVersion)
     {
@@ -48,5 +49,19 @@ public abstract class MobileBaseRecipe: BaseRecipe
         }
 
         return builders;
+    }
+
+    protected string PrepareUtrExecutable(IJobBuilder job, SystemType systemType)
+    {
+        if (systemType == SystemType.Android)
+        {
+            var executableName = "utr.bat";
+            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
+            var utrDownloadCommand = UtrCommand.Download(systemType, executableName);
+            job.WithCommands(utrDownloadCommand);
+            return executableName;
+        }
+
+        return "UnifiedTestRunner";
     }
 }

--- a/Tools/CI/Recipes/MobileFunctionalTests.cs
+++ b/Tools/CI/Recipes/MobileFunctionalTests.cs
@@ -86,16 +86,7 @@ public class MobileFunctionalTests: MobileBaseRecipe
             platform = Settings.iOS15Platform;
 
         IJobBuilder job = JobBuilder.Create(jobName).WithDescription(jobName).WithPlatform(platform);
-        
-        var utrExecutable = "UnifiedTestRunner";
-
-        if (platform.System == SystemType.Android)
-        {
-            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
-            utrExecutable = "utr.bat";
-            var utrDownloadCommand = UtrCommand.Download(platform.System, "utr.bat");
-            job.WithCommands(utrDownloadCommand);
-        }
+        var utrExecutable = PrepareUtrExecutable(job, platform.System);
 
         var utrCommand = UtrCommand.Run(platform.System, utrExecutable, b => b
                 .WithSuite(UtrTestSuiteType.Playmode)

--- a/Tools/CI/Recipes/MobileFunctionalTests.cs
+++ b/Tools/CI/Recipes/MobileFunctionalTests.cs
@@ -87,10 +87,17 @@ public class MobileFunctionalTests: MobileBaseRecipe
 
         IJobBuilder job = JobBuilder.Create(jobName).WithDescription(jobName).WithPlatform(platform);
         
-        if (platform.System == SystemType.Android)
-            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
+        var utrExecutable = "UnifiedTestRunner";
 
-        var utrCommand = UtrCommand.Run(platform.System, b => b
+        if (platform.System == SystemType.Android)
+        {
+            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
+            utrExecutable = "utr.bat";
+            var utrDownloadCommand = UtrCommand.Download(platform.System, "utr.bat");
+            job.WithCommands(utrDownloadCommand);
+        }
+
+        var utrCommand = UtrCommand.Run(platform.System, utrExecutable, b => b
                 .WithSuite(UtrTestSuiteType.Playmode)
                 .WithCategory("!Performance")
                 .WithRerun(1)

--- a/Tools/CI/Recipes/MobilePerformanceTests.cs
+++ b/Tools/CI/Recipes/MobilePerformanceTests.cs
@@ -87,17 +87,17 @@ public class MobilePerformanceTests: MobileBaseRecipe
             platform = Settings.iOS15Platform;
         
         IJobBuilder job = JobBuilder.Create(jobName).WithDescription(jobName).WithPlatform(platform);
+        var utrExecutable = "UnifiedTestRunner";
 
         if (platform.System == SystemType.Android)
-            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
-
-        if (platform.System == SystemType.Android || platform.System == SystemType.AndroidMacOS)
         {
-            var utrDownloadCommand = UtrCommand.Download(platform.System);
+            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);            
+            utrExecutable = "utr.bat";
+            var utrDownloadCommand = UtrCommand.Download(platform.System, "utr.bat");
             job.WithCommands(utrDownloadCommand);
         }
 
-        var utrCommand = UtrCommand.Run(platform.System, b => b
+        var utrCommand = UtrCommand.Run(platform.System, utrExecutable, b => b
                 .WithSuite(UtrTestSuiteType.Playmode)
                 .WithCategory("Performance")
                 .WithRerun(1)

--- a/Tools/CI/Recipes/MobilePerformanceTests.cs
+++ b/Tools/CI/Recipes/MobilePerformanceTests.cs
@@ -87,15 +87,7 @@ public class MobilePerformanceTests: MobileBaseRecipe
             platform = Settings.iOS15Platform;
         
         IJobBuilder job = JobBuilder.Create(jobName).WithDescription(jobName).WithPlatform(platform);
-        var utrExecutable = "UnifiedTestRunner";
-
-        if (platform.System == SystemType.Android)
-        {
-            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);            
-            utrExecutable = "utr.bat";
-            var utrDownloadCommand = UtrCommand.Download(platform.System, "utr.bat");
-            job.WithCommands(utrDownloadCommand);
-        }
+        var utrExecutable = PrepareUtrExecutable(job, platform.System);
 
         var utrCommand = UtrCommand.Run(platform.System, utrExecutable, b => b
                 .WithSuite(UtrTestSuiteType.Playmode)

--- a/Tools/CI/Recipes/MobilePerformanceTests.cs
+++ b/Tools/CI/Recipes/MobilePerformanceTests.cs
@@ -91,6 +91,12 @@ public class MobilePerformanceTests: MobileBaseRecipe
         if (platform.System == SystemType.Android)
             job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
 
+        if (platform.System == SystemType.Android || platform.System == SystemType.AndroidMacOS)
+        {
+            var utrDownloadCommand = UtrCommand.Download(platform.System);
+            job.WithCommands(utrDownloadCommand);
+        }
+
         var utrCommand = UtrCommand.Run(platform.System, b => b
                 .WithSuite(UtrTestSuiteType.Playmode)
                 .WithCategory("Performance")
@@ -106,6 +112,7 @@ public class MobilePerformanceTests: MobileBaseRecipe
             .WithDependencies(buildJob)
             .WithArtifact(new Artifact("logs", "build/test-results/**/*"))
             .WithInfrastructureInstabilityDetection<WrenchExtensions.CustomScriptInfo>();
+
         return job;
     }
 }


### PR DESCRIPTION
### Description

Android Jobs use Package-CI images to execute tests, but those images do not contain tools like SDK. This PR switches. the run job image to more appropriate android-execution image.

### Testing status & QA

Android Tests

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 1
- Halo Effect: 1

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
