### PR TITLE
FIX: Prevent SDL layouts from being created if a layout already exists

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/SDLDeviceBuilder.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Linux/SDLDeviceBuilder.cs
@@ -16,6 +16,11 @@ namespace UnityEngine.InputSystem.Linux
         internal static string OnFindLayoutForDevice(ref InputDeviceDescription description, string matchedLayout,
             InputDeviceExecuteCommandDelegate executeCommandDelegate)
         {
+            // If the system found a matching layout, there's nothing for us to do.
+            if (!string.IsNullOrEmpty(matchedLayout))
+                return null;
+            
+            // If the device isn't an SDL joystick, we have nothing to do.
             if (description.interfaceName != LinuxSupport.kInterfaceName)
                 return null;
 


### PR DESCRIPTION
### Description

Mirrored from: [1924](https://github.com/Unity-Technologies/InputSystem/pull/1924) as tests couldn't run on it
"Unity's HID layout generator does not generate a layout if one already exists. I added this functionality to the Linux/SDL layout generator."

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

N/A

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
