### PR TITLE
CHANGE: add ignore list for 6.6 APV

### DIFF
--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -34,6 +34,14 @@
           "com.unity.polyspatial.visionos",
           "com.unity.polyspatial.xr",
           "com.unity.xr.visionos"
+        ],
+        "6000.6": [
+          "com.unity.charactercontroller",
+          "com.unity.polyspatial",
+          "com.unity.polyspatial.extensions",
+          "com.unity.polyspatial.visionos",
+          "com.unity.polyspatial.xr",
+          "com.unity.xr.visionos"
         ]
       }
     }

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -125,7 +125,19 @@ public class InputSystemSettings : AnnotatedSettingsBase
                     "com.unity.xr.visionos",
                     "com.unity.charactercontroller"
                 }
-            }
+            },
+            {
+                new Editor("6000.6",  ""),
+                new HashSet<string>()
+                {
+                    "com.unity.polyspatial",
+                    "com.unity.polyspatial.visionos",
+                    "com.unity.polyspatial.extensions",
+                    "com.unity.polyspatial.xr",
+                    "com.unity.xr.visionos",
+                    "com.unity.charactercontroller"
+                }
+            },
         };
 
         InputSystemPackage.CoverageCommands.Enabled = true;


### PR DESCRIPTION
### Description

APV for 6.6 fails due to other packages using outdated APIs. This duplicates the 6.5 ignore list for 6.6


### Testing status & QA

- green APV suite 

### Overall Product Risks
- team needs to assess latest failures and clean up those lists in the future, just unblocking the release for now

- Complexity: low
- Halo Effect: low