### PR TITLE
FIX: Extra empty lines added in the control bindings drop-down for some mouse buttons

### DIFF
--- a/Assets/Tests/InputSystem.Editor/UGUITests.cs
+++ b/Assets/Tests/InputSystem.Editor/UGUITests.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_6000_0_OR_NEWER
+#if UNITY_EDITOR && UNITY_6000_0_OR_NEWER && UNITY_INPUT_SYSTEM_ENABLE_UI
 using System;
 using NUnit.Framework;
 using UnityEditor;

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -28,6 +28,7 @@ however, it has to be formatted properly to pass verification tests.
 - Deferred auto-registration of processors, interactions and composite binding types referenced by `InputActionAsset`
   to only happen once when an unresolved type reference is found in an action definition. This avoids reflective
   type loading from assemblies for all cases where the Input System is not extended. (ISXB-1766).
+- Fixed extra empty lines being displayed in the control binding list when mouse buttons are pressed [ISXB-1677](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1677)
 
 ## [1.16.0] - 2025-11-10
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -13,6 +13,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed warnings being generated on Unity 6.4 and 6.5. (ISX-2395).
+- Fixed extra empty lines being displayed in the control binding list when mouse buttons are pressed [ISXB-1677](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1677)
 
 ## [1.17.0] - 2025-11-25
 
@@ -28,7 +29,6 @@ however, it has to be formatted properly to pass verification tests.
 - Deferred auto-registration of processors, interactions and composite binding types referenced by `InputActionAsset`
   to only happen once when an unresolved type reference is found in an action definition. This avoids reflective
   type loading from assemblies for all cases where the Input System is not extended. (ISXB-1766).
-- Fixed extra empty lines being displayed in the control binding list when mouse buttons are pressed [ISXB-1677](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1677)
 
 ## [1.16.0] - 2025-11-10
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownDataSource.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/AdvancedDropdown/AdvancedDropdownDataSource.cs
@@ -118,7 +118,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             if (!item.children.Any())
             {
-                if (!item.IsSeparator())
+                if (!item.IsSeparator() && item.searchableName.Length > 0)
                     m_SearchableElements.Add(item);
                 return;
             }


### PR DESCRIPTION
### Description

This PR aims at fixing the following problem with empty entries in the input control list that is better illustrated by a gif below. Practically, many of the mouse buttons will add an extra empty line:

![62d4ef3cfa9813e51ec37bb7716e0f9c](https://github.com/user-attachments/assets/5ff16c84-4a15-4287-9ea7-46576d6d35c5)

The reason that happens is that we somehow have both searchable and not searchable advanced drop-down items for mouse in the list. The non-searchable have no name, and thus they're shown as empty lines. 

In this PR I opted for not populating the drop-down hierarchy with search results that are non-searchable for whatever reason. 

Case [ISXB-1677](https://jira.unity3d.com/browse/ISXB-1677)

### Testing status & QA

After fixing, I've basically followed the repro steps to make sure the problem is no longer there. I have a mouse with side buttons so it's easier to check on my end. 

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
