### PR TITLE
FIX: Align title font size with toolbar style in Input Action window

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -18,6 +18,7 @@ however, it has to be formatted properly to pass verification tests.
 ### Fixed
 
 - Fixed the `Auto-Save` toggle button with some extra pixels to align the text in the window better.
+- Align title font size with toolbar style in `Input Action` window.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -19,8 +19,8 @@
         <ui:VisualElement name="body" style="flex-direction: column; flex-grow: 1;">
             <ui:TwoPaneSplitView name="actions-split-view" fixed-pane-initial-dimension="200" view-data-key="actions-editor-splitter-1">
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
-                    <ui:VisualElement name="header" class="body-panel-header" style="font-size: 12px; height: 20px; min-height: 20px;">
-                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1; font-size: 12px;"/>
+                    <ui:VisualElement name="header" class="body-panel-header">
+                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;"/>
                         <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
@@ -30,8 +30,8 @@
                 </ui:VisualElement>
                 <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">
-                        <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between; font-size: 12px; height: 20px; min-height: 20px;">
-                            <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" style="font-size: 12px;"/>
+                        <ui:VisualElement name="header" class="body-panel-header">
+                            <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label"/>
                             <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;"/>
                         </ui:VisualElement>
                         <ui:VisualElement name="body">
@@ -40,8 +40,8 @@
                         <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="properties-container" class="body-panel-container body-panel-container" style="min-width: 310px;">
-                        <ui:VisualElement name="header" class="body-panel-header" style="font-size: 12px; height: 20px; min-height: 20px;">
-                            <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label" style="font-size: 12px;"/>
+                        <ui:VisualElement name="header" class="body-panel-header">
+                            <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label"/>
                         </ui:VisualElement>
                         <ui:ScrollView name="properties-scrollview">
                             <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout"/>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -1,55 +1,55 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
-    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
+    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles"/>
     <ui:VisualElement name="action-editor" style="flex-direction: column; flex-grow: 1;">
         <ui:VisualElement name="control-schemes-toolbar-container">
             <uie:Toolbar>
                 <ui:VisualElement style="flex-direction: row; flex-grow: 1;">
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;" />
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu" />
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;"/>
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu"/>
                 </ui:VisualElement>
                 <ui:VisualElement>
-                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
+                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;"/>
                 </ui:VisualElement>
                 <ui:VisualElement name="save-asset-toolbar-container" style="flex-direction: row; justify-content: flex-end;">
-                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;" />
-                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 69px;" />
+                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;"/>
+                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 69px;"/>
                 </ui:VisualElement>
             </uie:Toolbar>
         </ui:VisualElement>
         <ui:VisualElement name="body" style="flex-direction: column; flex-grow: 1;">
             <ui:TwoPaneSplitView name="actions-split-view" fixed-pane-initial-dimension="200" view-data-key="actions-editor-splitter-1">
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
-                    <ui:VisualElement name="header" class="body-panel-header">
-                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
-                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
+                    <ui:VisualElement name="header" class="body-panel-header" style="font-size: 12px; height: 20px; min-height: 20px;">
+                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1; font-size: 12px;"/>
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
-                        <ui:ListView focusable="true" name="action-maps-list-view" />
+                        <ui:ListView focusable="true" name="action-maps-list-view"/>
                     </ui:VisualElement>
-                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;" />
+                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;"/>
                 </ui:VisualElement>
                 <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">
-                        <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between;">
-                            <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" />
-                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;" />
+                        <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between; font-size: 12px; height: 20px; min-height: 20px;">
+                            <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" style="font-size: 12px;"/>
+                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;"/>
                         </ui:VisualElement>
                         <ui:VisualElement name="body">
-                            <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />
+                            <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20"/>
                         </ui:VisualElement>
-                        <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;" />
+                        <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="properties-container" class="body-panel-container body-panel-container" style="min-width: 310px;">
-                        <ui:VisualElement name="header" class="body-panel-header">
-                            <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label" />
+                        <ui:VisualElement name="header" class="body-panel-header" style="font-size: 12px; height: 20px; min-height: 20px;">
+                            <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label" style="font-size: 12px;"/>
                         </ui:VisualElement>
                         <ui:ScrollView name="properties-scrollview">
-                            <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout" />
+                            <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout"/>
                             <ui:Foldout text="Interactions" name="interactions-foldout" class="properties-foldout name-and-parameters-list-view">
-                                <ui:Label text="No interactions have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" style="display: flex;" />
+                                <ui:Label text="No interactions have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" style="display: flex;"/>
                             </ui:Foldout>
                             <ui:Foldout text="Processors" name="processors-foldout" class="properties-foldout name-and-parameters-list-view">
-                                <ui:Label text="No processors have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" />
+                                <ui:Label text="No processors have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label"/>
                             </ui:Foldout>
                         </ui:ScrollView>
                     </ui:VisualElement>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -30,7 +30,7 @@
                 </ui:VisualElement>
                 <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">
-                        <ui:VisualElement name="header" class="body-panel-header">
+                        <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between;">
                             <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label"/>
                             <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;"/>
                         </ui:VisualElement>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -106,9 +106,9 @@
     padding-top: 4px;
     padding-bottom: 4px;
     border-bottom-width: 1px;
-    height: 28px;
-    min-height: 28px;
-    font-size: 14px;
+    height: 20px;
+    min-height: 20px;
+    font-size: 12px;
     -unity-font-style: bold;
     align-items: center;
     justify-content: flex-start;


### PR DESCRIPTION
### Description

This PR is addressing some of the UI issues that design team reported to input system.
Align title font size with toolbar style in Input Action window.
```
Toolbar use toolbar style:
- The font is regular (12pt)
- Height is 20px
```

Before:
<img width="1728" height="1047" alt="Screenshot 2026-01-20 at 12 00 40" src="https://github.com/user-attachments/assets/31cc798e-955a-43ce-a635-3d0a54c0ffc4" />

After:
<img width="1728" height="1117" alt="Screenshot 2026-01-21 at 10 57 31" src="https://github.com/user-attachments/assets/0523e947-9b8b-420c-95b9-acf34f5eacfe" />



JIRA: https://jira.unity3d.com/browse/ISX-2340

### Testing status & QA

No testing is needed.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
