### PR TITLE
NEW: Adding labels to make settings more readable

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -137,8 +137,12 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.Separator();
                 EditorGUILayout.Space();
 
+                EditorGUILayout.LabelField("Action Properties - Processors", EditorStyles.boldLabel);
                 EditorGUILayout.PropertyField(m_DefaultDeadzoneMin, m_DefaultDeadzoneMinContent);
                 EditorGUILayout.PropertyField(m_DefaultDeadzoneMax, m_DefaultDeadzoneMaxContent);
+                EditorGUILayout.Space();
+
+                EditorGUILayout.LabelField("Action Properties - Interactions", EditorStyles.boldLabel);
                 EditorGUILayout.PropertyField(m_DefaultButtonPressPoint, m_DefaultButtonPressPointContent);
                 EditorGUILayout.PropertyField(m_ButtonReleaseThreshold, m_ButtonReleaseThresholdContent);
                 EditorGUILayout.PropertyField(m_DefaultTapTime, m_DefaultTapTimeContent);
@@ -146,6 +150,7 @@ namespace UnityEngine.InputSystem.Editor
                 EditorGUILayout.PropertyField(m_DefaultHoldTime, m_DefaultHoldTimeContent);
                 EditorGUILayout.PropertyField(m_TapRadius, m_TapRadiusContent);
                 EditorGUILayout.PropertyField(m_MultiTapDelayTime, m_MultiTapDelayTimeContent);
+                EditorGUILayout.Space();
 
                 EditorGUILayout.Space();
                 EditorGUILayout.Separator();


### PR DESCRIPTION
### Description

Adding labels to make settings more readable, values used in **Action Properties**: `interactions` and `processors`.

Result:
<img width="238" height="304" alt="Screenshot 2026-01-21 at 14 51 52" src="https://github.com/user-attachments/assets/8786ee9b-df32-4a99-87af-4d28cab1d92b" />

<img width="1728" height="1117" alt="Screenshot 2026-01-21 at 14 44 24" src="https://github.com/user-attachments/assets/d21a82c9-7884-40f0-b964-052fd13d1970" />

Values used here:
<img width="1728" height="1117" alt="Screenshot 2026-01-21 at 14 49 30" src="https://github.com/user-attachments/assets/296b702b-7ddc-43f7-97ff-d82bc5a637b9" />

### Testing status & QA

No need testing.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
