### PR TITLE
FIX: Summary update fixing a bug for TapInteraction

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -9,7 +9,7 @@ using UnityEngine.UIElements;
 namespace UnityEngine.InputSystem.Interactions
 {
     /// <summary>
-    /// Performs the action if the control is pressed held for at least the set
+    /// Performs the action if the control is pressed and released within the set
     /// duration (which defaults to <see cref="InputSettings.defaultTapTime"/>)
     /// and then released.
     /// </summary>


### PR DESCRIPTION
### Description

The interaction requires the control to be released within the timeout (the code uses <= durationOrDefault and cancels on timer expiry), so the comment should say "at most" / "within".

JIRA: [DOCATT-10042](https://jira.unity3d.com/browse/DOCATT-10042)

### Testing status & QA

N/A

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: low
- Halo Effect: low

### Comments to reviewers

Review carefully.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
