### PR TITLE
Fix ISXB-1794: Processor (and interaction) list use composite part va…

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/Selectors.cs
@@ -311,9 +311,7 @@ namespace UnityEngine.InputSystem.Editor
 
         public static IEnumerable<ParameterListView> GetInteractionsAsParameterListViews(InputActionsEditorState state, SerializedInputAction? inputAction)
         {
-            Type expectedValueType = null;
-            if (inputAction.HasValue && !string.IsNullOrEmpty(inputAction.Value.expectedControlType))
-                expectedValueType = EditorInputControlLayoutCache.GetValueType(inputAction.Value.expectedControlType);
+            var expectedValueType = GetExpectedValueTypeForProcessorsOrInteractions(state, inputAction);
 
             var interactions = string.Empty;
             if (inputAction.HasValue && state.selectionType == SelectionType.Action)
@@ -328,13 +326,35 @@ namespace UnityEngine.InputSystem.Editor
                 InputInteraction.GetValueType);
         }
 
+        /// <summary>
+        /// Expected value type for the current selection. When the selection is a composite part binding,
+        /// returns the part's value type (e.g. float) instead of the composite's (e.g. Vector2). ISXB-1794.
+        /// </summary>
+        private static Type GetExpectedValueTypeForProcessorsOrInteractions(InputActionsEditorState state, SerializedInputAction? inputAction)
+        {
+            if (state.selectionType == SelectionType.Binding)
+            {
+                var binding = GetSelectedBinding(state);
+                if (binding.HasValue && binding.Value.isPartOfComposite)
+                {
+                    var compositeName = NameAndParameters.Parse(binding.Value.compositePath).name;
+                    var partName = binding.Value.name;
+                    var expectedLayout = InputBindingComposite.GetExpectedControlLayoutName(compositeName, partName);
+                    if (!string.IsNullOrEmpty(expectedLayout))
+                        return EditorInputControlLayoutCache.GetValueType(expectedLayout);
+                }
+            }
+
+            if (inputAction.HasValue && !string.IsNullOrEmpty(inputAction.Value.expectedControlType))
+                return EditorInputControlLayoutCache.GetValueType(inputAction.Value.expectedControlType);
+
+            return null;
+        }
+
         public static IEnumerable<ParameterListView> GetProcessorsAsParameterListViews(InputActionsEditorState state, SerializedInputAction? inputAction)
         {
             var processors = string.Empty;
-            Type expectedValueType = null;
-
-            if (inputAction.HasValue && !string.IsNullOrEmpty(inputAction.Value.expectedControlType))
-                expectedValueType = EditorInputControlLayoutCache.GetValueType(inputAction.Value.expectedControlType);
+            var expectedValueType = GetExpectedValueTypeForProcessorsOrInteractions(state, inputAction);
 
             if (inputAction.HasValue && state.selectionType == SelectionType.Action)
                 processors = inputAction.Value.processors;


### PR DESCRIPTION
5. ISXB-1794 – Processor list shows Vector2 instead of float for composite part bindings
Link: https://jira.unity3d.com/browse/ISXB-1794

Why it’s easy: When editing a part of a composite (e.g. “UP: W” in a WASD composite), the Processors list is filtered by the composite’s value type (Vector2) instead of the part’s (float).
Fix: In the code that builds the processor list for a binding, use the value type of the current binding (or the composite part), not the parent composite, so float processors (e.g. Scale) show for “UP”/“DOWN”/etc.
Extra: Repro and attachments (IN-122827, project) are in the ticket; likely a single place in the editor that resolves the “current value type” for the processor dropdown.



Made-with: Cursor

### Description

_Please fill this section with a description what the pull request is trying to address and what changes were made._


### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
