### PR TITLE
FIX: UI inconsistencies - Add buttons use add icon in input actions window (1/x)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 
+- Fixed add buttons use add icon in input actions window (ISX-2340)
 - Fixed warnings being generated on Unity 6.4 and 6.5. (ISX-2395).
 - Fixed extra empty lines being displayed in the control binding list when mouse buttons are pressed [ISXB-1677](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1677)
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionMapsTreeViewItem.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionMapsTreeViewItem.uxml
@@ -5,6 +5,6 @@
             <ui:TextField picking-mode="Ignore" name="rename-text-field" is-delayed="true" focusable="true" class="unity-input-actions-editor-hidden" style="visibility: visible; flex-shrink: 1;" />
             <ui:Label text="binding-name" display-tooltip-when-elided="true" name="name" style="flex-grow: 1; justify-content: center; align-items: stretch; margin-left: 4px; -unity-font-style: normal;" />
         </ui:VisualElement>
-        <ui:Button text="+" display-tooltip-when-elided="true" enable-rich-text="false" name="add-new-binding-button" style="opacity: 1; background-color: rgba(255, 255, 255, 0); border-left-color: rgba(255, 255, 255, 0); border-right-color: rgba(255, 255, 255, 0); border-top-color: rgba(255, 255, 255, 0); border-bottom-color: rgba(255, 255, 255, 0); display: none; align-items: flex-end; align-self: auto; flex-direction: row-reverse;" />
+        <ui:Button display-tooltip-when-elided="true" enable-rich-text="false" name="add-new-binding-button" style="opacity: 1; background-color: rgba(255, 255, 255, 0); border-left-color: rgba(255, 255, 255, 0); border-right-color: rgba(255, 255, 255, 0); border-top-color: rgba(255, 255, 255, 0); border-bottom-color: rgba(255, 255, 255, 0); display: none; align-items: flex-end; align-self: auto; flex-direction: row-reverse;" />
     </ui:VisualElement>
 </ui:UXML>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -21,7 +21,7 @@
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
                     <ui:VisualElement name="header" class="body-panel-header">
                         <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
-                        <ui:Button text="+" display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
                         <ui:ListView focusable="true" name="action-maps-list-view" />

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -21,18 +21,18 @@
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
                     <ui:VisualElement name="header" class="body-panel-header">
                         <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
-                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto; background-color: rgba(255, 255, 255, 0);" />
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
                         <ui:ListView focusable="true" name="action-maps-list-view" />
                     </ui:VisualElement>
                     <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;" />
                 </ui:VisualElement>
-                <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" style="height: auto; min-width: 450px;" view-data-key="actions-editor-splitter-2">
+                <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">
                         <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between;">
                             <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" />
-                            <ui:Button text="+" display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;" />
+                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto; background-color: rgba(188, 188, 188, 0);" />
                         </ui:VisualElement>
                         <ui:VisualElement name="body">
                             <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -184,6 +184,16 @@
     -unity-background-scale-mode: scale-to-fit;
 }
 
+.add-button-dark-theme {
+    background-image: resource('d_Toolbar Plus.png');
+    -unity-background-scale-mode: scale-to-fit;
+}
+
+.add-button {
+    background-image: resource('Toolbar Plus.png');
+    -unity-background-scale-mode: scale-to-fit;
+}
+
 .search-field {
     display: none;
     width: 190px;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -175,21 +175,29 @@
 }
 
 .add-binging-button-dark-theme {
+    width: 14px;
+    height: 14px;
     background-image: resource('d_Toolbar Plus More.png');
     -unity-background-scale-mode: scale-to-fit;
 }
 
 .add-binging-button {
+    width: 14px;
+    height: 14px;
     background-image: resource('Toolbar Plus More.png');
     -unity-background-scale-mode: scale-to-fit;
 }
 
 .add-button-dark-theme {
+    width: 18px;
+    height: 18px;
     background-image: resource('d_Toolbar Plus.png');
     -unity-background-scale-mode: scale-to-fit;
 }
 
 .add-button {
+    width: 18px;
+    height: 18px;
     background-image: resource('Toolbar Plus.png');
     -unity-background-scale-mode: scale-to-fit;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -2,6 +2,7 @@
 using CmdEvents = UnityEngine.InputSystem.Editor.InputActionsEditorConstants.CommandEvents;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEditor;
 using UnityEngine.UIElements;
 
 namespace UnityEngine.InputSystem.Editor
@@ -65,6 +66,8 @@ namespace UnityEngine.InputSystem.Editor
             CreateSelector(Selectors.GetActionMapNames, Selectors.GetSelectedActionMap, (actionMapNames, actionMap, state) => new ViewState(actionMap, actionMapNames, state.GetDisabledActionMaps(actionMapNames.ToList())));
 
             m_AddActionMapButton = root.Q<Button>("add-new-action-map-button");
+            m_AddActionMapButton.AddToClassList(EditorGUIUtility.isProSkin ? "add-button-dark-theme" : "add-button");
+
             m_AddActionMapButton.clicked += AddActionMap;
 
             ContextMenu.GetContextMenuForActionMapsEmptySpace(this, root.Q<VisualElement>("rclick-area-to-add-new-action-map"));

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionsTreeView.cs
@@ -32,6 +32,7 @@ namespace UnityEngine.InputSystem.Editor
         {
             m_ActionMapsListView = root.Q<ListView>("action-maps-list-view");
             m_AddActionButton = root.Q<Button>("add-new-action-button");
+            m_AddActionButton.AddToClassList(EditorGUIUtility.isProSkin ? "add-button-dark-theme" : "add-button");
             m_PropertiesScrollview = root.Q<ScrollView>("properties-scrollview");
             m_ActionsTreeView = root.Q<TreeView>("actions-tree-view");
             //assign unique viewDataKey to store treeView states like expanded/collapsed items - make it unique to avoid conflicts with other TreeViews

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/PropertiesView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/PropertiesView.cs
@@ -39,6 +39,8 @@ namespace UnityEngine.InputSystem.Editor
             if (addInteractionButton == null)
             {
                 addInteractionButton = CreateAddButton(interactionsToggle, "add-new-interaction-button");
+                addInteractionButton.AddToClassList(EditorGUIUtility.isProSkin ? "add-binging-button-dark-theme" : "add-binging-button");
+
                 new ContextualMenuManipulator(_ => {}){target = addInteractionButton, activators = {new ManipulatorActivationFilter(){button = MouseButton.LeftMouse}}};
             }
             var processorToggle = processorsFoldout.Q<Toggle>();
@@ -46,6 +48,8 @@ namespace UnityEngine.InputSystem.Editor
             if (addProcessorButton == null)
             {
                 addProcessorButton = CreateAddButton(processorToggle, "add-new-processor-button");
+                addProcessorButton.AddToClassList(EditorGUIUtility.isProSkin ? "add-binging-button-dark-theme" : "add-binging-button");
+
                 new ContextualMenuManipulator(_ => {}){target = addProcessorButton, activators = {new ManipulatorActivationFilter(){button = MouseButton.LeftMouse}}};
             }
         }
@@ -53,7 +57,6 @@ namespace UnityEngine.InputSystem.Editor
         private TextElement CreateAddButton(Toggle toggle, string name)
         {
             var addButton = new Button();
-            addButton.text = "+";
             addButton.name = name;
             addButton.focusable = false;
             #if UNITY_EDITOR_OSX


### PR DESCRIPTION
### Description

Fixing UI inconsistencies (1/x)

- Add buttons use add icon and add dropdown icon
- Removed button background
- Removed "+" text button
- Interactions & Processors using the correct icon (add dropdown icon)

Before:
<img width="1160" height="708" alt="Screenshot 2025-12-15 at 13 17 54" src="https://github.com/user-attachments/assets/e86dc00f-4e44-421f-be87-eadbc14013b4" />

After:
<img width="994" height="677" alt="Screenshot 2025-12-15 at 13 18 26" src="https://github.com/user-attachments/assets/d0417c2f-069e-4039-aa0a-0514f8534b82" />

JIRA: ISX-2340

### Testing status & QA

Manually tested by clicking on the buttons.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
