### PR TITLE
CHANGE: Fixing warnings after updating editor (Player Input warning)

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
@@ -98,7 +98,7 @@ internal class InputActionReferenceEditorTestsWithScene
         EditorPrefsTestUtils.DisableDomainReload();
     }
 
-    private static InputActionBehaviour GetBehaviour() => Object.FindFirstObjectByType<InputActionBehaviour>();
+    private static InputActionBehaviour GetBehaviour() => Object.FindAnyObjectByType<InputActionBehaviour>();
     private static InputActionAsset GetAsset() => AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
 
     // For unclear reason, NUnit fails to assert throwing exceptions after transition into play-mode.

--- a/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
@@ -98,7 +98,7 @@ internal class InputActionReferenceEditorTestsWithScene
         EditorPrefsTestUtils.DisableDomainReload();
     }
 
-    private static InputActionBehaviour GetBehaviour() => Object.FindAnyObjectByType<InputActionBehaviour>();
+    private static InputActionBehaviour GetBehaviour() => Object.FindFirstObjectByType<InputActionBehaviour>();
     private static InputActionAsset GetAsset() => AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
 
     // For unclear reason, NUnit fails to assert throwing exceptions after transition into play-mode.

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -805,7 +805,14 @@ namespace UnityEngine.InputSystem
         ///
         /// Associating a camera with a player is necessary only when using split-screen (see <see cref="PlayerInputManager.splitScreen"/>).
         /// </remarks>
-        public Camera camera
+        public
+        #if UNITY_EDITOR
+        // camera property is deprecated and only available in Editor.
+#if !UNITY_6000_5_OR_NEWER
+        new
+#endif
+        #endif
+        Camera camera
         {
             get => m_Camera;
             set => m_Camera = value;

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -806,7 +806,7 @@ namespace UnityEngine.InputSystem
         /// Associating a camera with a player is necessary only when using split-screen (see <see cref="PlayerInputManager.splitScreen"/>).
         /// </remarks>
         public
-        #if UNITY_EDITOR
+#if UNITY_EDITOR
         // camera property is deprecated and only available in Editor.
 #if !UNITY_6000_5_OR_NEWER
         new

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs
@@ -805,12 +805,7 @@ namespace UnityEngine.InputSystem
         ///
         /// Associating a camera with a player is necessary only when using split-screen (see <see cref="PlayerInputManager.splitScreen"/>).
         /// </remarks>
-        public
-#if UNITY_EDITOR
-        // camera property is deprecated and only available in Editor.
-        new
-        #endif
-        Camera camera
+        public Camera camera
         {
             get => m_Camera;
             set => m_Camera = value;


### PR DESCRIPTION
### Description

Fixing warning after updating editor to `6000.5`: 

`Packages/com.unity.inputsystem/InputSystem/Plugins/PlayerInput/PlayerInput.cs(813,16): warning CS0109: The member 'PlayerInput.camera' does not hide an accessible member. The new keyword is not required.`

JIRA: [UUM-135199
](https://jira.unity3d.com/browse/UUM-135199)

Slack: https://unity.slack.com/archives/C04RDRXRJ1L/p1771861581262009

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
