### PR TITLE
FIX: InputSystem file with correct manual links to Processors page

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSystem.cs
@@ -868,7 +868,7 @@ namespace UnityEngine.InputSystem
         /// different names. When doing so, the first registration is considered as the "proper"
         /// name for the processor and all subsequent registrations will be considered aliases.
         ///
-        /// See the <a href="../manual/Processors.html">manual</a> for more details.
+        /// See the <a href="../manual/UsingProcessors.html">manual</a> for more details.
         /// </remarks>
         /// <seealso cref="InputProcessor{T}"/>
         /// <seealso cref="InputBinding.processors"/>
@@ -996,7 +996,7 @@ namespace UnityEngine.InputSystem
         /// different names. When doing so, the first registration is considered as the "proper"
         /// name for the processor and all subsequent registrations will be considered aliases.
         ///
-        /// See the <a href="../manual/Processors.html">manual</a> for more details.
+        /// See the <a href="../manual/UsingProcessors.html">manual</a> for more details.
         /// </remarks>
         /// <seealso cref="InputProcessor{T}"/>
         /// <seealso cref="InputBinding.processors"/>


### PR DESCRIPTION
### Description

Update InputSystem file with correct documentation manual links to **Processors**.

Before:
`/// See the <a href="../manual/Processors.html">manual</a> for more details.`

After:
`/// See the <a href="../manual/UsingProcessors.html">manual</a> for more details.`


<img width="1728" height="1117" alt="Screenshot 2025-11-25 at 16 34 23" src="https://github.com/user-attachments/assets/20455e1a-6996-478d-9263-d01e208a68c1" />


Current [page](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.16/api/UnityEngine.InputSystem.InputSystem.html#UnityEngine_InputSystem_InputSystem_RegisterProcessor_System_Type_System_String_) with broken links

Broken link: https://docs.unity3d.com/Packages/com.unity.inputsystem@1.16/manual/Processors.html

New link: https://docs.unity3d.com/Packages/com.unity.inputsystem@1.16/manual/UsingProcessors.html


JIRA: https://jira.unity3d.com/browse/DOCATT-9900

### Testing status & QA

n/a

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
