### PR TITLE
CHANGE: Set Android jobs to use UTR 1.42 to fix currently failed jobs

### DIFF
--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -25,6 +25,8 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 2022.3 - Android - mono
 inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_mono:
@@ -51,6 +53,8 @@ inputsystem-mobilefunctionaltests_-_2022_3_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_2022_3_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 2022.3 - IOS
 inputsystem-mobilefunctionaltests_-_2022_3_-_ios:
@@ -119,6 +123,8 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.0 - Android - mono
 inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono:
@@ -145,6 +151,8 @@ inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.0 - IOS
 inputsystem-mobilefunctionaltests_-_6000_0_-_ios:
@@ -213,6 +221,8 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.2 - Android - mono
 inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_mono:
@@ -239,6 +249,8 @@ inputsystem-mobilefunctionaltests_-_6000_2_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_2_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.2 - IOS
 inputsystem-mobilefunctionaltests_-_6000_2_-_ios:
@@ -307,6 +319,8 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.3 - Android - mono
 inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono:
@@ -333,6 +347,8 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.3 - IOS
 inputsystem-mobilefunctionaltests_-_6000_3_-_ios:
@@ -401,6 +417,8 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.4 - Android - mono
 inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono:
@@ -427,6 +445,8 @@ inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.4 - IOS
 inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
@@ -495,6 +515,8 @@ inputsystem-mobilefunctionaltests_-_6000_5_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.5 - Android - mono
 inputsystem-mobilefunctionaltests_-_6000_5_-_android_-_mono:
@@ -521,6 +543,8 @@ inputsystem-mobilefunctionaltests_-_6000_5_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobileFunctionalTests - 6000.5 - IOS
 inputsystem-mobilefunctionaltests_-_6000_5_-_ios:

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -25,6 +25,8 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_2022_3_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 2022.3 - Android - mono
 inputsystem-mobileperformancetests_-_2022_3_-_android_-_mono:
@@ -51,6 +53,8 @@ inputsystem-mobileperformancetests_-_2022_3_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_2022_3_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 2022.3 - IOS
 inputsystem-mobileperformancetests_-_2022_3_-_ios:
@@ -119,6 +123,8 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_0_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.0 - Android - mono
 inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono:
@@ -145,6 +151,8 @@ inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_0_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.0 - IOS
 inputsystem-mobileperformancetests_-_6000_0_-_ios:
@@ -213,6 +221,8 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_2_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.2 - Android - mono
 inputsystem-mobileperformancetests_-_6000_2_-_android_-_mono:
@@ -239,6 +249,8 @@ inputsystem-mobileperformancetests_-_6000_2_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_2_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.2 - IOS
 inputsystem-mobileperformancetests_-_6000_2_-_ios:
@@ -307,6 +319,8 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_3_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.3 - Android - mono
 inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono:
@@ -333,6 +347,8 @@ inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_3_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.3 - IOS
 inputsystem-mobileperformancetests_-_6000_3_-_ios:
@@ -401,6 +417,8 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.4 - Android - mono
 inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
@@ -427,6 +445,8 @@ inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.4 - IOS
 inputsystem-mobileperformancetests_-_6000_4_-_ios:
@@ -495,6 +515,8 @@ inputsystem-mobileperformancetests_-_6000_5_-_android_-_il2cpp:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_5_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.5 - Android - mono
 inputsystem-mobileperformancetests_-_6000_5_-_android_-_mono:
@@ -521,6 +543,8 @@ inputsystem-mobileperformancetests_-_6000_5_-_android_-_mono:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_5_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
 
 # InputSystem-MobilePerformanceTests - 6000.5 - IOS
 inputsystem-mobileperformancetests_-_6000_5_-_ios:

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -57,6 +57,8 @@ public abstract class MobileBaseRecipe : BaseRecipe
                     break;
                 job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
                 job.WithCommands(UtrCommand.Download(systemType, "utr.bat"));
+                // Yet another temporary fix. UTR 1.43.0 was failing on Android builds due to some internal issue so
+                // we are forcing UTR version 1.42.0 for Android platform.
                 job.WithEnvironmentVariable("UTR_VERSION", "1.42.0");
                 return "utr.bat";
             case SystemType.IOS:

--- a/Tools/CI/Recipes/MobileBaseRecipe.cs
+++ b/Tools/CI/Recipes/MobileBaseRecipe.cs
@@ -6,7 +6,7 @@ using RecipeEngine.Unity.Abstractions.Packages;
 
 namespace InputSystem.Cookbook.Recipes;
 
-public abstract class MobileBaseRecipe: BaseRecipe
+public abstract class MobileBaseRecipe : BaseRecipe
 {
     public override IEnumerable<IJobBuilder> GetJobs()
     {
@@ -57,6 +57,7 @@ public abstract class MobileBaseRecipe: BaseRecipe
                     break;
                 job.WithCommands(Settings.AndroidExtraCommands).WithAfterCommands(Settings.AndroidExtraAfterCommands);
                 job.WithCommands(UtrCommand.Download(systemType, "utr.bat"));
+                job.WithEnvironmentVariable("UTR_VERSION", "1.42.0");
                 return "utr.bat";
             case SystemType.IOS:
                 job.WithCommands(UtrCommand.Download(systemType, "utr"));


### PR DESCRIPTION
### Description

This PR fixes failing currently jobs on Android. The only difference I've seen between passing and failing Android jobs was the UTR version being used. Failing jobs used the version 1.43 and passing jobs used 1.42. 
To unblock us for now, I'll pin Android jobs to 1.42 as well and then we can understand what's happening for 1.43 that doesn't work.

### Testing status & QA

CI passed for one job, let's see if all Unity versions jobs pass as well.

### Overall Product Risks



- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
