### PR TITLE
NEW: Insights analytics support for the Input System

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -10,6 +10,7 @@ using Unity.Profiling;
 using UnityEngine.InputSystem.Utilities;
 
 using ProfilerMarker = Unity.Profiling.ProfilerMarker;
+using UnityEngineInternal.Input;
 
 ////TODO: now that we can bind to controls by display name, we need to re-resolve controls when those change (e.g. when the keyboard layout changes)
 
@@ -957,6 +958,14 @@ namespace UnityEngine.InputSystem
                 NotifyListenersOfActionChange(InputActionChange.ActionEnabled, map.m_SingletonAction);
             else
                 NotifyListenersOfActionChange(InputActionChange.ActionMapEnabled, map);
+
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+            // also report all actions to insights
+            foreach (var inputAction in map.actions)
+            {
+                NativeInputSystem.LogInputActionInsight(inputAction.name, inputAction.type.ToString());
+            }
+#endif
         }
 
         private void EnableControls(InputActionMap map)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -6,11 +6,9 @@ using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
-using Unity.Profiling;
 using UnityEngine.InputSystem.Utilities;
 
 using ProfilerMarker = Unity.Profiling.ProfilerMarker;
-using UnityEngineInternal.Input;
 
 ////TODO: now that we can bind to controls by display name, we need to re-resolve controls when those change (e.g. when the keyboard layout changes)
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -963,7 +963,7 @@ namespace UnityEngine.InputSystem
             // also report all actions to insights
             foreach (var inputAction in map.actions)
             {
-                NativeInputSystem.LogInputActionInsight(inputAction.name, inputAction.type.ToString());
+                InputSystem.s_Manager.m_Runtime.LogInputActionInsight( inputAction.name, inputAction.type.ToString() );
             }
 #endif
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -963,7 +963,7 @@ namespace UnityEngine.InputSystem
             // also report all actions to insights
             foreach (var inputAction in map.actions)
             {
-                InputSystem.s_Manager.m_Runtime.LogInputActionInsight( inputAction.name, inputAction.type.ToString() );
+                InputSystem.s_Manager.m_Runtime.LogInputActionInsight( inputAction );
             }
 #endif
         }

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -187,9 +187,9 @@ namespace UnityEngine.InputSystem.LowLevel
         void SendAnalytic(InputAnalytics.IInputAnalytic analytic);
         #endif // UNITY_ANALYTICS || UNITY_EDITOR
 
-        void LogDeviceConnectedInsight(string serial, string product, string deviceInterface, string version);
-        void LogDeviceDisconnectedInsight(string serial);
-        void LogInputActionInsight(string name, string type);
+        void LogDeviceConnectedInsight(InputDeviceDescription description);
+        void LogDeviceDisconnectedInsight(InputDeviceDescription description);
+        void LogInputActionInsight(InputAction action);
 
         #if UNITY_EDITOR
         Action<PlayModeStateChange> onPlayModeChanged { get; set; }

--- a/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/IInputRuntime.cs
@@ -187,6 +187,10 @@ namespace UnityEngine.InputSystem.LowLevel
         void SendAnalytic(InputAnalytics.IInputAnalytic analytic);
         #endif // UNITY_ANALYTICS || UNITY_EDITOR
 
+        void LogDeviceConnectedInsight(string serial, string product, string deviceInterface, string version);
+        void LogDeviceDisconnectedInsight(string serial);
+        void LogInputActionInsight(string name, string type);
+
         #if UNITY_EDITOR
         Action<PlayModeStateChange> onPlayModeChanged { get; set; }
         Action onProjectChange { get; set; }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2531,9 +2531,7 @@ namespace UnityEngine.InputSystem
             // Parse description, if need be.
             var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
 
-#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
-            NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
-#endif
+            m_Runtime.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
 
             // Add it.
             var markAsRemoved = false;
@@ -3601,9 +3599,8 @@ namespace UnityEngine.InputSystem
                         {
                             RemoveDevice(device, keepOnListOfAvailableDevices: false);
 
-#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
-                            NativeInputSystem.LogDeviceDisconnectedInsight(device.description.serial);
-#endif
+                            m_Runtime.LogDeviceDisconnectedInsight(device.description.serial);
+
                             // If it's a native device with a description, put it on the list of disconnected
                             // devices.
                             if (device.native && !device.description.empty)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2519,12 +2519,6 @@ namespace UnityEngine.InputSystem
 
         private void OnNativeDeviceDiscovered(int deviceId, string deviceDescriptor)
         {
-            var deviceTag = InputDeviceDescription.FromJson(deviceDescriptor).product;
-
-            Debug.Log($"OnNativeDeviceDiscovered {deviceTag}");
-
-            NativeInputSystem.LogDeviceConnectedInsight( deviceTag );
-
             // Make sure we're not adding to m_AvailableDevices before we restored what we
             // had before a domain reload.
             RestoreDevicesAfterDomainReloadIfNecessary();
@@ -2536,6 +2530,12 @@ namespace UnityEngine.InputSystem
 
             // Parse description, if need be.
             var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
+
+            var deviceTag = description.product;
+
+            Debug.Log($"OnNativeDeviceDiscovered {deviceTag}");
+
+            NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
 
             // Add it.
             var markAsRemoved = false;

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2531,7 +2531,7 @@ namespace UnityEngine.InputSystem
             // Parse description, if need be.
             var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
 
-#if UNITY_INPUTSYSTEM_SUPPORTS_INSIGHTS
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
             NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
 #endif
 
@@ -3601,7 +3601,7 @@ namespace UnityEngine.InputSystem
                         {
                             RemoveDevice(device, keepOnListOfAvailableDevices: false);
 
-#if UNITY_INPUTSYSTEM_SUPPORTS_INSIGHTS
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
                             NativeInputSystem.LogDeviceDisconnectedInsight(device.description.serial);
 #endif
                             // If it's a native device with a description, put it on the list of disconnected

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2531,7 +2531,7 @@ namespace UnityEngine.InputSystem
             // Parse description, if need be.
             var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
 
-            m_Runtime.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
+            m_Runtime.LogDeviceConnectedInsight(description);
 
             // Add it.
             var markAsRemoved = false;
@@ -3599,7 +3599,7 @@ namespace UnityEngine.InputSystem
                         {
                             RemoveDevice(device, keepOnListOfAvailableDevices: false);
 
-                            m_Runtime.LogDeviceDisconnectedInsight(device.description.serial);
+                            m_Runtime.LogDeviceDisconnectedInsight(device.description);
 
                             // If it's a native device with a description, put it on the list of disconnected
                             // devices.

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2531,7 +2531,9 @@ namespace UnityEngine.InputSystem
             // Parse description, if need be.
             var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
 
+#if UNITY_INPUTSYSTEM_SUPPORTS_INSIGHTS
             NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
+#endif
 
             // Add it.
             var markAsRemoved = false;
@@ -3599,8 +3601,9 @@ namespace UnityEngine.InputSystem
                         {
                             RemoveDevice(device, keepOnListOfAvailableDevices: false);
 
+#if UNITY_INPUTSYSTEM_SUPPORTS_INSIGHTS
                             NativeInputSystem.LogDeviceDisconnectedInsight(device.description.serial);
-
+#endif
                             // If it's a native device with a description, put it on the list of disconnected
                             // devices.
                             if (device.native && !device.description.empty)

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2519,6 +2519,12 @@ namespace UnityEngine.InputSystem
 
         private void OnNativeDeviceDiscovered(int deviceId, string deviceDescriptor)
         {
+            var deviceTag = InputDeviceDescription.FromJson(deviceDescriptor).product;
+
+            Debug.Log($"OnNativeDeviceDiscovered {deviceTag}");
+
+            NativeInputSystem.LogDeviceConnectedInsight( deviceTag );
+
             // Make sure we're not adding to m_AvailableDevices before we restored what we
             // had before a domain reload.
             RestoreDevicesAfterDomainReloadIfNecessary();

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2531,10 +2531,6 @@ namespace UnityEngine.InputSystem
             // Parse description, if need be.
             var description = device?.description ?? InputDeviceDescription.FromJson(deviceDescriptor);
 
-            var deviceTag = description.product;
-
-            Debug.Log($"OnNativeDeviceDiscovered {deviceTag}");
-
             NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
 
             // Add it.
@@ -3602,6 +3598,8 @@ namespace UnityEngine.InputSystem
                         case DeviceRemoveEvent.Type:
                         {
                             RemoveDevice(device, keepOnListOfAvailableDevices: false);
+
+                            NativeInputSystem.LogDeviceDisconnectedInsight(device.description.serial);
 
                             // If it's a native device with a description, put it on the list of disconnected
                             // devices.

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -423,6 +423,27 @@ namespace UnityEngine.InputSystem.LowLevel
         #endif //ENABLE_CLOUD_SERVICES_ANALYTICS
         }
 
-        #endif // UNITY_ANALYTICS || UNITY_EDITOR
+        public void LogDeviceConnectedInsight(string serial, string product, string deviceInterface, string version)
+        {
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+            NativeInputSystem.LogDeviceConnectedInsight(serial, product, deviceInterface, version);
+#endif
+        }
+
+        public void LogDeviceDisconnectedInsight(string serial)
+        {
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+            NativeInputSystem.LogDeviceDisconnectedInsight(serial);
+#endif
+        }
+
+        public void LogInputActionInsight(string name, string type)
+        {
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+            NativeInputSystem.LogInputActionInsight(name, type);
+#endif
+        }
+
+#endif // UNITY_ANALYTICS || UNITY_EDITOR
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -4,6 +4,8 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine.Analytics;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngineInternal.Input;
+using UnityEngine.InputSystem.Layouts;
+
 
 #if UNITY_EDITOR
 using System.Reflection;
@@ -423,24 +425,24 @@ namespace UnityEngine.InputSystem.LowLevel
         #endif //ENABLE_CLOUD_SERVICES_ANALYTICS
         }
 
-        public void LogDeviceConnectedInsight(string serial, string product, string deviceInterface, string version)
+        public void LogDeviceConnectedInsight(InputDeviceDescription description)
         {
 #if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
-            NativeInputSystem.LogDeviceConnectedInsight(serial, product, deviceInterface, version);
+            NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
 #endif
         }
 
-        public void LogDeviceDisconnectedInsight(string serial)
+        public void LogDeviceDisconnectedInsight(InputDeviceDescription description)
         {
 #if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
-            NativeInputSystem.LogDeviceDisconnectedInsight(serial);
+            NativeInputSystem.LogDeviceDisconnectedInsight(description.serial);
 #endif
         }
 
-        public void LogInputActionInsight(string name, string type)
+        public void LogInputActionInsight(InputAction action)
         {
 #if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
-            NativeInputSystem.LogInputActionInsight(name, type);
+            NativeInputSystem.LogInputActionInsight(action.name, action.type.ToString());
 #endif
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/NativeInputRuntime.cs
@@ -427,21 +427,21 @@ namespace UnityEngine.InputSystem.LowLevel
 
         public void LogDeviceConnectedInsight(InputDeviceDescription description)
         {
-#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS && !UNITY_EDITOR
             NativeInputSystem.LogDeviceConnectedInsight(description.serial, description.product, description.interfaceName, description.version);
 #endif
         }
 
         public void LogDeviceDisconnectedInsight(InputDeviceDescription description)
         {
-#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS && !UNITY_EDITOR
             NativeInputSystem.LogDeviceDisconnectedInsight(description.serial);
 #endif
         }
 
         public void LogInputActionInsight(InputAction action)
         {
-#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS
+#if UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS && !UNITY_EDITOR
             NativeInputSystem.LogInputActionInsight(action.name, action.type.ToString());
 #endif
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -92,11 +92,16 @@
             "expression": "6000.3.0a6",
             "define": "UNITY_INPUT_SYSTEM_PLATFORM_POLLING_FREQUENCY"
         },
-	{
-	    "name": "Unity",
+        {
+            "name": "Unity",
             "expression": "6000.4.0a4",
             "define": "UNITY_INPUTSYSTEM_SUPPORTS_MOUSE_SCRIPT_EVENTS"
-	}
+        },
+        {
+            "name": "Unity",
+            "expression": "6000.5.0a5",
+            "define": "UNITY_INPUTSYSTEM_SUPPORTS_INSIGHTS"
+        }        
     ],
     "noEngineReferences": false
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -100,7 +100,7 @@
         {
             "name": "Unity",
             "expression": "6000.5.0a5",
-            "define": "UNITY_INPUTSYSTEM_SUPPORTS_INSIGHTS"
+            "define": "UNITY_INPUT_SYSTEM_SUPPORTS_INSIGHTS"
         }        
     ],
     "noEngineReferences": false

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -481,6 +481,19 @@ namespace UnityEngine.InputSystem
             #endif // UNITY_2023_2_OR_NEWER
         }
 
-        #endif // UNITY_ANALYTICS || UNITY_EDITOR
+        // We don't want to populate Insights from within tests, even when running them in players
+        public void LogDeviceConnectedInsight(string serial, string product, string deviceInterface, string version)
+        {
+        }
+
+        public void LogDeviceDisconnectedInsight(string serial)
+        {
+        }
+
+        public void LogInputActionInsight(string name, string type)
+        {
+        }
+
+#endif // UNITY_ANALYTICS || UNITY_EDITOR
     }
 }

--- a/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
+++ b/Packages/com.unity.inputsystem/Tests/TestFixture/InputTestRuntime.cs
@@ -482,15 +482,15 @@ namespace UnityEngine.InputSystem
         }
 
         // We don't want to populate Insights from within tests, even when running them in players
-        public void LogDeviceConnectedInsight(string serial, string product, string deviceInterface, string version)
+        public void LogDeviceConnectedInsight(InputDeviceDescription description)
         {
         }
 
-        public void LogDeviceDisconnectedInsight(string serial)
+        public void LogDeviceDisconnectedInsight(InputDeviceDescription description)
         {
         }
 
-        public void LogInputActionInsight(string name, string type)
+        public void LogInputActionInsight(InputAction action)
         {
         }
 


### PR DESCRIPTION
### Description

This PR brings support for the Insights analytics module to Input System.

Requires native side PR to land first: https://github.cds.internal.unity3d.com/unity/unity/pull/83832

Currently, we send these kinds of data to Insights:

1) When a new input device is connected, we send this information:
* product (" DUALSHOCK 4 Wireless Controller")
* serial ("A0:5A:5E:92:0F:3E")
* version ("1.0")
* interface ("HID")

2) When an input device is disconnected, we send this information:
* serial (really intended to be matched with the event above at the time of analysis)

3) When a new Input Action Map is being loaded or activated, we scan for all the Input Actions that are being brought to life and for each one, we send the following data:
* name (e.g. "Jump")
* type (e.g. "Button")

### Testing status & QA

Local testing

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
