### PR TITLE
FIX: InputSystem warnings displayed with Unity editor 6000.6 version

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs
@@ -98,7 +98,7 @@ internal class InputActionReferenceEditorTestsWithScene
         EditorPrefsTestUtils.DisableDomainReload();
     }
 
-    private static InputActionBehaviour GetBehaviour() => Object.FindFirstObjectByType<InputActionBehaviour>();
+    private static InputActionBehaviour GetBehaviour() => Object.FindAnyObjectByType<InputActionBehaviour>();
     private static InputActionAsset GetAsset() => AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
 
     // For unclear reason, NUnit fails to assert throwing exceptions after transition into play-mode.

--- a/Assets/Tests/InputSystem/Plugins/UITests.cs
+++ b/Assets/Tests/InputSystem/Plugins/UITests.cs
@@ -4601,6 +4601,7 @@ internal partial class UITests : CoreTestsFixture
         IPointerMoveHandler, IPointerExitHandler, IPointerUpHandler, IMoveHandler, ISelectHandler, IDeselectHandler,
         IInitializePotentialDragHandler, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler, ISubmitHandler, ICancelHandler, IScrollHandler
     {
+        [Serializable]
         public struct Event
         {
             public EventType type { get; }

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/AxisControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.InputSystem.Processors;
@@ -16,6 +17,7 @@ namespace UnityEngine.InputSystem.Controls
     /// Can optionally be configured to perform normalization.
     /// Stored as either a float, a short, a byte, or a single bit.
     /// </remarks>
+    [Serializable]
     public class AxisControl : InputControl<float>
     {
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/ButtonControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Runtime.CompilerServices;
 using UnityEngine.InputSystem.LowLevel;
 using UnityEngine.Scripting;
@@ -15,6 +16,7 @@ namespace UnityEngine.InputSystem.Controls
     /// yield full floating-point values and may thus have a range of values. See
     /// <see cref="pressPoint"/> for how button presses on such buttons are handled.
     /// </remarks>
+    [Serializable]
     public class ButtonControl : AxisControl
     {
         private bool m_NeedsToCheckFramePress = false;

--- a/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Controls/InputControl.cs
@@ -83,6 +83,7 @@ namespace UnityEngine.InputSystem
     /// <seealso cref="InputDevice"/>
     /// <seealso cref="InputControlPath"/>
     /// <seealso cref="InputStateBlock"/>
+    [Serializable]
     [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public abstract class InputControl
     {
@@ -1283,6 +1284,7 @@ namespace UnityEngine.InputSystem
     /// <typeparam name="TValue">Type of value captured by the control. Note that this does not mean
     /// that the control has to store data in the given value format. A control that captures float
     /// values, for example, may be stored in state as byte values instead.</typeparam>
+    [Serializable]
     public abstract class InputControl<TValue> : InputControl
         where TValue : struct
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs
@@ -400,7 +400,7 @@ namespace UnityEngine.InputSystem.Editor
         // against any mutations.
         // When inspecting controls (as opposed to events), we copy all their various
         // state buffers and allow switching between them.
-        [SerializeField] private byte[][] m_StateBuffers;
+        [NonSerialized] private byte[][] m_StateBuffers;
         [SerializeField] private int m_SelectedStateBuffer;
         [SerializeField] private bool m_CompareStateBuffers;
         [SerializeField] private bool m_ShowDifferentOnly;

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -59,7 +59,7 @@ namespace UnityEngine.InputSystem.Editor
             return cutActionMapIndex ?? -1;
         }
     }
-    
+
     [Serializable]
     internal struct InputActionsEditorState
     {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorState.cs
@@ -59,6 +59,8 @@ namespace UnityEngine.InputSystem.Editor
             return cutActionMapIndex ?? -1;
         }
     }
+    
+    [Serializable]
     internal struct InputActionsEditorState
     {
         public int selectedActionMapIndex { get {return m_selectedActionMapIndex; } }

--- a/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/State/InputStateBuffers.cs
@@ -13,6 +13,7 @@ namespace UnityEngine.InputSystem.LowLevel
     // Internally, we perform only a single combined unmanaged allocation for all state
     // buffers needed by the system. Externally, we expose them as if they are each separate
     // buffers.
+    [Serializable]
     internal unsafe struct InputStateBuffers
     {
         // State buffers are set up in a double buffering scheme where the "back buffer"

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/FourCC.cs
@@ -11,6 +11,7 @@ namespace UnityEngine.InputSystem.Utilities
     /// FourCCs are frequently used in the input system to identify the format of data sent to or from
     /// the native backend representing events, input device state or commands sent to input devices.
     /// </remarks>
+    [Serializable]
     public struct FourCC : IEquatable<FourCC>
     {
         private int m_Code;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
@@ -24,7 +24,6 @@ namespace UnityEngine.InputSystem.Utilities
     /// There is a non-zero cost to creating an InternedString. The first time a new unique InternedString
     /// is encountered, there may also be a GC heap allocation.
     /// </remarks>
-    [Serializable]
     public struct InternedString : IEquatable<InternedString>, IComparable<InternedString>
     {
         private readonly string m_StringOriginalCase;

--- a/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Utilities/InternedString.cs
@@ -24,6 +24,7 @@ namespace UnityEngine.InputSystem.Utilities
     /// There is a non-zero cost to creating an InternedString. The first time a new unique InternedString
     /// is encountered, there may also be a GC heap allocation.
     /// </remarks>
+    [Serializable]
     public struct InternedString : IEquatable<InternedString>, IComparable<InternedString>
     {
         private readonly string m_StringOriginalCase;


### PR DESCRIPTION
### Description

InputSystem warnings displayed with Unity editor `6000.6 `version.


```
Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs(22,58): warning UAC1010: Field 'm_State' has [SerializeField] but its type 'UnityEngine.InputSystem.Editor.InputActionsEditorState' is not [Serializable]; Unity will ignore this field. Consider replacing [SerializeField] with [System.NonSerialized] or make the type [Serializable] if serialization is desired.

Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs(22,58): warning UAC1010: Field 'm_State' has [SerializeField] but its type 'UnityEngine.InputSystem.Editor.InputActionsEditorState' is not [Serializable]; Unity will ignore this field. Consider replacing [SerializeField] with [System.NonSerialized] or make the type [Serializable] if serialization is desired.

Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs(383,37): warning UAC1001: Field 'layouts' is a candidate for serialization but Unity will skip it because its type 'UnityEngine.InputSystem.Utilities.InternedString' lacks [Serializable] attribute. To fix this, either: make the field private (if serialization is not desired), add [System.NonSerialized] (to explicitly mark it as non-serialized), or add [Serializable] to type 'UnityEngine.InputSystem.Utilities.InternedString' (if serialization is desired).

Packages/com.unity.inputsystem/InputSystem/Editor/Internal/InputStateWindow.cs(403,43): warning UAC1009: Field 'm_StateBuffers' uses 'byte[][]' which is not supported by Unity serialization (multidimensional arrays, jagged arrays, dictionaries, and other unsupported collections are not serialized); consider adding [System.NonSerialized] to suppress this warning

Packages/com.unity.inputsystem/InputSystem/InputManager.cs(4332,38): warning UAC1001: Field 'buffers' is a candidate for serialization but Unity will skip it because its type 'UnityEngine.InputSystem.LowLevel.InputStateBuffers' lacks [Serializable] attribute. To fix this, either: make the field private (if serialization is not desired), add [System.NonSerialized] (to explicitly mark it as non-serialized), or add [Serializable] to type 'UnityEngine.InputSystem.LowLevel.InputStateBuffers' (if serialization is desired).

Packages/com.unity.inputsystem/InputSystem/Events/InputEventTrace.cs(1567,46): warning UAC1010: Field 'm_StateFormat' has [SerializeField] but its type 'UnityEngine.InputSystem.Utilities.FourCC' is not [Serializable]; Unity will ignore this field. Consider replacing [SerializeField] with [System.NonSerialized] or make the type [Serializable] if serialization is desired.

Assets/Tests/InputSystem.Editor/InputActionReferenceEditorTests.cs(101,59): warning CS0618: 'Object.FindFirstObjectByType<T>()' is obsolete: 'FindFirstObjectByType has been deprecated because it relies on instance ID ordering. Use FindAnyObjectByType instead, which does not depend on ordering.'

Assets/QA/Tests/Xbox Controller Basic/Scripts/GamepadButtonState.cs(9,26): warning UAC1001: Field 'buttonToTrack' is a candidate for serialization but Unity will skip it because its type 'UnityEngine.InputSystem.Controls.ButtonControl' lacks [Serializable] attribute. To fix this, either: make the field private (if serialization is not desired), add [System.NonSerialized] (to explicitly mark it as non-serialized), or add [Serializable] to type 'UnityEngine.InputSystem.Controls.ButtonControl' (if serialization is desired).

Assets/Tests/InputSystem/Plugins/UITests.cs(4626,28): warning UAC1001: Field 'events' is a candidate for serialization but Unity will skip it because its type 'UITests.UICallbackReceiver.Event' lacks [Serializable] attribute. To fix this, either: make the field private (if serialization is not desired), add [System.NonSerialized] (to explicitly mark it as non-serialized), or add [Serializable] to type 'UITests.UICallbackReceiver.Event' (if serialization is desired).
```

Some of the warnings:
<img width="3456" height="2234" alt="image" src="https://github.com/user-attachments/assets/a078044c-c5af-4397-8627-d138e08a6a13" />

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
