### PR TITLE
FIX: handled events still triggering actions when switching PlayerInput device

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_Events.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Events.cs
@@ -10,6 +10,7 @@ using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 using UnityEngine.Scripting;
 using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Users;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
@@ -1254,6 +1255,48 @@ partial class CoreTests
         InputSystem.Update();
 
         Assert.That(device.rightTrigger.ReadValue(), Is.EqualTo(0.0).Within(0.00001));
+    }
+
+    [Test]
+    [Category("Events")]
+    public void Events_HandledFirstEvent_DoesNotTriggerAction_OnSecondEventSameUpdate()
+    {
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        var action = new InputAction(type: InputActionType.Button, binding: "<Gamepad>/buttonSouth");
+        action.Enable();
+
+        var performedCount = 0;
+        action.performed += _ => ++performedCount;
+
+        var previousPolicy = InputSystem.s_Manager.inputEventHandledPolicy;
+        InputSystem.s_Manager.inputEventHandledPolicy = InputEventHandledPolicy.SuppressStateUpdates;
+
+        InputUser.listenForUnpairedDeviceActivity++;
+        var handledFirstEventId = 0;
+        Action<InputControl, InputEventPtr> onUnpaired = (control, eventPtr) =>
+        {
+            if (handledFirstEventId == 0)
+            {
+                handledFirstEventId = eventPtr.id;
+                eventPtr.handled = true;
+            }
+        };
+        InputUser.onUnpairedDeviceUsed += onUnpaired;
+
+        try
+        {
+            InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South));
+            InputSystem.QueueStateEvent(gamepad, new GamepadState().WithButton(GamepadButton.South));
+            InputSystem.Update();
+
+            Assert.That(performedCount, Is.EqualTo(0));
+        }
+        finally
+        {
+            InputUser.onUnpairedDeviceUsed -= onUnpaired;
+            InputUser.listenForUnpairedDeviceActivity--;
+            InputSystem.s_Manager.inputEventHandledPolicy = previousPolicy;
+        }
     }
 
     [Test]

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -21,6 +21,7 @@ however, it has to be formatted properly to pass verification tests.
 - Align title font size with toolbar style in `Input Action` window.
 - Updated Action Properties headers to use colors consistent with GameObject component headers.
 - Fixed misaligned Virtual Cursor when changing resolution [ISXB-1119](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1119)
+- Fixed handled input events from unpaired devices still triggering actions on the same physical press [ISXB-1097](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1097)
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/InputActionState.cs
@@ -1436,6 +1436,9 @@ namespace UnityEngine.InputSystem
             Debug.Assert(controlIndex >= 0 && controlIndex < totalControlCount, "Control index out of range");
             Debug.Assert(bindingIndex >= 0 && bindingIndex < totalBindingCount, "Binding index out of range");
 
+            if (InputSystem.s_Manager.ShouldSuppressActionsForDevice(controls[controlIndex].device))
+                return;
+
             using (InputActionRebindingExtensions.DeferBindingResolution())
             {
                 // Callbacks can do pretty much anything and thus trigger arbitrary state/configuration

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -2236,6 +2236,7 @@ namespace UnityEngine.InputSystem
         internal CallbackArray<InputDeviceCommandDelegate> m_DeviceCommandCallbacks;
         private CallbackArray<LayoutChangeListener> m_LayoutChangeListeners;
         private CallbackArray<EventListener> m_EventListeners;
+        private uint[] m_SuppressActionsForDeviceUpdate;
         private CallbackArray<UpdateListener> m_BeforeUpdateListeners;
         private CallbackArray<UpdateListener> m_AfterUpdateListeners;
         private CallbackArray<Action> m_SettingsChangedListeners;
@@ -3454,22 +3455,29 @@ namespace UnityEngine.InputSystem
                         }
                     }
 
+                    var currentEventPtr = new InputEventPtr(currentEventReadPtr);
+
                     // Give listeners a shot at the event.
                     // NOTE: We call listeners also for events where the device is disabled. This is crucial for code
                     //       such as TouchSimulation that disables the originating devices and then uses its events to
                     //       create simulated events from.
                     if (m_EventListeners.length > 0)
                     {
-                        DelegateHelpers.InvokeCallbacksSafe(ref m_EventListeners,
-                            new InputEventPtr(currentEventReadPtr), device, k_InputOnEventMarker, "InputSystem.onEvent");
-
-                        // If a listener marks the event as handled, we don't process it further.
-                        if (m_InputEventHandledPolicy == InputEventHandledPolicy.SuppressStateUpdates &&
-                            currentEventReadPtr->handled)
+                        if (DelegateHelpers.InvokeCallbacksSafeUntilHandled(ref m_EventListeners, currentEventPtr, device, k_InputOnEventMarker, "InputSystem.onEvent",
+                            m_InputEventHandledPolicy == InputEventHandledPolicy.SuppressStateUpdates))
                         {
+                            currentEventReadPtr->handled = true;
+                            SuppressActionsForDevice(device);
                             m_InputEventStream.Advance(false);
                             continue;
                         }
+                    }
+
+                    if (m_InputEventHandledPolicy == InputEventHandledPolicy.SuppressStateUpdates && currentEventPtr.handled)
+                    {
+                        SuppressActionsForDevice(device);
+                        m_InputEventStream.Advance(false);
+                        continue;
                     }
 
                     // Update metrics.
@@ -3484,8 +3492,6 @@ namespace UnityEngine.InputSystem
                         case StateEvent.Type:
                         case DeltaStateEvent.Type:
 
-                            var eventPtr = new InputEventPtr(currentEventReadPtr);
-
                             // Ignore the event if the last state update we received for the device was
                             // newer than this state event is. We don't allow devices to go back in time.
                             //
@@ -3496,7 +3502,7 @@ namespace UnityEngine.InputSystem
                             //       increasing timestamps across all such streams.
                             var deviceIsStateCallbackReceiver = device.hasStateCallbacks;
                             if (currentEventTimeInternal < device.m_LastUpdateTimeInternal &&
-                                !(deviceIsStateCallbackReceiver && device.stateBlock.format != eventPtr.stateFormat))
+                                !(deviceIsStateCallbackReceiver && device.stateBlock.format != currentEventPtr.stateFormat))
                             {
 #if UNITY_EDITOR
                                 m_Diagnostics?.OnEventTimestampOutdated(new InputEventPtr(currentEventReadPtr), device);
@@ -3520,14 +3526,14 @@ namespace UnityEngine.InputSystem
                                 m_ShouldMakeCurrentlyUpdatingDeviceCurrent = true;
                                 // NOTE: We leave it to the device to make sure the event has the right format. This allows the
                                 //       device to handle multiple different incoming formats.
-                                ((IInputStateCallbackReceiver)device).OnStateEvent(eventPtr);
+                                ((IInputStateCallbackReceiver)device).OnStateEvent(currentEventPtr);
 
                                 haveChangedStateOtherThanNoise = m_ShouldMakeCurrentlyUpdatingDeviceCurrent;
                             }
                             else
                             {
                                 // If the state format doesn't match, ignore the event.
-                                if (device.stateBlock.format != eventPtr.stateFormat)
+                                if (device.stateBlock.format != currentEventPtr.stateFormat)
                                 {
 #if UNITY_EDITOR
                                     m_Diagnostics?.OnEventFormatMismatch(currentEventReadPtr, device);
@@ -3535,23 +3541,23 @@ namespace UnityEngine.InputSystem
                                     break;
                                 }
 
-                                haveChangedStateOtherThanNoise = UpdateState(device, eventPtr, updateType);
+                                haveChangedStateOtherThanNoise = UpdateState(device, currentEventPtr, updateType);
                             }
 
-                            totalEventBytesProcessed += eventPtr.sizeInBytes;
+                            totalEventBytesProcessed += currentEventPtr.sizeInBytes;
 
-                            device.m_CurrentProcessedEventBytesOnUpdate += eventPtr.sizeInBytes;
+                            device.m_CurrentProcessedEventBytesOnUpdate += currentEventPtr.sizeInBytes;
 
                             // Update timestamp on device.
                             // NOTE: We do this here and not in UpdateState() so that InputState.Change() will *NOT* change timestamps.
                             //       Only events should. If running play mode updates in editor, we want to defer to the play mode
                             //       callbacks to set the last update time to avoid dropping events only processed by the editor state.
-                            if (device.m_LastUpdateTimeInternal <= eventPtr.internalTime
+                            if (device.m_LastUpdateTimeInternal <= currentEventPtr.internalTime
 #if UNITY_EDITOR
                                 && !(updateType == InputUpdateType.Editor && runPlayerUpdatesInEditMode)
 #endif
                             )
-                                device.m_LastUpdateTimeInternal = eventPtr.internalTime;
+                                device.m_LastUpdateTimeInternal = currentEventPtr.internalTime;
 
                             // Make device current. Again, only do this when receiving events.
                             if (haveChangedStateOtherThanNoise)
@@ -3889,6 +3895,31 @@ namespace UnityEngine.InputSystem
         }
 
         private bool m_ShouldMakeCurrentlyUpdatingDeviceCurrent;
+
+        private void SuppressActionsForDevice(InputDevice device)
+        {
+            if (m_InputEventHandledPolicy != InputEventHandledPolicy.SuppressStateUpdates || device == null)
+                return;
+
+            var deviceIndex = device.m_DeviceIndex;
+            if (m_SuppressActionsForDeviceUpdate == null || deviceIndex >= m_SuppressActionsForDeviceUpdate.Length)
+                Array.Resize(ref m_SuppressActionsForDeviceUpdate, deviceIndex + 1);
+            m_SuppressActionsForDeviceUpdate[deviceIndex] = InputUpdate.s_UpdateStepCount;
+        }
+
+        internal bool ShouldSuppressActionsForDevice(InputDevice device)
+        {
+            if (m_InputEventHandledPolicy != InputEventHandledPolicy.SuppressStateUpdates || device == null)
+                return false;
+
+            var deviceIndex = device.m_DeviceIndex;
+            if (m_SuppressActionsForDeviceUpdate == null || deviceIndex >= m_SuppressActionsForDeviceUpdate.Length)
+                return false;
+
+            var lastUpdate = (int)m_SuppressActionsForDeviceUpdate[deviceIndex];
+            var currentUpdate = (int)InputUpdate.s_UpdateStepCount;
+            return lastUpdate == currentUpdate || lastUpdate + 1 == currentUpdate;
+        }
 
         // This is a dirty hot fix to expose entropy from device back to input manager to make a choice if we want to make device current or not.
         // A proper fix would be to change IInputStateCallbackReceiver.OnStateEvent to return bool to make device current or not.

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using Unity.Profiling;
+using UnityEngine.InputSystem.LowLevel;
 
 namespace UnityEngine.InputSystem.Utilities
 {
@@ -80,6 +81,37 @@ namespace UnityEngine.InputSystem.Utilities
                 }
             }
             callbacks.UnlockForChanges();
+            marker.End();
+        }
+
+        public static bool InvokeCallbacksSafeUntilHandled(ref CallbackArray<Action<InputEventPtr, InputDevice>> callbacks,
+            InputEventPtr eventPtr, InputDevice device, ProfilerMarker marker, string callbackName, bool stopOnHandled)
+        {
+            if (callbacks.length == 0)
+                return false;
+
+            marker.Begin();
+            callbacks.LockForChanges();
+            for (var i = 0; i < callbacks.length; ++i)
+            {
+                try
+                {
+                    callbacks[i](eventPtr, device);
+                }
+                catch (Exception exception)
+                {
+                    Debug.LogException(exception);
+                    Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
+                }
+
+                if (stopOnHandled && eventPtr.handled)
+                {
+                    callbacks.UnlockForChanges();
+                    return true;
+                }
+            }
+            callbacks.UnlockForChanges();
+            return false;
             marker.End();
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/DelegateHelpers.cs
@@ -92,27 +92,35 @@ namespace UnityEngine.InputSystem.Utilities
 
             marker.Begin();
             callbacks.LockForChanges();
-            for (var i = 0; i < callbacks.length; ++i)
+            var handled = false;
+            try
             {
-                try
+                for (var i = 0; i < callbacks.length; ++i)
                 {
-                    callbacks[i](eventPtr, device);
-                }
-                catch (Exception exception)
-                {
-                    Debug.LogException(exception);
-                    Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
-                }
+                    try
+                    {
+                        callbacks[i](eventPtr, device);
+                    }
+                    catch (Exception exception)
+                    {
+                        Debug.LogException(exception);
+                        Debug.LogError($"{exception.GetType().Name} while executing '{callbackName}' callbacks");
+                    }
 
-                if (stopOnHandled && eventPtr.handled)
-                {
-                    callbacks.UnlockForChanges();
-                    return true;
+                    if (stopOnHandled && eventPtr.handled)
+                    {
+                        handled = true;
+                        break;
+                    }
                 }
             }
-            callbacks.UnlockForChanges();
-            return false;
-            marker.End();
+            finally
+            {
+                callbacks.UnlockForChanges();
+                marker.End();
+            }
+
+            return handled;
         }
 
         public static bool InvokeCallbacksSafe_AnyCallbackReturnsTrue<TValue1, TValue2>(ref CallbackArray<Func<TValue1, TValue2, bool>> callbacks,


### PR DESCRIPTION
### Description

  **Bug:** https://issuetracker.unity3d.com/issues/setting-inputeventptr-dot-handled-to-true-does-not-prevent-actions-from-triggering-when-changing-devices
  When `InputUser.onUnpairedDeviceUsed` marks `eventPtr.handled` = true, we expect no action to fire from that same
  button press.
  But on devices like DualSense, a single press can generate multiple input events. The handled flag only stops the
  one event, and another event in the same press still triggers the action.

  Root cause
  The action system is driven by state change events. We can see different eventIds for the handled event vs the
  action‑triggering event, so the action was coming from a separate input event.

  **Fix**

  - While dispatching `InputSystem.onEvent`, stop calling remaining listeners once handled becomes true.
  - When an event is handled (policy = SuppressStateUpdates), temporarily suppress action processing for that device
    for the rest of the update (and next update).
  - In `InputActionState`, skip processing control changes if the device is suppressed.


### Testing status & QA

Manually verified using repro project + dualsense controller. 

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers
  - Only applies when policy is `SuppressStateUpdates` and a listener explicitly sets handled = true.
  - Normal input flow remains unchanged.
  - This simply makes “handled” cover the entire physical press, even if it arrives as multiple events.
### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
