### PR TITLE
Revert "CHANGE: XRI test ignored as it is causing issues in the CI. I…

### DIFF
--- a/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
+++ b/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
@@ -38,7 +38,7 @@ public class XRIPackageTests
 
     [UnityTest]
     [Category("Integration")]
-    public IEnumerator AdddingLatestXRIPackageThrowsNoErrors()
+    public IEnumerator AddingLatestXRIPackageThrowsNoErrors()
     {
         Application.logMessageReceived += HandleLog;
 

--- a/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
+++ b/Assets/Tests/InputSystem.Editor/XRIPackageTest.cs
@@ -38,7 +38,6 @@ public class XRIPackageTests
 
     [UnityTest]
     [Category("Integration")]
-    [Ignore("ISX-2531 - This test is currently ignored as it is causing issues in the CI. It should be re-enabled once the underlying issue is resolved.")]
     public IEnumerator AdddingLatestXRIPackageThrowsNoErrors()
     {
         Application.logMessageReceived += HandleLog;


### PR DESCRIPTION
…t should be re-enabled once resolved (#2390)"

This reverts commit 0bb75c4c2a7260eb72200a17dbea1c5a6d9760d6.

In addition, this PR addresses the typo on the method.

Before:
`XRIPackageTests.AdddingLatestXRIPackageThrowsNoErrors`

After:
`XRIPackageTests.AddingLatestXRIPackageThrowsNoErrors`

Pass: 
https://unity-ci.cds.internal.unity3d.com/job/66074078/logs  🟢 

<img width="556" height="125" alt="Screenshot 2026-04-07 at 10 11 33" src="https://github.com/user-attachments/assets/67a5cc57-5ef3-4854-88b0-d864ab3a1c51" />
