### PR TITLE
[CHANGE] Removing legacy unity preprocessors mentions for 2022.3 or older

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,8 +10,8 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
-
-
+### Changed
+- Changed: removing legacy unity preprocessors mentions for editor versions 2022.3 or older.
 
 ## [1.16.0] - 2025-11-10
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemPluginControl.cs
@@ -37,12 +37,8 @@ namespace UnityEngine.InputSystem.Editor
             BuildTarget.tvOS,
             BuildTarget.LinuxHeadlessSimulation,
             BuildTarget.EmbeddedLinux,
-            #if UNITY_2022_1_OR_NEWER
             BuildTarget.QNX,
-            #endif
-            #if UNITY_2022_3_OR_NEWER
             BuildTarget.VisionOS,
-            #endif
             (BuildTarget)49,
             BuildTarget.NoTarget
         };

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/ExtendedPointerEventData.cs
@@ -94,9 +94,7 @@ namespace UnityEngine.InputSystem.UI
             stringBuilder.AppendLine("azimuthAngle: " + azimuthAngle);
             stringBuilder.AppendLine("altitudeAngle: " + altitudeAngle);
             stringBuilder.AppendLine("twist: " + twist);
-            #if UNITY_2022_3_OR_NEWER
             stringBuilder.AppendLine("displayIndex: " + displayIndex);
-            #endif
             return stringBuilder.ToString();
         }
 
@@ -138,27 +136,21 @@ namespace UnityEngine.InputSystem.UI
                 azimuthAngle = (pen.tilt.value.x + 1) * Mathf.PI / 2;
                 altitudeAngle = (pen.tilt.value.y + 1) * Mathf.PI / 2;
                 twist = pen.twist.value * Mathf.PI * 2;
-                #if UNITY_2022_3_OR_NEWER
                 displayIndex = pen.displayIndex.ReadValue();
-                #endif
             }
             else if (control.parent is TouchControl touchControl)
             {
                 uiToolkitPointerId = GetTouchPointerId(touchControl);
                 pressure = touchControl.pressure.magnitude;
                 radius = touchControl.radius.value;
-                #if UNITY_2022_3_OR_NEWER
                 displayIndex = touchControl.displayIndex.ReadValue();
-                #endif
             }
             else if (control.parent is Touchscreen touchscreen)
             {
                 uiToolkitPointerId = GetTouchPointerId(touchscreen.primaryTouch);
                 pressure = touchscreen.pressure.magnitude;
                 radius = touchscreen.radius.value;
-                #if UNITY_2022_3_OR_NEWER
                 displayIndex = touchscreen.displayIndex.ReadValue();
-                #endif
             }
             else
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1922,9 +1922,7 @@ namespace UnityEngine.InputSystem.UI
                     eventData.pointerType = pointerType;
                     eventData.pointerId = pointerId;
                     eventData.touchId = touchId;
-#if UNITY_2022_3_OR_NEWER
                     eventData.displayIndex = displayIndex;
-#endif
 
                     // Make sure these don't linger around when we switch to a different kind of pointer.
                     eventData.trackedDeviceOrientation = default;
@@ -2027,9 +2025,7 @@ namespace UnityEngine.InputSystem.UI
                 eventData = new ExtendedPointerEventData(eventSystem);
 
             eventData.pointerId = pointerId;
-#if UNITY_2022_3_OR_NEWER
             eventData.displayIndex = displayIndex;
-#endif
             eventData.touchId = touchId;
             eventData.pointerType = pointerType;
             eventData.control = control;
@@ -2160,9 +2156,7 @@ namespace UnityEngine.InputSystem.UI
 
             ref var state = ref GetPointerStateForIndex(index);
             state.screenPosition = context.ReadValue<Vector2>();
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         // NOTE: In the click events, we specifically react to the Canceled phase to make sure we do NOT perform
@@ -2191,9 +2185,7 @@ namespace UnityEngine.InputSystem.UI
             state.changedThisFrame = true;
             if (IgnoreNextClick(ref context, wasPressed))
                 state.leftButton.ignoreNextClick = true;
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         private void OnRightClickCallback(InputAction.CallbackContext context)
@@ -2208,9 +2200,7 @@ namespace UnityEngine.InputSystem.UI
             state.changedThisFrame = true;
             if (IgnoreNextClick(ref context, wasPressed))
                 state.rightButton.ignoreNextClick = true;
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         private void OnMiddleClickCallback(InputAction.CallbackContext context)
@@ -2225,9 +2215,7 @@ namespace UnityEngine.InputSystem.UI
             state.changedThisFrame = true;
             if (IgnoreNextClick(ref context, wasPressed))
                 state.middleButton.ignoreNextClick = true;
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         private bool CheckForRemovedDevice(ref InputAction.CallbackContext context)
@@ -2257,9 +2245,7 @@ namespace UnityEngine.InputSystem.UI
             // ISXB-704: convert input value to BaseInputModule convention.
             state.scrollDelta = (scrollDelta / InputSystem.scrollWheelDeltaPerTick) * scrollDeltaPerTick;
 
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         private void OnMoveCallback(InputAction.CallbackContext context)
@@ -2282,9 +2268,7 @@ namespace UnityEngine.InputSystem.UI
 
             ref var state = ref GetPointerStateForIndex(index);
             state.worldOrientation = context.ReadValue<Quaternion>();
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         private void OnTrackedDevicePositionCallback(InputAction.CallbackContext context)
@@ -2295,9 +2279,7 @@ namespace UnityEngine.InputSystem.UI
 
             ref var state = ref GetPointerStateForIndex(index);
             state.worldPosition = context.ReadValue<Vector3>();
-#if UNITY_2022_3_OR_NEWER
             state.eventData.displayIndex = GetDisplayIndexFor(context.control);
-#endif
         }
 
         private void OnControlsChanged(object obj)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -579,9 +579,7 @@ namespace UnityEngine.InputSystem.UI
                     if (!sendPointerHoverToParent && current == pointerParent)
                         break;
 
-#if UNITY_2021_3_OR_NEWER
                     eventData.fullyExited = current != commonRoot && eventData.pointerEnter != currentPointerTarget;
-#endif
                     ExecuteEvents.Execute(current.gameObject, eventData, ExecuteEvents.pointerExitHandler);
                     eventData.hovered.Remove(current.gameObject);
 
@@ -605,12 +603,10 @@ namespace UnityEngine.InputSystem.UI
                 Transform current = currentPointerTarget.transform;
                 while (current != null && !PointerShouldIgnoreTransform(current))
                 {
-#if UNITY_2021_3_OR_NEWER
                     eventData.reentered = current == commonRoot && current != oldPointerEnter;
                     // if we are sending the event to parent, they are already in hover mode at that point. No need to bubble up the event.
                     if (sendPointerHoverToParent && eventData.reentered)
                         break;
-#endif
 
                     ExecuteEvents.Execute(current.gameObject, eventData, ExecuteEvents.pointerEnterHandler);
                     if (wasMoved)

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/XInput/XboxGamepadMacOS.cs
@@ -127,12 +127,6 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
             RightThumbstickPress = 15,
         }
 
-        // IL2CPP on 2021 doesn't respect the FieldOffsets - as such, we need some padding fields
-#if UNITY_2021 && ENABLE_IL2CPP
-        [FieldOffset(0)]
-        private uint padding;
-#endif
-
         [InputControl(name = "buttonSouth", bit = (uint)Button.A, displayName = "A")]
         [InputControl(name = "buttonEast", bit = (uint)Button.B, displayName = "B")]
         [InputControl(name = "buttonWest", bit = (uint)Button.X, displayName = "X")]
@@ -154,18 +148,8 @@ namespace UnityEngine.InputSystem.XInput.LowLevel
         [InputControl(name = "leftTrigger", format = "BYTE")]
         [FieldOffset(6)] public byte leftTrigger;
 
-#if UNITY_2021 && ENABLE_IL2CPP
-        [FieldOffset(7)]
-        private byte triggerPadding;
-#endif
-
         [InputControl(name = "rightTrigger", format = "BYTE")]
         [FieldOffset(8)] public byte rightTrigger;
-
-#if UNITY_2021 && ENABLE_IL2CPP
-        [FieldOffset(9)]
-        private byte triggerPadding2;
-#endif
 
 
         [InputControl(name = "leftStick", layout = "Stick", format = "VC2S")]


### PR DESCRIPTION
### Description

This PR removes the legacy Unity preprocessors mentions for editors 2022.3 or older (e.g. 2021.x, 2020.x).

As stated in the [package.json](https://github.com/Unity-Technologies/InputSystem/blob/b60f6a76339f263fe67f939fe85cb67a72ab7b0d/Packages/com.unity.inputsystem/package.json#L5) minimum editor version supported is 2022.3.

### Testing status & QA

Compilation

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.

After merge:

- [ ] Create forward/backward port if needed. If you are blocked from creating a forward port now please add a task to ISX-1444.
