### PR TITLE
FIX: Icon fix for action maps buttons in background and resolution

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -21,7 +21,7 @@
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
                     <ui:VisualElement name="header" class="body-panel-header">
                         <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
-                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto; background-color: rgba(255, 255, 255, 0);" />
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
                         <ui:ListView focusable="true" name="action-maps-list-view" />
@@ -32,7 +32,7 @@
                     <ui:VisualElement name="actions-container" class="body-panel-container">
                         <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between;">
                             <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" />
-                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto; background-color: rgba(188, 188, 188, 0);" />
+                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;" />
                         </ui:VisualElement>
                         <ui:VisualElement name="body">
                             <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -175,29 +175,29 @@
 }
 
 .add-binging-button-dark-theme {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     background-image: resource('d_Toolbar Plus More.png');
     -unity-background-scale-mode: scale-to-fit;
 }
 
 .add-binging-button {
-    width: 14px;
-    height: 14px;
+    width: 16px;
+    height: 16px;
     background-image: resource('Toolbar Plus More.png');
     -unity-background-scale-mode: scale-to-fit;
 }
 
 .add-button-dark-theme {
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
     background-image: resource('d_Toolbar Plus.png');
     -unity-background-scale-mode: scale-to-fit;
 }
 
 .add-button {
-    width: 18px;
-    height: 18px;
+    width: 16px;
+    height: 16px;
     background-image: resource('Toolbar Plus.png');
     -unity-background-scale-mode: scale-to-fit;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -178,6 +178,7 @@
     width: 16px;
     height: 16px;
     background-image: resource('d_Toolbar Plus More.png');
+    background-color: transparent;
     -unity-background-scale-mode: scale-to-fit;
 }
 
@@ -185,6 +186,7 @@
     width: 16px;
     height: 16px;
     background-image: resource('Toolbar Plus More.png');
+    background-color: transparent;
     -unity-background-scale-mode: scale-to-fit;
 }
 
@@ -192,6 +194,7 @@
     width: 16px;
     height: 16px;
     background-image: resource('d_Toolbar Plus.png');
+    background-color: transparent;
     -unity-background-scale-mode: scale-to-fit;
 }
 
@@ -199,6 +202,7 @@
     width: 16px;
     height: 16px;
     background-image: resource('Toolbar Plus.png');
+    background-color: transparent;
     -unity-background-scale-mode: scale-to-fit;
 }
 


### PR DESCRIPTION
### Description

Icon fix for action maps buttons in background and resolution #2314

<img width="1348" height="811" alt="image (4)" src="https://github.com/user-attachments/assets/2642aef3-2f58-4467-b1a6-94c10082309c" />


JIRA: https://jira.unity3d.com/browse/UUM-131889

### Testing status & QA


https://github.com/user-attachments/assets/fd2b0648-03e3-43b6-8a15-34e8c3ae1207



### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: low
- Halo Effect: low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
