### PR TITLE
FIX: ISXB-1746 Fix for non-deterministic behaviour in asset import stages.

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -38,6 +38,7 @@ however, it has to be formatted properly to pass verification tests.
 - Limited the Add Control Scheme popup window max size to be its parent window, so that it won't resize beyond the visible area. [ISXB-1733](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1733)
 - Fixed an issue where the action icon would shrink or disappear from UI when an action has a very long name. [ISXB-1650](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1650).
 - Fixed upgrading input actions containing multiple processors [ISXB-1674](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1674).
+- Fixed an issue that led to non-deterministic behaviour during `.inputaction` asset imports that could lead to corrupted assets or Unity hanging during asset import when "Generate C# Scripts" was active in importer settings. [ISXB-1746](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1746)
 
 ## [1.15.0] - 2025-10-03
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -119,6 +119,8 @@ namespace UnityEngine.InputSystem.Editor
 
             foreach (var callback in s_OnImportCallbacks)
                 callback();
+
+            CreateFromJson(ctx);
         }
 
         internal static void SetupAsset(InputActionAsset asset)
@@ -253,6 +255,7 @@ namespace UnityEngine.InputSystem.Editor
                 namespaceName = codeNamespace,
                 className = codeClassName,
             };
+
 
             if (InputActionCodeGenerator.GenerateWrapperCode(wrapperFilePath, asset, options))
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -119,13 +119,6 @@ namespace UnityEngine.InputSystem.Editor
 
             foreach (var callback in s_OnImportCallbacks)
                 callback();
-
-            var asset = CreateFromJson(ctx);
-            if (asset == null)
-                return;
-
-            if (m_GenerateWrapperCode)
-                GenerateWrapperCode(ctx, asset, m_WrapperCodeNamespace, m_WrapperClassName, m_WrapperCodePath);
         }
 
         internal static void SetupAsset(InputActionAsset asset)
@@ -201,7 +194,7 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
-        private static void GenerateWrapperCode(AssetImportContext ctx, InputActionAsset asset, string codeNamespace, string codeClassName, string codePath)
+        private static void GenerateWrapperCode(string assetPath, InputActionAsset asset, string codeNamespace, string codeClassName, string codePath)
         {
             var maps = asset.actionMaps;
             // When using code generation, it is an error for any action map to be named the same as the asset itself.
@@ -210,7 +203,7 @@ namespace UnityEngine.InputSystem.Editor
             if (maps.Any(x =>
                 CSharpCodeHelpers.MakeTypeName(x.name) == className || CSharpCodeHelpers.MakeIdentifier(x.name) == className))
             {
-                ctx.LogImportError(
+                Debug.LogError(
                     $"{asset.name}: An action map in an .inputactions asset cannot be named the same as the asset itself if 'Generate C# Class' is used. "
                     + "You can rename the action map in the asset, rename the asset itself or assign a different C# class name in the import settings.");
                 return;
@@ -220,7 +213,6 @@ namespace UnityEngine.InputSystem.Editor
             if (string.IsNullOrEmpty(wrapperFilePath))
             {
                 // Placed next to .inputactions file.
-                var assetPath = ctx.assetPath;
                 var directory = Path.GetDirectoryName(assetPath);
                 var fileName = Path.GetFileNameWithoutExtension(assetPath);
                 wrapperFilePath = Path.Combine(directory, fileName) + ".cs";
@@ -229,7 +221,6 @@ namespace UnityEngine.InputSystem.Editor
                      wrapperFilePath.StartsWith("../") || wrapperFilePath.StartsWith("..\\"))
             {
                 // User-specified file relative to location of .inputactions file.
-                var assetPath = ctx.assetPath;
                 var directory = Path.GetDirectoryName(assetPath);
                 wrapperFilePath = Path.Combine(directory, wrapperFilePath);
             }
@@ -258,7 +249,7 @@ namespace UnityEngine.InputSystem.Editor
 
             var options = new InputActionCodeGenerator.Options
             {
-                sourceAssetPath = ctx.assetPath,
+                sourceAssetPath = assetPath,
                 namespaceName = codeNamespace,
                 className = codeClassName,
             };
@@ -378,13 +369,23 @@ namespace UnityEngine.InputSystem.Editor
         private class InputActionJsonNameModifierAssetProcessor : AssetPostprocessor
         {
             private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets,
-                string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
+                string[] movedAssets, string[] movedFromAssetPaths)
             {
                 var needToInvalidate = false;
                 foreach (var assetPath in importedAssets)
                 {
                     if (IsInputActionAssetPath(assetPath))
                     {
+                        // Generate C# code from asset if configured via importer settings.
+                        // We generate from a parsed temporary asset here since loading the asset won't work here.
+                        var importer = GetAtPath(assetPath) as InputActionImporter;
+                        if (importer != null)
+                        {
+                            var asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
+                            if (importer.m_GenerateWrapperCode)
+                                GenerateWrapperCode(assetPath, asset, importer.m_WrapperCodeNamespace, importer.m_WrapperClassName, importer.m_WrapperCodePath);
+                        }
+                        
                         needToInvalidate = true;
                         CheckAndRenameJsonNameIfDifferent(assetPath);
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -385,7 +385,7 @@ namespace UnityEngine.InputSystem.Editor
                             if (importer.m_GenerateWrapperCode)
                                 GenerateWrapperCode(assetPath, asset, importer.m_WrapperCodeNamespace, importer.m_WrapperClassName, importer.m_WrapperCodePath);
                         }
-                        
+
                         needToInvalidate = true;
                         CheckAndRenameJsonNameIfDifferent(assetPath);
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -120,7 +120,16 @@ namespace UnityEngine.InputSystem.Editor
             foreach (var callback in s_OnImportCallbacks)
                 callback();
 
-            CreateFromJson(ctx);
+            var asset = CreateFromJson(ctx);
+            if (asset == null)
+                return;
+
+            if (m_GenerateWrapperCode && HasMapWithSameNameAsAsset(asset, m_WrapperClassName))
+            {
+                ctx.LogImportError(
+                    $"{asset.name}: An action map in an .inputactions asset cannot be named the same as the asset itself if 'Generate C# Class' is used. "
+                    + "You can rename the action map in the asset, rename the asset itself or assign a different C# class name in the import settings.");
+            }
         }
 
         internal static void SetupAsset(InputActionAsset asset)
@@ -196,20 +205,20 @@ namespace UnityEngine.InputSystem.Editor
             }
         }
 
-        private static void GenerateWrapperCode(string assetPath, InputActionAsset asset, string codeNamespace, string codeClassName, string codePath)
+        private static bool HasMapWithSameNameAsAsset(InputActionAsset asset, string codeClassName)
         {
-            var maps = asset.actionMaps;
             // When using code generation, it is an error for any action map to be named the same as the asset itself.
             // https://fogbugz.unity3d.com/f/cases/1212052/
             var className = !string.IsNullOrEmpty(codeClassName) ? codeClassName : CSharpCodeHelpers.MakeTypeName(asset.name);
-            if (maps.Any(x =>
-                CSharpCodeHelpers.MakeTypeName(x.name) == className || CSharpCodeHelpers.MakeIdentifier(x.name) == className))
-            {
-                Debug.LogError(
-                    $"{asset.name}: An action map in an .inputactions asset cannot be named the same as the asset itself if 'Generate C# Class' is used. "
-                    + "You can rename the action map in the asset, rename the asset itself or assign a different C# class name in the import settings.");
+            return (asset.actionMaps.Any(x =>
+                CSharpCodeHelpers.MakeTypeName(x.name) == className ||
+                CSharpCodeHelpers.MakeIdentifier(x.name) == className));
+        }
+
+        private static void GenerateWrapperCode(string assetPath, InputActionAsset asset, string codeNamespace, string codeClassName, string codePath)
+        {
+            if (HasMapWithSameNameAsAsset(asset, codeClassName))
                 return;
-            }
 
             var wrapperFilePath = codePath;
             if (string.IsNullOrEmpty(wrapperFilePath))
@@ -382,11 +391,18 @@ namespace UnityEngine.InputSystem.Editor
                         // Generate C# code from asset if configured via importer settings.
                         // We generate from a parsed temporary asset here since loading the asset won't work here.
                         var importer = GetAtPath(assetPath) as InputActionImporter;
-                        if (importer != null)
+                        if (importer != null && importer.m_GenerateWrapperCode)
                         {
-                            var asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
-                            if (importer.m_GenerateWrapperCode)
-                                GenerateWrapperCode(assetPath, asset, importer.m_WrapperCodeNamespace, importer.m_WrapperClassName, importer.m_WrapperCodePath);
+                            try
+                            {
+                                var asset = InputActionAsset.FromJson(File.ReadAllText(assetPath));
+                                GenerateWrapperCode(assetPath, asset, importer.m_WrapperCodeNamespace,
+                                    importer.m_WrapperClassName, importer.m_WrapperCodePath);
+                            }
+                            catch (Exception e)
+                            {
+                                Debug.LogException(e);
+                            }
                         }
 
                         needToInvalidate = true;


### PR DESCRIPTION
### Description

This is a suggested fix for HUP: https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1746 

Follows suggested approach in: https://discussions.unity.com/t/changes-to-assetdatabase-apis-when-called-during-import/1689358, but not exactly since that approach suggest generating a <GUID>.cs file in library temp folder in that case which doesn't really solve anything for this use case.

This PR do not fix the existing problems:
- The feature goes against recommendations for how to handle and import assets:
- The generated code is not fully synced with the referenced asset, it gets regenerated when the asset is updated, but isn't properly moved with the asset (could be fixed), deleted with the asset (could be fixed), and doesn't get regenerated if deleted (could potentially be fixed).

Generally, IMO we should consider adding this feature to the list of potential things to remove.

### Testing status & QA

Only tested manually with 6000.3 beta. 

### Overall Product Risks

- Complexity: Small
- Halo Effect: Medium

We need to ensure there is not new side-effects to projects and/or CI with the change in approach.

### Comments to reviewers

Nothing special to call out apart from this being modified previously due to CI hanging in batch mode: https://github.com/Unity-Technologies/InputSystem/pull/2091

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
