### PR TITLE
FIX: Change type aliasing to use the type implementing static interface instead of using derived type.

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -21,11 +21,10 @@ using UnityEngine.Profiling;
 using UnityEngine.TestTools;
 using UnityEngine.TestTools.Utils;
 using UnityEngine.TestTools.Constraints;
-using Is = UnityEngine.TestTools.Constraints.Is;
+
+using Is = NUnit.Framework.Is;
 
 #pragma warning disable CS0649
-[SuppressMessage("ReSharper", "AccessToStaticMemberViaDerivedType")]
-
 // As should be obvious from the number of tests in here, the action system rivals the entire combined rest of the system
 // in terms of complexity.
 partial class CoreTests

--- a/Assets/Tests/InputSystem/CoreTests_Controls.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Controls.cs
@@ -16,7 +16,7 @@ using UnityEngine.InputSystem.Processors;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.Profiling;
 using UnityEngine.TestTools.Constraints;
-using Is = UnityEngine.TestTools.Constraints.Is;
+using Is = NUnit.Framework.Is;
 
 partial class CoreTests
 {

--- a/Assets/Tests/InputSystem/CoreTests_Devices.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Devices.cs
@@ -21,7 +21,7 @@ using UnityEngine.TestTools;
 using UnityEngine.TestTools.Utils;
 using Gyroscope = UnityEngine.InputSystem.Gyroscope;
 using UnityEngine.TestTools.Constraints;
-using Is = UnityEngine.TestTools.Constraints.Is;
+using Is = NUnit.Framework.Is;
 using Quaternion = UnityEngine.Quaternion;
 using TouchPhase = UnityEngine.InputSystem.TouchPhase;
 using Vector2 = UnityEngine.Vector2;

--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -19,7 +19,8 @@ using UnityEngine.Profiling;
 using UnityEngine.TestTools;
 using UnityEngine.TestTools.Constraints;
 using UnityEngine.TestTools.Utils;
-using Is = UnityEngine.TestTools.Constraints.Is;
+
+using Is = NUnit.Framework.Is;
 using Random = UnityEngine.Random;
 using TouchPhase = UnityEngine.InputSystem.TouchPhase;
 

--- a/Assets/Tests/InputSystem/CoreTests_MouseEvents.cs
+++ b/Assets/Tests/InputSystem/CoreTests_MouseEvents.cs
@@ -6,7 +6,6 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.TestTools;
-using Is = UnityEngine.TestTools.Constraints.Is;
 
 partial class CoreTests
 {

--- a/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/PlayerInputTests.cs
@@ -16,7 +16,7 @@ using UnityEngine.Profiling;
 using UnityEngine.TestTools.Constraints;
 using Object = UnityEngine.Object;
 using Gyroscope = UnityEngine.InputSystem.Gyroscope;
-using Is = UnityEngine.TestTools.Constraints.Is;
+using Is = NUnit.Framework.Is;
 using UnityEngine.InputSystem.OnScreen;
 
 /// <summary>

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -21,7 +21,7 @@ using UnityEngine.TestTools.Constraints;
 using UnityEngine.TestTools.Utils;
 using UnityEngine.UI;
 using Image = UnityEngine.UI.Image;
-using Is = UnityEngine.TestTools.Constraints.Is;
+using Is = NUnit.Framework.Is;
 using MouseButton = UnityEngine.InputSystem.LowLevel.MouseButton;
 using UnityEngine.Scripting;
 using Cursor = UnityEngine.Cursor;


### PR DESCRIPTION
### Description

The https://docs.unity3d.com/Packages/com.unity.test-framework@1.1/api/UnityEngine.TestTools.Constraints.AllocatingGCMemoryConstraint.html example is misleading since it guides to alias the extended Is from this package (adding a single extension). 

This leads to warnings in certain compilers/IDEs, e.g. https://www.jetbrains.com/help/resharper/AccessToStaticMemberViaDerivedType.html

However, the extension is extending NUnit.Framework.Is and hence the aliasing of Is can be made to this type instead to still support the extensions while also not generating warnings in aforementioned IDE.

This PR has no functional impact but allows noticing warnings in test code in Rider instead of getting hundreds of warnings about the above problem.

Skipping CHANGELOG entry since this is mainly internal.

### Testing status & QA

Just checked it compiles and no warnings in Rider 2025.2.3 with Unity 6000.2.7f2. 

### Overall Product Risks

Minimal.

- Complexity: Minmal
- Halo Effect: Minimal

### Comments to reviewers

No functional impact at all is expected.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
