### PR TITLE
Fix ISXB-1792: HaveDuplicateReferences inner loop bound (n < count no…

### DIFF
--- a/Assets/Tests/InputSystem/Utilities/ArrayHelperTests.cs
+++ b/Assets/Tests/InputSystem/Utilities/ArrayHelperTests.cs
@@ -120,6 +120,23 @@ internal class ArrayHelperTests
 
     [Test]
     [Category("Utilities")]
+    public void Utilities_HaveDuplicateReferences_DetectsDuplicatesInFullRange()
+    {
+        var withDup = new object[] { new object(), new object(), new object() };
+        withDup[2] = withDup[0]; // duplicate at 0 and 2
+        Assert.That(withDup.HaveDuplicateReferences(0, 3), Is.True);
+
+        var noDup = new object[] { new object(), new object(), new object() };
+        Assert.That(noDup.HaveDuplicateReferences(0, 3), Is.False);
+
+        // Regression test for ISXB-1792: inner loop was "n < count - i" so later pairs were never checked
+        var dupAtEnd = new object[] { new object(), new object(), new object(), new object() };
+        dupAtEnd[3] = dupAtEnd[2]; // duplicate at 2 and 3
+        Assert.That(dupAtEnd.HaveDuplicateReferences(0, 4), Is.True);
+    }
+
+    [Test]
+    [Category("Utilities")]
     public void Utilities_IndexOfPredicate__IsUsingPredicateForEqualityAndConstraintedByStartIndexAndCount()
     {
         var arr = new int[] { 0, 1, 2, 3, 4, 5 };

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/ArrayHelpers.cs
@@ -120,7 +120,7 @@ namespace UnityEngine.InputSystem.Utilities
             for (var i = 0; i < count; ++i)
             {
                 var element = first[i];
-                for (var n = i + 1; n < count - i; ++n)
+                for (var n = i + 1; n < count; ++n)
                 {
                     if (ReferenceEquals(element, first[n]))
                         return true;


### PR DESCRIPTION
1. ISXB-1792 – Faulty ArrayHelpers.HaveDuplicateReferences implementation
Link: https://jira.unity3d.com/browse/ISXB-1792

Why it’s easy: The ticket describes the exact bug and fix. The inner loop uses n < count - i but should use n < count, so the loop doesn’t cover the full range and duplicate detection is wrong.
Fix: In ArrayHelpers.cs (around line 118), change the inner loop condition from n < count - i to n < count.
Extra: Reporter suggests adding a test. Single file, one-line logic fix.

Made-with: Cursor

### Description

_Please fill this section with a description what the pull request is trying to address and what changes were made._


### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
