### PR TITLE
FIX: Update navigation state on move action swap

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/UI/InputSystemUIInputModule.cs
@@ -1347,7 +1347,15 @@ namespace UnityEngine.InputSystem.UI
         public InputActionReference move
         {
             get => m_MoveAction;
-            set => SwapAction(ref m_MoveAction, value, m_ActionsHooked, m_OnMoveDelegate);
+            set
+            {
+                SwapAction(ref m_MoveAction, value, m_ActionsHooked, m_OnMoveDelegate);
+                // Because moveAction is the only action cached in the navigation state,
+                // we need to read new action's current value to avoid stale state from the previous action.
+                m_NavigationState.move = m_MoveAction?.action != null && m_MoveAction.action.enabled
+                    ? m_MoveAction.action.ReadValue<Vector2>()
+                    : Vector2.zero;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

This is a PoC of a fix for this Slack thread: https://unity.slack.com/archives/C09Q7LYP9/p1773406813979019

Swapping `InputSystemUIInputModule.move` while a control was in a non-zero state caused phantom Navigate events. `SwapAction` unhooks the old action's callbacks before disabling it, so the cancelled event triggered on disable never reached `OnMoveCallback`. This left `m_NavigationState.move` is a staled state.

This PR add a fix that reads the new action's current value immediately after the swap, resynching the cached state.

Note: _I've thought of re-ordering the action disabling before the action call-backs are unhook (in `SwapAction`), but that might introduce regression as it would means that any action in non default state (button pressed) would cause a released event on Swap. That might be closer to what is expected in some situation, but that another of those semantic situation. The point being that some users might already depend on existing behaviour and we don't want to introduce regression._

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
