### PR TITLE
CHANGE: Removing old mentions of UNITY_2021

### DIFF
--- a/Assets/Tests/InputSystem/Plugins/DeviceSimulatorTests.cs
+++ b/Assets/Tests/InputSystem/Plugins/DeviceSimulatorTests.cs
@@ -1,4 +1,4 @@
-#if UNITY_EDITOR && UNITY_2021_1_OR_NEWER
+#if UNITY_EDITOR
 
 using System.Collections;
 using System.Reflection;

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3994,9 +3994,7 @@ internal partial class UITests : CoreTestsFixture
             ////FIXME: as of a time of writing, this line is broken on trunk due to the bug in UITK
             // The bug is https://fogbugz.unity3d.com/f/cases/1323488/
             // just adding a define as a safeguard measure to reenable it when trunk goes to next version cycle
-#if UNITY_2021_3_OR_NEWER
             Assert.That(scrollView.verticalScroller.value, Is.GreaterThan(0));
-#endif
 
             // Try a button press with the gamepad.
             // NOTE: The current version of UITK does not focus the button automatically. Fix for that is in the pipe.
@@ -4767,7 +4765,6 @@ internal partial class UITests : CoreTestsFixture
                 pointerType = extendedEventData.pointerType,
                 trackedDeviceOrientation = extendedEventData.trackedDeviceOrientation,
                 trackedDevicePosition = extendedEventData.trackedDevicePosition,
-#if UNITY_2021_1_OR_NEWER
                 pressure = eventData.pressure,
                 tangentialPressure = eventData.tangentialPressure,
                 altitudeAngle = eventData.altitudeAngle,
@@ -4775,7 +4772,6 @@ internal partial class UITests : CoreTestsFixture
                 twist = eventData.twist,
                 radius = eventData.radius,
                 radiusVariance = eventData.radiusVariance,
-#endif
 #if UNITY_2022_3_OR_NEWER
                 displayIndex = eventData.displayIndex,
 #endif

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -397,13 +397,7 @@ internal partial class UITests : CoreTestsFixture
         }
         yield return null;
 
-        const int kHaveMovementEvents =
-#if UNITY_2021_2_OR_NEWER
-            1
-#else
-            0
-#endif
-        ;
+        const int kHaveMovementEvents = 1;
 
         Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo((isTouch ? 3 : 1) + kHaveMovementEvents));
         Assert.That(scene.parentReceiver.events, Has.Count.EqualTo(1 + kHaveMovementEvents));
@@ -484,7 +478,6 @@ internal partial class UITests : CoreTestsFixture
             // Touch has no ability to point without pressing so pointer enter event is followed
             // right by pointer down event.
 
-#if UNITY_2021_2_OR_NEWER
             // PointerMove.
             Assert.That(scene.leftChildReceiver.events[0 + kHaveMovementEvents].type, Is.EqualTo(EventType.PointerMove));
             Assert.That(scene.leftChildReceiver.events[0 + kHaveMovementEvents].pointerData.button, Is.EqualTo(PointerEventData.InputButton.Left));
@@ -512,7 +505,6 @@ internal partial class UITests : CoreTestsFixture
             Assert.That(scene.leftChildReceiver.events[0 + kHaveMovementEvents].pointerData.pointerPressRaycast.gameObject, Is.Null);
             Assert.That(scene.leftChildReceiver.events[0 + kHaveMovementEvents].pointerData.pointerPressRaycast.screenPosition,
                 Is.EqualTo(default(Vector2)).Using(Vector2EqualityComparer.Instance));
-#endif
 
             // PointerDown.
             Assert.That(scene.leftChildReceiver.events[1 + kHaveMovementEvents].type, Is.EqualTo(EventType.PointerDown));
@@ -739,7 +731,6 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerCurrentRaycast.screenPosition", secondScreenPosition),
 
                 // PointerMove.
-#if UNITY_2021_2_OR_NEWER
                 OneEvent("type", EventType.PointerMove),
                 OneEvent("dragging", false),
                 // Again, pointer movement is processed exclusively "from" the left button.
@@ -753,7 +744,6 @@ internal partial class UITests : CoreTestsFixture
                 OneEvent("lastPress", clickButton == PointerEventData.InputButton.Left ? null : scene.leftGameObject),
                 OneEvent("pointerPressRaycast.gameObject", clickButton == PointerEventData.InputButton.Left ? scene.leftGameObject : null),
                 OneEvent("pointerPressRaycast.screenPosition", clickButton == PointerEventData.InputButton.Left ? firstScreenPosition : Vector2.zero),
-#endif
 
                 // BeginDrag.
                 OneEvent("type", EventType.BeginDrag),
@@ -786,12 +776,7 @@ internal partial class UITests : CoreTestsFixture
         );
 
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
-        Assert.That(scene.parentReceiver.events,
-            EventSequence(
-#if UNITY_2021_2_OR_NEWER
-                OneEvent("type", EventType.PointerMove)
-#endif
-            )
+        Assert.That(scene.parentReceiver.events, EventSequence(OneEvent("type", EventType.PointerMove))
         );
 
         scene.leftChildReceiver.events.Clear();
@@ -817,12 +802,7 @@ internal partial class UITests : CoreTestsFixture
         Assert.That(scene.eventSystem.IsPointerOverGameObject(pointerId), Is.True);
         // Should not have seen pointer enter/exit on parent (we only moved from one of its
         // children to another) but *should* have seen a move event.
-        Assert.That(scene.parentReceiver.events,
-            EventSequence(
-#if UNITY_2021_2_OR_NEWER
-                OneEvent("type", EventType.PointerMove)
-#endif
-            )
+        Assert.That(scene.parentReceiver.events, EventSequence(OneEvent("type", EventType.PointerMove))
         );
 
         if (isTracked)
@@ -923,10 +903,8 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerPressRaycast.gameObject", clickButton == PointerEventData.InputButton.Left ? scene.leftGameObject : null),
                 AllEvents("pointerPressRaycast.screenPosition", clickButton == PointerEventData.InputButton.Left ? firstScreenPosition : Vector2.zero),
 
-                OneEvent("type", EventType.PointerEnter)
-#if UNITY_2021_2_OR_NEWER
-                , OneEvent("type", EventType.PointerMove)
-#endif
+                OneEvent("type", EventType.PointerEnter), 
+                OneEvent("type", EventType.PointerMove)
             )
         );
 
@@ -2019,12 +1997,10 @@ internal partial class UITests : CoreTestsFixture
                     AllEvents("pointerType", UIPointerType.Touch),
                     AllEvents("touchId", 1),
                     AllEvents("position", scene.From640x480ToScreen(180, 180)),
-                    OneEvent("type", EventType.PointerEnter)
-#if UNITY_2021_2_OR_NEWER
-                    , OneEvent("type", EventType.PointerMove)
-#endif
-                    , OneEvent("type", EventType.PointerDown)
-                    , OneEvent("type", EventType.InitializePotentialDrag)
+                    OneEvent("type", EventType.PointerEnter),
+                    OneEvent("type", EventType.PointerMove),
+                    OneEvent("type", EventType.PointerDown),
+                    OneEvent("type", EventType.InitializePotentialDrag)
                 )
             );
 
@@ -2161,9 +2137,8 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerId", trackedDevice2.deviceId),
                 AllEvents("device", trackedDevice2),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.leftGameObject, Vector3.left)),
-                OneEvent("type", EventType.PointerEnter)
-                , OneEvent("type", EventType.PointerMove)
-#endif
+                OneEvent("type", EventType.PointerEnter),
+                OneEvent("type", EventType.PointerMove)
             )
         );
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
@@ -2221,9 +2196,7 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerId", trackedDevice1.deviceId),
                 AllEvents("device", trackedDevice1),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.rightGameObject)),
-#if UNITY_2021_2_OR_NEWER
                 OneEvent("type", EventType.PointerMove),
-#endif
                 OneEvent("type", EventType.PointerExit)
             )
         );
@@ -2233,10 +2206,8 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerId", trackedDevice1.deviceId),
                 AllEvents("device", trackedDevice1),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.rightGameObject)),
-                OneEvent("type", EventType.PointerEnter)
-#if UNITY_2021_2_OR_NEWER
-                , OneEvent("type", EventType.PointerMove)
-#endif
+                OneEvent("type", EventType.PointerEnter),
+                OneEvent("type", EventType.PointerMove)
             )
         );
 
@@ -2253,9 +2224,7 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerId", trackedDevice2.deviceId),
                 AllEvents("device", trackedDevice2),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.rightGameObject, Vector3.right)),
-#if UNITY_2021_2_OR_NEWER
                 OneEvent("type", EventType.PointerMove),
-#endif
                 OneEvent("type", EventType.PointerExit)
             )
         );
@@ -2266,9 +2235,7 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("device", trackedDevice2),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.rightGameObject, Vector3.right)),
                 OneEvent("type", EventType.PointerEnter)
-#if UNITY_2021_2_OR_NEWER
                 , OneEvent("type", EventType.PointerMove)
-#endif
             )
         );
     }
@@ -2591,13 +2558,8 @@ internal partial class UITests : CoreTestsFixture
 
         var raycastResult = scene.uiModule.GetLastRaycastResult(trackedDevice.deviceId);
         Assert.That(raycastResult.isValid, Is.True);
-
-        //2021.2 added an additional move event.
-#if UNITY_2021_2_OR_NEWER
+        
         Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(2));
-#else
-        Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(1));
-#endif
         Assert.That(scene.leftChildReceiver.events[0].pointerData, Is.Not.Null);
 
         var eventRaycastResult = scene.leftChildReceiver.events[0].pointerData.pointerCurrentRaycast;
@@ -4162,9 +4124,7 @@ internal partial class UITests : CoreTestsFixture
         Assert.That(scene.leftChildReceiver.events,
             EventSequence(
                 OneEvent("type", EventType.PointerEnter),
-#if UNITY_2021_2_OR_NEWER
                 OneEvent("type", EventType.PointerMove),
-#endif
                 OneEvent("type", EventType.PointerDown),
                 OneEvent("type", EventType.InitializePotentialDrag)
             )
@@ -4627,9 +4587,7 @@ internal partial class UITests : CoreTestsFixture
         PointerUp,
         PointerEnter,
         PointerExit,
-#if UNITY_2021_2_OR_NEWER
         PointerMove,
-#endif
         Select,
         Deselect,
         InitializePotentialDrag,
@@ -4644,11 +4602,8 @@ internal partial class UITests : CoreTestsFixture
     }
 
     private class UICallbackReceiver : MonoBehaviour, IPointerClickHandler, IPointerDownHandler, IPointerEnterHandler,
-#if UNITY_2021_2_OR_NEWER
-        IPointerMoveHandler,
-#endif
-        IPointerExitHandler, IPointerUpHandler, IMoveHandler, ISelectHandler, IDeselectHandler, IInitializePotentialDragHandler,
-        IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler, ISubmitHandler, ICancelHandler, IScrollHandler
+        IPointerMoveHandler, IPointerExitHandler, IPointerUpHandler, IMoveHandler, ISelectHandler, IDeselectHandler,
+        IInitializePotentialDragHandler, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler, ISubmitHandler, ICancelHandler, IScrollHandler
     {
         public struct Event
         {
@@ -4700,14 +4655,11 @@ internal partial class UITests : CoreTestsFixture
             events.Add(new Event(EventType.PointerUp, ClonePointerEventData(eventData)));
         }
 
-#if UNITY_2021_2_OR_NEWER
         public void OnPointerMove(PointerEventData eventData)
         {
             events.Add(new Event(EventType.PointerMove, ClonePointerEventData(eventData)));
         }
-
-#endif
-
+        
         public void OnMove(AxisEventData eventData)
         {
             events.Add(new Event(EventType.Move, CloneAxisEventData(eventData)));

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -903,7 +903,7 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerPressRaycast.gameObject", clickButton == PointerEventData.InputButton.Left ? scene.leftGameObject : null),
                 AllEvents("pointerPressRaycast.screenPosition", clickButton == PointerEventData.InputButton.Left ? firstScreenPosition : Vector2.zero),
 
-                OneEvent("type", EventType.PointerEnter), 
+                OneEvent("type", EventType.PointerEnter),
                 OneEvent("type", EventType.PointerMove)
             )
         );
@@ -2558,7 +2558,7 @@ internal partial class UITests : CoreTestsFixture
 
         var raycastResult = scene.uiModule.GetLastRaycastResult(trackedDevice.deviceId);
         Assert.That(raycastResult.isValid, Is.True);
-        
+
         Assert.That(scene.leftChildReceiver.events, Has.Count.EqualTo(2));
         Assert.That(scene.leftChildReceiver.events[0].pointerData, Is.Not.Null);
 
@@ -4657,7 +4657,7 @@ internal partial class UITests : CoreTestsFixture
         {
             events.Add(new Event(EventType.PointerMove, ClonePointerEventData(eventData)));
         }
-        
+
         public void OnMove(AxisEventData eventData)
         {
             events.Add(new Event(EventType.Move, CloneAxisEventData(eventData)));

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -31,9 +31,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 #endif
 
-#if UNITY_2021_2_OR_NEWER
 using UnityEngine.UIElements;
-#endif
 
 #pragma warning disable CS0649
 ////TODO: app focus handling
@@ -852,7 +850,6 @@ internal partial class UITests : CoreTestsFixture
                 // press positions on the moves will be zero.
 
                 // PointerMove.
-#if UNITY_2021_2_OR_NEWER
                 OneEvent("type", EventType.PointerMove),
                 OneEvent("button", PointerEventData.InputButton.Left),
                 OneEvent("pointerEnter", scene.leftGameObject),
@@ -867,7 +864,6 @@ internal partial class UITests : CoreTestsFixture
                 OneEvent("dragging", clickButton == PointerEventData.InputButton.Left ? true : false),
                 OneEvent("pointerPressRaycast.gameObject", clickButton == PointerEventData.InputButton.Left ? scene.leftGameObject : null),
                 OneEvent("pointerPressRaycast.screenPosition", clickButton == PointerEventData.InputButton.Left ? firstScreenPosition : Vector2.zero),
-#endif
 
                 // PointerExit.
                 OneEvent("type", EventType.PointerExit),
@@ -1892,7 +1888,6 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
 
-#if UNITY_2021_2_OR_NEWER
         Assert.That(scene.rightChildReceiver.events,
             Has.Exactly(1).With.Property("type").EqualTo(EventType.PointerMove).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.device == touchScreen).And
@@ -1900,7 +1895,6 @@ internal partial class UITests : CoreTestsFixture
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerId == pointerIdTouch2).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.pointerType == UIPointerType.Touch).And
                 .Matches((UICallbackReceiver.Event e) => e.pointerData.position == secondPosition));
-#endif
 
         // Pointer 3
         Assert.That(scene.rightChildReceiver.events,
@@ -2149,10 +2143,8 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("pointerId", trackedDevice1.deviceId),
                 AllEvents("device", trackedDevice1),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.leftGameObject)),
-                OneEvent("type", EventType.PointerEnter)
-#if UNITY_2021_2_OR_NEWER
-                , OneEvent("type", EventType.PointerMove)
-#endif
+                OneEvent("type", EventType.PointerEnter),
+                OneEvent("type", EventType.PointerMove)
             )
         );
         Assert.That(scene.rightChildReceiver.events, Is.Empty);
@@ -2170,7 +2162,6 @@ internal partial class UITests : CoreTestsFixture
                 AllEvents("device", trackedDevice2),
                 AllEvents("trackedDeviceOrientation", scene.GetLookAtQuaternion(Vector3.zero, scene.leftGameObject, Vector3.left)),
                 OneEvent("type", EventType.PointerEnter)
-#if UNITY_2021_2_OR_NEWER
                 , OneEvent("type", EventType.PointerMove)
 #endif
             )


### PR DESCRIPTION
### Description

CHANGE: Removing old mentions of `UNITY_2021`


### Testing status & QA

N/A

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
