### PR TITLE
DOCS: Warn against switching action maps from within action callbacks

### DIFF
--- a/Packages/com.unity.inputsystem/Documentation~/RespondingToActions.md
+++ b/Packages/com.unity.inputsystem/Documentation~/RespondingToActions.md
@@ -177,6 +177,30 @@ Each callback receives an [`InputAction.CallbackContext`](xref:UnityEngine.Input
 > [!NOTE]
 > The contents of the structure are only valid for the duration of the callback. In particular, it isn't safe to store the received context and later access its properties from outside the callback.
 
+> [!WARNING]
+> Do not enable or disable action maps (or call [`PlayerInput.SwitchCurrentActionMap`](xref:UnityEngine.InputSystem.PlayerInput.SwitchCurrentActionMap(System.String))) from within an action callback. The Input System is in the middle of processing events at that point, and modifying which maps are enabled can corrupt internal state and trigger errors. Instead, defer the switch to the next frame using a flag:
+>
+> ```CSharp
+> bool m_SwitchActionMap;
+> string m_NextActionMap;
+>
+> void OnFire(InputAction.CallbackContext context)
+> {
+>     // Do not switch maps here directly — defer it instead.
+>     m_SwitchActionMap = true;
+>     m_NextActionMap = "UI";
+> }
+>
+> void Update()
+> {
+>     if (m_SwitchActionMap)
+>     {
+>         m_SwitchActionMap = false;
+>         playerInput.SwitchCurrentActionMap(m_NextActionMap);
+>     }
+> }
+> ```
+
 When and how the callbacks are triggered depends on the [Interactions](xref:input-system-interactions) present on the respective Bindings. If the Bindings have no Interactions that apply to them, the [default Interaction](xref:input-system-interactions#default-interaction) applies.
 
 ##### `InputActionMap.actionTriggered` callback


### PR DESCRIPTION
### Description

**Issue**: The documentation for action callbacks did not warn users against enabling/disabling action maps (or calling PlayerInput.SwitchCurrentActionMap) from within a callback. Doing so while the Input System is processing events can corrupt internal state and trigger errors.

**Fix**: Added a WARNING callout to `RespondingToActions.md` (in the action callbacks section) that explains the restriction and provides a deferred-switch pattern using a flag + Update() as the recommended workaround.

https://jira.unity3d.com/browse/ISXB-1367

### Testing status & QA

NA

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: None
- Halo Effect: None

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
