### PR TITLE
DOCS: Add more information about Layout C# inheritance

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/Layouts.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Layouts.md
@@ -240,6 +240,8 @@ You can derive a layout from an existing layout. This process is based on mergin
 * For layouts defined in JSON, you can specify the base layout in the `extends` property of the root node.
 * For layouts created in code using [`InputControlLayout.Builder`](xref:UnityEngine.InputSystem.Layouts.InputControlLayout.Builder), you can specify a base layout using [`InputControlLayout.Builder.Extend()`](xref:UnityEngine.InputSystem.Layouts.InputControlLayout.Builder.Extend(System.String)).
 
+> **Note:** The layout hierarchy also determines which binding paths in Input Action Assets resolve controls on your device. When a path such as `<Gamepad>/buttonSouth` is resolved, the Input System walks the device's base layout chain upward until it finds a match. If your device class does not inherit from `Gamepad` (or whichever base layout the path references), that path will not resolves controls, no state change monitors will be created, and the corresponding actions will not fire. This also applies to custom base layouts: if you define a family of devices that share binding paths under a common layout name (e.g. `<MyBaseLayout>/...`), every device in that family must inherit from the C# class registered for that base layout.
+
 ## Control items
 
 Each layout is comprised of zero or more Control items. Each item either describes a new Control, or modifies the properties of an existing Control. The latter can also reach down into the hierarchy and modify properties of a Control added implicitly as a child by another item.


### PR DESCRIPTION
### Description

While working on an ISS issue, I found out that they were creating a family of devices sharing the same binding paths un a layout name, but they were not using a common C# class registered for the base layout. 
This was causing issue because no state change monitoring was created for these derived devices. 
While I've provided them with a fix [here](https://unity.slack.com/archives/C09Q7LYP9/p1774287455361429?thread_ts=1772626705.750009&cid=C09Q7LYP9), I want to add a small note in our documentation to make the implication of that C# inheritance clearer.

### Testing status & QA

NA

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: NA
- Halo Effect: NA

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
