### PR TITLE
CHANGE: Deprecate useIMGUIEditorForAssets

### DIFF
--- a/Assets/Samples/CustomComposite/CustomComposite.cs
+++ b/Assets/Samples/CustomComposite/CustomComposite.cs
@@ -136,13 +136,6 @@ public class CustomCompositeEditor : InputParameterEditor<CustomComposite>
 {
     public override void OnGUI()
     {
-        // Using the 'target' property, we can access an instance of our composite.
-        var currentValue = target.scaleFactor;
-
-        // The easiest way to lay out our UI is to simply use EditorGUILayout.
-        // We simply assign the changed value back to the 'target' object. The input
-        // system will automatically detect a change in value.
-        target.scaleFactor = EditorGUILayout.Slider(m_ScaleFactorLabel, currentValue, 0, 2);
     }
 
     public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Assets/Samples/CustomComposite/CustomComposite.cs
+++ b/Assets/Samples/CustomComposite/CustomComposite.cs
@@ -134,6 +134,10 @@ public class CustomComposite : InputBindingComposite<Vector2>
 #if UNITY_EDITOR
 public class CustomCompositeEditor : InputParameterEditor<CustomComposite>
 {
+    public override void OnGUI()
+    {
+    }
+
     public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
     {
         var slider = new Slider(m_ScaleFactorLabel.text, 0, 2)

--- a/Assets/Samples/CustomComposite/CustomComposite.cs
+++ b/Assets/Samples/CustomComposite/CustomComposite.cs
@@ -134,10 +134,6 @@ public class CustomComposite : InputBindingComposite<Vector2>
 #if UNITY_EDITOR
 public class CustomCompositeEditor : InputParameterEditor<CustomComposite>
 {
-    public override void OnGUI()
-    {
-    }
-
     public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
     {
         var slider = new Slider(m_ScaleFactorLabel.text, 0, 2)

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -35,7 +35,6 @@ partial class CoreTests
     [TestCase(InputFeatureNames.kParanoidReadValueCachingChecks)]
     [TestCase(InputFeatureNames.kDisableUnityRemoteSupport)]
     [TestCase(InputFeatureNames.kRunPlayerUpdatesInEditMode)]
-    [TestCase(InputFeatureNames.kUseIMGUIEditorForAssets)]
     public void Settings_ShouldStoreSettingsAndFeatureFlags(string featureName)
     {
         using (var settings = Scoped.Object(InputSettings.CreateInstance<InputSettings>()))

--- a/Assets/Tests/InputSystem/CoreTests_Analytics.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Analytics.cs
@@ -458,7 +458,6 @@ partial class CoreTests
             Assert.That(data.feature_paranoid_read_value_caching_checks_enabled, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kParanoidReadValueCachingChecks)));
             Assert.That(data.feature_disable_unity_remote_support, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kDisableUnityRemoteSupport)));
             Assert.That(data.feature_run_player_updates_in_editmode, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kRunPlayerUpdatesInEditMode)));
-            Assert.That(data.feature_use_imgui_editor_for_assets, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets)));
         }
         finally
         {
@@ -554,7 +553,6 @@ partial class CoreTests
             Assert.That(data.feature_paranoid_read_value_caching_checks_enabled, Is.True);
             Assert.That(data.feature_disable_unity_remote_support, Is.True);
             Assert.That(data.feature_run_player_updates_in_editmode, Is.True);
-            Assert.That(data.feature_use_imgui_editor_for_assets, Is.True);
         }
         finally
         {

--- a/Assets/Tests/InputSystem/CoreTests_Analytics.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Analytics.cs
@@ -506,7 +506,6 @@ partial class CoreTests
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kParanoidReadValueCachingChecks, true);
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kDisableUnityRemoteSupport, true);
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kRunPlayerUpdatesInEditMode, true);
-            customSettings.SetInternalFeatureFlag(InputFeatureNames.kUseIMGUIEditorForAssets, true);
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kUseReadValueCaching, true);
 
             InputSystem.settings = customSettings;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,7 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Changed
-- Project-Wide Input Actions support can no longer compiled out (removed the UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS define). (ISX-2397)
+- Project-Wide Input Actions support can no longer be compiled out (removed the UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS define). (ISX-2397)
 - Removed code that had to do with Unity versions older than Unity 2022.3 LTS. (ISX-2396)
 - Auto-save on focus lost can no longer be compiled out (ISX-2397)
 - Deprecated the USE_IMGUI_EDITOR_FOR_ASSETS feature option (ISX-2397)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,10 +11,10 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Changed
-- Project-Wide Input Actions support can no longer be compiled out (removed the UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS define). (ISX-2397)
+- Project-Wide Input Actions support can no longer be compiled out (removed the `UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS` define). (ISX-2397)
 - Removed code that had to do with Unity versions older than Unity 2022.3 LTS. (ISX-2396)
 - Auto-save on focus lost can no longer be compiled out (ISX-2397)
-- Deprecated the USE_IMGUI_EDITOR_FOR_ASSETS feature option (ISX-2397)
+- Deprecated the `USE_IMGUI_EDITOR_FOR_ASSETS` feature option (ISX-2397)
 
 ### Fixed
 - An issue where a UITK MouseEvent was triggered when changing from Scene View to Game View in the Editor has been fixed. [ISXB-1671](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1671)

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,9 +11,10 @@ however, it has to be formatted properly to pass verification tests.
 ## [Unreleased] - yyyy-mm-dd
 
 ### Changed
-- Project-Wide Input Actions support can no longer be disabled (removed the UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS define). (ISX-2397)
+- Project-Wide Input Actions support can no longer compiled out (removed the UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS define). (ISX-2397)
 - Removed code that had to do with Unity versions older than Unity 2022.3 LTS. (ISX-2396)
 - Auto-save on focus lost can no longer be compiled out (ISX-2397)
+- Deprecated the USE_IMGUI_EDITOR_FOR_ASSETS feature option (ISX-2397)
 
 ### Fixed
 - An issue where a UITK MouseEvent was triggered when changing from Scene View to Game View in the Editor has been fixed. [ISXB-1671](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1671)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -216,10 +216,6 @@ namespace UnityEngine.InputSystem.Composites
             + "If 'Neither' is selected, the result is 0 (or, more precisely, "
             + "the midpoint between minValue and maxValue).";
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField(label, target.whichSideWins)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -212,7 +212,7 @@ namespace UnityEngine.InputSystem.Composites
     internal class AxisCompositeEditor : InputParameterEditor<AxisComposite>
     {
         private const string label = "Which Side Wins";
-        private const string tooltip = "Determine which axis 'wins' if both are actuated at the same time. "
+        private const string tooltipText = "Determine which axis 'wins' if both are actuated at the same time. "
             + "If 'Neither' is selected, the result is 0 (or, more precisely, "
             + "the midpoint between minValue and maxValue).";
 
@@ -224,7 +224,7 @@ namespace UnityEngine.InputSystem.Composites
         {
             var modeField = new EnumField(label, target.whichSideWins)
             {
-                tooltip = tooltip
+                tooltip = tooltipText
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -216,6 +216,10 @@ namespace UnityEngine.InputSystem.Composites
             + "If 'Neither' is selected, the result is 0 (or, more precisely, "
             + "the midpoint between minValue and maxValue).";
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField(label, target.whichSideWins)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -212,7 +212,7 @@ namespace UnityEngine.InputSystem.Composites
     internal class AxisCompositeEditor : InputParameterEditor<AxisComposite>
     {
         private const string label = "Which Side Wins";
-        private const string tolltip = "Determine which axis 'wins' if both are actuated at the same time. "
+        private const string tooltip = "Determine which axis 'wins' if both are actuated at the same time. "
             + "If 'Neither' is selected, the result is 0 (or, more precisely, "
             + "the midpoint between minValue and maxValue).";
 
@@ -220,7 +220,7 @@ namespace UnityEngine.InputSystem.Composites
         {
             var modeField = new EnumField(label, target.whichSideWins)
             {
-                tooltip = tolltip
+                tooltip = tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -5,7 +5,6 @@ using UnityEngine.InputSystem.Utilities;
 
 #if UNITY_EDITOR
 using System;
-using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
 #endif
@@ -212,24 +211,20 @@ namespace UnityEngine.InputSystem.Composites
     #if UNITY_EDITOR
     internal class AxisCompositeEditor : InputParameterEditor<AxisComposite>
     {
-        private GUIContent m_WhichAxisWinsLabel = new GUIContent("Which Side Wins",
-            "Determine which axis 'wins' if both are actuated at the same time. "
+        private const string label = "Which Side Wins";
+        private const string tolltip = "Determine which axis 'wins' if both are actuated at the same time. "
             + "If 'Neither' is selected, the result is 0 (or, more precisely, "
-            + "the midpoint between minValue and maxValue).");
+            + "the midpoint between minValue and maxValue).";
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            target.whichSideWins = (AxisComposite.WhichSideWins)EditorGUILayout.EnumPopup(m_WhichAxisWinsLabel, target.whichSideWins);
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField(m_WhichAxisWinsLabel.text, target.whichSideWins)
+            var modeField = new EnumField(label, target.whichSideWins)
             {
-                tooltip = m_WhichAxisWinsLabel.tooltip
+                tooltip = tolltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -196,10 +196,6 @@ namespace UnityEngine.InputSystem.Composites
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
             + "floating-point magnitudes as read from controls.";
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField(label, target.mode)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -196,6 +196,10 @@ namespace UnityEngine.InputSystem.Composites
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
             + "floating-point magnitudes as read from controls.";
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField(label, target.mode)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -192,7 +192,7 @@ namespace UnityEngine.InputSystem.Composites
     internal class Vector2CompositeEditor : InputParameterEditor<Vector2Composite>
     {
         private const string label = "Mode";
-        private const string tooltip = "How to synthesize a Vector2 from the inputs. Digital "
+        private const string tooltipText = "How to synthesize a Vector2 from the inputs. Digital "
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
             + "floating-point magnitudes as read from controls.";
 
@@ -204,7 +204,7 @@ namespace UnityEngine.InputSystem.Composites
         {
             var modeField = new EnumField(label, target.mode)
             {
-                tooltip = tooltip
+                tooltip = tooltipText
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -5,7 +5,6 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 
 #if UNITY_EDITOR
-using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
 #endif
@@ -192,24 +191,20 @@ namespace UnityEngine.InputSystem.Composites
     #if UNITY_EDITOR
     internal class Vector2CompositeEditor : InputParameterEditor<Vector2Composite>
     {
-        private GUIContent m_ModeLabel = new GUIContent("Mode",
-            "How to synthesize a Vector2 from the inputs. Digital "
+        private const string label = "Mode";
+        private const string tooltip = "How to synthesize a Vector2 from the inputs. Digital "
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
-            + "floating-point magnitudes as read from controls.");
+            + "floating-point magnitudes as read from controls.";
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            target.mode = (Vector2Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField(m_ModeLabel.text, target.mode)
+            var modeField = new EnumField(label, target.mode)
             {
-                tooltip = m_ModeLabel.tooltip
+                tooltip = tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -4,7 +4,6 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 
 #if UNITY_EDITOR
-using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
 #endif
@@ -172,24 +171,20 @@ namespace UnityEngine.InputSystem.Composites
     #if UNITY_EDITOR
     internal class Vector3CompositeEditor : InputParameterEditor<Vector3Composite>
     {
-        private GUIContent m_ModeLabel = new GUIContent("Mode",
-            "How to synthesize a Vector3 from the inputs. Digital "
+        private const string label = "Mode";
+        private const string tooltip = "How to synthesize a Vector3 from the inputs. Digital "
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
-            + "floating-point magnitudes as read from controls.");
+            + "floating-point magnitudes as read from controls.";
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            target.mode = (Vector3Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField(m_ModeLabel.text, target.mode)
+            var modeField = new EnumField(label, target.mode)
             {
-                tooltip = m_ModeLabel.tooltip
+                tooltip = tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -176,6 +176,10 @@ namespace UnityEngine.InputSystem.Composites
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
             + "floating-point magnitudes as read from controls.";
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField(label, target.mode)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -176,10 +176,6 @@ namespace UnityEngine.InputSystem.Composites
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
             + "floating-point magnitudes as read from controls.";
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var modeField = new EnumField(label, target.mode)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.Scripting;
+
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
@@ -124,11 +124,6 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            m_PressPointSetting.OnGUI();
-            m_DurationSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -122,10 +122,6 @@ namespace UnityEngine.InputSystem.Interactions
                 () => target.duration, x => target.duration = x, () => InputSystem.settings.defaultHoldTime);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -122,6 +122,10 @@ namespace UnityEngine.InputSystem.Interactions
                 () => target.duration, x => target.duration = x, () => InputSystem.settings.defaultHoldTime);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -1,11 +1,9 @@
 using System;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.Scripting;
+
 #if UNITY_EDITOR
-using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
 #endif
 
 ////TODO: add ability to respond to any of the taps in the sequence (e.g. one response for single tap, another for double tap)
@@ -196,21 +194,14 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            target.tapCount = EditorGUILayout.IntField(m_TapCountLabel, target.tapCount);
-            m_TapDelaySetting.OnGUI();
-            m_TapTimeSetting.OnGUI();
-            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var tapCountField = new IntegerField(m_TapCountLabel.text)
+            var tapCountField = new IntegerField(tapLabel)
             {
                 value = target.tapCount,
-                tooltip = m_TapCountLabel.tooltip
+                tooltip = tapTooltip
             };
             tapCountField.RegisterValueChangedCallback(evt =>
             {
@@ -224,7 +215,8 @@ namespace UnityEngine.InputSystem.Interactions
             m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);
         }
 
-        private readonly GUIContent m_TapCountLabel = new GUIContent("Tap Count", "How many taps need to be performed in succession. Two means double-tap, three means triple-tap, and so on.");
+        private const string tapLabel = "Tap Count";
+        private const string tapTooltip = "How many taps need to be performed in succession. Two means double-tap, three means triple-tap, and so on.";
 
         private CustomOrDefaultSetting m_PressPointSetting;
         private CustomOrDefaultSetting m_TapTimeSetting;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -192,10 +192,6 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var tapCountField = new IntegerField(tapLabel)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -192,6 +192,10 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             var tapCountField = new IntegerField(tapLabel)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -1,12 +1,9 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.Scripting;
 #if UNITY_EDITOR
-using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
-using UnityEditor.UIElements;
 #endif
 
 ////TODO: protect against the control *hovering* around the press point; this should not fire the press repeatedly; probably need a zone around the press point
@@ -213,21 +210,15 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            EditorGUILayout.HelpBox(s_HelpBoxText);
-            target.behavior = (PressBehavior)EditorGUILayout.EnumPopup(s_PressBehaviorLabel, target.behavior);
-            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            root.Add(new HelpBox(s_HelpBoxText.text, HelpBoxMessageType.None));
+            root.Add(new HelpBox(helpLabel, HelpBoxMessageType.None));
 
-            var behaviourDropdown = new EnumField(s_PressBehaviorLabel.text, target.behavior)
+            var behaviourDropdown = new EnumField(triggerLabel, target.behavior)
             {
-                tooltip = s_PressBehaviorLabel.tooltip
+                tooltip = triggerTooltip
             };
             behaviourDropdown.RegisterValueChangedCallback(evt =>
             {
@@ -241,14 +232,13 @@ namespace UnityEngine.InputSystem.Interactions
 
         private CustomOrDefaultSetting m_PressPointSetting;
 
-        private static readonly GUIContent s_HelpBoxText = EditorGUIUtility.TrTextContent("Note that the 'Press' interaction is only "
+        private const string helpLabel = "Note that the 'Press' interaction is only "
             + "necessary when wanting to customize button press behavior. For default press behavior, simply set the action type to 'Button' "
-            + "and use the action without interactions added to it.");
-
-        private static readonly GUIContent s_PressBehaviorLabel = EditorGUIUtility.TrTextContent("Trigger Behavior",
-            "Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
+            + "and use the action without interactions added to it.";
+        private const string triggerLabel = "Trigger Behavior";
+        private const string triggerTooltip = "Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
             + "With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is performed on press and "
-            + "canceled on release.");
+            + "canceled on release.";
     }
     #endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -208,6 +208,10 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             root.Add(new HelpBox(helpLabel, HelpBoxMessageType.None));

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -208,10 +208,6 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             root.Add(new HelpBox(helpLabel, HelpBoxMessageType.None));

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
@@ -88,11 +87,6 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            m_DurationSetting.OnGUI();
-            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
@@ -85,10 +85,6 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
@@ -85,6 +85,10 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -1,7 +1,6 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
-using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
@@ -114,11 +113,6 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            m_DurationSetting.OnGUI();
-            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -111,10 +111,6 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -111,6 +111,10 @@ namespace UnityEngine.InputSystem.Interactions
                 () => InputSystem.settings.defaultButtonPressPoint);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine.Scripting;
 
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
@@ -93,11 +92,6 @@ namespace UnityEngine.InputSystem.Processors
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            m_MinSetting.OnGUI();
-            m_MaxSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -90,6 +90,10 @@ namespace UnityEngine.InputSystem.Processors
                 () => InputSystem.settings.defaultDeadzoneMax);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_MinSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -90,10 +90,6 @@ namespace UnityEngine.InputSystem.Processors
                 () => InputSystem.settings.defaultDeadzoneMax);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_MinSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine.Scripting;
 
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
@@ -82,11 +81,6 @@ namespace UnityEngine.InputSystem.Processors
 
         public override void OnGUI()
         {
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            m_MinSetting.OnGUI();
-            m_MaxSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -79,10 +79,6 @@ namespace UnityEngine.InputSystem.Processors
                 () => InputSystem.settings.defaultDeadzoneMax);
         }
 
-        public override void OnGUI()
-        {
-        }
-
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_MinSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -79,6 +79,10 @@ namespace UnityEngine.InputSystem.Processors
                 () => InputSystem.settings.defaultDeadzoneMax);
         }
 
+        public override void OnGUI()
+        {
+        }
+
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
             m_MinSetting.OnDrawVisualElements(root, onChangedCallback);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Analytics/InputBuildAnalytic.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Analytics/InputBuildAnalytic.cs
@@ -195,9 +195,6 @@ namespace UnityEngine.InputSystem.Editor
                 feature_paranoid_read_value_caching_checks_enabled =
                     settings.IsFeatureEnabled(InputFeatureNames.kParanoidReadValueCachingChecks);
 
-                feature_use_imgui_editor_for_assets =
-                    settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets);
-
                 feature_disable_unity_remote_support =
                     settings.IsFeatureEnabled(InputFeatureNames.kDisableUnityRemoteSupport);
                 feature_run_player_updates_in_editmode =
@@ -329,12 +326,6 @@ namespace UnityEngine.InputSystem.Editor
             /// as defined in InputSystem 1.8.x.
             /// </summary>
             public bool feature_paranoid_read_value_caching_checks_enabled;
-
-            /// <summary>
-            /// Represents internal feature flag <see cref="InputFeatureNames.kUseIMGUIEditorForAssets" />
-            /// as defined in InputSystem 1.8.x.
-            /// </summary>
-            public bool feature_use_imgui_editor_for_assets;
 
             /// <summary>
             /// Represents internal feature flag <see cref="InputFeatureNames.kDisableUnityRemoteSupport" />

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -134,7 +134,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                     parameter.value = parameter.value.ConvertTo(underlyingTypeCode);
 
                     // Read enum names and values.
-                    parameter.enumNames = Enum.GetNames(fieldType).Select(x => new GUIContent(x)).ToArray();
+                    parameter.enumNames = Enum.GetNames(fieldType);
                     ////REVIEW: this probably falls apart if multiple members have the same value
                     var list = new List<int>();
                     foreach (var value in Enum.GetValues(fieldType))
@@ -223,7 +223,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 m_ParameterEditor = null;
 
                 // Create parameter labels.
-                m_ParameterLabels = new GUIContent[m_Parameters.Length];
+                m_ParameterLabels = new Tuple<string, string>[m_Parameters.Length];
                 for (var i = 0; i < m_Parameters.Length; ++i)
                 {
                     // Look up tooltip from field.
@@ -235,7 +235,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
                     // Create label.
                     var niceName = ObjectNames.NicifyVariableName(m_Parameters[i].value.name);
-                    m_ParameterLabels[i] = new GUIContent(niceName, tooltip);
+                    m_ParameterLabels[i] = new Tuple<string, string>(niceName, tooltip);
                 }
             }
         }
@@ -276,15 +276,15 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
                 if (parameter.isEnum)
                 {
-                    var names = parameter.enumNames.Select(c => c.text).ToList();
+                    var names = parameter.enumNames.ToList();
                     var rawValue = parameter.value.value.ToInt32();
                     var selectedIndex = parameter.enumValues.IndexOf(rawValue);
                     if (selectedIndex < 0 || selectedIndex >= names.Count)
                         selectedIndex = 0;
 
-                    var field = new DropdownField(label.text, names, selectedIndex)
+                    var field = new DropdownField(label.Item1, names, selectedIndex)
                     {
-                        tooltip = label.tooltip
+                        tooltip = label.Item2
                     };
 
                     field.RegisterValueChangedCallback(evt =>
@@ -301,7 +301,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Int64 || parameter.value.type == TypeCode.UInt64)
                 {
                     var longValue = parameter.value.value.ToInt64();
-                    var field = new LongField(label.text) { value = longValue, tooltip = label.tooltip };
+                    var field = new LongField(label.Item1) { value = longValue, tooltip = label.Item2 };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -309,7 +309,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type.IsInt())
                 {
                     var intValue = parameter.value.value.ToInt32();
-                    var field = new IntegerField(label.text) { value = intValue, tooltip = label.tooltip };
+                    var field = new IntegerField(label.Item1) { value = intValue, tooltip = label.Item2 };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -317,7 +317,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Single)
                 {
                     var floatValue = parameter.value.value.ToSingle();
-                    var field = new FloatField(label.text) { value = floatValue, tooltip = label.tooltip };
+                    var field = new FloatField(label.Item1) { value = floatValue, tooltip = label.Item2 };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -325,7 +325,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Double)
                 {
                     var floatValue = parameter.value.value.ToDouble();
-                    var field = new DoubleField(label.text) { value = floatValue, tooltip = label.tooltip };
+                    var field = new DoubleField(label.Item1) { value = floatValue, tooltip = label.Item2 };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -333,7 +333,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Boolean)
                 {
                     var boolValue = parameter.value.value.ToBoolean();
-                    var field = new Toggle(label.text) { value = boolValue, tooltip = label.tooltip };
+                    var field = new Toggle(label.Item1) { value = boolValue, tooltip = label.Item2 };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterValueChangedCallback(_ => OnEditEnd());
                     root.Add(field);
@@ -382,14 +382,16 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
         private InputParameterEditor m_ParameterEditor;
         private EditableParameterValue[] m_Parameters;
-        private GUIContent[] m_ParameterLabels;
+
+        // .Item1 is text, .Item2 is tooltip
+        private Tuple<string, string>[] m_ParameterLabels;
 
         private struct EditableParameterValue
         {
             public NamedValue value;
             public NamedValue? defaultValue;
             public int[] enumValues;
-            public GUIContent[] enumNames;
+            public string[] enumNames;
             public FieldInfo field;
 
             public bool isEnum => enumValues != null;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -223,7 +223,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 m_ParameterEditor = null;
 
                 // Create parameter labels.
-                m_ParameterLabels = new Tuple<string, string>[m_Parameters.Length];
+                m_ParameterLabels = new (string text, string tooltip)[m_Parameters.Length];
                 for (var i = 0; i < m_Parameters.Length; ++i)
                 {
                     // Look up tooltip from field.
@@ -235,7 +235,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
                     // Create label.
                     var niceName = ObjectNames.NicifyVariableName(m_Parameters[i].value.name);
-                    m_ParameterLabels[i] = new Tuple<string, string>(niceName, tooltip);
+                    m_ParameterLabels[i] = (niceName, tooltip);
                 }
             }
         }
@@ -282,9 +282,9 @@ namespace UnityEngine.InputSystem.Editor.Lists
                     if (selectedIndex < 0 || selectedIndex >= names.Count)
                         selectedIndex = 0;
 
-                    var field = new DropdownField(label.Item1, names, selectedIndex)
+                    var field = new DropdownField(label.text, names, selectedIndex)
                     {
-                        tooltip = label.Item2
+                        tooltip = label.tooltip
                     };
 
                     field.RegisterValueChangedCallback(evt =>
@@ -301,7 +301,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Int64 || parameter.value.type == TypeCode.UInt64)
                 {
                     var longValue = parameter.value.value.ToInt64();
-                    var field = new LongField(label.Item1) { value = longValue, tooltip = label.Item2 };
+                    var field = new LongField(label.text) { value = longValue, tooltip = label.tooltip };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -309,7 +309,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type.IsInt())
                 {
                     var intValue = parameter.value.value.ToInt32();
-                    var field = new IntegerField(label.Item1) { value = intValue, tooltip = label.Item2 };
+                    var field = new IntegerField(label.text) { value = intValue, tooltip = label.tooltip };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -317,7 +317,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Single)
                 {
                     var floatValue = parameter.value.value.ToSingle();
-                    var field = new FloatField(label.Item1) { value = floatValue, tooltip = label.Item2 };
+                    var field = new FloatField(label.text) { value = floatValue, tooltip = label.tooltip };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -325,7 +325,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Double)
                 {
                     var floatValue = parameter.value.value.ToDouble();
-                    var field = new DoubleField(label.Item1) { value = floatValue, tooltip = label.Item2 };
+                    var field = new DoubleField(label.text) { value = floatValue, tooltip = label.tooltip };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterCallback<BlurEvent>(_ => OnEditEnd());
                     root.Add(field);
@@ -333,7 +333,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 else if (parameter.value.type == TypeCode.Boolean)
                 {
                     var boolValue = parameter.value.value.ToBoolean();
-                    var field = new Toggle(label.Item1) { value = boolValue, tooltip = label.Item2 };
+                    var field = new Toggle(label.text) { value = boolValue, tooltip = label.tooltip };
                     field.RegisterValueChangedCallback(evt => OnValueChanged(ref parameter, evt.newValue, closedIndex));
                     field.RegisterValueChangedCallback(_ => OnEditEnd());
                     root.Add(field);
@@ -382,8 +382,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
         private InputParameterEditor m_ParameterEditor;
         private EditableParameterValue[] m_Parameters;
 
-        // .Item1 is text, .Item2 is tooltip
-        private Tuple<string, string>[] m_ParameterLabels;
+        private (string text, string tooltip)[] m_ParameterLabels;
 
         private struct EditableParameterValue
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
-using UnityEditor.UIElements;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.UIElements;
@@ -350,72 +349,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
         public void OnGUI()
         {
-            // If we have a dedicated parameter editor, let it do all the work.
-            if (m_ParameterEditor != null)
-            {
-                EditorGUI.BeginChangeCheck();
-                m_ParameterEditor.OnGUI();
-                if (EditorGUI.EndChangeCheck())
-                {
-                    ReadParameterValuesFrom(m_ParameterEditor.target);
-                    onChange?.Invoke();
-                }
-                return;
-            }
-
-            // handled by OnDrawVisualElements with UI Toolkit
-            if (!InputSystem.settings.useIMGUIEditorForAssets)
-                return;
-
-            // Otherwise, fall back to our default logic.
-            if (m_Parameters == null)
-                return;
-            for (var i = 0; i < m_Parameters.Length; i++)
-            {
-                var parameter = m_Parameters[i];
-                var label = m_ParameterLabels[i];
-
-                EditorGUI.BeginChangeCheck();
-
-                object result = null;
-                if (parameter.isEnum)
-                {
-                    var intValue = parameter.value.value.ToInt32();
-                    result = EditorGUILayout.IntPopup(label, intValue, parameter.enumNames, parameter.enumValues);
-                }
-                else if (parameter.value.type == TypeCode.Int64 || parameter.value.type == TypeCode.UInt64)
-                {
-                    var longValue = parameter.value.value.ToInt64();
-                    result = EditorGUILayout.LongField(label, longValue);
-                }
-                else if (parameter.value.type.IsInt())
-                {
-                    var intValue = parameter.value.value.ToInt32();
-                    result = EditorGUILayout.IntField(label, intValue);
-                }
-                else if (parameter.value.type == TypeCode.Single)
-                {
-                    var floatValue = parameter.value.value.ToSingle();
-                    result = EditorGUILayout.FloatField(label, floatValue);
-                }
-                else if (parameter.value.type == TypeCode.Double)
-                {
-                    var floatValue = parameter.value.value.ToDouble();
-                    result = EditorGUILayout.DoubleField(label, floatValue);
-                }
-                else if (parameter.value.type == TypeCode.Boolean)
-                {
-                    var boolValue = parameter.value.value.ToBoolean();
-                    result = EditorGUILayout.Toggle(label, boolValue);
-                }
-
-                if (EditorGUI.EndChangeCheck())
-                {
-                    parameter.value.value = PrimitiveValue.FromObject(result).ConvertTo(parameter.value.type);
-                    m_Parameters[i] = parameter;
-                    onChange?.Invoke();
-                }
-            }
+            
         }
 
         ////REVIEW: check whether parameters have *actually* changed?

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -223,7 +223,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 m_ParameterEditor = null;
 
                 // Create parameter labels.
-                m_ParameterLabels = new (string text, string tooltip)[m_Parameters.Length];
+                m_ParameterLabels = new(string text, string tooltip)[m_Parameters.Length];
                 for (var i = 0; i < m_Parameters.Length; ++i)
                 {
                     // Look up tooltip from field.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -349,7 +349,6 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
         public void OnGUI()
         {
-            
         }
 
         ////REVIEW: check whether parameters have *actually* changed?

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -28,11 +28,6 @@ namespace UnityEngine.InputSystem.Editor
         public object target { get; internal set; }
 
         /// <summary>
-        /// Callback for implementing a custom UI.
-        /// </summary>
-        public abstract void OnGUI();
-
-        /// <summary>
         /// Add visual elements for this parameter editor to a root VisualElement.
         /// </summary>
         /// <param name="root">The VisualElement that parameter editor elements should be added to.</param>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -28,6 +28,11 @@ namespace UnityEngine.InputSystem.Editor
         public object target { get; internal set; }
 
         /// <summary>
+        /// Callback for implementing a custom UI.
+        /// </summary>
+        public abstract void OnGUI();
+
+        /// <summary>
         /// Add visual elements for this parameter editor to a root VisualElement.
         /// </summary>
         /// <param name="root">The VisualElement that parameter editor elements should be added to.</param>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -28,6 +28,13 @@ namespace UnityEngine.InputSystem.Editor
         public object target { get; internal set; }
 
         /// <summary>
+        /// Callback for implementing a custom UI.
+        /// It was mostly needed for the imgui-based editors and should be avoided now.
+        /// Should be removed once we can release the next major version.
+        /// </summary>
+        public void OnGUI() { }
+
+        /// <summary>
         /// Add visual elements for this parameter editor to a root VisualElement.
         /// </summary>
         /// <param name="root">The VisualElement that parameter editor elements should be added to.</param>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -32,7 +32,7 @@ namespace UnityEngine.InputSystem.Editor
         /// It was mostly needed for the imgui-based editors and should be avoided now.
         /// Should be removed once we can release the next major version.
         /// </summary>
-        public void OnGUI() { }
+        public void OnGUI() {}
 
         /// <summary>
         /// Add visual elements for this parameter editor to a root VisualElement.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputParameterEditor.cs
@@ -28,13 +28,6 @@ namespace UnityEngine.InputSystem.Editor
         public object target { get; internal set; }
 
         /// <summary>
-        /// Callback for implementing a custom UI.
-        /// It was mostly needed for the imgui-based editors and should be avoided now.
-        /// Should be removed once we can release the next major version.
-        /// </summary>
-        public void OnGUI() {}
-
-        /// <summary>
         /// Add visual elements for this parameter editor to a root VisualElement.
         /// </summary>
         /// <param name="root">The VisualElement that parameter editor elements should be added to.</param>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -58,9 +58,6 @@ namespace UnityEngine.InputSystem.Editor
 
         private static bool OpenAsset(Object obj)
         {
-            if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
-                return false;
-
             // Grab InputActionAsset.
             // NOTE: We defer checking out an asset until we save it. This allows a user to open an .inputactions asset and look at it
             //       without forcing a checkout.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -171,8 +171,6 @@ namespace UnityEngine.InputSystem.Editor
             var foldout = container.Q<Foldout>("Foldout");
             foldout.text = parameterListView.name;
             parameterListView.OnDrawVisualElements(foldout);
-
-            foldout.Add(new IMGUIContainer(parameterListView.OnGUI));
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -984,7 +984,7 @@ namespace UnityEngine.InputSystem
         }
 
 #if UNITY_EDITOR
-        [Obsolete("The useIMGUIEditorForAssets feature is obsolete and will be removed in a future release.")]
+        [Obsolete("useIMGUIEditorForAssets is obsolete and will be removed in a future release.")]
         public bool useIMGUIEditorForAssets => false;
 #endif
 

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -739,6 +739,11 @@ namespace UnityEngine.InputSystem
             if (string.IsNullOrEmpty(featureName))
                 throw new ArgumentNullException(nameof(featureName));
 
+            if (featureName == InputFeatureNames.kUseIMGUIEditorForAssets)
+            {
+                throw new ArgumentException($"The {InputFeatureNames.kUseIMGUIEditorForAssets} feature flag is no longer supported.");
+            }
+
             if (m_FeatureFlags == null)
                 m_FeatureFlags = new HashSet<string>();
 
@@ -979,14 +984,8 @@ namespace UnityEngine.InputSystem
         }
 
 #if UNITY_EDITOR
-        /// <summary>
-        /// Determines if we should render the UI with IMGUI even if an UI Toolkit UI is available.
-        ///
-        /// This should be used when writing a custom <see cref="InputParameterEditor"/> to :
-        /// * support inspector view which only work in IMGUI for now.
-        /// * prevent the UI to be rendered in IMGUI and UI Toolkit in the Input Actions Editor window.
-        /// </summary>
-        public bool useIMGUIEditorForAssets => UnityEditor.EditorGUI.indentLevel > 0 || IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets);
+        [Obsolete("The useIMGUIEditorForAssets feature is obsolete and will be removed in a future release.")]
+        public bool useIMGUIEditorForAssets => false;
 #endif
 
         private static bool CompareFloats(float a, float b)


### PR DESCRIPTION
### Description

Here we deprecate the useIMGUIEditorForAssets feature flag. 

The aim is to reduce total variability caused by having to keep code that can work both ways - with uitk and without. We've had the uitk code running for a while now, and with the minimum supported Editor being 22.3 TLS we no longer have to care about the case when uitk wasn't available. 

### Testing status & QA

Local testing

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
