### PR TITLE
FIX: InputSystem warnings displayed with Unity editor 6000.6 version

### DIFF
--- a/Assets/QA/Tests/Xbox Controller Basic/Scripts/GamepadButtonState.cs
+++ b/Assets/QA/Tests/Xbox Controller Basic/Scripts/GamepadButtonState.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
@@ -6,7 +7,7 @@ using UnityEngine.InputSystem.XInput;
 
 public class GamepadButtonState : MonoBehaviour
 {
-    public ButtonControl buttonToTrack;
+    [NonSerialized] public ButtonControl buttonToTrack;
 
     [Header("If left empty, will try to auto populate with GetComponent<Image>()")]
     public Image stateImage;

--- a/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
@@ -98,7 +98,7 @@ internal class InputActionReferenceEditorTestsWithScene
         EditorPrefsTestUtils.DisableDomainReload();
     }
 
-    private static InputActionBehaviour GetBehaviour() => Object.FindFirstObjectByType<InputActionBehaviour>();
+    private static InputActionBehaviour GetBehaviour() => Object.FindAnyObjectByType<InputActionBehaviour>();
     private static InputActionAsset GetAsset() => AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
 
     // For unclear reason, NUnit fails to assert throwing exceptions after transition into play-mode.

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -4623,7 +4623,7 @@ internal partial class UITests : CoreTestsFixture
             }
         }
 
-        public List<Event> events = new List<Event>();
+        [NonSerialized] public List<Event> events = new List<Event>();
 
         public void OnPointerClick(PointerEventData eventData)
         {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -562,7 +562,7 @@ namespace UnityEngine.InputSystem.Layouts
             public string[] products;
             public string version;
             public string[] versions;
-            public Capability[] capabilities;
+            [NonSerialized] public Capability[] capabilities;
 
             public struct Capability
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -562,9 +562,8 @@ namespace UnityEngine.InputSystem.Layouts
             public string[] products;
             public string version;
             public string[] versions;
-            public Capability[] capabilities;
+            [NonSerialized] public Capability[] capabilities;
 
-            [Serialized]
             public struct Capability
             {
                 public string path;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/InputDeviceMatcher.cs
@@ -562,8 +562,9 @@ namespace UnityEngine.InputSystem.Layouts
             public string[] products;
             public string version;
             public string[] versions;
-            [NonSerialized] public Capability[] capabilities;
+            public Capability[] capabilities;
 
+            [Serialized]
             public struct Capability
             {
                 public string path;

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -380,7 +380,7 @@ namespace UnityEngine.InputSystem
         internal struct RemoteSender
         {
             public int senderId;
-            public InternedString[] layouts; // Each item is the unqualified name of the layout (without namespace)
+            [NonSerialized] public InternedString[] layouts; // Each item is the unqualified name of the layout (without namespace)
             public RemoteInputDevice[] devices;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
@@ -400,7 +400,7 @@ namespace UnityEngine.InputSystem.Editor
         // against any mutations.
         // When inspecting controls (as opposed to events), we copy all their various
         // state buffers and allow switching between them.
-        [SerializeField] private byte[][] m_StateBuffers;
+        [NonSerialized] private byte[][] m_StateBuffers;
         [SerializeField] private int m_SelectedStateBuffer;
         [SerializeField] private bool m_CompareStateBuffers;
         [SerializeField] private bool m_ShowDifferentOnly;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -19,7 +19,7 @@ namespace UnityEngine.InputSystem.Editor
         // For UI testing purpose
         internal InputActionAsset currentAssetInEditor => m_AssetObjectForEditing;
         [SerializeField] private InputActionAsset m_AssetObjectForEditing;
-        [SerializeField] private InputActionsEditorState m_State;
+        [NonSerialized] private InputActionsEditorState m_State;
         [SerializeField] private string m_AssetGUID;
 
         private string m_AssetJson;

--- a/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs
@@ -1564,7 +1564,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
             [SerializeField] internal int m_DeviceId;
             [SerializeField] internal string m_Layout;
-            [SerializeField] internal FourCC m_StateFormat;
+            [NonSerialized] internal FourCC m_StateFormat;
             [SerializeField] internal int m_StateSizeInBytes;
             [SerializeField] internal string m_FullLayoutJson;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -4329,7 +4329,7 @@ namespace UnityEngine.InputSystem
             public InputEventHandledPolicy inputEventHandledPolicy;
             public DeviceState[] devices;
             public AvailableDevice[] availableDevices;
-            public InputStateBuffers buffers;
+            [NonSerialized] public InputStateBuffers buffers;
             public InputUpdate.SerializedState updateState;
             public InputUpdateType updateMask;
             public InputSettings.ScrollDeltaBehavior scrollDeltaBehavior;


### PR DESCRIPTION
### Description

InputSystem warnings displayed with Unity editor `6000.6` version.

Warnings:
<img width="1728" height="1117" alt="Screenshot 2026-03-12 at 12 24 38" src="https://github.com/user-attachments/assets/c3269e27-ff77-4fb7-94fe-8d52843350c1" />


### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 1
- Halo Effect: 1

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
