### PR TITLE
Fix ISXB-1782: Invert processor (and other parameterless items) no lo…

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -138,6 +138,11 @@
 .name-and-parameters-list-foldout {
 }
 
+/* ISXB-1782: Hide expand arrow when processor/interaction has no properties (e.g. Invert) */
+.name-and-parameters-list-foldout--no-content .unity-foldout__checkmark {
+    display: none;
+}
+
 .name-and-parameters-list-view .name-and-parameters-list-foldout-button {
     width: 12px;
     height: 12px;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -170,9 +170,19 @@ namespace UnityEngine.InputSystem.Editor
 
             var foldout = container.Q<Foldout>("Foldout");
             foldout.text = parameterListView.name;
-            parameterListView.OnDrawVisualElements(foldout);
 
-            foldout.Add(new IMGUIContainer(parameterListView.OnGUI));
+            if (parameterListView.hasUIToShow)
+            {
+                parameterListView.OnDrawVisualElements(foldout);
+                foldout.Add(new IMGUIContainer(parameterListView.OnGUI));
+            }
+            else
+            {
+                // ISXB-1782: No expandable foldout when processor/interaction has no properties (e.g. Invert)
+                foldout.value = false;
+                foldout.SetEnabled(false);
+                foldout.AddToClassList("name-and-parameters-list-foldout--no-content");
+            }
         }
     }
 }


### PR DESCRIPTION
4. ISXB-1783 – Buttons overlap when Input Actions Editor is narrow
Link: https://jira.unity3d.com/browse/ISXB-1783

Why it’s easy: Standard layout issue when the window is docked and narrow: top buttons (Save Asset, Devices, Control Schemes) overlap.
Fix: In the Input Actions Editor UI, add a minimum width and/or make the button bar wrap or use overflow (e.g. menu) when width is small so buttons don’t overlap.
Extra: Same editor as 1782; repro is “dock + resize to narrow”.



Made-with: Cursor

### Description

_Please fill this section with a description what the pull request is trying to address and what changes were made._


### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
