### PR TITLE
NEW: keywords for InputSystem project settings window

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,7 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Added
 
-- Added `keyboards` for InputSystem project settings window.
+- Added `keywords` for InputSystem project settings window.
 
 ## [1.18.0] - 2026-01-14
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,8 +19,9 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed the `Auto-Save` toggle button with some extra pixels to align the text in the window better.
 
-
 ### Added
+
+- Added `keyboards` for InputSystem project settings window.
 
 ## [1.18.0] - 2026-01-14
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEditorInternal;
@@ -8,7 +9,6 @@ using UnityEngine.UIElements;
 
 ////TODO: detect if new input backends are enabled and put UI in here to enable them if needed
 
-////TODO: keywords (2019.1+)
 #pragma warning disable CS0414
 namespace UnityEngine.InputSystem.Editor
 {
@@ -35,7 +35,8 @@ namespace UnityEngine.InputSystem.Editor
             {
                 // We put this in a child node called "Settings" when Project-wide Actions is enabled.
                 // When not enabled it sits on the main package Settings node.
-                label = "Settings"
+                label = "Settings",
+                keywords = new HashSet<string>(new[] { "Input", "Action", "Controls", "Gamepad", "Keyboard", "Mouse", "Touch" })
             };
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -22,6 +22,11 @@ namespace UnityEngine.InputSystem.Editor
 
         public const string kSettingsPath = InputSettingsPath.kSettingsRootPath + "/Settings";
 
+        private static readonly string[] kInputSettingsKeywords =
+        {
+            "Input", "Action", "Controls", "Gamepad", "Keyboard", "Mouse", "Touch"
+        };
+
         public static void Open()
         {
             SettingsService.OpenProjectSettings(kSettingsPath);
@@ -35,10 +40,7 @@ namespace UnityEngine.InputSystem.Editor
                 // We put this in a child node called "Settings" when Project-wide Actions is enabled.
                 // When not enabled it sits on the main package Settings node.
                 label = "Settings",
-                keywords = new[]
-                {
-                    "Input", "Action", "Controls", "Gamepad", "Keyboard", "Mouse", "Touch"
-                }
+                keywords = kInputSettingsKeywords
             };
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -1,6 +1,5 @@
 #if UNITY_EDITOR
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEditorInternal;
@@ -36,7 +35,10 @@ namespace UnityEngine.InputSystem.Editor
                 // We put this in a child node called "Settings" when Project-wide Actions is enabled.
                 // When not enabled it sits on the main package Settings node.
                 label = "Settings",
-                keywords = new HashSet<string>(new[] { "Input", "Action", "Controls", "Gamepad", "Keyboard", "Mouse", "Touch" })
+                keywords = new[]
+                {
+                    "Input", "Action", "Controls", "Gamepad", "Keyboard", "Mouse", "Touch"
+                }
             };
         }
 


### PR DESCRIPTION
### Description

As mentioned in the `TODO`. Adding `keywords` for InputSystem project settings window.



https://github.com/user-attachments/assets/2e0c5914-26de-419d-9fcd-7634c287c34e


Jira: https://jira.unity3d.com/browse/ISX-2470 

### Testing status & QA

No need for testing, manually tested as video shows above.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
