### PR TITLE
DOCS: Add information about IgnoreFocus to InputSettings.cs

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -855,6 +855,23 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Determines how the applications behaves when running in the background. See <see cref="backgroundBehavior"/>.
         /// </summary>
+        /// <remarks>
+        /// Limitations:
+        ////
+        /// Receiving input while the application is not in the foreground is platform and device-dependent, and should not be relied upon. 
+        /// IgnoreFocus does not grant the ability to receive input in the background; it only prevents the Input System from resetting/disabling devices on focus changes.
+        ///
+        /// Specifically:
+        ///
+        /// Keyboard: InputSystem doesn't receive events while unfocused. 
+        /// Even on platforms where OS-level hooks could technically capture background keyboard input, Unity doesn't forward it to the managed Input System.
+        /// 
+        /// Mouse: Only receives events when the cursor is hovering over the application window.
+        /// 
+        /// XR HMDs: May continue receiving tracking data while unfocused, depending on the XR runtime. 
+        /// These devices report canRunInBackground == true and are the primary use case for ResetAndDisableNonBackgroundDevices, 
+        /// which leaves them untouched while resetting everything else.
+        /// </remarks>
         /// <seealso href="https://docs.unity3d.com/ScriptReference/Application-isFocused.html"/>
         /// <seealso href="https://docs.unity3d.com/ScriptReference/Application-runInBackground.html"/>
         /// <seealso cref="backgroundBehavior"/>

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -857,7 +857,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         /// <remarks>
         /// Limitations:
-        ////
+        ///
         /// Receiving input while the application is not in the foreground is platform and device-dependent, and should not be relied upon.
         /// IgnoreFocus does not grant the ability to receive input in the background; it only prevents the Input System from resetting/disabling devices on focus changes.
         ///

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -858,18 +858,18 @@ namespace UnityEngine.InputSystem
         /// <remarks>
         /// Limitations:
         ////
-        /// Receiving input while the application is not in the foreground is platform and device-dependent, and should not be relied upon. 
+        /// Receiving input while the application is not in the foreground is platform and device-dependent, and should not be relied upon.
         /// IgnoreFocus does not grant the ability to receive input in the background; it only prevents the Input System from resetting/disabling devices on focus changes.
         ///
         /// Specifically:
         ///
-        /// Keyboard: InputSystem doesn't receive events while unfocused. 
+        /// Keyboard: InputSystem doesn't receive events while unfocused.
         /// Even on platforms where OS-level hooks could technically capture background keyboard input, Unity doesn't forward it to the managed Input System.
-        /// 
+        ///
         /// Mouse: Only receives events when the cursor is hovering over the application window.
-        /// 
-        /// XR HMDs: May continue receiving tracking data while unfocused, depending on the XR runtime. 
-        /// These devices report canRunInBackground == true and are the primary use case for ResetAndDisableNonBackgroundDevices, 
+        ///
+        /// XR HMDs: May continue receiving tracking data while unfocused, depending on the XR runtime.
+        /// These devices report canRunInBackground == true and are the primary use case for ResetAndDisableNonBackgroundDevices,
         /// which leaves them untouched while resetting everything else.
         /// </remarks>
         /// <seealso href="https://docs.unity3d.com/ScriptReference/Application-isFocused.html"/>
@@ -906,10 +906,10 @@ namespace UnityEngine.InputSystem
 
             /// <summary>
             /// Ignore all changes in focus and leave devices untouched. This also disables focus checks in <see cref="UI.InputSystemUIInputModule"/>.
-            /// This mode doesn't disable devices when the application loses focus. It also doesn't reset or sync device state on focus changes. 
-            /// As a result, input controls may retain a stale state after focus transitions. 
+            /// This mode doesn't disable devices when the application loses focus. It also doesn't reset or sync device state on focus changes.
+            /// As a result, input controls may retain a stale state after focus transitions.
             /// For example, if a key is held when the application loses focus and released while unfocused, the Input System still reports that key as pressed
-            /// when the focus returns. This is the expected behavior, not a bug. 
+            /// when the focus returns. This is the expected behavior, not a bug.
             /// If you need a reliable state after focus changes, use ResetAndDisableNonBackgroundDevices (default) or ResetAndDisableAllDevices.
             /// </summary>
             IgnoreFocus = 2,

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -912,7 +912,8 @@ namespace UnityEngine.InputSystem
             /// when the focus returns. This is the expected behavior, not a bug. 
             /// If you need a reliable state after focus changes, use ResetAndDisableNonBackgroundDevices (default) or ResetAndDisableAllDevices.
             /// </summary>
-            IgnoreFocus = 2,}
+            IgnoreFocus = 2,
+        }
 
         /// <summary>
         /// Determines how player focus is handled with respect to input when we are in play mode in the editor.

--- a/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputSettings.cs
@@ -889,9 +889,13 @@ namespace UnityEngine.InputSystem
 
             /// <summary>
             /// Ignore all changes in focus and leave devices untouched. This also disables focus checks in <see cref="UI.InputSystemUIInputModule"/>.
+            /// This mode doesn't disable devices when the application loses focus. It also doesn't reset or sync device state on focus changes. 
+            /// As a result, input controls may retain a stale state after focus transitions. 
+            /// For example, if a key is held when the application loses focus and released while unfocused, the Input System still reports that key as pressed
+            /// when the focus returns. This is the expected behavior, not a bug. 
+            /// If you need a reliable state after focus changes, use ResetAndDisableNonBackgroundDevices (default) or ResetAndDisableAllDevices.
             /// </summary>
-            IgnoreFocus = 2,
-        }
+            IgnoreFocus = 2,}
 
         /// <summary>
         /// Determines how player focus is handled with respect to input when we are in play mode in the editor.


### PR DESCRIPTION
### Description

From DOCATT-10243: information about BackgroundBehavior.IgnoreFocus

### Testing status & QA

Docs only

### Overall Product Risks

None

### Comments to reviewers

Docs only

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
