### PR TITLE
FIX: Implement caching for InputControlPath display name

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Fixed
 
+- Fixed caching for InputControlPath display name.
 - Fixed the `Auto-Save` toggle button with some extra pixels to align the text in the window better.
 - Align title font size with toolbar style in `Input Action` window.
 - Updated Action Properties headers to use colors consistent with GameObject component headers.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -139,7 +139,7 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             var displayName = m_CachedDisplayName;
-            
+
             // Either show dropdown control that opens path picker or show path directly as
             // text, if manual path editing is toggled on.
             if (m_PickerState.manualPathEditMode)
@@ -225,7 +225,7 @@ namespace UnityEngine.InputSystem.Editor
 
         private string m_CachedPath;
         private string m_CachedDisplayName;
-        
+
         private InputControlPickerDropdown m_PickerDropdown;
         private readonly InputControlPickerState m_PickerState;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -215,6 +215,9 @@ namespace UnityEngine.InputSystem.Editor
         private string m_ExpectedControlLayout;
         private string[] m_ControlPathsToMatch;
 
+        private string m_CachedPath;
+        private string m_CachedDisplayName;
+        
         private InputControlPickerDropdown m_PickerDropdown;
         private readonly InputControlPickerState m_PickerState;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -123,7 +123,7 @@ namespace UnityEngine.InputSystem.Editor
                 return;
             }
 
-            // To cache per path value and only recompute when the string actually changes.
+            // Cache the display name per path value and only recompute when the string actually changes.
             if (!string.Equals(path, m_CachedPath, StringComparison.Ordinal))
             {
                 m_CachedPath = path;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -127,7 +127,15 @@ namespace UnityEngine.InputSystem.Editor
             if (!string.Equals(path, m_CachedPath, StringComparison.Ordinal))
             {
                 m_CachedPath = path;
-                m_CachedDisplayName = InputControlPath.ToHumanReadableString(path);
+
+                if (string.IsNullOrEmpty(path))
+                {
+                    m_CachedDisplayName = string.Empty;
+                }
+                else
+                {
+                    m_CachedDisplayName = InputControlPath.ToHumanReadableString(path);
+                }
             }
 
             var displayName = m_CachedDisplayName;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPathEditor.cs
@@ -123,9 +123,15 @@ namespace UnityEngine.InputSystem.Editor
                 return;
             }
 
-            ////TODO: this should be cached; generates needless GC churn
-            var displayName = InputControlPath.ToHumanReadableString(path);
+            // To cache per path value and only recompute when the string actually changes.
+            if (!string.Equals(path, m_CachedPath, StringComparison.Ordinal))
+            {
+                m_CachedPath = path;
+                m_CachedDisplayName = InputControlPath.ToHumanReadableString(path);
+            }
 
+            var displayName = m_CachedDisplayName;
+            
             // Either show dropdown control that opens path picker or show path directly as
             // text, if manual path editing is toggled on.
             if (m_PickerState.manualPathEditMode)


### PR DESCRIPTION
### Description

Purpose of this PR is to fix the TODO by caching per path value and only recompute when the string actually changes.

### Testing status & QA

Check that it works as before, when inputing in the `InputControlPath`.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
