### PR TITLE
FIX: XR input replay preserves device usages

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -269,6 +269,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 writer.Write(device.layout);
                 writer.Write(device.stateFormat);
                 writer.Write(device.stateSizeInBytes);
+                writer.Write(device.m_UsagesJson ?? string.Empty);
                 writer.Write(device.m_FullLayoutJson ?? string.Empty);
             }
 
@@ -392,6 +393,7 @@ namespace UnityEngine.InputSystem.LowLevel
                             layout = reader.ReadString(),
                             stateFormat = reader.ReadInt32(),
                             stateSizeInBytes = reader.ReadInt32(),
+                            m_UsagesJson = reader.ReadString(),
                             m_FullLayoutJson = reader.ReadString()
                         };
                     }
@@ -923,6 +925,12 @@ namespace UnityEngine.InputSystem.LowLevel
                         m_Layout = device.layout,
                         m_StateFormat = device.stateBlock.format,
                         m_StateSizeInBytes = (int)device.stateBlock.alignedSizeInBytes,
+
+                        // if the device has usages, store them as JSON in the device info
+                        // This way, when replaying the trace, we can recreate the device with the correct usages. For example XR devices
+                        m_UsagesJson = device.usages.Count > 0
+                            ? JsonUtility.ToJson(new DeviceInfo.UsagesJsonWrapper(device.usages))
+                            : null,
 
                         // If it's a generated layout, store the full layout JSON in the device info. We do this so that
                         // when saving traces for this kind of input, we can recreate the device.
@@ -1498,8 +1506,38 @@ namespace UnityEngine.InputSystem.LowLevel
                                 InputSystem.RegisterLayout(deviceInfo.m_FullLayoutJson);
                             }
 
+                            // Make sure original device is in a clean state.
+                            // Its useful to avoid some inactive devices to overwrite recorded state, for example what happens with XRHMD.
+                            var originalDevice = InputSystem.GetDeviceById(deviceInfo.m_DeviceId);
+                            if (originalDevice != null)
+                                InputSystem.ResetDevice(originalDevice);
+
+                            // Retrieve original usages. For example, LeftHand, RightHand, etc.
+                            ReadOnlyArray<InternedString> originalUsages = null;
+                            if (!string.IsNullOrEmpty(deviceInfo.m_UsagesJson))
+                                originalUsages = DeviceInfo.UsagesJsonWrapper.GetUsagesFromJson(deviceInfo.m_UsagesJson);
+
                             // Create device.
                             var device = InputSystem.AddDevice(layoutName);
+
+                            // Ensure usages from original device are present on the new device.
+                            bool usagesUpdated = false;
+                            for (int i = originalUsages.Count - 1; i >= 0; i--)
+                            {
+                                InternedString usage = originalUsages[i];
+                                if (!device.usages.Contains(usage))
+                                {
+                                    // Adds missing usages from original device.
+                                    device.AddDeviceUsage(usage);
+                                    usagesUpdated = true;
+                                }
+                            }
+                            if (usagesUpdated)
+                            {
+                                // Notify about usage change. Needed for XR devices to work with input replay.
+                                InputActionState.OnDeviceChange(device, InputDeviceChange.UsageChanged);
+                            }
+                            
                             WithDeviceMappedFromTo(originalDeviceId, device.deviceId);
                             m_CreatedDevices.AppendWithCapacity(device);
                             return device.deviceId;
@@ -1567,6 +1605,37 @@ namespace UnityEngine.InputSystem.LowLevel
             [SerializeField] internal FourCC m_StateFormat;
             [SerializeField] internal int m_StateSizeInBytes;
             [SerializeField] internal string m_FullLayoutJson;
+            [SerializeField] internal string m_UsagesJson;
+
+            [Serializable]
+            public struct UsagesJsonWrapper
+            {
+                [SerializeField] internal string[] m_usages;
+
+                public static ReadOnlyArray<InternedString> GetUsagesFromJson(string json)
+                {
+                    return JsonUtility.FromJson<UsagesJsonWrapper>(json).GetUsagesInternedStringArray();
+                }
+
+                public UsagesJsonWrapper(ReadOnlyArray<InternedString> usages)
+                {
+                    m_usages = new string[usages.Count];
+                    for (int i = 0; i < usages.Count; i++)
+                    {
+                        m_usages[i] = usages[i].ToString();
+                    }
+                }
+
+                internal readonly ReadOnlyArray<InternedString> GetUsagesInternedStringArray()
+                {
+                    InternedString[] internedUsages = new InternedString[m_usages.Length];
+                    for (int i = 0; i < m_usages.Length; i++)
+                    {
+                        internedUsages[i] = new InternedString(m_usages[i]);
+                    }
+                    return new ReadOnlyArray<InternedString>(internedUsages);
+				}
+			}
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -269,8 +269,8 @@ namespace UnityEngine.InputSystem.LowLevel
                 writer.Write(device.layout);
                 writer.Write(device.stateFormat);
                 writer.Write(device.stateSizeInBytes);
-                writer.Write(device.m_UsagesJson ?? string.Empty);
                 writer.Write(device.m_FullLayoutJson ?? string.Empty);
+                writer.Write(device.m_UsagesJson ?? string.Empty);
             }
 
             // Write offset of device list.
@@ -393,8 +393,8 @@ namespace UnityEngine.InputSystem.LowLevel
                             layout = reader.ReadString(),
                             stateFormat = reader.ReadInt32(),
                             stateSizeInBytes = reader.ReadInt32(),
-                            m_UsagesJson = reader.ReadString(),
-                            m_FullLayoutJson = reader.ReadString()
+                            m_FullLayoutJson = reader.ReadString(),
+                            m_UsagesJson = kFileVersion >= 2 ? reader.ReadString() : null
                         };
                     }
 
@@ -926,16 +926,16 @@ namespace UnityEngine.InputSystem.LowLevel
                         m_StateFormat = device.stateBlock.format,
                         m_StateSizeInBytes = (int)device.stateBlock.alignedSizeInBytes,
 
-                        // if the device has usages, store them as JSON in the device info
-                        // This way, when replaying the trace, we can recreate the device with the correct usages. For example XR devices
-                        m_UsagesJson = device.usages.Count > 0
-                            ? JsonUtility.ToJson(new DeviceInfo.UsagesJsonWrapper(device.usages))
-                            : null,
-
                         // If it's a generated layout, store the full layout JSON in the device info. We do this so that
                         // when saving traces for this kind of input, we can recreate the device.
                         m_FullLayoutJson = InputControlLayout.s_Layouts.IsGeneratedLayout(device.m_Layout)
                             ? InputSystem.LoadLayout(device.layout).ToJson()
+                            : null,
+
+                        // if the device has usages, store them as JSON in the device info
+                        // This way, when replaying the trace, we can recreate the device with the correct usages. For example XR devices
+                        m_UsagesJson = device.usages.Count > 0
+                            ? JsonUtility.ToJson(new DeviceInfo.UsagesJsonWrapper(device.usages))
                             : null
                     });
             }
@@ -987,7 +987,7 @@ namespace UnityEngine.InputSystem.LowLevel
         }
 
         private static FourCC kFileFormat => new FourCC('I', 'E', 'V', 'T');
-        private static int kFileVersion = 1;
+        private static int kFileVersion = 2;
 
         [Flags]
         private enum FileFlags

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -325,7 +325,8 @@ namespace UnityEngine.InputSystem.LowLevel
             // Read header.
             if (reader.ReadInt32() != kFileFormat)
                 throw new IOException($"Stream does not appear to be an InputEventTrace (no '{kFileFormat}' code)");
-            if (reader.ReadInt32() > kFileVersion)
+			int fileVersion = reader.ReadInt32();
+            if (fileVersion > kFileVersion)
                 throw new IOException($"Stream is an InputEventTrace but a newer version (expected version {kFileVersion} or below)");
             reader.ReadInt32(); // Flags; ignored for now.
             reader.ReadInt32(); // Platform; for now we're not doing anything with it.
@@ -394,7 +395,7 @@ namespace UnityEngine.InputSystem.LowLevel
                             stateFormat = reader.ReadInt32(),
                             stateSizeInBytes = reader.ReadInt32(),
                             m_FullLayoutJson = reader.ReadString(),
-                            m_UsagesJson = kFileVersion >= 2 ? reader.ReadString() : null
+                            m_UsagesJson = fileVersion >= 2 ? reader.ReadString() : null // Usages were added in version 2
                         };
                     }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -1507,14 +1507,8 @@ namespace UnityEngine.InputSystem.LowLevel
                                 InputSystem.RegisterLayout(deviceInfo.m_FullLayoutJson);
                             }
 
-                            // Make sure original device is in a clean state.
-                            // Its useful to avoid some inactive devices to overwrite recorded state, for example what happens with XRHMD.
-                            var originalDevice = InputSystem.GetDeviceById(deviceInfo.m_DeviceId);
-                            if (originalDevice != null)
-                                InputSystem.ResetDevice(originalDevice);
-
                             // Retrieve original usages. For example, LeftHand, RightHand, etc.
-                            ReadOnlyArray<InternedString> originalUsages = null;
+                            ReadOnlyArray<InternedString> originalUsages = default;
                             if (!string.IsNullOrEmpty(deviceInfo.m_UsagesJson))
                                 originalUsages = DeviceInfo.UsagesJsonWrapper.GetUsagesFromJson(deviceInfo.m_UsagesJson);
 
@@ -1629,6 +1623,8 @@ namespace UnityEngine.InputSystem.LowLevel
 
                 internal readonly ReadOnlyArray<InternedString> GetUsagesInternedStringArray()
                 {
+					if(m_usages == null)
+						return default;
                     InternedString[] internedUsages = new InternedString[m_usages.Length];
                     for (int i = 0; i < m_usages.Length; i++)
                     {


### PR DESCRIPTION
### Description

Enhance `InputEventTrace` so device usages (e.g. LeftHand, RightHand) are captured, serialized, and restored when recording and replaying input. This prevents XR devices recreated from traces from losing their usages and failing to match XR control schemes or being overridden by live input.

Key changes:
- Device usages are serialized to JSON and stored in `DeviceInfo` when tracing input events, allowing accurate recreation of usages during replay.
- The `WriteTo` and `ReadFrom` methods now handle the new `m_UsagesJson` field so usages are included in the trace file and restored on load.
- During device mapping in replay, usages from the original device are restored on the recreated device, and a `UsageChanged` notification is triggered to ensure XR devices correctly participate in action resolution and control schemes.
- Added `UsagesJsonWrapper` to serialize/deserialize device usages as JSON, with helpers to convert between arrays and `ReadOnlyArray<InternedString>`.
- File format version updated so that older traces can still be deserialized correctly (they simply have no usages stored).


### Testing status & QA

- Manually tested in the editor with:
  - Meta Quest 3 controllers (OpenXR) using recorded traces.
  - Mouse and keyboard input traces.
- Verified that:
  - XR devices now replay correctly with their Left/Right usages restored.
  - Saving and loading traces preserves XR device usages.
  - All the XR recording still working even if Initialize XR on Startup is disabled.
  - Older files still loading properly (without usages, as before).

_No new automated tests have been added._

### Overall Product Risks

Complexity: low
Halo Effect: Low

Potential risk areas:
- Replay on new devices path go through this code changes, not only XR usage, although the change should be backwards compatible for non-XR devices.

### Comments to reviewers

Main things to focus on:
- Verify XR input replay with controllers (Left/Right) and confirm usages are restored correctly and actions/control schemes behave as expected.
- Confirm that traces recorded prior to this change still load and replay without regressions (apart from not having usages stored).
> [!NOTE]
> On some headsets (e.g. Meta Quest), the XRHMD tracking state may remain active even when the device appears idle. In those cases, replayed rotation can still compete with live HMD rotation unless rotation input is configured accordingly (e.g. PassThrough mode Input Action or headset powered off). This appears to be platform/Input system behaviour rather than an InputEventTrace issue.


### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
