### PR TITLE
CHANGE: XRI test ignored as it is causing issues in the CI. It should be re-enabled once the underlying issue is resolved

### DIFF
--- a/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
+++ b/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
@@ -38,6 +38,7 @@ public class XRIPackageTests
 
     [UnityTest]
     [Category("Integration")]
+    [Ignore("ISX-2531 - This test is currently ignored as it is causing issues in the CI. It should be re-enabled once the underlying issue is resolved.")]
     public IEnumerator AdddingLatestXRIPackageThrowsNoErrors()
     {
         Application.logMessageReceived += HandleLog;


### PR DESCRIPTION
### Description

XRI test ignored as it is causing issues in the CI. It should be re-enabled once the underlying issue is resolved.

Reason:
`Library/PackageCache/com.unity.xr.interaction.toolkit@e986f3a5995f/Editor/Debugger/XRTargetFiltersTreeView.cs(243,28): error CS0619: 'EntityId.implicit operator EntityId(int)' is obsolete: 'EntityId will not be representable by an int in the future. This casting operator will be removed in a future version.'`

CI now:
<img width="1303" height="138" alt="Screenshot 2026-03-19 at 10 58 47" src="https://github.com/user-attachments/assets/bb61aa8d-f745-4f93-8a70-a5bd50d115a9" />


Slack: https://unity.slack.com/archives/C95QR0BNJ/p1773843670885359

JIRA: https://jira.unity3d.com/browse/ISX-2531

### Testing status & QA

Check CI is skipping this test.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:0
- Halo Effect:0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
