### PR TITLE
FIX: Only dispatch when there is a valid selected item

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed a `NullReferenceException` thrown when removing all action maps [UUM-137116](https://jira.unity3d.com/browse/UUM-137116)
 - Simplified default setting messaging by consolidating repetitive messages into a single HelpBox.
 - Fixed a `NullPointerReferenceException` thrown in `InputManagerStateMonitors.FireStateChangeNotifications` logging by adding validation [UUM-136095].
 - Fixed auto-save not working for Input System actions in Project Settings when both the Project Settings and Input System Actions windows were open [UUM-134035](https://jira.unity3d.com/browse/UUM-134035)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -21,7 +21,8 @@ namespace UnityEngine.InputSystem.Editor
             m_ListViewSelectionChangeFilter = new CollectionViewSelectionChangeFilter(m_ListView);
             m_ListViewSelectionChangeFilter.selectedIndicesChanged += (selectedIndices) =>
             {
-                Dispatch(Commands.SelectActionMap(((ActionMapData)m_ListView.selectedItem).mapName));
+                if (m_ListView.selectedItem is ActionMapData mapData)
+                    Dispatch(Commands.SelectActionMap(mapData.mapName));
             };
 
             m_ListView.bindItem = (element, i) =>


### PR DESCRIPTION
### Description

This PR is fixing the `NullReferenceException` error that triggers when **removing all action maps**


The `selectedIndicesChanged` callback always accessed `((ActionMapData)m_ListView.selectedItem).mapName`. However, when the list view is refreshed (for example in RedrawUI when `itemsSource` is reassigned), the framework may trigger `selectedIndicesChanged` while no item is selected. In that situation, `m_ListView.selectedItem` is null, causing the cast and property access to throw a `NullReferenceException`.

JIRA: https://jira.unity3d.com/browse/UUM-137116

Before:
https://github.com/user-attachments/assets/1fe91523-5b09-428e-9fa9-6e81bf1a60de

After:
https://github.com/user-attachments/assets/8e9be1f8-b2d1-4036-a440-23bfc23dfdbe


### Testing status & QA

Check that no errors are thrown when removing all action maps.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 1
- Halo Effect: 1

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
