### PR TITLE
CHANGE:  Update asset Actions.inputactions to use UI Toolkit framework 

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Changed the UI for `Actions.inputactions` asset to use UI Toolkit framework.
+
 ### Added
 
 - Support for entering the play mode with domain reload turned off (i.e. Faster Enter Playmode feature) [ISX-2411]

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -19,6 +19,9 @@ namespace UnityEngine.InputSystem.Editor
         public override VisualElement CreateInspectorGUI()
         {
             var root = new VisualElement();
+            root.styleSheets.Add(AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                InputActionsEditorConstants.PackagePath +
+                "/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss"));
             var inputActionAsset = GetAsset();
 
             // ScriptedImporterEditor in 2019.2 now requires explicitly updating the SerializedObject
@@ -36,15 +39,12 @@ namespace UnityEngine.InputSystem.Editor
             {
                 text = GetOpenEditorButtonText(inputActionAsset)
             };
-            editButton.style.height = 30;
-            editButton.style.marginTop = 4;
-            editButton.style.marginBottom = 4;
+            editButton.AddToClassList("input-action-importer-editor__edit-button");
             editButton.SetEnabled(inputActionAsset != null);
             root.Add(editButton);
 
             var projectWideContainer = new VisualElement();
-            projectWideContainer.style.marginTop = 6;
-            projectWideContainer.style.marginBottom = 6;
+            projectWideContainer.AddToClassList("input-action-importer-editor__project-wide-container");
             root.Add(projectWideContainer);
             BuildProjectWideSection(projectWideContainer, inputActionAsset);
 
@@ -113,12 +113,11 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             var pathRow = new VisualElement();
-            pathRow.style.flexDirection = FlexDirection.Row;
-            pathRow.style.alignItems = Align.Center;
+            pathRow.AddToClassList("input-action-importer-editor__path-row");
             codeGenContainer.Add(pathRow);
 
             var pathField = new TextField("C# Class File") { bindingPath = "m_WrapperCodePath" };
-            pathField.style.flexGrow = 1;
+            pathField.AddToClassList("input-action-importer-editor__path-field");
             pathField.AddToClassList(BaseField<string>.alignedFieldUssClassName);
             SetupPlaceholder(pathField, defaultFileName);
             pathRow.Add(pathField);
@@ -141,7 +140,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 text = "…"
             };
-            browseButton.style.width = 25;
+            browseButton.AddToClassList("input-action-importer-editor__browse-button");
             pathRow.Add(browseButton);
 
             // Class name
@@ -204,9 +203,7 @@ namespace UnityEngine.InputSystem.Editor
 
             var placeholderLabel = new Label(placeholder);
             placeholderLabel.pickingMode = PickingMode.Ignore;
-            placeholderLabel.style.position = Position.Absolute;
-            placeholderLabel.style.opacity = 0.5f;
-            placeholderLabel.style.paddingLeft = 2;
+            placeholderLabel.AddToClassList("input-action-importer-editor__placeholder");
 
             textField.RegisterCallback<GeometryChangedEvent>(_ =>
             {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -91,6 +91,7 @@ namespace UnityEngine.InputSystem.Editor
             {
                 text = "Assign as the Project-wide Input Actions"
             };
+            assignButton.AddToClassList("input-action-importer-editor__assign-button");
             assignButton.SetEnabled(!EditorApplication.isPlayingOrWillChangePlaymode);
             container.Add(assignButton);
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -21,6 +21,10 @@ namespace UnityEngine.InputSystem.Editor
             var root = new VisualElement();
             var inputActionAsset = GetAsset();
 
+            // ScriptedImporterEditor in 2019.2 now requires explicitly updating the SerializedObject
+            // like in other types of editors.
+            serializedObject.Update();
+
             if (inputActionAsset == null)
             {
                 root.Add(new HelpBox(

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -119,6 +119,7 @@ namespace UnityEngine.InputSystem.Editor
 
             var pathField = new TextField("C# Class File") { bindingPath = "m_WrapperCodePath" };
             pathField.style.flexGrow = 1;
+            pathField.AddToClassList(BaseField<string>.alignedFieldUssClassName);
             SetupPlaceholder(pathField, defaultFileName);
             pathRow.Add(pathField);
 
@@ -150,6 +151,7 @@ namespace UnityEngine.InputSystem.Editor
                 : null;
 
             var classNameField = new TextField("C# Class Name") { bindingPath = "m_WrapperClassName" };
+            classNameField.AddToClassList(BaseField<string>.alignedFieldUssClassName);
             SetupPlaceholder(classNameField, typeName ?? "<Class name>");
             codeGenContainer.Add(classNameField);
 
@@ -168,6 +170,7 @@ namespace UnityEngine.InputSystem.Editor
 
             // Namespace
             var namespaceField = new TextField("C# Class Namespace") { bindingPath = "m_WrapperCodeNamespace" };
+            namespaceField.AddToClassList(BaseField<string>.alignedFieldUssClassName);
             SetupPlaceholder(namespaceField, "<Global namespace>");
             codeGenContainer.Add(namespaceField);
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -1,9 +1,10 @@
 #if UNITY_EDITOR
-using System;
 using System.IO;
 using UnityEngine.InputSystem.Utilities;
 using UnityEditor;
 using UnityEditor.AssetImporters;
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
 
 ////TODO: support for multi-editing
 
@@ -15,90 +16,212 @@ namespace UnityEngine.InputSystem.Editor
     [CustomEditor(typeof(InputActionImporter))]
     internal class InputActionImporterEditor : ScriptedImporterEditor
     {
-        public override void OnInspectorGUI()
+        public override VisualElement CreateInspectorGUI()
         {
+            var root = new VisualElement();
             var inputActionAsset = GetAsset();
 
-            // ScriptedImporterEditor in 2019.2 now requires explicitly updating the SerializedObject
-            // like in other types of editors.
-            serializedObject.Update();
-
-            EditorGUILayout.Space();
-
             if (inputActionAsset == null)
-                EditorGUILayout.HelpBox("The currently selected object is not an editable input action asset.",
-                    MessageType.Info);
-
-            // Button to pop up window to edit the asset.
-            using (new EditorGUI.DisabledScope(inputActionAsset == null))
             {
-                if (GUILayout.Button(GetOpenEditorButtonText(inputActionAsset), GUILayout.Height(30)))
-                    OpenEditor(inputActionAsset);
+                root.Add(new HelpBox(
+                    "The currently selected object is not an editable input action asset.",
+                    HelpBoxMessageType.Info));
             }
 
-            EditorGUILayout.Space();
-
-            // Project-wide Input Actions Asset UI.
-            InputAssetEditorUtils.DrawMakeActiveGui(InputSystem.actions, inputActionAsset,
-                inputActionAsset ? inputActionAsset.name : "Null", "Project-wide Input Actions",
-                (value) => InputSystem.actions = value, !EditorApplication.isPlayingOrWillChangePlaymode);
-
-            EditorGUILayout.Space();
-
-            // Importer settings UI.
-            var generateWrapperCodeProperty = serializedObject.FindProperty("m_GenerateWrapperCode");
-            EditorGUILayout.PropertyField(generateWrapperCodeProperty, m_GenerateWrapperCodeLabel);
-            if (generateWrapperCodeProperty.boolValue)
+            var editButton = new Button(() => OpenEditor(inputActionAsset))
             {
-                var wrapperCodePathProperty = serializedObject.FindProperty("m_WrapperCodePath");
-                var wrapperClassNameProperty = serializedObject.FindProperty("m_WrapperClassName");
-                var wrapperCodeNamespaceProperty = serializedObject.FindProperty("m_WrapperCodeNamespace");
+                text = GetOpenEditorButtonText(inputActionAsset)
+            };
+            editButton.style.height = 30;
+            editButton.style.marginTop = 4;
+            editButton.style.marginBottom = 4;
+            editButton.SetEnabled(inputActionAsset != null);
+            root.Add(editButton);
 
-                EditorGUILayout.BeginHorizontal();
+            var projectWideContainer = new VisualElement();
+            projectWideContainer.style.marginTop = 6;
+            projectWideContainer.style.marginBottom = 6;
+            root.Add(projectWideContainer);
+            BuildProjectWideSection(projectWideContainer, inputActionAsset);
 
-                string defaultFileName = "";
-                if (inputActionAsset != null)
-                {
-                    var assetPath = AssetDatabase.GetAssetPath(inputActionAsset);
-                    defaultFileName = Path.ChangeExtension(assetPath, ".cs");
-                }
+            BuildCodeGenerationSection(root, inputActionAsset);
 
-                wrapperCodePathProperty.PropertyFieldWithDefaultText(m_WrapperCodePathLabel, defaultFileName);
+            root.Add(new IMGUIContainer(() =>
+            {
+                serializedObject.ApplyModifiedProperties();
+                ApplyRevertGUI();
+            }));
 
-                if (GUILayout.Button("…", EditorStyles.miniButton, GUILayout.MaxWidth(20)))
-                {
-                    var fileName = EditorUtility.SaveFilePanel("Location for generated C# file",
-                        Path.GetDirectoryName(defaultFileName),
-                        Path.GetFileName(defaultFileName), "cs");
-                    if (!string.IsNullOrEmpty(fileName))
-                    {
-                        if (fileName.StartsWith(Application.dataPath))
-                            fileName = "Assets/" + fileName.Substring(Application.dataPath.Length + 1);
+            return root;
+        }
 
-                        wrapperCodePathProperty.stringValue = fileName;
-                    }
-                }
-                EditorGUILayout.EndHorizontal();
+        private void BuildProjectWideSection(VisualElement container, InputActionAsset inputActionAsset)
+        {
+            container.Clear();
 
-                string typeName = null;
-                if (inputActionAsset != null)
-                    typeName = CSharpCodeHelpers.MakeTypeName(inputActionAsset?.name);
-                wrapperClassNameProperty.PropertyFieldWithDefaultText(m_WrapperClassNameLabel, typeName ?? "<Class name>");
+            var currentActions = InputSystem.actions;
 
-                if (!CSharpCodeHelpers.IsEmptyOrProperIdentifier(wrapperClassNameProperty.stringValue))
-                    EditorGUILayout.HelpBox("Must be a valid C# identifier", MessageType.Error);
-
-                wrapperCodeNamespaceProperty.PropertyFieldWithDefaultText(m_WrapperCodeNamespaceLabel, "<Global namespace>");
-
-                if (!CSharpCodeHelpers.IsEmptyOrProperNamespaceName(wrapperCodeNamespaceProperty.stringValue))
-                    EditorGUILayout.HelpBox("Must be a valid C# namespace name", MessageType.Error);
+            if (currentActions == inputActionAsset)
+            {
+                container.Add(new HelpBox(
+                    "These actions are assigned as the Project-wide Input Actions.",
+                    HelpBoxMessageType.Info));
+                return;
             }
 
-            // Using ApplyRevertGUI requires calling Update and ApplyModifiedProperties around the serializedObject,
-            // and will print warning messages otherwise (see warning message in ApplyRevertGUI implementation).
-            serializedObject.ApplyModifiedProperties();
+            var message = "These actions are not assigned as the Project-wide Input Actions for the Input System.";
+            if (currentActions != null)
+            {
+                var currentPath = AssetDatabase.GetAssetPath(currentActions);
+                if (!string.IsNullOrEmpty(currentPath))
+                    message += $" The actions currently assigned as the Project-wide Input Actions are: {currentPath}. ";
+            }
 
-            ApplyRevertGUI();
+            container.Add(new HelpBox(message, HelpBoxMessageType.Warning));
+
+            var assignButton = new Button(() =>
+            {
+                InputSystem.actions = inputActionAsset;
+                BuildProjectWideSection(container, inputActionAsset);
+            })
+            {
+                text = "Assign as the Project-wide Input Actions"
+            };
+            assignButton.SetEnabled(!EditorApplication.isPlayingOrWillChangePlaymode);
+            container.Add(assignButton);
+        }
+
+        private void BuildCodeGenerationSection(VisualElement root, InputActionAsset inputActionAsset)
+        {
+            var generateField = new PropertyField(
+                serializedObject.FindProperty("m_GenerateWrapperCode"), "Generate C# Class");
+            root.Add(generateField);
+
+            var codeGenContainer = new VisualElement();
+            root.Add(codeGenContainer);
+
+            // File path with browse button
+            string defaultFileName = "";
+            if (inputActionAsset != null)
+            {
+                var assetPath = AssetDatabase.GetAssetPath(inputActionAsset);
+                defaultFileName = Path.ChangeExtension(assetPath, ".cs");
+            }
+
+            var pathRow = new VisualElement();
+            pathRow.style.flexDirection = FlexDirection.Row;
+            pathRow.style.alignItems = Align.Center;
+            codeGenContainer.Add(pathRow);
+
+            var pathField = new TextField("C# Class File") { bindingPath = "m_WrapperCodePath" };
+            pathField.style.flexGrow = 1;
+            SetupPlaceholder(pathField, defaultFileName);
+            pathRow.Add(pathField);
+
+            var browseButton = new Button(() =>
+            {
+                var fileName = EditorUtility.SaveFilePanel("Location for generated C# file",
+                    Path.GetDirectoryName(defaultFileName),
+                    Path.GetFileName(defaultFileName), "cs");
+                if (!string.IsNullOrEmpty(fileName))
+                {
+                    if (fileName.StartsWith(Application.dataPath))
+                        fileName = "Assets/" + fileName.Substring(Application.dataPath.Length + 1);
+
+                    var prop = serializedObject.FindProperty("m_WrapperCodePath");
+                    prop.stringValue = fileName;
+                    serializedObject.ApplyModifiedProperties();
+                }
+            })
+            {
+                text = "…"
+            };
+            browseButton.style.width = 25;
+            browseButton.style.minWidth = 25;
+            pathRow.Add(browseButton);
+
+            // Class name
+            string typeName = inputActionAsset != null
+                ? CSharpCodeHelpers.MakeTypeName(inputActionAsset.name)
+                : null;
+
+            var classNameField = new TextField("C# Class Name") { bindingPath = "m_WrapperClassName" };
+            SetupPlaceholder(classNameField, typeName ?? "<Class name>");
+            codeGenContainer.Add(classNameField);
+
+            var classNameError = new HelpBox("Must be a valid C# identifier", HelpBoxMessageType.Error);
+            codeGenContainer.Add(classNameError);
+
+            var classNameProp = serializedObject.FindProperty("m_WrapperClassName");
+            classNameError.style.display = !CSharpCodeHelpers.IsEmptyOrProperIdentifier(classNameProp.stringValue)
+                ? DisplayStyle.Flex : DisplayStyle.None;
+
+            classNameField.RegisterValueChangedCallback(evt =>
+            {
+                classNameError.style.display = !CSharpCodeHelpers.IsEmptyOrProperIdentifier(evt.newValue)
+                    ? DisplayStyle.Flex : DisplayStyle.None;
+            });
+
+            // Namespace
+            var namespaceField = new TextField("C# Class Namespace") { bindingPath = "m_WrapperCodeNamespace" };
+            SetupPlaceholder(namespaceField, "<Global namespace>");
+            codeGenContainer.Add(namespaceField);
+
+            var namespaceError = new HelpBox("Must be a valid C# namespace name", HelpBoxMessageType.Error);
+            codeGenContainer.Add(namespaceError);
+
+            var namespaceProp = serializedObject.FindProperty("m_WrapperCodeNamespace");
+            namespaceError.style.display = !CSharpCodeHelpers.IsEmptyOrProperNamespaceName(namespaceProp.stringValue)
+                ? DisplayStyle.Flex : DisplayStyle.None;
+
+            namespaceField.RegisterValueChangedCallback(evt =>
+            {
+                namespaceError.style.display = !CSharpCodeHelpers.IsEmptyOrProperNamespaceName(evt.newValue)
+                    ? DisplayStyle.Flex : DisplayStyle.None;
+            });
+
+            // Show/hide code gen fields based on toggle
+            var generateProp = serializedObject.FindProperty("m_GenerateWrapperCode");
+            codeGenContainer.style.display = generateProp.boolValue ? DisplayStyle.Flex : DisplayStyle.None;
+
+            generateField.RegisterValueChangeCallback(evt =>
+            {
+                codeGenContainer.style.display = evt.changedProperty.boolValue
+                    ? DisplayStyle.Flex : DisplayStyle.None;
+            });
+        }
+
+        private static void SetupPlaceholder(TextField textField, string placeholder)
+        {
+            if (string.IsNullOrEmpty(placeholder))
+                return;
+
+            var placeholderLabel = new Label(placeholder);
+            placeholderLabel.pickingMode = PickingMode.Ignore;
+            placeholderLabel.style.position = Position.Absolute;
+            placeholderLabel.style.unityTextAlign = TextAnchor.MiddleLeft;
+            placeholderLabel.style.opacity = 0.5f;
+            placeholderLabel.style.paddingLeft = 2;
+
+            textField.RegisterCallback<GeometryChangedEvent>(_ =>
+            {
+                var textInput = textField.Q("unity-text-input");
+                if (textInput != null && placeholderLabel.parent != textInput)
+                {
+                    textInput.Add(placeholderLabel);
+                    UpdatePlaceholder(textField, placeholderLabel);
+                }
+            });
+
+            textField.RegisterValueChangedCallback(_ => UpdatePlaceholder(textField, placeholderLabel));
+            textField.RegisterCallback<FocusInEvent>(_ => placeholderLabel.style.display = DisplayStyle.None);
+            textField.RegisterCallback<FocusOutEvent>(_ => UpdatePlaceholder(textField, placeholderLabel));
+        }
+
+        private static void UpdatePlaceholder(TextField textField, Label placeholder)
+        {
+            placeholder.style.display = string.IsNullOrEmpty(textField.value)
+                ? DisplayStyle.Flex : DisplayStyle.None;
         }
 
         private InputActionAsset GetAsset()
@@ -131,7 +254,6 @@ namespace UnityEngine.InputSystem.Editor
 
         private static void OpenEditor(InputActionAsset asset)
         {
-            // Redirect to Project-settings Input Actions editor if this is the project-wide actions asset
             if (IsProjectWideActionsAsset(asset))
             {
                 SettingsService.OpenProjectSettings(InputSettingsPath.kSettingsRootPath);
@@ -140,11 +262,6 @@ namespace UnityEngine.InputSystem.Editor
 
             InputActionsEditorWindow.OpenEditor(asset);
         }
-
-        private readonly GUIContent m_GenerateWrapperCodeLabel = EditorGUIUtility.TrTextContent("Generate C# Class");
-        private readonly GUIContent m_WrapperCodePathLabel = EditorGUIUtility.TrTextContent("C# Class File");
-        private readonly GUIContent m_WrapperClassNameLabel = EditorGUIUtility.TrTextContent("C# Class Name");
-        private readonly GUIContent m_WrapperCodeNamespaceLabel = EditorGUIUtility.TrTextContent("C# Class Namespace");
     }
 }
 #endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.cs
@@ -142,7 +142,6 @@ namespace UnityEngine.InputSystem.Editor
                 text = "…"
             };
             browseButton.style.width = 25;
-            browseButton.style.minWidth = 25;
             pathRow.Add(browseButton);
 
             // Class name
@@ -206,7 +205,6 @@ namespace UnityEngine.InputSystem.Editor
             var placeholderLabel = new Label(placeholder);
             placeholderLabel.pickingMode = PickingMode.Ignore;
             placeholderLabel.style.position = Position.Absolute;
-            placeholderLabel.style.unityTextAlign = TextAnchor.MiddleLeft;
             placeholderLabel.style.opacity = 0.5f;
             placeholderLabel.style.paddingLeft = 2;
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss
@@ -1,0 +1,29 @@
+.input-action-importer-editor__edit-button {
+    height: 30px;
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.input-action-importer-editor__project-wide-container {
+    margin-top: 6px;
+    margin-bottom: 6px;
+}
+
+.input-action-importer-editor__path-row {
+    flex-direction: row;
+    align-items: center;
+}
+
+.input-action-importer-editor__path-field {
+    flex-grow: 1;
+}
+
+.input-action-importer-editor__browse-button {
+    width: 25px;
+}
+
+.input-action-importer-editor__placeholder {
+    position: absolute;
+    opacity: 0.5;
+    padding-left: 2px;
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss
@@ -1,7 +1,14 @@
 .input-action-importer-editor__edit-button {
-    height: 30px;
+    min-height: 30px;
     margin-top: 4px;
     margin-bottom: 4px;
+    white-space: normal;
+    overflow: hidden;
+}
+
+.input-action-importer-editor__assign-button {
+    white-space: normal;
+    overflow: hidden;
 }
 
 .input-action-importer-editor__project-wide-container {

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporterEditor.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 75f1bd16a0cc446448d0702e965aa290
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0


### PR DESCRIPTION
### Description

This PR is updating the UI for asset `Actions.inputactions` to use UI Toolkit framework.

(`Revert` and `Apply` buttons still use `IMGUI`)

<img width="1728" height="1117" alt="Screenshot 2026-03-23 at 13 52 41" src="https://github.com/user-attachments/assets/71fbb178-8a5d-4cb3-a928-f36b5cce2b9d" />


### Testing status & QA

Manually test buttons and UI expecting same results than before.

https://github.com/user-attachments/assets/935bf645-f24a-4691-8ead-1a10471d6666



### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 1
- Halo Effect: 1

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
