### PR TITLE
CHANGE: Removing old mentions of UNITY_2022

### DIFF
--- a/Assets/Tests/InputSystem/CorePerformanceTests.cs
+++ b/Assets/Tests/InputSystem/CorePerformanceTests.cs
@@ -1099,9 +1099,7 @@ internal class CorePerformanceTests : CoreTestsFixture
     }
 
 #endif
-
-    #if UNITY_2022_3_OR_NEWER
-
+    
     // All the profiler markers in the package code.
     // Needed for the tests below.
     string[] allInputSystemProfilerMarkers =
@@ -1263,6 +1261,4 @@ internal class CorePerformanceTests : CoreTestsFixture
 
         EnhancedTouchSupport.Disable();
     }
-
-    #endif
 }

--- a/Assets/Tests/InputSystem/CorePerformanceTests.cs
+++ b/Assets/Tests/InputSystem/CorePerformanceTests.cs
@@ -1099,7 +1099,7 @@ internal class CorePerformanceTests : CoreTestsFixture
     }
 
 #endif
-    
+
     // All the profiler markers in the package code.
     // Needed for the tests below.
     string[] allInputSystemProfilerMarkers =

--- a/Assets/Tests/InputSystem/CoreTests_Editor.cs
+++ b/Assets/Tests/InputSystem/CoreTests_Editor.cs
@@ -3393,12 +3393,10 @@ partial class CoreTests
         var cp = new CompilerParameters { CompilerOptions = options };
         cp.ReferencedAssemblies.Add(typeof(UnityEngine.Vector2).Assembly.Location);
         cp.ReferencedAssemblies.Add("Library/ScriptAssemblies/Unity.InputSystem.dll");
-#if UNITY_2022_1_OR_NEWER
         // Currently there is are cross-references to netstandard, e.g. System.IEquatable<UnityEngine.Vector2>, System.IFormattable
         // causing compilation failure for 2022 versions. This is a workaround for running these tests.
         var netstandard = Assembly.Load("netstandard, Version=2.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51");
         cp.ReferencedAssemblies.Add(netstandard.Location);
-#endif
         var cr = codeProvider.CompileAssemblyFromSource(cp, code);
 
         var assembly = cr.CompiledAssembly;

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -3920,7 +3920,6 @@ internal partial class UITests : CoreTestsFixture
     // to our manifest without breaking test runs with previous versions of Unity. However, in 2021.2, all the UITK functionality
     // has moved into the com.unity.modules.uielements module which is also available in previous versions of Unity. This way we
     // can have a reference to UITK that doesn't break things in previous versions of Unity.
-#if UNITY_2022_3_OR_NEWER
     [UnityTest]
     [Category("UI")]
     [TestCase(UIPointerBehavior.AllPointersAsIs, ExpectedResult = 1)]
@@ -4074,7 +4073,6 @@ internal partial class UITests : CoreTestsFixture
 #endif
         }
     }
-#endif
 
     static bool[] canRunInBackgroundValueSource = new[] { false, true };
 


### PR DESCRIPTION
### Description

CHANGE: Removing old mentions of `UNITY_2022`


### Testing status & QA

N/A

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
