### PR TITLE
FIX: headers under Action Properties similar to gameObject component headers 

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,6 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed the `Auto-Save` toggle button with some extra pixels to align the text in the window better.
 - Align title font size with toolbar style in `Input Action` window.
+- Fixed headers under Action Properties similar color than gameObject component headers.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -19,7 +19,7 @@ however, it has to be formatted properly to pass verification tests.
 
 - Fixed the `Auto-Save` toggle button with some extra pixels to align the text in the window better.
 - Align title font size with toolbar style in `Input Action` window.
-- Fixed headers under Action Properties similar color than gameObject component headers.
+- Updated Action Properties headers to use colors consistent with GameObject component headers.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -1,18 +1,18 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
-    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
+    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles"/>
     <ui:VisualElement name="action-editor" style="flex-direction: column; flex-grow: 1;">
         <ui:VisualElement name="control-schemes-toolbar-container">
             <uie:Toolbar>
                 <ui:VisualElement style="flex-direction: row; flex-grow: 1;">
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;" />
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu" />
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;"/>
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu"/>
                 </ui:VisualElement>
                 <ui:VisualElement>
-                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
+                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;"/>
                 </ui:VisualElement>
                 <ui:VisualElement name="save-asset-toolbar-container" style="flex-direction: row; justify-content: flex-end;">
-                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;" />
-                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 69px;" />
+                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;"/>
+                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 69px;"/>
                 </ui:VisualElement>
             </uie:Toolbar>
         </ui:VisualElement>
@@ -20,36 +20,36 @@
             <ui:TwoPaneSplitView name="actions-split-view" fixed-pane-initial-dimension="200" view-data-key="actions-editor-splitter-1">
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
                     <ui:VisualElement name="header" class="body-panel-header">
-                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
-                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
+                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;"/>
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
-                        <ui:ListView focusable="true" name="action-maps-list-view" />
+                        <ui:ListView focusable="true" name="action-maps-list-view"/>
                     </ui:VisualElement>
-                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;" />
+                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;"/>
                 </ui:VisualElement>
                 <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">
                         <ui:VisualElement name="header" class="body-panel-header" style="justify-content: space-between;">
-                            <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label" />
-                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;" />
+                            <ui:Label text="Actions" display-tooltip-when-elided="true" name="actions-label"/>
+                            <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;"/>
                         </ui:VisualElement>
                         <ui:VisualElement name="body">
-                            <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20" />
+                            <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20"/>
                         </ui:VisualElement>
-                        <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;" />
+                        <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="properties-container" class="body-panel-container body-panel-container" style="min-width: 310px;">
                         <ui:VisualElement name="header" class="body-panel-header">
-                            <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label" />
+                            <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label"/>
                         </ui:VisualElement>
                         <ui:ScrollView name="properties-scrollview">
-                            <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout" />
-                            <ui:Foldout text="Interactions" name="interactions-foldout" class="properties-foldout name-and-parameters-list-view">
-                                <ui:Label text="No interactions have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" style="display: flex;" />
+                            <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout" style="background-color: rgba(255, 255, 255, 0);"/>
+                            <ui:Foldout text="Interactions" name="interactions-foldout" class="properties-foldout name-and-parameters-list-view" style="background-color: rgba(255, 255, 255, 0);">
+                                <ui:Label text="No interactions have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" style="display: flex;"/>
                             </ui:Foldout>
-                            <ui:Foldout text="Processors" name="processors-foldout" class="properties-foldout name-and-parameters-list-view">
-                                <ui:Label text="No processors have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" />
+                            <ui:Foldout text="Processors" name="processors-foldout" class="properties-foldout name-and-parameters-list-view" style="background-color: rgba(255, 255, 255, 0);">
+                                <ui:Label text="No processors have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label"/>
                             </ui:Foldout>
                         </ui:ScrollView>
                     </ui:VisualElement>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -44,11 +44,11 @@
                             <ui:Label text="Action Properties" display-tooltip-when-elided="true" name="properties-header-label"/>
                         </ui:VisualElement>
                         <ui:ScrollView name="properties-scrollview">
-                            <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout" style="background-color: rgba(255, 255, 255, 0);"/>
-                            <ui:Foldout text="Interactions" name="interactions-foldout" class="properties-foldout name-and-parameters-list-view" style="background-color: rgba(255, 255, 255, 0);">
+                            <ui:Foldout text="Action Properties" name="properties-foldout" class="properties-foldout"/>
+                            <ui:Foldout text="Interactions" name="interactions-foldout" class="properties-foldout name-and-parameters-list-view">
                                 <ui:Label text="No interactions have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label" style="display: flex;"/>
                             </ui:Foldout>
-                            <ui:Foldout text="Processors" name="processors-foldout" class="properties-foldout name-and-parameters-list-view" style="background-color: rgba(255, 255, 255, 0);">
+                            <ui:Foldout text="Processors" name="processors-foldout" class="properties-foldout name-and-parameters-list-view">
                                 <ui:Label text="No processors have been added." name="no-parameters-added-label" display-tooltip-when-elided="true" class="name-and-parameter-empty-label"/>
                             </ui:Foldout>
                         </ui:ScrollView>

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -125,18 +125,9 @@
     height: 20px;
 }
 
-
 .properties-foldout-toggle:hover {
     background-color: var(--input-editor-colors-properties-foldout-toggle-hover);
-    /*
-    background-color: #474747;
-    */
 }
-/*!* Dark theme hover *!
-!* Light theme hover – pick a lighter hover color that fits the light palette *!
-.properties-foldout-toggle.light:hover {
-    background-color: #e6e6e6;
-}*/
 
 .name-and-parameter-empty-label {
     margin-top: 5px;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -125,9 +125,18 @@
     height: 20px;
 }
 
+
 .properties-foldout-toggle:hover {
+    background-color: var(--input-editor-colors-properties-foldout-toggle-hover);
+    /*
     background-color: #474747;
+    */
 }
+/*!* Dark theme hover *!
+!* Light theme hover – pick a lighter hover color that fits the light palette *!
+.properties-foldout-toggle.light:hover {
+    background-color: #e6e6e6;
+}*/
 
 .name-and-parameter-empty-label {
     margin-top: 5px;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -122,6 +122,11 @@
 
 .properties-foldout-toggle {
     background-color: var(--input-editor-colors-properties-foldout);
+    height: 20px;
+}
+
+.properties-foldout-toggle:hover {
+    background-color: #474747;
 }
 
 .name-and-parameter-empty-label {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
@@ -1,4 +1,4 @@
 :root {
-    --input-editor-colors-properties-foldout: rgb(62, 62, 62);
+    --input-editor-colors-properties-foldout: #3E3E3E;
     --input-editor-colors-properties-foldout-border: #303030;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
@@ -1,4 +1,5 @@
 :root {
     --input-editor-colors-properties-foldout: #3E3E3E;
     --input-editor-colors-properties-foldout-border: #1A1A1A;
+    --input-editor-colors-properties-foldout-toggle-hover: #474747;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
@@ -1,4 +1,4 @@
 :root {
     --input-editor-colors-properties-foldout: #3E3E3E;
-    --input-editor-colors-properties-foldout-border: #303030;
+    --input-editor-colors-properties-foldout-border: #1A1A1A;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
@@ -1,4 +1,4 @@
 :root {
     --input-editor-colors-properties-foldout: rgb(62, 62, 62);
-    --input-editor-colors-properties-foldout-border: #808080;
+    --input-editor-colors-properties-foldout-border: #303030;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorDark.uss
@@ -1,4 +1,4 @@
 :root {
-    --input-editor-colors-properties-foldout: rgb(34, 34, 34);
+    --input-editor-colors-properties-foldout: rgb(62, 62, 62);
     --input-editor-colors-properties-foldout-border: #808080;
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorLight.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputAssetEditorLight.uss
@@ -1,4 +1,5 @@
 :root {
     --input-editor-colors-properties-foldout: #DFDFDF;
     --input-editor-colors-properties-foldout-border: #808080;
+    --input-editor-colors-properties-foldout-toggle-hover: #e6e6e6;
 }


### PR DESCRIPTION
### Description

This PR is addressing some of the UI issues that design team reported to input system.
Removing wrong background and using component header colors.

```
No “Shadow” section headers
Use headers similar to component headers that allows for buttons
```

- Changed background color to match unity header components (Dark/Light themes).
- Added a hover effect to march unity header components (Dark/Light themes).

Before:
<img width="1156" height="910" alt="Screenshot 2026-01-21 at 13 45 33" src="https://github.com/user-attachments/assets/66042c92-6ce2-41e8-9f1f-2d479a95ef89" />

After:

https://github.com/user-attachments/assets/76c1e1e2-0721-441f-8ca6-8acbfc960890


JIRA: https://jira.unity3d.com/browse/ISX-2340


### Testing status & QA

No testing is needed.



### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
