### PR TITLE
CHANGE: Alignment with Press Point under HOLD interaction

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Actions/DeferBindingResolutionContext.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/DeferBindingResolutionContext.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 40a986dbf9066476b8a3b360e74e99de
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -111,15 +111,15 @@ namespace UnityEngine.InputSystem.Interactions
     internal class HoldInteractionEditor : InputParameterEditor<HoldInteraction>
     {
         protected override void OnEnable()
-        {
-            m_PressPointSetting.Initialize("Press Point",
-                "Float value that an axis control has to cross for it to be considered pressed.",
-                "Default Button Press Point",
-                () => target.pressPoint, v => target.pressPoint = v, () => ButtonControl.s_GlobalDefaultButtonPressPoint);
+        { 
             m_DurationSetting.Initialize("Hold Time",
                 "Time (in seconds) that a control has to be held in order for it to register as a hold.",
                 "Default Hold Time",
                 () => target.duration, x => target.duration = x, () => InputSystem.settings.defaultHoldTime);
+            m_PressPointSetting.Initialize("Press Point",
+                "Float value that an axis control has to cross for it to be considered pressed.",
+                "Default Button Press Point",
+                () => target.pressPoint, v => target.pressPoint = v, () => ButtonControl.s_GlobalDefaultButtonPressPoint);
         }
 
         public override void OnGUI()
@@ -127,18 +127,18 @@ namespace UnityEngine.InputSystem.Interactions
             if (!InputSystem.settings.useIMGUIEditorForAssets)
                 return;
 
-            m_PressPointSetting.OnGUI();
             m_DurationSetting.OnGUI();
+            m_PressPointSetting.OnGUI();
         }
 
         public override void OnDrawVisualElements(VisualElement root, Action onChangedCallback)
         {
-            m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);
             m_DurationSetting.OnDrawVisualElements(root, onChangedCallback);
+            m_PressPointSetting.OnDrawVisualElements(root, onChangedCallback);
         }
 
-        private CustomOrDefaultSetting m_PressPointSetting;
         private CustomOrDefaultSetting m_DurationSetting;
+        private CustomOrDefaultSetting m_PressPointSetting;
     }
     #endif
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Actions/Interactions/HoldInteraction.cs
@@ -111,7 +111,7 @@ namespace UnityEngine.InputSystem.Interactions
     internal class HoldInteractionEditor : InputParameterEditor<HoldInteraction>
     {
         protected override void OnEnable()
-        { 
+        {
             m_DurationSetting.Initialize("Hold Time",
                 "Time (in seconds) that a control has to be held in order for it to register as a hold.",
                 "Default Hold Time",


### PR DESCRIPTION
### Description

Alignment with `Press Point` under HOLD interaction.

New order:
  1. Hold Time
  2. Press Point

Before:
<img width="342" height="329" alt="Screenshot 2026-03-10 at 10 42 01" src="https://github.com/user-attachments/assets/06ef6880-101a-4db4-8b77-92366c120354" />

After:
<img width="809" height="264" alt="Screenshot 2026-03-10 at 14 29 58" src="https://github.com/user-attachments/assets/6cdd68d8-87be-4823-bc33-38a8013348b0" />



### Testing status & QA

Check that Hold Time and Press Point are in the new order.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
