### PR TITLE
CHANGE: Revert: Deprecate useIMGUIEditorForAssets #2283

### DIFF
--- a/Assets/Samples/CustomComposite/CustomComposite.cs
+++ b/Assets/Samples/CustomComposite/CustomComposite.cs
@@ -136,6 +136,13 @@ public class CustomCompositeEditor : InputParameterEditor<CustomComposite>
 {
     public override void OnGUI()
     {
+        // Using the 'target' property, we can access an instance of our composite.
+        var currentValue = target.scaleFactor;
+
+        // The easiest way to lay out our UI is to simply use EditorGUILayout.
+        // We simply assign the changed value back to the 'target' object. The input
+        // system will automatically detect a change in value.
+        target.scaleFactor = EditorGUILayout.Slider(m_ScaleFactorLabel, currentValue, 0, 2);
     }
 
     public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Assets/Tests/InputSystem/CoreTests_Actions.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Actions.cs
@@ -35,6 +35,7 @@ partial class CoreTests
     [TestCase(InputFeatureNames.kParanoidReadValueCachingChecks)]
     [TestCase(InputFeatureNames.kDisableUnityRemoteSupport)]
     [TestCase(InputFeatureNames.kRunPlayerUpdatesInEditMode)]
+    [TestCase(InputFeatureNames.kUseIMGUIEditorForAssets)]
     public void Settings_ShouldStoreSettingsAndFeatureFlags(string featureName)
     {
         using (var settings = Scoped.Object(InputSettings.CreateInstance<InputSettings>()))

--- a/Assets/Tests/InputSystem/CoreTests_Analytics.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Analytics.cs
@@ -458,6 +458,7 @@ partial class CoreTests
             Assert.That(data.feature_paranoid_read_value_caching_checks_enabled, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kParanoidReadValueCachingChecks)));
             Assert.That(data.feature_disable_unity_remote_support, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kDisableUnityRemoteSupport)));
             Assert.That(data.feature_run_player_updates_in_editmode, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kRunPlayerUpdatesInEditMode)));
+            Assert.That(data.feature_use_imgui_editor_for_assets, Is.EqualTo(defaultSettings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets)));
         }
         finally
         {
@@ -506,6 +507,7 @@ partial class CoreTests
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kParanoidReadValueCachingChecks, true);
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kDisableUnityRemoteSupport, true);
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kRunPlayerUpdatesInEditMode, true);
+            customSettings.SetInternalFeatureFlag(InputFeatureNames.kUseIMGUIEditorForAssets, true);
             customSettings.SetInternalFeatureFlag(InputFeatureNames.kUseReadValueCaching, true);
 
             InputSystem.settings = customSettings;
@@ -552,6 +554,7 @@ partial class CoreTests
             Assert.That(data.feature_paranoid_read_value_caching_checks_enabled, Is.True);
             Assert.That(data.feature_disable_unity_remote_support, Is.True);
             Assert.That(data.feature_run_player_updates_in_editmode, Is.True);
+            Assert.That(data.feature_use_imgui_editor_for_assets, Is.True);
         }
         finally
         {

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -12,6 +12,7 @@ however, it has to be formatted properly to pass verification tests.
 
 ### Changed
 
+- Reverted the deprecation of the USE_IMGUI_EDITOR_FOR_ASSETS feature option (ISX-2397).
 - Updated `m_ActionAssetInstanceID` in PlayerInputEditor.cs to use `EntityId` instead of `InstanceID`.
 - Consecutive wildcard characters ('*') used in input control-paths are now collapsed into a single wildcard when multiple consecutive wildcard characters are present.
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/AxisComposite.cs
@@ -5,6 +5,7 @@ using UnityEngine.InputSystem.Utilities;
 
 #if UNITY_EDITOR
 using System;
+using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
 #endif
@@ -211,20 +212,24 @@ namespace UnityEngine.InputSystem.Composites
     #if UNITY_EDITOR
     internal class AxisCompositeEditor : InputParameterEditor<AxisComposite>
     {
-        private const string label = "Which Side Wins";
-        private const string tooltipText = "Determine which axis 'wins' if both are actuated at the same time. "
+        private GUIContent m_WhichAxisWinsLabel = new GUIContent("Which Side Wins",
+            "Determine which axis 'wins' if both are actuated at the same time. "
             + "If 'Neither' is selected, the result is 0 (or, more precisely, "
-            + "the midpoint between minValue and maxValue).";
+            + "the midpoint between minValue and maxValue).");
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            target.whichSideWins = (AxisComposite.WhichSideWins)EditorGUILayout.EnumPopup(m_WhichAxisWinsLabel, target.whichSideWins);
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField(label, target.whichSideWins)
+            var modeField = new EnumField(m_WhichAxisWinsLabel.text, target.whichSideWins)
             {
-                tooltip = tooltipText
+                tooltip = m_WhichAxisWinsLabel.tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector2Composite.cs
@@ -5,6 +5,7 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 
 #if UNITY_EDITOR
+using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
 #endif
@@ -191,20 +192,24 @@ namespace UnityEngine.InputSystem.Composites
     #if UNITY_EDITOR
     internal class Vector2CompositeEditor : InputParameterEditor<Vector2Composite>
     {
-        private const string label = "Mode";
-        private const string tooltipText = "How to synthesize a Vector2 from the inputs. Digital "
+        private GUIContent m_ModeLabel = new GUIContent("Mode",
+            "How to synthesize a Vector2 from the inputs. Digital "
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
-            + "floating-point magnitudes as read from controls.";
+            + "floating-point magnitudes as read from controls.");
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            target.mode = (Vector2Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField(label, target.mode)
+            var modeField = new EnumField(m_ModeLabel.text, target.mode)
             {
-                tooltip = tooltipText
+                tooltip = m_ModeLabel.tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/Vector3Composite.cs
@@ -4,6 +4,7 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 
 #if UNITY_EDITOR
+using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
 #endif
@@ -171,20 +172,24 @@ namespace UnityEngine.InputSystem.Composites
     #if UNITY_EDITOR
     internal class Vector3CompositeEditor : InputParameterEditor<Vector3Composite>
     {
-        private const string label = "Mode";
-        private const string tooltip = "How to synthesize a Vector3 from the inputs. Digital "
+        private GUIContent m_ModeLabel = new GUIContent("Mode",
+            "How to synthesize a Vector3 from the inputs. Digital "
             + "treats part bindings as buttons (on/off) whereas Analog preserves "
-            + "floating-point magnitudes as read from controls.";
+            + "floating-point magnitudes as read from controls.");
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            target.mode = (Vector3Composite.Mode)EditorGUILayout.EnumPopup(m_ModeLabel, target.mode);
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var modeField = new EnumField(label, target.mode)
+            var modeField = new EnumField(m_ModeLabel.text, target.mode)
             {
-                tooltip = tooltip
+                tooltip = m_ModeLabel.tooltip
             };
 
             modeField.RegisterValueChangedCallback(evt =>

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -1,7 +1,7 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
-
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
@@ -124,6 +124,11 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            m_PressPointSetting.OnGUI();
+            m_DurationSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/MultiTapInteraction.cs
@@ -1,9 +1,11 @@
 using System;
 using UnityEngine.InputSystem.Controls;
-
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
+using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
+using UnityEditor.UIElements;
 #endif
 
 ////TODO: add ability to respond to any of the taps in the sequence (e.g. one response for single tap, another for double tap)
@@ -194,14 +196,21 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            target.tapCount = EditorGUILayout.IntField(m_TapCountLabel, target.tapCount);
+            m_TapDelaySetting.OnGUI();
+            m_TapTimeSetting.OnGUI();
+            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            var tapCountField = new IntegerField(tapLabel)
+            var tapCountField = new IntegerField(m_TapCountLabel.text)
             {
                 value = target.tapCount,
-                tooltip = tapTooltip
+                tooltip = m_TapCountLabel.tooltip
             };
             tapCountField.RegisterValueChangedCallback(evt =>
             {
@@ -215,8 +224,7 @@ namespace UnityEngine.InputSystem.Interactions
             m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);
         }
 
-        private const string tapLabel = "Tap Count";
-        private const string tapTooltip = "How many taps need to be performed in succession. Two means double-tap, three means triple-tap, and so on.";
+        private readonly GUIContent m_TapCountLabel = new GUIContent("Tap Count", "How many taps need to be performed in succession. Two means double-tap, three means triple-tap, and so on.");
 
         private CustomOrDefaultSetting m_PressPointSetting;
         private CustomOrDefaultSetting m_TapTimeSetting;

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/PressInteraction.cs
@@ -1,9 +1,12 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
+using UnityEditor;
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
+using UnityEditor.UIElements;
 #endif
 
 ////TODO: protect against the control *hovering* around the press point; this should not fire the press repeatedly; probably need a zone around the press point
@@ -210,15 +213,21 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            EditorGUILayout.HelpBox(s_HelpBoxText);
+            target.behavior = (PressBehavior)EditorGUILayout.EnumPopup(s_PressBehaviorLabel, target.behavior);
+            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            root.Add(new HelpBox(helpLabel, HelpBoxMessageType.None));
+            root.Add(new HelpBox(s_HelpBoxText.text, HelpBoxMessageType.None));
 
-            var behaviourDropdown = new EnumField(triggerLabel, target.behavior)
+            var behaviourDropdown = new EnumField(s_PressBehaviorLabel.text, target.behavior)
             {
-                tooltip = triggerTooltip
+                tooltip = s_PressBehaviorLabel.tooltip
             };
             behaviourDropdown.RegisterValueChangedCallback(evt =>
             {
@@ -232,13 +241,14 @@ namespace UnityEngine.InputSystem.Interactions
 
         private CustomOrDefaultSetting m_PressPointSetting;
 
-        private const string helpLabel = "Note that the 'Press' interaction is only "
+        private static readonly GUIContent s_HelpBoxText = EditorGUIUtility.TrTextContent("Note that the 'Press' interaction is only "
             + "necessary when wanting to customize button press behavior. For default press behavior, simply set the action type to 'Button' "
-            + "and use the action without interactions added to it.";
-        private const string triggerLabel = "Trigger Behavior";
-        private const string triggerTooltip = "Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
+            + "and use the action without interactions added to it.");
+
+        private static readonly GUIContent s_PressBehaviorLabel = EditorGUIUtility.TrTextContent("Trigger Behavior",
+            "Determines how button presses trigger the action. By default (PressOnly), the action is performed on press. "
             + "With ReleaseOnly, the action is performed on release. With PressAndRelease, the action is performed on press and "
-            + "canceled on release.";
+            + "canceled on release.");
     }
     #endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/SlowTapInteraction.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
@@ -87,6 +88,11 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            m_DurationSetting.OnGUI();
+            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/TapInteraction.cs
@@ -1,6 +1,7 @@
 using System;
 using System.ComponentModel;
 using UnityEngine.InputSystem.Controls;
+using UnityEngine.Scripting;
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
 using UnityEngine.UIElements;
@@ -113,6 +114,11 @@ namespace UnityEngine.InputSystem.Interactions
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            m_DurationSetting.OnGUI();
+            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/AxisDeadzoneProcessor.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine.Scripting;
 
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
@@ -92,6 +93,11 @@ namespace UnityEngine.InputSystem.Processors
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            m_MinSetting.OnGUI();
+            m_MaxSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/Processors/StickDeadzoneProcessor.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine.Scripting;
 
 #if UNITY_EDITOR
 using UnityEngine.InputSystem.Editor;
@@ -81,6 +82,11 @@ namespace UnityEngine.InputSystem.Processors
 
         public override void OnGUI()
         {
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            m_MinSetting.OnGUI();
+            m_MaxSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Analytics/InputBuildAnalytic.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Analytics/InputBuildAnalytic.cs
@@ -195,6 +195,9 @@ namespace UnityEngine.InputSystem.Editor
                 feature_paranoid_read_value_caching_checks_enabled =
                     settings.IsFeatureEnabled(InputFeatureNames.kParanoidReadValueCachingChecks);
 
+                feature_use_imgui_editor_for_assets =
+                    settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets);
+
                 feature_disable_unity_remote_support =
                     settings.IsFeatureEnabled(InputFeatureNames.kDisableUnityRemoteSupport);
                 feature_run_player_updates_in_editmode =
@@ -326,6 +329,12 @@ namespace UnityEngine.InputSystem.Editor
             /// as defined in InputSystem 1.8.x.
             /// </summary>
             public bool feature_paranoid_read_value_caching_checks_enabled;
+
+            /// <summary>
+            /// Represents internal feature flag <see cref="InputFeatureNames.kUseIMGUIEditorForAssets" />
+            /// as defined in InputSystem 1.8.x.
+            /// </summary>
+            public bool feature_use_imgui_editor_for_assets;
 
             /// <summary>
             /// Represents internal feature flag <see cref="InputFeatureNames.kDisableUnityRemoteSupport" />

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetEditor/ParameterListView.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.Utilities;
 using UnityEngine.UIElements;
@@ -134,7 +135,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                     parameter.value = parameter.value.ConvertTo(underlyingTypeCode);
 
                     // Read enum names and values.
-                    parameter.enumNames = Enum.GetNames(fieldType);
+                    parameter.enumNames = Enum.GetNames(fieldType).Select(x => new GUIContent(x)).ToArray();
                     ////REVIEW: this probably falls apart if multiple members have the same value
                     var list = new List<int>();
                     foreach (var value in Enum.GetValues(fieldType))
@@ -223,7 +224,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
                 m_ParameterEditor = null;
 
                 // Create parameter labels.
-                m_ParameterLabels = new(string text, string tooltip)[m_Parameters.Length];
+                m_ParameterLabels = new GUIContent[m_Parameters.Length];
                 for (var i = 0; i < m_Parameters.Length; ++i)
                 {
                     // Look up tooltip from field.
@@ -235,7 +236,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
                     // Create label.
                     var niceName = ObjectNames.NicifyVariableName(m_Parameters[i].value.name);
-                    m_ParameterLabels[i] = (niceName, tooltip);
+                    m_ParameterLabels[i] = new GUIContent(niceName, tooltip);
                 }
             }
         }
@@ -276,7 +277,7 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
                 if (parameter.isEnum)
                 {
-                    var names = parameter.enumNames.ToList();
+                    var names = parameter.enumNames.Select(c => c.text).ToList();
                     var rawValue = parameter.value.value.ToInt32();
                     var selectedIndex = parameter.enumValues.IndexOf(rawValue);
                     if (selectedIndex < 0 || selectedIndex >= names.Count)
@@ -349,6 +350,72 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
         public void OnGUI()
         {
+            // If we have a dedicated parameter editor, let it do all the work.
+            if (m_ParameterEditor != null)
+            {
+                EditorGUI.BeginChangeCheck();
+                m_ParameterEditor.OnGUI();
+                if (EditorGUI.EndChangeCheck())
+                {
+                    ReadParameterValuesFrom(m_ParameterEditor.target);
+                    onChange?.Invoke();
+                }
+                return;
+            }
+
+            // handled by OnDrawVisualElements with UI Toolkit
+            if (!InputSystem.settings.useIMGUIEditorForAssets)
+                return;
+
+            // Otherwise, fall back to our default logic.
+            if (m_Parameters == null)
+                return;
+            for (var i = 0; i < m_Parameters.Length; i++)
+            {
+                var parameter = m_Parameters[i];
+                var label = m_ParameterLabels[i];
+
+                EditorGUI.BeginChangeCheck();
+
+                object result = null;
+                if (parameter.isEnum)
+                {
+                    var intValue = parameter.value.value.ToInt32();
+                    result = EditorGUILayout.IntPopup(label, intValue, parameter.enumNames, parameter.enumValues);
+                }
+                else if (parameter.value.type == TypeCode.Int64 || parameter.value.type == TypeCode.UInt64)
+                {
+                    var longValue = parameter.value.value.ToInt64();
+                    result = EditorGUILayout.LongField(label, longValue);
+                }
+                else if (parameter.value.type.IsInt())
+                {
+                    var intValue = parameter.value.value.ToInt32();
+                    result = EditorGUILayout.IntField(label, intValue);
+                }
+                else if (parameter.value.type == TypeCode.Single)
+                {
+                    var floatValue = parameter.value.value.ToSingle();
+                    result = EditorGUILayout.FloatField(label, floatValue);
+                }
+                else if (parameter.value.type == TypeCode.Double)
+                {
+                    var floatValue = parameter.value.value.ToDouble();
+                    result = EditorGUILayout.DoubleField(label, floatValue);
+                }
+                else if (parameter.value.type == TypeCode.Boolean)
+                {
+                    var boolValue = parameter.value.value.ToBoolean();
+                    result = EditorGUILayout.Toggle(label, boolValue);
+                }
+
+                if (EditorGUI.EndChangeCheck())
+                {
+                    parameter.value.value = PrimitiveValue.FromObject(result).ConvertTo(parameter.value.type);
+                    m_Parameters[i] = parameter;
+                    onChange?.Invoke();
+                }
+            }
         }
 
         ////REVIEW: check whether parameters have *actually* changed?
@@ -381,15 +448,14 @@ namespace UnityEngine.InputSystem.Editor.Lists
 
         private InputParameterEditor m_ParameterEditor;
         private EditableParameterValue[] m_Parameters;
-
-        private (string text, string tooltip)[] m_ParameterLabels;
+        private GUIContent[] m_ParameterLabels;
 
         private struct EditableParameterValue
         {
             public NamedValue value;
             public NamedValue? defaultValue;
             public int[] enumValues;
-            public string[] enumNames;
+            public GUIContent[] enumNames;
             public FieldInfo field;
 
             public bool isEnum => enumValues != null;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -58,6 +58,9 @@ namespace UnityEngine.InputSystem.Editor
 
         private static bool OpenAsset(Object obj)
         {
+            if (InputSystem.settings.IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets))
+                return false;
+
             // Grab InputActionAsset.
             // NOTE: We defer checking out an asset until we save it. This allows a user to open an .inputactions asset and look at it
             //       without forcing a checkout.

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -171,6 +171,8 @@ namespace UnityEngine.InputSystem.Editor
             var foldout = container.Q<Foldout>("Foldout");
             foldout.text = parameterListView.name;
             parameterListView.OnDrawVisualElements(foldout);
+
+            foldout.Add(new IMGUIContainer(parameterListView.OnGUI));
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -719,11 +719,6 @@ namespace UnityEngine.InputSystem
             if (string.IsNullOrEmpty(featureName))
                 throw new ArgumentNullException(nameof(featureName));
 
-            if (featureName == InputFeatureNames.kUseIMGUIEditorForAssets)
-            {
-                throw new ArgumentException($"The {InputFeatureNames.kUseIMGUIEditorForAssets} feature flag is no longer supported.");
-            }
-
             if (m_FeatureFlags == null)
                 m_FeatureFlags = new HashSet<string>();
 
@@ -964,8 +959,14 @@ namespace UnityEngine.InputSystem
         }
 
 #if UNITY_EDITOR
-        [Obsolete("useIMGUIEditorForAssets is obsolete and will be removed in a future release.")]
-        public bool useIMGUIEditorForAssets => false;
+        /// <summary>
+        /// Determines if we should render the UI with IMGUI even if an UI Toolkit UI is available.
+        ///
+        /// This should be used when writing a custom <see cref="InputParameterEditor"/> to :
+        /// * support inspector view which only work in IMGUI for now.
+        /// * prevent the UI to be rendered in IMGUI and UI Toolkit in the Input Actions Editor window.
+        /// </summary>
+        public bool useIMGUIEditorForAssets => UnityEditor.EditorGUI.indentLevel > 0 || IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets);
 #endif
 
         private static bool CompareFloats(float a, float b)


### PR DESCRIPTION
### Description

Reverting: CHANGE: Deprecate useIMGUIEditorForAssets #2283 

This PR fixes the **regression** introduced by the PR above since it does not serialize `Interactions` and `Processors`.

JIRA: [UUM-133864](https://jira.unity3d.com/browse/UUM-133864)

Before:
<img width="335" height="611" alt="Screenshot 2026-02-17 at 13 23 12" src="https://github.com/user-attachments/assets/ba978370-2f1a-4e68-a478-151e5ddbb056" />


After:
<img width="307" height="629" alt="Screenshot 2026-02-17 at 13 15 27" src="https://github.com/user-attachments/assets/f4d95b55-f9da-4321-8862-fad5f2df822e" />


### Testing status & QA

Make a monobehaviour script and Serialize InputActions. Add Interactions and Processors as shown above.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
