### PR TITLE
CHANGE: Remove 6000.2 from CI

### DIFF
--- a/.yamato/config.metadata
+++ b/.yamato/config.metadata
@@ -1,7 +1,6 @@
 editors:
   - version: 2022.3
   - version: 6000.0
-  - version: 6000.2
   - version: 6000.3
   - version: 6000.4
   - version: trunk


### PR DESCRIPTION
### Description

This [one](https://github.com/Unity-Technologies/InputSystem/pull/2318) already tried to remove 6000.2 but there were still mentions of it left over in the config. Reran `dotnet run --project Tools/CI/InputSystem.Cookbook.csproj` just in case but didn't seem to change anything.

### Testing status & QA

CI Only

### Overall Product Risks

N/A

### Comments to reviewers

N/A

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
