### PR TITLE
FIX: InputActionReference not set on Prefab and ScriptableObject (ISBX-1787)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -14,6 +14,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed warnings being generated on Unity 6.4 and 6.5. (ISX-2395).
 - Fixed extra empty lines being displayed in the control binding list when mouse buttons are pressed [ISXB-1677](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1677)
+- Fixed InputActionReference not being set when attempting to set it on a Prefab or ScriptableObject [ISXB-1787](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1787)
 
 ### Changed
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionReferencePropertyDrawer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/PropertyDrawers/InputActionReferencePropertyDrawer.cs
@@ -48,9 +48,7 @@ namespace UnityEngine.InputSystem.Editor
             // Only assign the value was actually changed by the user.
             if (EditorGUI.EndChangeCheck() && !Equals(candidate, current))
             {
-                var reference = candidate as InputActionReference;
-                property.objectReferenceValue = reference ?
-                    InputActionReference.Create(reference.action) : null;
+                property.objectReferenceValue = candidate as InputActionReference; // set to either the reference or null.
             }
 
             EditorGUI.EndProperty();


### PR DESCRIPTION
### Description

This PR addresses a regression caused by [this change](https://github.com/Unity-Technologies/InputSystem/pull/2248/files?file-filters%5B%5D=.cs&show-viewed-files=true#diff-862d86d5ea01423b7c307f08579cb5538da6de4ab18aebb083223ed10c872bb6R67). 

The root cause of the issue was that the new implementation of the `InputActionReferencePropertyDrawer` was trying to assigned a virtual input asset ref (not yet registered in asset database) to the `SerializedObject.objectReferenceValue`. This is not supported as the field needs to be assigned to an asset written on the disk.

The fix is to assign directly the retrieved asset reference. 

* [x] Jira ticket: [ISXB-1787](https://jira.unity3d.com/browse/ISXB-1787)
* [x] CHANGELOG.md

### Testing status & QA

Used the following minimal reproduction steps:
1. Create a new project
2. Create a new MonoBehaviour and ScriptableObject that both implement a public `InputActionReference` field.
3. Try to assign the an input action to the field.

**Result:**
![fixes-inputactiondrawer](https://github.com/user-attachments/assets/f8146fb4-a6b9-4a46-9cf0-2658d5306167)

**No automated tests added as testing property drawers directly is challenging because they require GUI interaction.**

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [X] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
