### PR TITLE
Adding TwoAxisVector2Composite for Legacy Joysticks with Twin Dual Axes

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 ### Added
-
+- Added TwoAxisVector2Composite
 
 ## [1.19.0] - 2026-02-24
 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/TwoAxisVector2Composite.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/TwoAxisVector2Composite.cs
@@ -1,0 +1,46 @@
+﻿#if UNITY_EDITOR
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.Utilities;
+
+
+#endif
+
+namespace UnityEngine.InputSystem.Composites
+{
+    /// <summary>
+    /// A Vector2 composite consisting of two Axis values.
+    /// </summary>
+    /// <remarks>
+    /// This composite allows for two Axis inputs to be combined into a Vector2 representation.
+    /// 
+    /// This is particularly useful for legacy Joysticks without Gamepad-promised Vector2 representations.
+    /// </remarks>
+    [DisplayStringFormat("{xAxis}+{yAxis}")]
+    public class TwoAxisVector2Composite : InputBindingComposite<Vector2>
+    {
+        [InputControl(layout = "Axis")]
+        public int xAxis;
+
+        [InputControl(layout = "Axis")]
+        public int yAxis;
+
+        public override Vector2 ReadValue(ref InputBindingCompositeContext context)
+        {
+            var firstPartValue = context.ReadValue<float>(xAxis);
+            var secondPartValue = context.ReadValue<float>(yAxis);
+
+            return new(firstPartValue, secondPartValue);
+        }
+
+        static TwoAxisVector2Composite()
+        {
+            InputSystem.RegisterBindingComposite<TwoAxisVector2Composite>();
+        }
+
+        [RuntimeInitializeOnLoadMethod]
+        static void Init() { } // Trigger static constructor.
+    }
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/TwoAxisVector2Composite.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Composites/TwoAxisVector2Composite.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 42bb5bf482de61a478150f4d825a9120


### PR DESCRIPTION
### Description

This adds a new TwoAxisVector2Composite class, an ImputBindingComposite that converts two Axis values into a Vector2. 
Some old Joystick devices don't support Vector2 output for a second Stick but do provide two Axis values representing it, so this class was made for such purposes. I am currently using it to support a PS2 controller hooked up to a third party PS2-to-PC adapter found at a thrift store; I imagine adding this class would contribute to improving developer accessibility associated with income brackets and help solve headaches sooner regarding broader controller compatibility with Unity products. 

### Testing status & QA

This has been tested in my unity project. It's based off the documented (and presumably tested) CustomComposite script [here](https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/manual/ActionBindings.html?&_ga=2.110396358.274091956.1612840461-1813738166.1611803663#writing-custom-composites) , with the only major change being the removal of the `[InitializeOnLoad]` attribute to match the pattern of other built-in composites already in this repository. I have not tested it as part of this base repository but based on comparable Composite scripts it seems unlikely to cause problems.

### Overall Product Risks

Very low risk; this feature doesn't affect other aspects of the software dramatically and has very barebones functionality. It is an added utility that may require documentation updating however.

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

N/A

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
