### PR TITLE
FIX: InputSystem warnings displayed with Unity editor 6000.6 version

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
@@ -98,7 +98,7 @@ internal class InputActionReferenceEditorTestsWithScene
         EditorPrefsTestUtils.DisableDomainReload();
     }
 
-    private static InputActionBehaviour GetBehaviour() => Object.FindFirstObjectByType<InputActionBehaviour>();
+    private static InputActionBehaviour GetBehaviour() => Object.FindAnyObjectByType<InputActionBehaviour>();
     private static InputActionAsset GetAsset() => AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
 
     // For unclear reason, NUnit fails to assert throwing exceptions after transition into play-mode.

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -4601,6 +4601,7 @@ internal partial class UITests : CoreTestsFixture
         IPointerMoveHandler, IPointerExitHandler, IPointerUpHandler, IMoveHandler, ISelectHandler, IDeselectHandler,
         IInitializePotentialDragHandler, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler, ISubmitHandler, ICancelHandler, IScrollHandler
     {
+        [Serializable]
         public struct Event
         {
             public EventType type { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
@@ -16,6 +17,7 @@ namespace UnityEngine.InputSystem.Controls
     /// Can optionally be configured to perform normalization.
     /// Stored as either a float, a short, a byte, or a single bit.
     /// </remarks>
+    [Serializable]
     public class AxisControl : InputControl<float>
     {
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.Scripting;
@@ -15,6 +16,7 @@ namespace UnityEngine.InputSystem.Controls
     /// yield full floating-point values and may thus have a range of values. See
     /// <see cref="pressPoint"/> for how button presses on such buttons are handled.
     /// </remarks>
+    [Serializable]
     public class ButtonControl : AxisControl
     {
         private bool m_NeedsToCheckFramePress = false;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
@@ -400,7 +400,7 @@ namespace UnityEngine.InputSystem.Editor
         // against any mutations.
         // When inspecting controls (as opposed to events), we copy all their various
         // state buffers and allow switching between them.
-        [SerializeField] private byte[][] m_StateBuffers;
+        [NonSerialized] private byte[][] m_StateBuffers;
         [SerializeField] private int m_SelectedStateBuffer;
         [SerializeField] private bool m_CompareStateBuffers;
         [SerializeField] private bool m_ShowDifferentOnly;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -59,6 +59,8 @@ namespace UnityEngine.InputSystem.Editor
             return cutActionMapIndex ?? -1;
         }
     }
+    
+    [Serializable]
     internal struct InputActionsEditorState
     {
         public int selectedActionMapIndex { get {return m_selectedActionMapIndex; } }

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -13,6 +13,7 @@ namespace UnityEngine.InputSystem.LowLevel
     // Internally, we perform only a single combined unmanaged allocation for all state
     // buffers needed by the system. Externally, we expose them as if they are each separate
     // buffers.
+    [Serializable]
     internal unsafe struct InputStateBuffers
     {
         // State buffers are set up in a double buffering scheme where the "back buffer"

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
@@ -11,6 +11,7 @@ namespace UnityEngine.InputSystem.Utilities
     /// FourCCs are frequently used in the input system to identify the format of data sent to or from
     /// the native backend representing events, input device state or commands sent to input devices.
     /// </remarks>
+    [Serializable]
     public struct FourCC : IEquatable<FourCC>
     {
         private int m_Code;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
@@ -24,6 +24,7 @@ namespace UnityEngine.InputSystem.Utilities
     /// There is a non-zero cost to creating an InternedString. The first time a new unique InternedString
     /// is encountered, there may also be a GC heap allocation.
     /// </remarks>
+    [Serializable]
     public struct InternedString : IEquatable<InternedString>, IComparable<InternedString>
     {
         private readonly string m_StringOriginalCase;


### PR DESCRIPTION
### Description

InputSystem warnings displayed with Unity editor `6000.6` version.



### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
