### PR TITLE
CHANGE: Use UTR 1.42.0 for iOS jobs

### DIFF
--- a/.yamato/input-system-mobile-functional-build-jobs.yml
+++ b/.yamato/input-system-mobile-functional-build-jobs.yml
@@ -66,9 +66,9 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_ios:
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c iOS --fast --wait
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -167,9 +167,9 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_ios:
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c iOS --fast --wait
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -268,9 +268,9 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_ios:
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c iOS --fast --wait
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -369,9 +369,9 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_ios:
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c iOS --fast --wait
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -471,9 +471,9 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios:
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c iOS --fast --wait
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -573,9 +573,9 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_ios:
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c iOS --fast --wait
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-functional-build-jobs.yml
+++ b/.yamato/input-system-mobile-functional-build-jobs.yml
@@ -9,16 +9,10 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -37,16 +31,10 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -110,16 +98,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -138,16 +120,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -211,16 +187,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -239,16 +209,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -312,16 +276,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -340,16 +298,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -414,16 +366,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -442,16 +388,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -516,16 +456,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -544,16 +478,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:

--- a/.yamato/input-system-mobile-functional-build-jobs.yml
+++ b/.yamato/input-system-mobile-functional-build-jobs.yml
@@ -9,10 +9,16 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -31,10 +37,16 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -53,7 +65,10 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -63,6 +78,8 @@ inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_ios:
     players:
       paths:
       - build/players/**/*
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalBuildJobs - 2022.3 - TvOS
 inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_tvos:
@@ -93,10 +110,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -115,10 +138,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -137,7 +166,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -147,6 +179,8 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_ios:
     players:
       paths:
       - build/players/**/*
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalBuildJobs - 6000.0 - TvOS
 inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_tvos:
@@ -177,10 +211,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -199,10 +239,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -221,7 +267,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -231,6 +280,8 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_ios:
     players:
       paths:
       - build/players/**/*
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalBuildJobs - 6000.2 - TvOS
 inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_tvos:
@@ -261,10 +312,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -283,10 +340,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -305,7 +368,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -317,6 +383,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_ios:
       - build/players/**/*
   variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalBuildJobs - 6000.3 - TvOS
 inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_tvos:
@@ -347,10 +414,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -369,10 +442,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -391,7 +470,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -403,6 +485,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios:
       - build/players/**/*
   variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalBuildJobs - 6000.4 - TvOS
 inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_tvos:
@@ -433,10 +516,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_il2cpp:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -455,10 +544,16 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_mono:
     flavor: b1.xlarge
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
     logs:
@@ -477,7 +572,10 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: ./utr.bat --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -489,6 +587,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_ios:
       - build/players/**/*
   variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalBuildJobs - 6000.5 - TvOS
 inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_tvos:

--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -62,9 +62,9 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_ios:
     model: SE
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -156,9 +156,9 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_ios:
     model: SE
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -250,9 +250,9 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_ios:
     model: SE
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -344,9 +344,9 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_ios:
     model: SE-Gen3
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -438,9 +438,9 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
     model: SE-Gen3
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -532,9 +532,9 @@ inputsystem-mobilefunctionaltests_-_6000_5_-_ios:
     model: SE-Gen3
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -61,7 +61,10 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -70,6 +73,8 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 2022.3 - TvOS
 inputsystem-mobilefunctionaltests_-_2022_3_-_tvos:
@@ -150,7 +155,10 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -159,6 +167,8 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.0 - TvOS
 inputsystem-mobilefunctionaltests_-_6000_0_-_tvos:
@@ -239,7 +249,10 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,6 +261,8 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.2 - TvOS
 inputsystem-mobilefunctionaltests_-_6000_2_-_tvos:
@@ -328,7 +343,10 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -337,6 +355,8 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.3 - TvOS
 inputsystem-mobilefunctionaltests_-_6000_3_-_tvos:
@@ -417,7 +437,10 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -426,6 +449,8 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.4 - TvOS
 inputsystem-mobilefunctionaltests_-_6000_4_-_tvos:
@@ -506,7 +531,10 @@ inputsystem-mobilefunctionaltests_-_6000_5_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -515,6 +543,8 @@ inputsystem-mobilefunctionaltests_-_6000_5_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.5 - TvOS
 inputsystem-mobilefunctionaltests_-_6000_5_-_tvos:

--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -64,7 +64,7 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -158,7 +158,7 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -252,7 +252,7 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -346,7 +346,7 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -440,7 +440,7 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -534,7 +534,7 @@ inputsystem-mobilefunctionaltests_-_6000_5_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-performance-build-jobs.yml
+++ b/.yamato/input-system-mobile-performance-build-jobs.yml
@@ -11,7 +11,7 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -33,7 +33,7 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_android_-_mono:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -53,7 +53,10 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 2022.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -63,6 +66,8 @@ inputsystem-mobileperformancebuildjobs_-_2022_3_-_ios:
     players:
       paths:
       - build/players/**/*
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceBuildJobs - 2022.3 - TvOS
 inputsystem-mobileperformancebuildjobs_-_2022_3_-_tvos:
@@ -95,7 +100,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -117,7 +122,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -137,7 +142,10 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -147,6 +155,8 @@ inputsystem-mobileperformancebuildjobs_-_6000_0_-_ios:
     players:
       paths:
       - build/players/**/*
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceBuildJobs - 6000.0 - TvOS
 inputsystem-mobileperformancebuildjobs_-_6000_0_-_tvos:
@@ -179,7 +189,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -201,7 +211,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -221,7 +231,10 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.2/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -231,6 +244,8 @@ inputsystem-mobileperformancebuildjobs_-_6000_2_-_ios:
     players:
       paths:
       - build/players/**/*
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceBuildJobs - 6000.2 - TvOS
 inputsystem-mobileperformancebuildjobs_-_6000_2_-_tvos:
@@ -263,7 +278,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -285,7 +300,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -305,7 +320,10 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -317,6 +335,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_ios:
       - build/players/**/*
   variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceBuildJobs - 6000.3 - TvOS
 inputsystem-mobileperformancebuildjobs_-_6000_3_-_tvos:
@@ -349,7 +368,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_il2cpp:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -371,7 +390,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_mono:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -391,7 +410,10 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u 6000.4/staging -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -403,6 +425,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_4_-_ios:
       - build/players/**/*
   variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceBuildJobs - 6000.4 - TvOS
 inputsystem-mobileperformancebuildjobs_-_6000_4_-_tvos:
@@ -435,7 +458,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_5_-_android_-_il2cpp:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -457,7 +480,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_5_-_android_-_mono:
   - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:
@@ -477,7 +500,10 @@ inputsystem-mobileperformancebuildjobs_-_6000_5_-_ios:
     flavor: m1.mac
   commands:
   - command: unity-downloader-cli -u trunk -c Editor -c iOS --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -489,6 +515,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_5_-_ios:
       - build/players/**/*
   variables:
     UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceBuildJobs - 6000.5 - TvOS
 inputsystem-mobileperformancebuildjobs_-_6000_5_-_tvos:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -64,7 +64,7 @@ inputsystem-mobileperformancetests_-_2022_3_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -158,7 +158,7 @@ inputsystem-mobileperformancetests_-_6000_0_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -252,7 +252,7 @@ inputsystem-mobileperformancetests_-_6000_2_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -346,7 +346,7 @@ inputsystem-mobileperformancetests_-_6000_3_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -440,7 +440,7 @@ inputsystem-mobileperformancetests_-_6000_4_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -534,7 +534,7 @@ inputsystem-mobileperformancetests_-_6000_5_-_ios:
   - command: |-
       curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
       chmod u+x utr.bat
-  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -61,7 +61,10 @@ inputsystem-mobileperformancetests_-_2022_3_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -70,6 +73,8 @@ inputsystem-mobileperformancetests_-_2022_3_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_2022_3_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 2022.3 - TvOS
 inputsystem-mobileperformancetests_-_2022_3_-_tvos:
@@ -150,7 +155,10 @@ inputsystem-mobileperformancetests_-_6000_0_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -159,6 +167,8 @@ inputsystem-mobileperformancetests_-_6000_0_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_0_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.0 - TvOS
 inputsystem-mobileperformancetests_-_6000_0_-_tvos:
@@ -239,7 +249,10 @@ inputsystem-mobileperformancetests_-_6000_2_-_ios:
     flavor: m1.mac
     model: SE
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -248,6 +261,8 @@ inputsystem-mobileperformancetests_-_6000_2_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_2_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.2 - TvOS
 inputsystem-mobileperformancetests_-_6000_2_-_tvos:
@@ -328,7 +343,10 @@ inputsystem-mobileperformancetests_-_6000_3_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -337,6 +355,8 @@ inputsystem-mobileperformancetests_-_6000_3_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_3_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.3 - TvOS
 inputsystem-mobileperformancetests_-_6000_3_-_tvos:
@@ -417,7 +437,10 @@ inputsystem-mobileperformancetests_-_6000_4_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -426,6 +449,8 @@ inputsystem-mobileperformancetests_-_6000_4_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.4 - TvOS
 inputsystem-mobileperformancetests_-_6000_4_-_tvos:
@@ -506,7 +531,10 @@ inputsystem-mobileperformancetests_-_6000_5_-_ios:
     flavor: m1.mac
     model: SE-Gen3
   commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
+      chmod u+x utr.bat
+  - command: utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -515,6 +543,8 @@ inputsystem-mobileperformancetests_-_6000_5_-_ios:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_5_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.5 - TvOS
 inputsystem-mobileperformancetests_-_6000_5_-_tvos:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -62,9 +62,9 @@ inputsystem-mobileperformancetests_-_2022_3_-_ios:
     model: SE
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -156,9 +156,9 @@ inputsystem-mobileperformancetests_-_6000_0_-_ios:
     model: SE
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -250,9 +250,9 @@ inputsystem-mobileperformancetests_-_6000_2_-_ios:
     model: SE
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -344,9 +344,9 @@ inputsystem-mobileperformancetests_-_6000_3_-_ios:
     model: SE-Gen3
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -438,9 +438,9 @@ inputsystem-mobileperformancetests_-_6000_4_-_ios:
     model: SE-Gen3
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:
@@ -532,9 +532,9 @@ inputsystem-mobileperformancetests_-_6000_5_-_ios:
     model: SE-Gen3
   commands:
   - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr.bat
-      chmod u+x utr.bat
-  - command: ./utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
   artifacts:

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -60,7 +60,7 @@ public abstract class MobileBaseRecipe: BaseRecipe
             case SystemType.IOS:
                 job.WithCommands(utrDownloadCommand);
                 job.WithEnvironmentVariable("UTR_VERSION", "1.42.0");
-                return executableName;
+                return "./" + executableName;
             default:
                 return "UnifiedTestRunner";
         }

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -49,18 +49,18 @@ public abstract class MobileBaseRecipe: BaseRecipe
 
     protected string PrepareUtrExecutable(IJobBuilder job, SystemType systemType)
     {
-        var executableName = "utr.bat";
-        var utrDownloadCommand = UtrCommand.Download(systemType, executableName);
         switch (systemType)
         {
             case SystemType.Android:
                 job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
-                job.WithCommands(utrDownloadCommand);
-                return executableName;
+                job.WithCommands(UtrCommand.Download(systemType, "utr.bat"));
+                return "utr.bat";
             case SystemType.IOS:
-                job.WithCommands(utrDownloadCommand);
+                job.WithCommands(UtrCommand.Download(systemType, "utr"));
+                // A temporary fix for the issue where UTR 1.41.0 cannot handle new signing for 6000.5 on iOS platform.
+                // It can be removed once https://artifactory.prd.it.unity3d.com/ui/native/unity-tools-local/utr-standalone/utr has been bumped to 1.42.0 or above.
                 job.WithEnvironmentVariable("UTR_VERSION", "1.42.0");
-                return "./" + executableName;
+                return "./utr";
             default:
                 return "UnifiedTestRunner";
         }

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -52,6 +52,9 @@ public abstract class MobileBaseRecipe: BaseRecipe
         switch (systemType)
         {
             case SystemType.Android:
+                // For build jobs on Android, we still use the built-in UTR and the extra commands are not needed.
+                if (job.Name.Contains("BuildJobs"))
+                    break;
                 job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
                 job.WithCommands(UtrCommand.Download(systemType, "utr.bat"));
                 return "utr.bat";
@@ -61,8 +64,8 @@ public abstract class MobileBaseRecipe: BaseRecipe
                 // It can be removed once https://artifactory.prd.it.unity3d.com/ui/native/unity-tools-local/utr-standalone/utr has been bumped to 1.42.0 or above.
                 job.WithEnvironmentVariable("UTR_VERSION", "1.42.0");
                 return "./utr";
-            default:
-                return "UnifiedTestRunner";
         }
+
+        return "UnifiedTestRunner";
     }
 }

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -19,10 +19,6 @@ public abstract class MobileBaseRecipe: BaseRecipe
             var supportedVersions = package.SupportedEditorVersions;
             foreach (var version in supportedVersions)
             {
-                // Skip tests on 2021.3 as it is longer supported
-                if (version == "2021.3")
-                    continue;
-
                 if (platform.System == SystemType.Android)
                 {
                     builders.AddRange(ProduceJobsForAndroid(package, platform, version));
@@ -53,15 +49,20 @@ public abstract class MobileBaseRecipe: BaseRecipe
 
     protected string PrepareUtrExecutable(IJobBuilder job, SystemType systemType)
     {
-        if (systemType == SystemType.Android)
+        var executableName = "utr.bat";
+        var utrDownloadCommand = UtrCommand.Download(systemType, executableName);
+        switch (systemType)
         {
-            var executableName = "utr.bat";
-            job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
-            var utrDownloadCommand = UtrCommand.Download(systemType, executableName);
-            job.WithCommands(utrDownloadCommand);
-            return executableName;
+            case SystemType.Android:
+                job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
+                job.WithCommands(utrDownloadCommand);
+                return executableName;
+            case SystemType.IOS:
+                job.WithCommands(utrDownloadCommand);
+                job.WithEnvironmentVariable("UTR_VERSION", "1.42.0");
+                return executableName;
+            default:
+                return "UnifiedTestRunner";
         }
-
-        return "UnifiedTestRunner";
     }
 }

--- a/Tools/CI/Recipes/MobileFunctionalTests.cs
+++ b/Tools/CI/Recipes/MobileFunctionalTests.cs
@@ -26,8 +26,10 @@ public class MobileFunctionalBuildJobs: MobileBaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform)
             .WithCommands(Utilities.GetEditorDownloadCommand(unityBranch, platform));
+        
+        var utrExecutable = PrepareUtrExecutable(job, platform.System);
 
-        var utrCommand = UtrCommand.Run(platform.System, b => b
+        var utrCommand = UtrCommand.Run(platform.System, utrExecutable,b => b
                 .WithTestProject($"{ProjectPath}")
                 .WithEditor(".Editor")
                 .WithSuite(UtrTestSuiteType.Playmode)

--- a/Tools/CI/Recipes/MobilePerformanceTests.cs
+++ b/Tools/CI/Recipes/MobilePerformanceTests.cs
@@ -26,8 +26,10 @@ public class MobilePerformanceBuildJobs: MobileBaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform)
             .WithCommands(Utilities.GetEditorDownloadCommand(unityBranch, platform));
+        
+        var utrExecutable = PrepareUtrExecutable(job, platform.System);
 
-        var utrCommand = UtrCommand.Run(platform.System, b => b
+        var utrCommand = UtrCommand.Run(platform.System, utrExecutable,b => b
                 .WithTestProject($"{ProjectPath}")
                 .WithEditor(".Editor")
                 .WithSuite(UtrTestSuiteType.Playmode)

--- a/Tools/CI/Recipes/Triggers.cs
+++ b/Tools/CI/Recipes/Triggers.cs
@@ -15,16 +15,16 @@ public class Triggers: RecipeBase
     IEnumerable<Dependency> allEditorFunctionalTests = new EditorFunctionalTests().AsDependencies();
     IEnumerable<Dependency> allStandaloneFunctionalTests = new StandaloneFunctionalTests().AsDependencies();
     IEnumerable<Dependency> allStandaloneIl2CppFunctionalTests = new StandaloneIl2CppFunctionalTests().AsDependencies();
-    // Run functional tests in all Unity versions on all mobile platforms except for TvOS, which only runs in 2021.3.
-    IEnumerable<Dependency> allMobileFunctionalTests = new MobileFunctionalTests().AsDependencies().Where( d => !d.JobId.Contains("TvOS") || d.JobId.Contains("2021.3"));
+    // Run functional tests in all Unity versions on all mobile platforms except TvOS.
+    IEnumerable<Dependency> allMobileFunctionalTests = new MobileFunctionalTests().AsDependencies().Where( d => !d.JobId.Contains("TvOS"));
     // Run functional build jobs on TvOS for all Unity versions.
     IEnumerable<Dependency> allTvOSFunctionalBuildJobs = new MobileFunctionalBuildJobs().AsDependencies().Where(d=> d.JobId.Contains("TvOS"));
     
     IEnumerable<Dependency> allEditorPerformanceTests = new EditorPerformanceTests().AsDependencies();
     IEnumerable<Dependency> allStandalonePerformanceTests = new StandalonePerformanceTests().AsDependencies();
     IEnumerable<Dependency> allStandaloneIl2CppPerformanceTests = new StandaloneIl2CppPerformanceTests().AsDependencies();
-    // Run performance tests in all Unity versions on all mobile platforms except for TvOS, which only runs in 2021.3.
-    IEnumerable<Dependency> allMobilePerformanceTests = new MobilePerformanceTests().AsDependencies().Where( d => !d.JobId.Contains("TvOS") || d.JobId.Contains("2021.3"));
+    // Run performance tests in all Unity versions on all mobile platforms except TvOS.
+    IEnumerable<Dependency> allMobilePerformanceTests = new MobilePerformanceTests().AsDependencies().Where( d => !d.JobId.Contains("TvOS"));
     // Run performance build jobs on TvOS for all Unity versions.
     IEnumerable<Dependency> allTvOSPerformanceBuildJobs = new MobilePerformanceBuildJobs().AsDependencies().Where(d=> d.JobId.Contains("TvOS"));
         


### PR DESCRIPTION
### Description

Explicitly set UTR to `1.42.0` for iOS jobs to fix signing issue.

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
