### PR TITLE
CHANGE: APIVerificationTests exclusions cleanup

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -589,13 +589,14 @@ class APIVerificationTests
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem.LowLevel", "public struct KeyboardState : IInputStateTypeInfo", "public fixed byte keys[14];")]
     // Allow Key.IMESelected to be marked as Obsolete
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem", "public enum Key", "IMESelected = 111,")]
-
     // Steam support is conditional (#if UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT) and absent when
     // the steam plugin is not installed, so all Steam types are excluded from the comparison.
     [Property("Exclusions", @"1.0.0
         public SteamHandle(ulong handle) {}
         public static ulong op_Explicit(UnityEngine.InputSystem.Steam.SteamHandle<TObject> handle);
+    ")]
 #if !UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT
+    [Property("Exclusions", @"1.0.0
         namespace UnityEngine.InputSystem.Steam
         public interface ISteamControllerAPI
         public void ActivateActionSet(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> actionSetHandle);
@@ -639,8 +640,8 @@ class APIVerificationTests
         public static string GenerateInputDeviceFromSteamIGA(string vdf, string namespaceAndClassName);
         public static string GetSteamControllerInputType(InputAction action);
         public static System.Collections.Generic.Dictionary<string, object> ParseVDF(string vdf);
-#endif
     ")]
+#endif
 
     public void API_MinorVersionsHaveNoBreakingChanges()
     {

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -551,45 +551,29 @@ class APIVerificationTests
         public class OpenVROculusTouchController : UnityEngine.InputSystem.XR.XRControllerWithRumble
         public class ViveWand : UnityEngine.InputSystem.XR.XRControllerWithRumble
     ")]
-    // API scraper in 1.0.0 emitted incomplete default argument expressions for these overloads.
+    // New scraper version (com.unity.coding:0.1.0-preview.26) includes default argument expressions for these overloads.
     [Property("Exclusions", @"1.0.0
         public static string GetBindingDisplayString(this InputAction action, int bindingIndex, InputBinding.DisplayStringOptions options = );
         public static string GetBindingDisplayString(this InputAction action, InputBinding bindingMask, InputBinding.DisplayStringOptions options = );
         public static string GetBindingDisplayString(this InputAction action, InputBinding.DisplayStringOptions options = , string group = default(string));
         public static string GetBindingDisplayString(this InputAction action, int bindingIndex, out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = );
         public string ToDisplayString(InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));
-        public string ToDisplayString(out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));
-        DontIncludeInteractions = 4,
-        DontOmitDevice = 2,
-        DontUseShortDisplayNames = 1,
-        IgnoreBindingOverrides = 8,
-        OmitDevice = 2,
-        UseShortNames = 4,
-        BufferedBytes = 256,
-        Constant = 1,
-        NonLinear = 16,
-        NoPreferred = 32,
-        NullState = 64,
-        Relative = 4,
-        Variable = 2,
-        Volatile = 128,
-        Wrap = 8,
-        public FourCC(char a, char b =  , char c =  , char d =  ) {}
+        public string ToDisplayString(out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));        
         public static string ToHumanReadableString(string path, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
-        public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
-        public class InputStateHistory<TValue> : InputStateHistory, System.Collections.Generic.IEnumerable<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.Generic.IReadOnlyCollection<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.Generic.IReadOnlyList<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.IEnumerable where TValue : struct, new()
+        public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));        
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> RecordStateChange(UnityEngine.InputSystem.InputControl<TValue> control, TValue value, double time = -1d);        
+    ")]
+    // New scraper version (com.unity.coding:0.1.0-preview.26) is able to qualify nested types inside a generic class.
+    [Property("Exclusions", @"1.0.0
         public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> this[int index] { get; set; }
         public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> AddRecord(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> record);
         public System.Collections.Generic.IEnumerator<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>> GetEnumerator();
-        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> RecordStateChange(UnityEngine.InputSystem.InputControl<TValue> control, TValue value, double time = -1d);
         public struct Record : System.IEquatable<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>
         public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> next { get; }
-        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> owner { get; }
         public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> previous { get; }
         public void CopyFrom(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> record);
         public bool Equals(UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> other);
-        public SteamHandle(ulong handle) {}
-        public static ulong op_Explicit(UnityEngine.InputSystem.Steam.SteamHandle<TObject> handle);
+        public class InputStateHistory<TValue> : InputStateHistory, System.Collections.Generic.IEnumerable<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.Generic.IReadOnlyCollection<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.Generic.IReadOnlyList<UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue>>, System.Collections.IEnumerable where TValue : struct, new()
     ")]
     // Api scraper seems to be unstable with fields with default values, sometimes "= 0;" appears (locally) and sometimes (on CI) doesn't.
     [Property("Exclusions", @"1.0.0
@@ -606,10 +590,12 @@ class APIVerificationTests
     // Allow Key.IMESelected to be marked as Obsolete
     [ScopedExclusionProperty("1.0.0", "UnityEngine.InputSystem", "public enum Key", "IMESelected = 111,")]
 
-#if !UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT
     // Steam support is conditional (#if UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT) and absent when
     // the steam plugin is not installed, so all Steam types are excluded from the comparison.
     [Property("Exclusions", @"1.0.0
+        public SteamHandle(ulong handle) {}
+        public static ulong op_Explicit(UnityEngine.InputSystem.Steam.SteamHandle<TObject> handle);
+#if !UNITY_ENABLE_STEAM_CONTROLLER_SUPPORT
         namespace UnityEngine.InputSystem.Steam
         public interface ISteamControllerAPI
         public void ActivateActionSet(UnityEngine.InputSystem.Steam.SteamHandle<SteamController> controllerHandle, UnityEngine.InputSystem.Steam.SteamHandle<InputActionMap> actionSetHandle);
@@ -653,8 +639,8 @@ class APIVerificationTests
         public static string GenerateInputDeviceFromSteamIGA(string vdf, string namespaceAndClassName);
         public static string GetSteamControllerInputType(InputAction action);
         public static System.Collections.Generic.Dictionary<string, object> ParseVDF(string vdf);
-    ")]
 #endif
+    ")]
 
     public void API_MinorVersionsHaveNoBreakingChanges()
     {

--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -558,10 +558,10 @@ class APIVerificationTests
         public static string GetBindingDisplayString(this InputAction action, InputBinding.DisplayStringOptions options = , string group = default(string));
         public static string GetBindingDisplayString(this InputAction action, int bindingIndex, out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = );
         public string ToDisplayString(InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));
-        public string ToDisplayString(out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));        
+        public string ToDisplayString(out string deviceLayoutName, out string controlPath, InputBinding.DisplayStringOptions options = , InputControl control = default(InputControl));
         public static string ToHumanReadableString(string path, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
-        public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));        
-        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> RecordStateChange(UnityEngine.InputSystem.InputControl<TValue> control, TValue value, double time = -1d);        
+        public static string ToHumanReadableString(string path, out string deviceLayoutName, out string controlPath, InputControlPath.HumanReadableStringOptions options = InputControlPath.HumanReadableStringOptions.None, InputControl control = default(InputControl));
+        public UnityEngine.InputSystem.LowLevel.InputStateHistory<TValue> RecordStateChange(UnityEngine.InputSystem.InputControl<TValue> control, TValue value, double time = -1d);
     ")]
     // New scraper version (com.unity.coding:0.1.0-preview.26) is able to qualify nested types inside a generic class.
     [Property("Exclusions", @"1.0.0


### PR DESCRIPTION
### Description

Follow up on #2391 to refine the exclusions list:

There are 3 categories that needed to be added because the new scraped API is more accurate:
* New API from dependencies (like XR package or Steam)
* The scraped API format is a bit different and while the improvements on filtering helps to catch false exceptions, default argument expressions are now taken into account and need to be manually added
* Nested types inside a generic class

Slack thread: https://unity.slack.com/archives/C04RDRXRJ1L/p1774447194805529?thread_ts=1773774517.408119&cid=C04RDRXRJ1L

### Testing status & QA

Running the test Locally + CI 

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
