### PR TITLE
FIX: [ISXB-1716] Add support for all existing InputControl types in InputTestFixture.Trigger 

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 - Added an example of how to swap two similar controls to the `RebindingUISample`. This is accessible via a button with two arrows at the right hand-side of the screen. Pressing the button allows swapping the current bindings of the "Move" and "Look" gamepad bindings via the new `RebindActionUI.SwapBinding(RebindActionUI other)` method.
 - Added support for (MonoBehavior OnMouse events) [https://docs.unity3d.com/ScriptReference/MonoBehaviour.html] when running the Input System on Unity 6000.4 or newer.
 - Added tests and a sample for MonoBehavior OnMouse events using the InputSystem package.
+- Added support for all the existing InputControl types in InputTestFixture.Trigger [ISXB-1716]
 
 ### Fixed
 - Fixed warnings being generated on Unity 6.3 (beta). (ISXB-1718).

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -13,7 +13,6 @@ using UnityEngine.TestTools;
 using UnityEngine.TestTools.Utils;
 using UnityEngine.InputSystem.XR;
 
-
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -11,6 +11,9 @@ using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.TestTools;
 using UnityEngine.TestTools.Utils;
+using UnityEngine.InputSystem.XR;
+
+
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEngine.InputSystem.Editor;
@@ -728,32 +731,111 @@ namespace UnityEngine.InputSystem
                 throw new ArgumentException(
                     $"Action '{action}' must be bound to controls in order to be able to trigger it", nameof(action));
 
-            // See if we have a button we can trigger.
+            // We iterate controls to see if there are any that we know how to trigger
             for (var i = 0; i < controls.Count; ++i)
             {
-                if (!(controls[i] is ButtonControl button))
-                    continue;
+                var control = controls[i];
 
-                // Press and release button.
-                Set(button, 1);
-                Set(button, 0);
+                // for buttons, we literally trigger them pressed and released
+                if (control is ButtonControl buttonControl)
+                {
+                    Set(buttonControl, 1);
+                    Set(buttonControl, 0);
 
-                return;
+                    return;
+                }
+
+                // for the other types of controls we simply perform a small change in value as applicable
+                const float minorChange = 0.01f;
+
+                if (control is AxisControl axisControl)
+                {
+                    Set(axisControl, axisControl.ReadValue() + minorChange);
+
+                    return;
+                }
+
+                if (control is Vector2Control vec2Control)
+                {
+                    Set(vec2Control, vec2Control.ReadValue() + Vector2.one * minorChange);
+
+                    return;
+                }
+
+                if (control is Vector3Control vec3Control)
+                {
+                    Set(vec3Control, vec3Control.ReadValue() + Vector3.one * minorChange);
+
+                    return;
+                }
+
+                if (control is QuaternionControl quatControl)
+                {
+                    var q = quatControl.ReadValue();
+                    q.ToAngleAxis(out float angle, out Vector3 axis);
+                    Set(quatControl, Quaternion.AngleAxis(angle + minorChange, axis));
+
+                    return;
+                }
+
+                if (control is IntegerControl integerControl)
+                {
+                    Set(integerControl, integerControl.ReadValue() + 1);
+
+                    return;
+                }
+
+                if (control is TouchControl touchControl)
+                {
+                    var state = touchControl.ReadValue();
+                    state.position += Vector2.one * minorChange;
+                    Set(touchControl, state);
+
+                    return;
+                }
+
+                // this one is a bit weird, but there's not much to change other than picking the next phase in the list
+                if (control is TouchPhaseControl touchPhaseControl)
+                {
+                    var phase = touchPhaseControl.ReadValue();
+                    var values = Enum.GetValues(typeof(TouchPhase));
+                    var index = Array.IndexOf(values, phase);
+                    var newIndex = (index + 1) % values.Length;
+                    Set(touchPhaseControl, phase);
+
+                    return;
+                }
+
+                if (control is PoseControl poseControl)
+                {
+                    var pose = poseControl.ReadValue();
+                    pose.position += minorChange * Vector3.one;
+                    Set(poseControl, pose);
+
+                    return;
+                }
+
+                if (control is BoneControl boneControl)
+                {
+                    var bone = boneControl.ReadValue();
+                    bone.position += minorChange * Vector3.one;
+                    Set(boneControl, bone);
+
+                    return;
+                }
+
+                if (control is EyesControl eyesControl)
+                {
+                    var eyes = eyesControl.ReadValue();
+                    eyes.leftEyePosition += minorChange * Vector3.one;
+                    Set(eyesControl, eyes);
+
+                    return;
+                }
+
             }
 
-            // See if we have an axis we can slide a bit.
-            for (var i = 0; i < controls.Count; ++i)
-            {
-                if (!(controls[i] is AxisControl axis))
-                    continue;
-
-                // We do, so nudge its value a bit.
-                Set(axis, axis.ReadValue() + 0.01f);
-
-                return;
-            }
-
-            ////TODO: support a wider range of controls
+            // If it's not a control that we know how to trigger - it's not implemented yet
             throw new NotImplementedException();
         }
 

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -805,15 +805,6 @@ namespace UnityEngine.InputSystem
                     return;
                 }
 
-                if (control is PoseControl poseControl)
-                {
-                    var pose = poseControl.ReadValue();
-                    pose.position += minorChange * Vector3.one;
-                    Set(poseControl, pose);
-
-                    return;
-                }
-
                 if (control is BoneControl boneControl)
                 {
                     var bone = boneControl.ReadValue();
@@ -832,6 +823,9 @@ namespace UnityEngine.InputSystem
                     return;
                 }
             }
+
+            // Initially I wanted to implement PoseControl too, but it's got a very complicated ifdef that enables it.
+            // Didn't want to carry that #ifdef here. Let's see how many people really need to trigger PoseControl.
 
             // If it's not a control that we know how to trigger - it's not implemented yet
             throw new NotImplementedException();

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -800,7 +800,7 @@ namespace UnityEngine.InputSystem
                     var values = Enum.GetValues(typeof(TouchPhase));
                     var index = Array.IndexOf(values, phase);
                     var newIndex = (index + 1) % values.Length;
-                    Set(touchPhaseControl, phase);
+                    Set(touchPhaseControl, (TouchPhase)values.GetValue(newIndex));
 
                     return;
                 }

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestFixture.cs
@@ -832,7 +832,6 @@ namespace UnityEngine.InputSystem
 
                     return;
                 }
-
             }
 
             // If it's not a control that we know how to trigger - it's not implemented yet

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,7 +5,4 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes: []
-  m_configObjects:
-    com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 0cfafdaf330c8481b9ae4210786b578d,
-      type: 3}
-  m_UseUCBPForAssetBundles: 0
+  m_configObjects: {}

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -5,4 +5,7 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes: []
-  m_configObjects: {}
+  m_configObjects:
+    com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 0cfafdaf330c8481b9ae4210786b578d,
+      type: 3}
+  m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
### Description

There was a problem reported that if you invoke InputTestFixture.Trigger with anything other than a Button or an Axis, there would be a NotImplementedException thrown.

Here, we address it by logically extending the approach originally taken by the Axis implementation (change the value slightly as an effect from Trigger) to all other possible InputControl variations that we have. We only have two outliers here -- the integer control just gets its value incremented by one instead of the regular small change. Also the TouchState thing gets the next state in the list as well. 

### Testing status & QA

Local testing 

### Overall Product Risks

- Complexity:  Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
