### PR TITLE
CHANGE: Auto-save on focus lost can no longer be compiled out

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Changed
 - Project-Wide Input Actions support can no longer be disabled (removed the UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS define). (ISX-2397)
 - Removed code that had to do with Unity versions older than Unity 2022.3 LTS. (ISX-2396)
+- Auto-save on focus lost can no longer be compiled out (ISX-2397)
 
 ### Fixed
 - An issue where a UITK MouseEvent was triggered when changing from Scene View to Game View in the Editor has been fixed. [ISXB-1671](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1671)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorSettingsProvider.cs
@@ -118,11 +118,9 @@ namespace UnityEngine.InputSystem.Editor
 
         void SaveAssetOnFocusLost()
         {
-#if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
             var asset = GetAsset();
             if (asset != null)
                 ValidateAndSaveAsset(asset);
-#endif
         }
 
         public static void SetIMGUIDropdownVisible(bool visible, bool optionWasSelected)
@@ -173,18 +171,6 @@ namespace UnityEngine.InputSystem.Editor
             m_ActionEditorAnalytics.RegisterEditorFocusOut();
 
             DelayFocusLost(element == null);
-        }
-
-        private void OnStateChanged(InputActionsEditorState newState, UIRebuildMode editorRebuildMode)
-        {
-#if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
-            // No action, auto-saved on edit-focus lost
-#else
-            // Project wide input actions always auto save - don't check the asset auto save status
-            var asset = GetAsset();
-            if (asset != null)
-                ValidateAndSaveAsset(asset);
-#endif
         }
 
         private void ValidateAndSaveAsset(InputActionAsset asset)
@@ -259,7 +245,6 @@ namespace UnityEngine.InputSystem.Editor
             if (hasAsset)
             {
                 m_StateContainer = new StateContainer(m_State, AssetDatabase.AssetPathToGUID(AssetDatabase.GetAssetPath(asset)));
-                m_StateContainer.StateChanged += OnStateChanged;
                 m_View = new InputActionsEditorView(m_RootVisualElement, m_StateContainer, true, null);
                 m_StateContainer.Initialize(m_RootVisualElement.Q("action-editor"));
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -267,14 +267,6 @@ namespace UnityEngine.InputSystem.Editor
         {
             DirtyInputActionsEditorWindow(newState);
             m_State = newState;
-
-            #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
-            // No action taken apart from setting dirty flag, auto-save triggered as part of having a dirty asset
-            // and editor loosing focus instead.
-            #else
-            if (InputEditorUserSettings.autoSaveInputActionAssets)
-                Save(isAutoSave: false);
-            #endif
         }
 
         private void UpdateWindowTitle()
@@ -313,13 +305,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private void DirtyInputActionsEditorWindow(InputActionsEditorState newState)
         {
-            #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
-            // Window is dirty is equivalent to if asset has changed
             var isWindowDirty = HasContentChanged();
-            #else
-            // Window is dirty is never true since every change is auto-saved
-            var isWindowDirty = !InputEditorUserSettings.autoSaveInputActionAssets && HasContentChanged();
-            #endif
 
             if (m_IsDirty == isWindowDirty)
                 return;
@@ -345,16 +331,15 @@ namespace UnityEngine.InputSystem.Editor
 
         private void OnLostFocus()
         {
-            // Auto-save triggers on focus-lost instead of on every change
-            #if UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST
             if (InputEditorUserSettings.autoSaveInputActionAssets && m_IsDirty)
+            {
                 // We'd like to avoid saving in case the focus was lost due to the drop-down window being spawned.
                 // This code should be cleaned up once we migrate the InputControl stuff from ImGUI completely.
                 // Since at that point it stops being a separate window that steals focus.
                 // (See case ISXB-1221)
                 if (!InputControlPathEditor.IsShowingDropdown)
                     Save(isAutoSave: true);
-            #endif
+            }
 
             analytics.RegisterEditorFocusOut();
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Unity.InputSystem.asmdef
@@ -54,11 +54,6 @@
         },
         {
             "name": "Unity",
-            "expression": "1",
-            "define": "UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST"
-        },
-        {
-            "name": "Unity",
             "expression": "6000.0.9",
             "define": "UNITY_INPUT_SYSTEM_PLATFORM_SCROLL_DELTA"
         },


### PR DESCRIPTION
### Description

Here we remove the `UNITY_INPUT_SYSTEM_INPUT_ACTIONS_EDITOR_AUTO_SAVE_ON_FOCUS_LOST` compile time define that theoretically allowed to have the Input package to be compiled without this feature but instead have it save on every change in the editor windows. The define has been set by default for a while so we're confident it's time to remove this bit of variability. 

### Testing status & QA

Local compilation

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
