### PR TITLE
FIX: APIVerificationTests failing on scrapped API new format

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -258,7 +258,7 @@ class APIVerificationTests
 
     // The .api files are platform-specific so we can only compare on the platform
     // they were built on.
-    #if UNITY_EDITOR_WIN
+#if UNITY_EDITOR_WIN
 
     // We disable "API Verification" tests running as part of the validation suite as they give us
     // false positives (specifically, for setters having changes accessibility from private to protected).
@@ -563,7 +563,6 @@ class APIVerificationTests
         DontOmitDevice = 2,
         DontUseShortDisplayNames = 1,
         IgnoreBindingOverrides = 8,
-        protected System.UInt32 stateOffsetRelativeToDeviceRoot { get; }
         OmitDevice = 2,
         UseShortNames = 4,
         BufferedBytes = 256,
@@ -575,59 +574,6 @@ class APIVerificationTests
         Variable = 2,
         Volatile = 128,
         Wrap = 8,
-        public System.UInt32 bit { get; set; }
-        public System.UInt32 offset { get; set; }
-        public System.UInt32 sizeInBits { get; set; }
-        public InputControlLayout.Builder.ControlBuilder WithBitOffset(System.UInt32 bit);
-        public InputControlLayout.Builder.ControlBuilder WithByteOffset(System.UInt32 offset);
-        public InputControlLayout.Builder.ControlBuilder WithSizeInBits(System.UInt32 sizeInBits);
-        public System.UInt32 bit { get; }
-        public System.UInt32 offset { get; }
-        public System.UInt32 sizeInBits { get; }
-        public System.UInt32 stateOffset;
-        public System.UInt32 deltaStateSizeInBytes { get; }
-        public System.UInt32 buttons;
-        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref System.UInt32 offset);
-        public System.UInt32 sizeInBytes { get; set; }
-        public System.UInt32 sizeInBytes { get; }
-        public static System.UInt32 updateCount { get; }
-        public const System.UInt32 AutomaticOffset = 4294967294;
-        public const System.UInt32 InvalidOffset = 4294967295;
-        public System.UInt32 bitOffset { get; set; }
-        public System.UInt32 byteOffset { get; set; }
-        public System.UInt32 version { get; }
-        public System.UInt32 version;
-        public System.UInt32 stateSizeInBytes { get; }
-        public const System.UInt32 InvalidId = 0;
-        public System.UInt32 id { get; }
-        public System.UInt32 parentBoneIndex { get; set; }
-        public System.UInt32 customSize;
-        public System.UInt32 samplesAvailable;
-        public System.UInt32 samplesQueued;
-        public System.UInt32 frequencyHz;
-        public System.UInt32 maxBufferSize;
-        public System.UInt32 numChannels;
-        public System.UInt32 frequencyHz { get; }
-        public System.UInt32 maxBufferSize { get; }
-        public System.UInt32 numChannels { get; }
-        public HapticCapabilities(System.UInt32 numChannels, System.UInt32 frequencyHz, System.UInt32 maxBufferSize) {}
-        public System.UInt32 samplesAvailable { get; }
-        public System.UInt32 samplesQueued { get; }
-        public HapticState(System.UInt32 samplesQueued, System.UInt32 samplesAvailable) {}
-        public PrimitiveValue(System.UInt16 value) {}
-        public PrimitiveValue(System.UInt32 value) {}
-        public PrimitiveValue(System.UInt64 value) {}
-        public static PrimitiveValue FromUInt16(System.UInt16 value);
-        public static PrimitiveValue FromUInt32(System.UInt32 value);
-        public static PrimitiveValue FromUInt64(System.UInt64 value);
-        public static PrimitiveValue op_Implicit(System.UInt16 value);
-        public static PrimitiveValue op_Implicit(System.UInt32 value);
-        public static PrimitiveValue op_Implicit(System.UInt64 value);
-        public System.UInt16 ToUInt16(System.IFormatProvider provider = default(System.IFormatProvider));
-        public System.UInt32 ToUInt32(System.IFormatProvider provider = default(System.IFormatProvider));
-        public System.UInt64 ToUInt64(System.IFormatProvider provider = default(System.IFormatProvider));
-        public System.UInt64 handle { get; }
-        public InputUserAccountHandle(string apiName, System.UInt64 handle) {}
         public FourCC(char a, char b =  , char c =  , char d =  ) {}
         public static string ToHumanReadableString(string path, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
         public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
@@ -642,11 +588,8 @@ class APIVerificationTests
         public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> previous { get; }
         public void CopyFrom(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> record);
         public bool Equals(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> other);
-        public System.UInt16 buttons;
-        public System.UInt16 clickCount;
-        public System.UInt64 handle;
-        public SteamHandle(System.UInt64 handle) {}
-        public static System.UInt64 op_Explicit(UnityEngine.InputSystem.Steam.SteamHandle<TObject> handle);
+        public SteamHandle(ulong handle) {}
+        public static ulong op_Explicit(UnityEngine.InputSystem.Steam.SteamHandle<TObject> handle);
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0
@@ -735,6 +678,32 @@ class APIVerificationTests
         if (line.Length == 0)
             return line;
 
+        // Older API scraper versions emitted fully-qualified C# primitive type names (e.g. System.UInt32),
+        // while newer versions emit C# language aliases (e.g. uint). Normalize to aliases so that a scraper
+        // version change does not produce false-positive breaking change reports.
+        line = line
+            .Replace("System.UInt64", "ulong")
+            .Replace("System.UInt32", "uint")
+            .Replace("System.UInt16", "ushort")
+            .Replace("System.Int64", "long")
+            .Replace("System.Int32", "int")
+            .Replace("System.Int16", "short")
+            .Replace("System.Boolean", "bool")
+            .Replace("System.Single", "float")
+            .Replace("System.Double", "double")
+            .Replace("System.Byte", "byte")
+            .Replace("System.SByte", "sbyte")
+            .Replace("System.Char", "char");
+
+        // Normalize constant expressions that different scraper versions emit differently.
+        // Older scrapers resolved expressions to decimal; newer scrapers may keep symbolic forms.
+        line = line.Replace("uint.MaxValue", "4294967295")
+            .Replace("uint.MinValue", "0");
+        line = Regex.Replace(line, @"\b0x([0-9a-fA-F]+)\b",
+            m => Convert.ToUInt64(m.Groups[1].Value, 16).ToString());
+        line = Regex.Replace(line, @"\b(\d+) << (\d+)\b",
+            m => (ulong.Parse(m.Groups[1].Value) << int.Parse(m.Groups[2].Value)).ToString());
+
         var pos = 0;
         while (true)
         {
@@ -742,21 +711,44 @@ class APIVerificationTests
             while (pos < line.Length && char.IsWhiteSpace(line[pos]))
                 ++pos;
 
-            if (pos < line.Length && line[pos] != '[')
+            if (pos >= line.Length || line[pos] != '[')
                 return line;
 
             var startPos = pos;
             ++pos;
-            while (pos < line.Length + 1 && !(line[pos] == ']' && line[pos + 1] == ' '))
-                ++pos;
-            ++pos;
 
-            var length = pos - startPos - 2;
-            var attribute = line.Substring(startPos + 1, length);
-            if (!attribute.StartsWith("System.Obsolete"))
+            // Find the matching closing ']' using bracket depth tracking.
+            // This correctly handles new[] syntax in attribute arguments, e.g.:
+            //   [InputControl(aliases = new[] {@"a", @"b"})] public uint buttons;
+            // The old scraper used Mono.Cecil.CustomAttributeArgument[] (inner ] followed by ,)
+            // but the new scraper uses new[] {...} where the inner ] is followed by a space,
+            // which the old naive scan would incorrectly treat as the end of the attribute.
+            var depth = 1;
+            while (pos < line.Length && depth > 0)
+            {
+                if (line[pos] == '[') depth++;
+                else if (line[pos] == ']') depth--;
+                if (depth > 0) ++pos;
+            }
+
+            if (pos >= line.Length)
+                return line; // No matching ']' found, bail out.
+
+            ++pos; // Move past the closing ']'.
+
+            // The attribute must be followed by a space to have any content after it.
+            if (pos >= line.Length || line[pos] != ' ')
+                return line;
+
+            var attributeContent = line.Substring(startPos + 1, pos - startPos - 2);
+            if (!attributeContent.StartsWith("System.Obsolete"))
             {
                 line = line.Substring(0, startPos) + line.Substring(pos + 1); // Snip space after ']'.
-                pos -= length + 2;
+                pos = startPos;
+            }
+            else
+            {
+                ++pos; // Skip the space after the kept Obsolete attribute.
             }
         }
     }

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -577,6 +577,16 @@ class APIVerificationTests
         Wrap = 8,
         public System.UInt32 bit { get; set; }
         public System.UInt32 offset { get; set; }
+        public System.UInt32 sizeInBits { get; set; }
+        public InputControlLayout.Builder.ControlBuilder WithBitOffset(System.UInt32 bit);
+        public InputControlLayout.Builder.ControlBuilder WithByteOffset(System.UInt32 offset);
+        public InputControlLayout.Builder.ControlBuilder WithSizeInBits(System.UInt32 sizeInBits);
+        public System.UInt32 bit { get; }
+        public System.UInt32 offset { get; }
+        public System.UInt32 sizeInBits { get; }
+        public System.UInt32 stateOffset;
+        public System.UInt32 deltaStateSizeInBytes { get; }
+        public System.UInt32 buttons;
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -642,6 +642,11 @@ class APIVerificationTests
         public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> previous { get; }
         public void CopyFrom(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> record);
         public bool Equals(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> other);
+        public System.UInt16 buttons;
+        public System.UInt16 clickCount;
+        public System.UInt64 handle;
+        public SteamHandle(System.UInt64 handle) {}
+        public static System.UInt64 op_Explicit(UnityEngine.InputSystem.Steam.SteamHandle<TObject> handle);
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -712,7 +712,7 @@ class APIVerificationTests
             var line = oldApiContents[i];
             if (line.Trim().StartsWith("{"))
             {
-                scopeStack.Add(oldApiContents[i - 1]);
+                scopeStack.Add(i > 0 ? oldApiContents[i - 1] : string.Empty);
             }
             else if (line.Trim().StartsWith("}"))
             {
@@ -724,13 +724,20 @@ class APIVerificationTests
         }
     }
 
+    // Matches hex literals (0xFF).
+    private static readonly Regex s_HexLiteralRegex =
+        new Regex(@"\b0x([0-9a-fA-F]+)\b", RegexOptions.Compiled);
+    // Matches bitwise shift expressions (1 << 8).
+    private static readonly Regex s_ShiftExprRegex =
+        new Regex(@"\b(\d+) << (\d+)\b", RegexOptions.Compiled);
+
     private static string FilterIgnoredChanges(string line)
     {
         if (line.Length == 0)
             return line;
 
-        // Older API scraper versions emitted fully-qualified C# primitive type names (e.g. System.UInt32),
-        // while newer versions emit C# language aliases (e.g. uint). Normalize to aliases so that a scraper
+        // Older API scraper versions emitted fully-qualified C# primitive type names (System.UInt32),
+        // while newer versions emit C# language aliases (uint). Normalize to aliases so that a scraper
         // version change does not produce false-positive breaking change reports.
         line = line
             .Replace("System.UInt64", "ulong")
@@ -750,9 +757,11 @@ class APIVerificationTests
         // Older scrapers resolved expressions to decimal; newer scrapers may keep symbolic forms.
         line = line.Replace("uint.MaxValue", "4294967295")
             .Replace("uint.MinValue", "0");
-        line = Regex.Replace(line, @"\b0x([0-9a-fA-F]+)\b",
-            m => Convert.ToUInt64(m.Groups[1].Value, 16).ToString());
-        line = Regex.Replace(line, @"\b(\d+) << (\d+)\b",
+        // Normalize hex literals (0xFF -> 255).
+        line = s_HexLiteralRegex.Replace(line,
+                    m => Convert.ToUInt64(m.Groups[1].Value, 16).ToString());
+        // Normalize bitwise shift expressions (1 << 8 -> 256).
+        line = s_ShiftExprRegex.Replace(line,
             m => (ulong.Parse(m.Groups[1].Value) << int.Parse(m.Groups[2].Value)).ToString());
 
         var pos = 0;
@@ -760,20 +769,21 @@ class APIVerificationTests
         {
             // Skip whitespace.
             while (pos < line.Length && char.IsWhiteSpace(line[pos]))
+            {
                 ++pos;
+            }
 
             if (pos >= line.Length || line[pos] != '[')
+            {
                 return line;
+            }
 
             var startPos = pos;
             ++pos;
 
             // Find the matching closing ']' using bracket depth tracking.
-            // This correctly handles new[] syntax in attribute arguments, e.g.:
+            // This correctly handles new[] syntax in attribute arguments:
             //   [InputControl(aliases = new[] {@"a", @"b"})] public uint buttons;
-            // The old scraper used Mono.Cecil.CustomAttributeArgument[] (inner ] followed by ,)
-            // but the new scraper uses new[] {...} where the inner ] is followed by a space,
-            // which the old naive scan would incorrectly treat as the end of the attribute.
             var depth = 1;
             while (pos < line.Length && depth > 0)
             {
@@ -783,15 +793,20 @@ class APIVerificationTests
             }
 
             if (pos >= line.Length)
-                return line; // No matching ']' found, bail out.
+            {
+                return line; // No matching ']' found, so out.
+            }
 
             ++pos; // Move past the closing ']'.
 
-            // The attribute must be followed by a space to have any content after it.
+            // The attribute must be followed by a space. 
+            // If it is the last character there is nothing else to strip, so out.
             if (pos >= line.Length || line[pos] != ' ')
                 return line;
 
-            var attributeContent = line.Substring(startPos + 1, pos - startPos - 2);
+            // Extract the content between '[' and ']'.
+            var closingBracket = pos - 1; // pos is now one past ']'
+            var attributeContent = line.Substring(startPos + 1, closingBracket - startPos - 1);
             if (!attributeContent.StartsWith("System.Obsolete"))
             {
                 line = line.Substring(0, startPos) + line.Substring(pos + 1); // Snip space after ']'.
@@ -829,12 +844,21 @@ class APIVerificationTests
             var namespaceScope = string.Empty;
             var typeScope = string.Empty;
 
+            // Walk inside-out so we pick up the innermost namespace and type scopes first.
             for (var i = scopeStack.Count - 1; i >= 0; i--)
             {
                 if (scopeStack[i].StartsWith("namespace"))
-                    namespaceScope = scopeStack[i].Substring(scopeStack[i].IndexOf(' ') + 1);
-                else
+                {
+                    if (namespaceScope.Length == 0)
+                        namespaceScope = scopeStack[i].Substring(scopeStack[i].IndexOf(' ') + 1);
+                }
+                else if (typeScope.Length == 0)
+                {
                     typeScope = scopeStack[i].Trim();
+                }
+
+                if (namespaceScope.Length > 0 && typeScope.Length > 0)
+                    break;
             }
 
             return namespaceScope == Namespace && typeScope == Type && Members.Contains(member.Trim());

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -587,6 +587,50 @@ class APIVerificationTests
         public System.UInt32 stateOffset;
         public System.UInt32 deltaStateSizeInBytes { get; }
         public System.UInt32 buttons;
+        public bool GetStateOffsetForEvent(InputControl control, InputEventPtr eventPtr, ref System.UInt32 offset);
+        public System.UInt32 sizeInBytes { get; set; }
+        public System.UInt32 sizeInBytes { get; }
+        public static System.UInt32 updateCount { get; }
+        public const System.UInt32 AutomaticOffset = 4294967294;
+        public const System.UInt32 InvalidOffset = 4294967295;
+        public System.UInt32 bitOffset { get; set; }
+        public System.UInt32 byteOffset { get; set; }
+        public System.UInt32 version { get; }
+        public System.UInt32 version;
+        public System.UInt32 stateSizeInBytes { get; }
+        public const System.UInt32 InvalidId = 0;
+        public System.UInt32 id { get; }
+        public System.UInt32 parentBoneIndex { get; set; }
+        public System.UInt32 customSize;
+        public System.UInt32 samplesAvailable;
+        public System.UInt32 samplesQueued;
+        public System.UInt32 frequencyHz;
+        public System.UInt32 maxBufferSize;
+        public System.UInt32 numChannels;
+        public System.UInt32 frequencyHz { get; }
+        public System.UInt32 maxBufferSize { get; }
+        public System.UInt32 numChannels { get; }
+        public HapticCapabilities(System.UInt32 numChannels, System.UInt32 frequencyHz, System.UInt32 maxBufferSize) {}
+        public System.UInt32 samplesAvailable { get; }
+        public System.UInt32 samplesQueued { get; }
+        public HapticState(System.UInt32 samplesQueued, System.UInt32 samplesAvailable) {}
+        public PrimitiveValue(System.UInt16 value) {}
+        public PrimitiveValue(System.UInt32 value) {}
+        public PrimitiveValue(System.UInt64 value) {}
+        public static PrimitiveValue FromUInt16(System.UInt16 value);
+        public static PrimitiveValue FromUInt32(System.UInt32 value);
+        public static PrimitiveValue FromUInt64(System.UInt64 value);
+        public static PrimitiveValue op_Implicit(System.UInt16 value);
+        public static PrimitiveValue op_Implicit(System.UInt32 value);
+        public static PrimitiveValue op_Implicit(System.UInt64 value);
+        public System.UInt16 ToUInt16(System.IFormatProvider provider = default(System.IFormatProvider));
+        public System.UInt32 ToUInt32(System.IFormatProvider provider = default(System.IFormatProvider));
+        public System.UInt64 ToUInt64(System.IFormatProvider provider = default(System.IFormatProvider));
+        public System.UInt64 handle { get; }
+        public InputUserAccountHandle(string apiName, System.UInt64 handle) {}
+        public FourCC(char a, char b =  , char c =  , char d =  ) {}
+        public static string ToHumanReadableString(string path, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
+        public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -557,6 +557,16 @@ class APIVerificationTests
         public static string GetBindingDisplayString(this InputAction action, InputBinding bindingMask, InputBinding.DisplayStringOptions options = );
         public static string GetBindingDisplayString(this InputAction action, InputBinding.DisplayStringOptions options = , string group = default(string));
         public static string GetBindingDisplayString(this InputAction action, int bindingIndex, out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = );
+        public string ToDisplayString(InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));
+        public string ToDisplayString(out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));
+        DontIncludeInteractions = 4,
+        DontOmitDevice = 2,
+        DontUseShortDisplayNames = 1,
+        IgnoreBindingOverrides = 8,
+        protected System.UInt32 stateOffsetRelativeToDeviceRoot { get; }
+        OmitDevice = 2,
+        UseShortNames = 4,
+        BufferedBytes = 256,
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -567,6 +567,16 @@ class APIVerificationTests
         OmitDevice = 2,
         UseShortNames = 4,
         BufferedBytes = 256,
+        Constant = 1,
+        NonLinear = 16,
+        NoPreferred = 32,
+        NullState = 64,
+        Relative = 4,
+        Variable = 2,
+        Volatile = 128,
+        Wrap = 8,
+        public System.UInt32 bit { get; set; }
+        public System.UInt32 offset { get; set; }
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -850,7 +850,7 @@ class APIVerificationTests
                 if (scopeStack[i].StartsWith("namespace"))
                 {
                     if (namespaceScope.Length == 0)
-                        namespaceScope = scopeStack[i].Substring(scopeStack[i].IndexOf(' ') + 1);
+                        namespaceScope = scopeStack[i].Substring(scopeStack[i].IndexOf(' ') + 1).Trim();
                 }
                 else if (typeScope.Length == 0)
                 {

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -541,6 +541,23 @@ class APIVerificationTests
         public InputTestFixture.ActionConstraint Performed(InputAction action, InputControl control = default(InputControl), System.Nullable<double> time = default(System.Nullable<double>), System.Nullable<double> duration = default(System.Nullable<double>));
         public InputTestFixture.ActionConstraint Started(InputAction action, InputControl control = default(InputControl), System.Nullable<double> time = default(System.Nullable<double>));
     ")]
+    // API scraper output for these built-in XR controller types differs depending on installed XR replacement packages.
+    [Property("Exclusions", @"1.0.0
+        public class DaydreamController : UnityEngine.InputSystem.XR.XRController
+        public class GearVRTrackedController : UnityEngine.InputSystem.XR.XRController
+        public class OculusTouchController : UnityEngine.InputSystem.XR.XRControllerWithRumble
+        public class HandedViveTracker : ViveTracker
+        public class OpenVRControllerWMR : UnityEngine.InputSystem.XR.XRController
+        public class OpenVROculusTouchController : UnityEngine.InputSystem.XR.XRControllerWithRumble
+        public class ViveWand : UnityEngine.InputSystem.XR.XRControllerWithRumble
+    ")]
+    // API scraper in 1.0.0 emitted incomplete default argument expressions for these overloads.
+    [Property("Exclusions", @"1.0.0
+        public static string GetBindingDisplayString(this InputAction action, int bindingIndex, InputBinding.DisplayStringOptions options = );
+        public static string GetBindingDisplayString(this InputAction action, InputBinding bindingMask, InputBinding.DisplayStringOptions options = );
+        public static string GetBindingDisplayString(this InputAction action, InputBinding.DisplayStringOptions options = , string group = default(string));
+        public static string GetBindingDisplayString(this InputAction action, int bindingIndex, out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = );
+    ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0
         public int negative = 0;

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -759,7 +759,7 @@ class APIVerificationTests
             .Replace("uint.MinValue", "0");
         // Normalize hex literals (0xFF -> 255).
         line = s_HexLiteralRegex.Replace(line,
-                    m => Convert.ToUInt64(m.Groups[1].Value, 16).ToString());
+            m => Convert.ToUInt64(m.Groups[1].Value, 16).ToString());
         // Normalize bitwise shift expressions (1 << 8 -> 256).
         line = s_ShiftExprRegex.Replace(line,
             m => (ulong.Parse(m.Groups[1].Value) << int.Parse(m.Groups[2].Value)).ToString());
@@ -799,7 +799,7 @@ class APIVerificationTests
 
             ++pos; // Move past the closing ']'.
 
-            // The attribute must be followed by a space. 
+            // The attribute must be followed by a space.
             // If it is the last character there is nothing else to strip, so out.
             if (pos >= line.Length || line[pos] != ' ')
                 return line;

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -605,6 +605,57 @@ class APIVerificationTests
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem.LowLevel", "public struct KeyboardState : IInputStateTypeInfo", "public fixed byte keys[14];")]
     // Allow Key.IMESelected to be marked as Obsolete
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem", "public enum Key", "IMESelected = 111,")]
+
+#if !UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT
+    // Steam support is conditional (#if UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT) and absent when
+    // the steam plugin is not installed, so all Steam types are excluded from the comparison.
+    [Property("Exclusions", @"1.0.0
+        namespace UnityEngine.InputSystem.Steam
+        public interface ISteamControllerAPI
+        public void ActivateActionSet(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> actionSetHandle);
+        public void ActivateActionSetLayer(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> actionSetLayerHandle);
+        public void DeactivateActionSetLayer(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> actionSetLayerHandle);
+        public void DeactivateAllActionSetLayers(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle);
+        public UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> GetActionSetHandle(string actionSetName);
+        public int GetActiveActionSetLayers(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, out UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> handlesOut);
+        public SteamAnalogActionData GetAnalogActionData(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputAction> analogActionHandle);
+        public UnityEngine.InputSystem.Steam.SteamHandle<InputAction> GetAnalogActionHandle(string actionName);
+        public int GetConnectedControllers(UnityEngine.InputSystem.Steam.SteamHandle<SteamController>[] outHandles);
+        public UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> GetCurrentActionSet(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle);
+        public SteamDigitalActionData GetDigitalActionData(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputAction> digitalActionHandle);
+        public UnityEngine.InputSystem.Steam.SteamHandle<InputAction> GetDigitalActionHandle(string actionName);
+        public void RunFrame();
+        public struct SteamAnalogActionData
+        public bool active { get; set; }
+        public Vector2 position { get; set; }
+        public abstract class SteamController : InputDevice
+        public bool autoActivateSets { get; set; }
+        public UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> currentSteamActionSet { get; }
+        public abstract UnityEngine.InputSystem.Utilities.ReadOnlyArray<SteamController.SteamActionSetInfo> steamActionSets { get; }
+        public UnityEngine.InputSystem.Steam.SteamHandle<SteamController> steamControllerHandle { get; }
+        protected SteamController() {}
+        public void ActivateSteamActionSet(UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> actionSet);
+        protected abstract void ResolveSteamActions(ISteamControllerAPI api);
+        protected abstract void Update(ISteamControllerAPI api);
+        public struct SteamActionSetInfo
+        public UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> handle { get; set; }
+        public struct SteamDigitalActionData
+        public bool active { get; set; }
+        public bool pressed { get; set; }
+        public struct SteamHandle<TObject> : System.IEquatable<UnityEngine.InputSystem.Steam.SteamHandle<TObject>>
+        public bool Equals(UnityEngine.InputSystem.Steam.SteamHandle<TObject> other);
+        public static bool operator ==(UnityEngine.InputSystem.Steam.SteamHandle<TObject> a, UnityEngine.InputSystem.Steam.SteamHandle<TObject> b);
+        public static bool operator !=(UnityEngine.InputSystem.Steam.SteamHandle<TObject> a, UnityEngine.InputSystem.Steam.SteamHandle<TObject> b);
+        namespace UnityEngine.InputSystem.Steam.Editor
+        public static class SteamIGAConverter
+        public static string ConvertInputActionsToSteamIGA(System.Collections.Generic.IEnumerable<InputActionMap> actionMaps, string locale = @""english"");
+        public static string ConvertInputActionsToSteamIGA(InputActionAsset asset, string locale = @""english"");
+        public static string GenerateInputDeviceFromSteamIGA(string vdf, string namespaceAndClassName);
+        public static string GetSteamControllerInputType(InputAction action);
+        public static System.Collections.Generic.Dictionary<string, object> ParseVDF(string vdf);
+    ")]
+#endif
+
     public void API_MinorVersionsHaveNoBreakingChanges()
     {
         var currentVersion = CoreTests.PackageJson.ReadVersion();

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -631,6 +631,17 @@ class APIVerificationTests
         public FourCC(char a, char b =  , char c =  , char d =  ) {}
         public static string ToHumanReadableString(string path, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
         public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
+        public class InputStateHistory<TValue> : InputStateHistory, System.Collections.Generic.IEnumerable<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.Generic.IReadOnlyCollection<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.Generic.IReadOnlyList<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.IEnumerable where TValue : struct, new()
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> this[int index] { get; set; }
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> AddRecord(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> record);
+        public System.Collections.Generic.IEnumerator<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>> GetEnumerator();
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> RecordStateChange(UnityEngine.InputSystem.InputControl<TValue> control, TValue value, double time = -1d);
+        public struct Record : System.IEquatable<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> next { get; }
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> owner { get; }
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> previous { get; }
+        public void CopyFrom(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> record);
+        public bool Equals(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> other);
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0


### PR DESCRIPTION
### Description

**co-authored with @MorganHoarau** 

**Problem**

1 - Upgrading `com.unity.coding` from `preview.24` to `preview.26` (done in #2382 )  changed how the API scraper formats its output (type names, constants, and attribute syntax all differ between the two versions). Since the test baseline (`Tools/API/1.0.0/`) was generated with the old scraper, every comparison started failing, making the test report hundreds of false-positive breaking changes.

2 - Some new API imported from dependencies also needed to be excluded.

**Solution**

This PR fixed the comparison logic in `FilterIgnoredChanges` to normalize scraper format differences before comparing:
* Type aliases: `System.UInt32` -> `uint, System.Boolean` -> `bool`, etc.
* Hex literals: `0xb` -> `11`
* Bit-shift expressions: `1 << 3` -> `8`
* Symbolic constants: `uint.MaxValue` -> `4294967295`
* Attribute parsing: rewrote bracket-depth tracking to correctly handle `new[] {@"..."}` syntax

Also added explicit exclusions for Steam controller types (`SteamController`, `ISteamControllerAPI`, `SteamHandle<T>`, etc.) which are not available when `UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT` is not defined.

### Testing status & QA

Local testing of the failing test + CI

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Medium
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
