### PR TITLE
FIX: Adding [NonSerialized] to layouts (struct RemoteSender)

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -380,7 +380,7 @@ namespace UnityEngine.InputSystem
         internal struct RemoteSender
         {
             public int senderId;
-            [NonSerialized] public InternedString[] layouts;
+            [NonSerialized] public InternedString[] layouts; // Each item is the unqualified name of the layout (without namespace)
             public RemoteInputDevice[] devices;
         }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs
@@ -380,7 +380,7 @@ namespace UnityEngine.InputSystem
         internal struct RemoteSender
         {
             public int senderId;
-            public InternedString[] layouts; // Each item is the unqualified name of the layout (without namespace)
+            [NonSerialized] public InternedString[] layouts;
             public RemoteInputDevice[] devices;
         }
 


### PR DESCRIPTION
### Description

Added `[NonSerialized]` to the layouts field at InputRemoting.cs:383. This suppresses the UAC1001 warning without touching InternedString or affecting runtime behavior, the field is purely transient state tracking which layouts were received from a remote sender.                     

_Fixed 6000.6 editor warning:_
`Packages/com.unity.inputsystem/InputSystem/Devices/Remote/InputRemoting.cs(383,37): warning UAC1001: Field 'layouts' is a candidate for serialization but Unity will skip it because its type 'UnityEngine.InputSystem.Utilities.InternedString' lacks [Serializable] attribute. To fix this, either: make the field private (if serialization is not desired), add [System.NonSerialized] (to explicitly mark it as non-serialized), or add [Serializable] to type 'UnityEngine.InputSystem.Utilities.InternedString' (if serialization is desired).`

Previous PR: https://github.com/Unity-Technologies/InputSystem/pull/2381

### Testing status & QA

No need to do manual testing.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 1
- Halo Effect: 1

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
