### PR TITLE
FIX: Address compilation warnings from Unity 6.4 and 6.5

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,7 +10,9 @@ however, it has to be formatted properly to pass verification tests.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
 
+- Fixed warnings being generated on Unity 6.4 and 6.5. (ISX-2395).
 
 ## [1.17.0] - 2025-11-25
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -328,8 +328,13 @@ namespace UnityEngine.InputSystem.Editor
         [MenuItem("Assets/Create/Input Actions")]
         public static void CreateInputAsset()
         {
+            #if UNITY_6000_4_OR_NEWER
             ProjectWindowUtil.CreateAssetWithTextContent("New Actions." + InputActionAsset.Extension,
                 InputActionAsset.kDefaultAssetLayoutJson, InputActionAssetIconLoader.LoadAssetIcon());
+            #else
+            ProjectWindowUtil.CreateAssetWithContent("New Actions." + InputActionAsset.Extension,
+                InputActionAsset.kDefaultAssetLayoutJson, InputActionAssetIconLoader.LoadAssetIcon());
+            #endif
         }
 
         // File extension of the associated asset

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -328,7 +328,7 @@ namespace UnityEngine.InputSystem.Editor
         [MenuItem("Assets/Create/Input Actions")]
         public static void CreateInputAsset()
         {
-            ProjectWindowUtil.CreateAssetWithContent("New Actions." + InputActionAsset.Extension,
+            ProjectWindowUtil.CreateAssetWithTextContent("New Actions." + InputActionAsset.Extension,
                 InputActionAsset.kDefaultAssetLayoutJson, InputActionAssetIconLoader.LoadAssetIcon());
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionAssetSearchProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionAssetSearchProvider.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Search;
-using UnityEngine.Search;
 
 namespace UnityEngine.InputSystem.Editor
 {
@@ -11,8 +10,6 @@ namespace UnityEngine.InputSystem.Editor
     {
         const string k_AssetFolderSearchProviderId = "AssetsInputActionAssetSearchProvider";
         const string k_ProjectWideActionsSearchProviderId = "ProjectWideInputActionAssetSearchProvider";
-
-        const string k_ProjectWideAssetIdentificationString = " [Project Wide Input Actions]";
 
         internal static SearchProvider CreateInputActionAssetSearchProvider()
         {
@@ -120,7 +117,6 @@ namespace UnityEngine.InputSystem.Editor
         // consistent between CreateItem and additional fetchLabel calls.
         private static string FetchLabel(Object obj)
         {
-            // if (obj == InputSystem.actions) return $"{obj.name}{k_ProjectWideAssetIdentificationString}";
             return obj.name;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionAssetSearchProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionAssetSearchProvider.cs
@@ -101,7 +101,17 @@ namespace UnityEngine.InputSystem.Editor
 
                 if (!label.Contains(context.searchText, System.StringComparison.InvariantCultureIgnoreCase))
                     continue; // Ignore due to filtering
-                yield return provider.CreateItem(context, asset.GetInstanceID().ToString(), label, createItemFetchDescription(asset),
+
+                string itemId;
+
+                // 6.4 deprecated instance ids in favour of entity ids
+                #if UNITY_6000_4_OR_NEWER
+                itemId = asset.GetEntityId().ToString();
+                #else
+                itemId = asset.GetInstanceID().ToString();
+                #endif
+
+                yield return provider.CreateItem(context, itemId, label, createItemFetchDescription(asset),
                     thumbnail, asset);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionReferenceSearchProviders.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionReferenceSearchProviders.cs
@@ -12,7 +12,7 @@ namespace UnityEngine.InputSystem.Editor
         // SearchFlags: these flags are used to customize how search is performed and how search
         // results are displayed in the advanced object picker.
         // Note: SearchFlags.Packages is not currently used and hides all results from packages.
-        internal static readonly SearchFlags PickerSearchFlags = SearchFlags.Sorted | SearchFlags.OpenPicker;
+        internal static readonly SearchFlags PickerSearchFlags = SearchFlags.OpenPicker;
 
         // Search.SearchViewFlags : these flags are used to customize the appearance of the PickerWindow.
         internal static readonly Search.SearchViewFlags PickerViewFlags = SearchViewFlags.DisableBuilderModeToggle

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionReferenceSearchProviders.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionReferenceSearchProviders.cs
@@ -84,7 +84,17 @@ namespace UnityEngine.InputSystem.Editor
                 var label = fetchObjectLabel(asset);
                 if (!label.Contains(context.searchText, System.StringComparison.InvariantCultureIgnoreCase))
                     continue; // Ignore due to filtering
-                yield return provider.CreateItem(context, asset.GetInstanceID().ToString(), label, createItemFetchDescription(asset),
+
+                string itemId;
+
+                // 6.4 deprecated instance ids in favour of entity ids
+                #if UNITY_6000_4_OR_NEWER
+                itemId = asset.GetEntityId().ToString();
+                #else
+                itemId = asset.GetInstanceID().ToString();
+                #endif
+
+                yield return provider.CreateItem(context, itemId, label, createItemFetchDescription(asset),
                     null, asset);
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInputEditor.cs
@@ -278,7 +278,16 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (m_ActionsProperty.objectReferenceValue != null)
             {
-                var assetInstanceID = m_ActionsProperty.objectReferenceValue.GetInstanceID();
+                // 6.4 deprecates instance id in favour of entity ids (a class)
+                // Fortunately, there is an implicit cast from entity id to an integer so we can have minimum footprint for now.
+                int assetInstanceID;
+
+                #if UNITY_6000_4_OR_NEWER
+                assetInstanceID = m_ActionsProperty.objectReferenceValue.GetEntityId();
+                #else
+                assetInstanceID = m_ActionsProperty.objectReferenceValue.GetInstanceID();
+                #endif
+
                 // if the m_ActionAssetInstanceID is 0 the PlayerInputEditor has not been initialized yet, but the asset did not change
                 bool result = assetInstanceID != m_ActionAssetInstanceID && m_ActionAssetInstanceID != 0;
                 m_ActionAssetInstanceID = (int)assetInstanceID;


### PR DESCRIPTION
### Description

Not much to add on top of the PR title. We've accumulated a few warnings that show up when the package is used with Unity 6.4 and 6.5. Basically, these classes of warnings:

1) (6.4) Related to GetInstanceId() -> GetEntityId() migration, this creates a fair bit of new ifdef split based on Unity version since we need to store different data here.

2) (6.4) Related to CreateAssetWithContent -> CreateAssetWithTextContent

3) (6.5) Related to SearchFlags.Sorted being deprecated now - I've migrated without ifdef too, since the Unity Search developers confirmed that this flag is not taken into account for the picker window. The window has its own sorting mechanism.

### Testing status & QA

No feature change hopefully, compiles locally, waiting for CI now

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
