### PR TITLE
CHANGE: Fixed-item-height in Actions aligned with Action Maps height

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -1,18 +1,18 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
-    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
+    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles"/>
     <ui:VisualElement name="action-editor" style="flex-direction: column; flex-grow: 1;">
         <ui:VisualElement name="control-schemes-toolbar-container">
             <uie:Toolbar>
                 <ui:VisualElement style="flex-direction: row; flex-grow: 1;">
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;" />
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu" />
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;"/>
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu"/>
                 </ui:VisualElement>
                 <ui:VisualElement>
-                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
+                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;"/>
                 </ui:VisualElement>
                 <ui:VisualElement name="save-asset-toolbar-container" style="flex-direction: row; justify-content: flex-end;">
-                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;" />
-                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 73px;" />
+                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;"/>
+                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 73px;"/>
                 </ui:VisualElement>
             </uie:Toolbar>
         </ui:VisualElement>
@@ -20,13 +20,13 @@
             <ui:TwoPaneSplitView name="actions-split-view" fixed-pane-initial-dimension="200" view-data-key="actions-editor-splitter-1">
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
                     <ui:VisualElement name="header" class="body-panel-header">
-                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
-                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
+                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;"/>
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;"/>
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
-                        <ui:ListView focusable="true" name="action-maps-list-view" />
+                        <ui:ListView focusable="true" name="action-maps-list-view"/>
                     </ui:VisualElement>
-                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;" />
+                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;"/>
                 </ui:VisualElement>
                 <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditor.uxml
@@ -1,18 +1,18 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../../../../UIElementsSchema/UIElements.xsd" editor-extension-mode="True">
-    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles"/>
+    <Style src="project://database/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss?fileID=7433441132597879392&amp;guid=7dac9c49a90bca4499371d0adc9b617b&amp;type=3#InputActionsEditorStyles" />
     <ui:VisualElement name="action-editor" style="flex-direction: column; flex-grow: 1;">
         <ui:VisualElement name="control-schemes-toolbar-container">
             <uie:Toolbar>
                 <ui:VisualElement style="flex-direction: row; flex-grow: 1;">
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;"/>
-                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu"/>
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="No Control Schemes" name="control-schemes-toolbar-menu" style="min-width: 135px;" />
+                    <uie:ToolbarMenu display-tooltip-when-elided="true" text="All Devices" enabled="false" name="control-schemes-filter-toolbar-menu" />
                 </ui:VisualElement>
                 <ui:VisualElement>
-                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;"/>
+                    <uie:ToolbarSearchField focusable="true" name="search-actions-text-field" class="search-field" style="display: none;" />
                 </ui:VisualElement>
                 <ui:VisualElement name="save-asset-toolbar-container" style="flex-direction: row; justify-content: flex-end;">
-                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;"/>
-                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 73px;"/>
+                    <uie:ToolbarButton text="Save Asset" display-tooltip-when-elided="true" name="save-asset-toolbar-button" style="align-items: auto;" />
+                    <uie:ToolbarToggle focusable="false" label="Auto-Save" name="auto-save-toolbar-toggle" style="width: 73px;" />
                 </ui:VisualElement>
             </uie:Toolbar>
         </ui:VisualElement>
@@ -20,13 +20,13 @@
             <ui:TwoPaneSplitView name="actions-split-view" fixed-pane-initial-dimension="200" view-data-key="actions-editor-splitter-1">
                 <ui:VisualElement name="action-maps-container" class="body-panel-container actions-container">
                     <ui:VisualElement name="header" class="body-panel-header">
-                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;"/>
-                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;"/>
+                        <ui:Label text="Action Maps" display-tooltip-when-elided="true" style="flex-grow: 1;" />
+                        <ui:Button display-tooltip-when-elided="true" name="add-new-action-map-button" style="align-items: auto;" />
                     </ui:VisualElement>
                     <ui:VisualElement name="body">
-                        <ui:ListView focusable="true" name="action-maps-list-view"/>
+                        <ui:ListView focusable="true" name="action-maps-list-view" />
                     </ui:VisualElement>
-                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;"/>
+                    <ui:VisualElement name="rclick-area-to-add-new-action-map" style="flex-direction: column; flex-grow: 1;" />
                 </ui:VisualElement>
                 <ui:TwoPaneSplitView name="actions-and-properties-split-view" fixed-pane-index="1" fixed-pane-initial-dimension="320" view-data-key="actions-editor-splitter-2" style="height: auto; min-width: 450px;">
                     <ui:VisualElement name="actions-container" class="body-panel-container">
@@ -35,7 +35,7 @@
                             <ui:Button display-tooltip-when-elided="true" name="add-new-action-button" style="align-items: auto;"/>
                         </ui:VisualElement>
                         <ui:VisualElement name="body">
-                            <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" fixed-item-height="20"/>
+                            <ui:TreeView view-data-key="unity-tree-view" focusable="true" name="actions-tree-view" show-border="false" reorderable="true" show-alternating-row-backgrounds="None" />
                         </ui:VisualElement>
                         <ui:VisualElement name="rclick-area-to-add-new-action" style="flex-direction: column; flex-grow: 1;"/>
                     </ui:VisualElement>


### PR DESCRIPTION
### Description

Small fix with minimum height alignment between columns `ActionMap` and `Actions`. 
There. was a 2px misalignment.

Before:
<img width="603" height="98" alt="Screenshot 2026-02-26 at 12 04 30" src="https://github.com/user-attachments/assets/c9f73fdd-44e6-4565-9f45-5a681d87a804" />

After:
<img width="715" height="115" alt="Screenshot 2026-02-26 at 12 24 34" src="https://github.com/user-attachments/assets/d64b87fe-1760-4e61-b9b6-6a9f93ffc200" />



### Testing status & QA

N/A

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
