### PR TITLE
FIX: Fixed ISXB-586 for 2022.3.69f1 and up.

### DIFF
--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -63,7 +63,12 @@
         },
         {
             "name": "Unity",
-            "expression": ">=2022.3.69 && <6000.0 || >=6000.0.15",
+            "expression": "2022.3.69",
+            "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
+        },
+        {
+            "name": "Unity",
+            "expression": "6000.0.15",
             "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
         },
         {

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -63,7 +63,7 @@
         },
         {
             "name": "Unity",
-            "expression": "2022.3.69",
+            "expression": "[2022.3.69,2023.0.0]",
             "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
         },
         {

--- a/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
+++ b/Assets/Tests/InputSystem/Unity.InputSystem.Tests.asmdef
@@ -63,7 +63,7 @@
         },
         {
             "name": "Unity",
-            "expression": "6000.0.15",
+            "expression": ">=2022.3.69 && <6000.0 || >=6000.0.15",
             "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
         },
         {

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,7 @@ however, it has to be formatted properly to pass verification tests.
 - Fixed an issue in `DeltaStateEvent.From` where unsafe code would throw exception or crash if internal pointer `currentStatePtr` was `null`. [ISXB-1637](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1637).
 - Fixed an issue in `InputTestFixture.Set` where attempting to change state of a device not belonging to the test fixture context would result in null pointer exception or crash. [ISXB-1637](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1637).
 - Fixed an issue where input action parameter overrides applied via `InputActionRebindingExtensions.ApplyParameterOverride` would not be applied if the associated binding has the empty string as `InputBinding.name`and the binding mask also has the empty string as name. (ISXB-1721).
+- Fixed InputSystemUIInputModule calling pointer events on parent objects even when the "Send Pointer Hover To Parent" is off on 2022.3.XX. This was  was previously only available on Unity 6 versions since 1.11.0. [ISXB-1296]
 
 ## [1.15.0] - 2025-10-03
 

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -99,7 +99,12 @@
         },
         {
             "name": "Unity",
-            "expression": ">=2022.3.69 && <6000.0 || >=6000.0.15",
+            "expression": "2022.3.69",
+            "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
+        },
+        {
+            "name": "Unity",
+            "expression": "6000.0.15",
             "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
         },
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -99,7 +99,7 @@
         },
         {
             "name": "Unity",
-            "expression": "6000.0.15",
+            "expression": ">=2022.3.69 && <6000.0 || >=6000.0.15",
             "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
         },
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -99,7 +99,7 @@
         },
         {
             "name": "Unity",
-            "expression": "2022.3.69",
+            "expression": "[2022.3.69,2023.0.0]",
             "define": "UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT"
         },
         {


### PR DESCRIPTION
### Description

Original PR: https://github.com/Unity-Technologies/InputSystem/pull/1975

Jira ticket: https://jira.unity3d.com/browse/ISXB-586
2022.3 PR: https://github.cds.internal.unity3d.com/unity/unity/pull/81547

2022.3 PR has successfully landed before this PR.

### Testing status & QA

Adds 2022.3.69f1 to `#define` flag `UNITY_INPUT_SYSTEM_SENDPOINTERHOVERTOPARENT` which was used in original fix.

From the original fix:
Implements BaseInputModule sendPointerHoverToParent property for InputSystemUIInputModule. Also properly set PointerEventData reentered and fullyExited properties.

### Overall Product Risks

- Complexity: 0
- Halo Effect: 1

### Comments to reviewers

I did not do any kind of testing whatsoever on this backport fix.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
