### PR TITLE
FIX: ISXB-1319 Input recorder game view focus

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed `InputRecorder` playback not starting when the Game View is not focused in the Editor [ISXB-1319](https://jira.unity3d.com/browse/ISXB-1319)
 - Fixed a `NullReferenceException` thrown when removing all action maps [UUM-137116](https://jira.unity3d.com/browse/UUM-137116)
 - Simplified default setting messaging by consolidating repetitive messages into a single HelpBox.
 - Fixed a `NullPointerReferenceException` thrown in `InputManagerStateMonitors.FireStateChangeNotifications` logging by adding validation [UUM-136095].

--- a/Packages/com.unity.inputsystem/Documentation~/Events.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Events.md
@@ -224,7 +224,7 @@ trace.Dispose();
 Dispose event traces after use, so that they do not leak memory on the unmanaged (C++) memory heap.
 
 > [!NOTE]
-> **Keyboard text input is not replayed to UI text fields.** Keyboard state (key presses) is captured and replayed correctly and remains accessible via `Keyboard.current`. However there is a known limitation with character delivery to UI Framework components (uGUI `InputField` or UIToolkit `TextField`). These components receive text through a separate native pipeline that is not fed by event replay. As a result, text typed into UI text fields during recording will not appear during playback.
+> **Keyboard text input is not replayed to UI text fields.** Keyboard state (key presses) is captured and replayed correctly and remains accessible via `Keyboard.current`. However, there is a known limitation with character delivery to UI Framework components (uGUI `InputField` or UI Toolkit `TextField`). These components receive text through a separate native pipeline that is not fed by event replay. As a result, text typed into UI text fields during recording will not appear during playback.
 
 You can also write event traces out to files/streams, load them back in, and replay recorded streams.
 

--- a/Packages/com.unity.inputsystem/Documentation~/Events.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Events.md
@@ -223,6 +223,9 @@ trace.Dispose();
 
 Dispose event traces after use, so that they do not leak memory on the unmanaged (C++) memory heap.
 
+> [!NOTE]
+> **Keyboard text input is not replayed to UI text fields.** Keyboard state (key presses) is captured and replayed correctly and remains accessible via `Keyboard.current`. However there is a known limitation with character delivery to UI Framework components (uGUI `InputField` or UIToolkit `TextField`). These components receive text through a separate native pipeline that is not fed by event replay. As a result, text typed into UI text fields during recording will not appear during playback.
+
 You can also write event traces out to files/streams, load them back in, and replay recorded streams.
 
 ```CSharp

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1106,6 +1106,11 @@ namespace UnityEngine.InputSystem.LowLevel
             // editor updates where they reach the editor UI instead of the game.
             private void BeginReplayBypass()
             {
+                if (m_ClearReplayBypassCallback != null)
+                {
+                    InputSystem.onAfterUpdate -= m_ClearReplayBypassCallback;
+                }
+
                 if (!m_ReplayBypassActive)
                 {
                     m_ReplayBypassActive = true;
@@ -1121,8 +1126,12 @@ namespace UnityEngine.InputSystem.LowLevel
                 if (!m_ReplayBypassActive)
                     return;
 
-                if (m_ClearReplayBypassCallback == null)
-                    m_ClearReplayBypassCallback = EndReplayBypass;
+                if (m_ClearReplayBypassCallback != null)
+                {
+                    return;
+                }
+
+                m_ClearReplayBypassCallback = EndReplayBypass;
                 InputSystem.onAfterUpdate += m_ClearReplayBypassCallback;
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1148,6 +1148,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     --InputSystem.s_Manager.m_ActiveReplayCount;
                 }
             }
+
 #endif
             /// <summary>
             /// Replay events recorded from <paramref name="recordedDevice"/> on device <paramref name="playbackDevice"/>.

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1135,6 +1135,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 InputSystem.onAfterUpdate -= DeferredStopEditorEventPassthrough;
                 StopEditorEventPassthrough();
             }
+
 #endif
             /// <summary>
             /// Replay events recorded from <paramref name="recordedDevice"/> on device <paramref name="playbackDevice"/>.

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1072,8 +1072,10 @@ namespace UnityEngine.InputSystem.LowLevel
             private double m_StartTimeAsPerRuntime;
             private int m_AllEventsByTimeIndex = 0;
             private List<InputEventPtr> m_AllEventsByTime;
+#if UNITY_EDITOR
             private bool m_ReplayBypassActive;
             private Action m_ClearReplayBypassCallback;
+#endif
 
             internal ReplayController(InputEventTrace trace)
             {
@@ -1090,13 +1092,15 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 InputSystem.onBeforeUpdate -= OnBeginFrame;
                 finished = true;
+#if UNITY_EDITOR
                 EndReplayBypass();
-
+#endif
                 foreach (var device in m_CreatedDevices)
                     InputSystem.RemoveDevice(device);
                 m_CreatedDevices = default;
             }
 
+#if UNITY_EDITOR
             // Signals InputManager to treat events as if game view has focus, bypassing
             // editor focus routing that would otherwise defer pointer/keyboard events to
             // editor updates where they reach the editor UI instead of the game.
@@ -1135,7 +1139,7 @@ namespace UnityEngine.InputSystem.LowLevel
                     --InputSystem.s_Manager.m_ActiveReplayCount;
                 }
             }
-
+#endif
             /// <summary>
             /// Replay events recorded from <paramref name="recordedDevice"/> on device <paramref name="playbackDevice"/>.
             /// </summary>
@@ -1291,7 +1295,9 @@ namespace UnityEngine.InputSystem.LowLevel
             public ReplayController PlayAllFramesOneByOne()
             {
                 finished = false;
+#if UNITY_EDITOR
                 BeginReplayBypass();
+#endif
                 InputSystem.onBeforeUpdate += OnBeginFrame;
                 return this;
             }
@@ -1310,7 +1316,9 @@ namespace UnityEngine.InputSystem.LowLevel
             public ReplayController PlayAllEvents()
             {
                 finished = false;
+#if UNITY_EDITOR
                 BeginReplayBypass();
+#endif
                 try
                 {
                     while (MoveNext(true, out var eventPtr))
@@ -1355,7 +1363,9 @@ namespace UnityEngine.InputSystem.LowLevel
 
                 // Start playback.
                 finished = false;
+#if UNITY_EDITOR
                 BeginReplayBypass();
+#endif
                 m_StartTimeAsPerFirstEvent = -1;
                 m_AllEventsByTimeIndex = -1;
                 InputSystem.onBeforeUpdate += OnBeginFrame;
@@ -1426,9 +1436,11 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 finished = true;
                 InputSystem.onBeforeUpdate -= OnBeginFrame;
+#if UNITY_EDITOR
                 // Schedule bypass removal for after the next OnUpdate, so any events already
                 // queued into the native buffer this frame are still processed with the bypass active.
                 ScheduleEndReplayBypass();
+#endif
                 m_OnFinished?.Invoke();
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1072,6 +1072,8 @@ namespace UnityEngine.InputSystem.LowLevel
             private double m_StartTimeAsPerRuntime;
             private int m_AllEventsByTimeIndex = 0;
             private List<InputEventPtr> m_AllEventsByTime;
+            private bool m_ReplayBypassActive;
+            private Action m_ClearReplayBypassCallback;
 
             internal ReplayController(InputEventTrace trace)
             {
@@ -1088,10 +1090,50 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 InputSystem.onBeforeUpdate -= OnBeginFrame;
                 finished = true;
+                EndReplayBypass();
 
                 foreach (var device in m_CreatedDevices)
                     InputSystem.RemoveDevice(device);
                 m_CreatedDevices = default;
+            }
+
+            // Signals InputManager to treat events as if game view has focus, bypassing
+            // editor focus routing that would otherwise defer pointer/keyboard events to
+            // editor updates where they reach the editor UI instead of the game.
+            private void BeginReplayBypass()
+            {
+                if (!m_ReplayBypassActive)
+                {
+                    m_ReplayBypassActive = true;
+                    ++InputSystem.s_Manager.m_ActiveReplayCount;
+                }
+            }
+
+            // Schedules the bypass to be cleared after the current OnUpdate finishes processing
+            // events (via onAfterUpdate). This ensures events already queued in the native buffer
+            // are still processed with the bypass active before it is removed.
+            private void ScheduleEndReplayBypass()
+            {
+                if (!m_ReplayBypassActive)
+                    return;
+
+                if (m_ClearReplayBypassCallback == null)
+                    m_ClearReplayBypassCallback = EndReplayBypass;
+                InputSystem.onAfterUpdate += m_ClearReplayBypassCallback;
+            }
+
+            private void EndReplayBypass()
+            {
+                if (m_ClearReplayBypassCallback != null)
+                {
+                    InputSystem.onAfterUpdate -= m_ClearReplayBypassCallback;
+                    m_ClearReplayBypassCallback = null;
+                }
+                if (m_ReplayBypassActive)
+                {
+                    m_ReplayBypassActive = false;
+                    --InputSystem.s_Manager.m_ActiveReplayCount;
+                }
             }
 
             /// <summary>
@@ -1249,6 +1291,7 @@ namespace UnityEngine.InputSystem.LowLevel
             public ReplayController PlayAllFramesOneByOne()
             {
                 finished = false;
+                BeginReplayBypass();
                 InputSystem.onBeforeUpdate += OnBeginFrame;
                 return this;
             }
@@ -1267,6 +1310,7 @@ namespace UnityEngine.InputSystem.LowLevel
             public ReplayController PlayAllEvents()
             {
                 finished = false;
+                BeginReplayBypass();
                 try
                 {
                     while (MoveNext(true, out var eventPtr))
@@ -1311,6 +1355,7 @@ namespace UnityEngine.InputSystem.LowLevel
 
                 // Start playback.
                 finished = false;
+                BeginReplayBypass();
                 m_StartTimeAsPerFirstEvent = -1;
                 m_AllEventsByTimeIndex = -1;
                 InputSystem.onBeforeUpdate += OnBeginFrame;
@@ -1381,6 +1426,9 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 finished = true;
                 InputSystem.onBeforeUpdate -= OnBeginFrame;
+                // Schedule bypass removal for after the next OnUpdate, so any events already
+                // queued into the native buffer this frame are still processed with the bypass active.
+                ScheduleEndReplayBypass();
                 m_OnFinished?.Invoke();
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1294,7 +1294,6 @@ namespace UnityEngine.InputSystem.LowLevel
 #if UNITY_EDITOR
                 StartEditorEventPassthrough();
 #endif
-                m_OnReplayStart?.Invoke();
                 InputSystem.onBeforeUpdate += OnBeginFrame;
                 return this;
             }
@@ -1316,7 +1315,6 @@ namespace UnityEngine.InputSystem.LowLevel
 #if UNITY_EDITOR
                 StartEditorEventPassthrough();
 #endif
-                m_OnReplayStart?.Invoke();
                 try
                 {
                     while (MoveNext(true, out var eventPtr))

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1145,7 +1145,8 @@ namespace UnityEngine.InputSystem.LowLevel
                 if (m_ReplayBypassActive)
                 {
                     m_ReplayBypassActive = false;
-                    --InputSystem.s_Manager.m_ActiveReplayCount;
+                    if (InputSystem.s_Manager != null)
+                        --InputSystem.s_Manager.m_ActiveReplayCount;
                 }
             }
 

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Events/InputEventTrace.cs
@@ -1073,8 +1073,7 @@ namespace UnityEngine.InputSystem.LowLevel
             private int m_AllEventsByTimeIndex = 0;
             private List<InputEventPtr> m_AllEventsByTime;
 #if UNITY_EDITOR
-            private bool m_ReplayBypassActive;
-            private Action m_ClearReplayBypassCallback;
+            private bool m_EditorEventPassthroughActive;
 #endif
 
             internal ReplayController(InputEventTrace trace)
@@ -1093,7 +1092,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 InputSystem.onBeforeUpdate -= OnBeginFrame;
                 finished = true;
 #if UNITY_EDITOR
-                EndReplayBypass();
+                StopEditorEventPassthrough();
 #endif
                 foreach (var device in m_CreatedDevices)
                     InputSystem.RemoveDevice(device);
@@ -1101,55 +1100,41 @@ namespace UnityEngine.InputSystem.LowLevel
             }
 
 #if UNITY_EDITOR
-            // Signals InputManager to treat events as if game view has focus, bypassing
-            // editor focus routing that would otherwise defer pointer/keyboard events to
-            // editor updates where they reach the editor UI instead of the game.
-            private void BeginReplayBypass()
+            private void StartEditorEventPassthrough()
             {
-                if (m_ClearReplayBypassCallback != null)
+                if (!m_EditorEventPassthroughActive)
                 {
-                    InputSystem.onAfterUpdate -= m_ClearReplayBypassCallback;
-                }
-
-                if (!m_ReplayBypassActive)
-                {
-                    m_ReplayBypassActive = true;
-                    ++InputSystem.s_Manager.m_ActiveReplayCount;
+                    m_EditorEventPassthroughActive = true;
+                    InputManager.StartEditorEventPassthrough();
                 }
             }
 
-            // Schedules the bypass to be cleared after the current OnUpdate finishes processing
-            // events (via onAfterUpdate). This ensures events already queued in the native buffer
-            // are still processed with the bypass active before it is removed.
-            private void ScheduleEndReplayBypass()
+            private void StopEditorEventPassthrough()
             {
-                if (!m_ReplayBypassActive)
+                // Clean up any pending deferred stop.
+                InputSystem.onAfterUpdate -= DeferredStopEditorEventPassthrough;
+
+                if (m_EditorEventPassthroughActive)
+                {
+                    m_EditorEventPassthroughActive = false;
+                    InputManager.StopEditorEventPassthrough();
+                }
+            }
+
+            // Defers passthrough stop to after the current update so events already queued
+            // in the native buffer are still processed with passthrough active.
+            private void ScheduleStopEditorEventPassthrough()
+            {
+                if (!m_EditorEventPassthroughActive)
                     return;
-
-                if (m_ClearReplayBypassCallback != null)
-                {
-                    return;
-                }
-
-                m_ClearReplayBypassCallback = EndReplayBypass;
-                InputSystem.onAfterUpdate += m_ClearReplayBypassCallback;
+                InputSystem.onAfterUpdate += DeferredStopEditorEventPassthrough;
             }
 
-            private void EndReplayBypass()
+            private void DeferredStopEditorEventPassthrough()
             {
-                if (m_ClearReplayBypassCallback != null)
-                {
-                    InputSystem.onAfterUpdate -= m_ClearReplayBypassCallback;
-                    m_ClearReplayBypassCallback = null;
-                }
-                if (m_ReplayBypassActive)
-                {
-                    m_ReplayBypassActive = false;
-                    if (InputSystem.s_Manager != null)
-                        --InputSystem.s_Manager.m_ActiveReplayCount;
-                }
+                InputSystem.onAfterUpdate -= DeferredStopEditorEventPassthrough;
+                StopEditorEventPassthrough();
             }
-
 #endif
             /// <summary>
             /// Replay events recorded from <paramref name="recordedDevice"/> on device <paramref name="playbackDevice"/>.
@@ -1307,8 +1292,9 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 finished = false;
 #if UNITY_EDITOR
-                BeginReplayBypass();
+                StartEditorEventPassthrough();
 #endif
+                m_OnReplayStart?.Invoke();
                 InputSystem.onBeforeUpdate += OnBeginFrame;
                 return this;
             }
@@ -1328,8 +1314,9 @@ namespace UnityEngine.InputSystem.LowLevel
             {
                 finished = false;
 #if UNITY_EDITOR
-                BeginReplayBypass();
+                StartEditorEventPassthrough();
 #endif
+                m_OnReplayStart?.Invoke();
                 try
                 {
                     while (MoveNext(true, out var eventPtr))
@@ -1375,7 +1362,7 @@ namespace UnityEngine.InputSystem.LowLevel
                 // Start playback.
                 finished = false;
 #if UNITY_EDITOR
-                BeginReplayBypass();
+                StartEditorEventPassthrough();
 #endif
                 m_StartTimeAsPerFirstEvent = -1;
                 m_AllEventsByTimeIndex = -1;
@@ -1448,9 +1435,9 @@ namespace UnityEngine.InputSystem.LowLevel
                 finished = true;
                 InputSystem.onBeforeUpdate -= OnBeginFrame;
 #if UNITY_EDITOR
-                // Schedule bypass removal for after the next OnUpdate, so any events already
-                // queued into the native buffer this frame are still processed with the bypass active.
-                ScheduleEndReplayBypass();
+                // Defer passthrough stop so events already queued in the native buffer
+                // this frame are still processed with passthrough active.
+                ScheduleStopEditorEventPassthrough();
 #endif
                 m_OnFinished?.Invoke();
             }

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -492,7 +492,17 @@ namespace UnityEngine.InputSystem
             set => m_RunPlayerUpdatesInEditMode = value;
         }
 
+        /// <summary>
+        /// Number of active <see cref="InputEventTrace.ReplayController"/> instances currently replaying.
+        /// When greater than zero, focus-based gating is bypassed so that replayed events reach the game
+        /// regardless of Game View focus. This affects event routing (A), disabled-device discard (B),
+        /// and UI module processing (C). See ISXB-1319.
+        /// </summary>
+        internal int m_ActiveReplayCount;
+
+        internal bool isReplayActive => m_ActiveReplayCount > 0;
 #endif // UNITY_EDITOR
+
 
         private bool gameIsPlaying =>
 #if UNITY_EDITOR
@@ -504,7 +514,7 @@ namespace UnityEngine.InputSystem
 
         private bool gameHasFocus =>
 #if UNITY_EDITOR
-                     m_RunPlayerUpdatesInEditMode || applicationHasFocus || gameShouldGetInputRegardlessOfFocus;
+                     m_RunPlayerUpdatesInEditMode || applicationHasFocus || gameShouldGetInputRegardlessOfFocus || isReplayActive;
 #else
             applicationHasFocus || gameShouldGetInputRegardlessOfFocus;
 #endif
@@ -3372,7 +3382,9 @@ namespace UnityEngine.InputSystem
 
                     // If device is disabled, we let the event through only in certain cases.
                     // Removal and configuration change events should always be processed.
-                    if (device != null && !device.enabled &&
+                    // During replay, allow events through for devices disabled due to background
+                    // focus loss — the replay intentionally re-injects events for those devices.
+                    if (device != null && !device.enabled && !isReplayActive &&
                         currentEventType != DeviceRemoveEvent.Type &&
                         currentEventType != DeviceConfigurationEvent.Type &&
                         (device.m_DeviceFlags & (InputDevice.DeviceFlags.DisabledInRuntime |
@@ -3411,7 +3423,6 @@ namespace UnityEngine.InputSystem
 #endif
                         if (!shouldProcess)
                         {
-                            // Skip event if PreProcessEvent considers it to be irrelevant.
                             m_InputEventStream.Advance(false);
                             continue;
                         }

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -493,14 +493,40 @@ namespace UnityEngine.InputSystem
         }
 
         /// <summary>
-        /// Number of active <see cref="InputEventTrace.ReplayController"/> instances currently replaying.
-        /// When greater than zero, focus-based gating is bypassed so that replayed events reach the game
-        /// regardless of Game View focus. This affects event routing (A), disabled-device discard (B),
-        /// and UI module processing (C). See ISXB-1319.
+        /// Ref-counted flag that bypasses Game View focus gating for event processing.
+        /// When greater than zero, events are processed as if the Game View has focus,
+        /// regardless of actual focus state. This affects event routing, disabled-device
+        /// discard, and UI module processing.
         /// </summary>
-        internal int m_ActiveReplayCount;
+        /// <remarks>
+        /// Use <see cref="StartEditorEventPassthrough"/> / <see cref="StopEditorEventPassthrough"/>
+        /// to manage this counter. Follows the same pattern as
+        /// <c>AssetDatabase.StartAssetEditing/StopAssetEditing</c>.
+        /// </remarks>
+        /// <seealso cref="StartEditorEventPassthrough"/>
+        /// <seealso cref="StopEditorEventPassthrough"/>
+        private int m_EditorEventPassthroughCount;
 
-        internal bool isReplayActive => m_ActiveReplayCount > 0;
+        internal bool isEditorEventPassthroughActive => m_EditorEventPassthroughCount > 0;
+
+        /// <summary>
+        /// Signals that events should bypass Game View focus gating. Ref-counted:
+        /// each call must be balanced by a corresponding <see cref="StopEditorEventPassthrough"/>.
+        /// </summary>
+        internal static void StartEditorEventPassthrough()
+        {
+            ++s_Manager.m_EditorEventPassthroughCount;
+        }
+
+        /// <summary>
+        /// Signals that the caller no longer needs events to bypass Game View focus gating.
+        /// Decrements the ref count started by <see cref="StartEditorEventPassthrough"/>.
+        /// </summary>
+        internal static void StopEditorEventPassthrough()
+        {
+            if (s_Manager != null && s_Manager.m_EditorEventPassthroughCount > 0)
+                --s_Manager.m_EditorEventPassthroughCount;
+        }
 #endif // UNITY_EDITOR
 
 
@@ -514,7 +540,7 @@ namespace UnityEngine.InputSystem
 
         private bool gameHasFocus =>
 #if UNITY_EDITOR
-                     m_RunPlayerUpdatesInEditMode || applicationHasFocus || gameShouldGetInputRegardlessOfFocus || isReplayActive;
+                     m_RunPlayerUpdatesInEditMode || applicationHasFocus || gameShouldGetInputRegardlessOfFocus || isEditorEventPassthroughActive;
 #else
             applicationHasFocus || gameShouldGetInputRegardlessOfFocus;
 #endif
@@ -3386,7 +3412,7 @@ namespace UnityEngine.InputSystem
                     // focus loss — the replay intentionally re-injects events for those devices.
                     if (device != null && !device.enabled &&
 #if UNITY_EDITOR
-                        !isReplayActive &&
+                        !isEditorEventPassthroughActive &&
 #endif
                         currentEventType != DeviceRemoveEvent.Type &&
                         currentEventType != DeviceConfigurationEvent.Type &&

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -527,6 +527,7 @@ namespace UnityEngine.InputSystem
             if (InputSystem.s_Manager != null && InputSystem.s_Manager.m_EditorEventPassthroughCount > 0)
                 --InputSystem.s_Manager.m_EditorEventPassthroughCount;
         }
+
 #endif // UNITY_EDITOR
 
 

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -515,7 +515,7 @@ namespace UnityEngine.InputSystem
         /// </summary>
         internal static void StartEditorEventPassthrough()
         {
-            ++s_Manager.m_EditorEventPassthroughCount;
+            ++InputSystem.s_Manager.m_EditorEventPassthroughCount;
         }
 
         /// <summary>
@@ -524,8 +524,8 @@ namespace UnityEngine.InputSystem
         /// </summary>
         internal static void StopEditorEventPassthrough()
         {
-            if (s_Manager != null && s_Manager.m_EditorEventPassthroughCount > 0)
-                --s_Manager.m_EditorEventPassthroughCount;
+            if (InputSystem.s_Manager != null && InputSystem.s_Manager.m_EditorEventPassthroughCount > 0)
+                --InputSystem.s_Manager.m_EditorEventPassthroughCount;
         }
 #endif // UNITY_EDITOR
 

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -3384,7 +3384,10 @@ namespace UnityEngine.InputSystem
                     // Removal and configuration change events should always be processed.
                     // During replay, allow events through for devices disabled due to background
                     // focus loss — the replay intentionally re-injects events for those devices.
-                    if (device != null && !device.enabled && !isReplayActive &&
+                    if (device != null && !device.enabled &&
+#if UNITY_EDITOR
+                        !isReplayActive &&
+#endif
                         currentEventType != DeviceRemoveEvent.Type &&
                         currentEventType != DeviceConfigurationEvent.Type &&
                         (device.m_DeviceFlags & (InputDevice.DeviceFlags.DisabledInRuntime |

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/UI/InputSystemUIInputModule.cs
@@ -999,9 +999,9 @@ namespace UnityEngine.InputSystem.UI
             // react.
             get => explictlyIgnoreFocus || InputRuntime.s_Instance.runInBackground
 #if UNITY_EDITOR
-                || InputSystem.s_Manager.isReplayActive
+            || InputSystem.s_Manager.isReplayActive
 #endif
-                ;
+            ;
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/UI/InputSystemUIInputModule.cs
@@ -999,7 +999,7 @@ namespace UnityEngine.InputSystem.UI
             // react.
             get => explictlyIgnoreFocus || InputRuntime.s_Instance.runInBackground
 #if UNITY_EDITOR
-            || InputSystem.s_Manager.isReplayActive
+            || InputSystem.s_Manager.isEditorEventPassthroughActive
 #endif
             ;
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/UI/InputSystemUIInputModule.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/UI/InputSystemUIInputModule.cs
@@ -997,7 +997,11 @@ namespace UnityEngine.InputSystem.UI
             // if running in the background is enabled, we already have rules in place what kind of input
             // is allowed through and what isn't. And for the input that *IS* allowed through, the UI should
             // react.
-            get => explictlyIgnoreFocus || InputRuntime.s_Instance.runInBackground;
+            get => explictlyIgnoreFocus || InputRuntime.s_Instance.runInBackground
+#if UNITY_EDITOR
+                || InputSystem.s_Manager.isReplayActive
+#endif
+                ;
         }
 
         /// <summary>


### PR DESCRIPTION
### Description

PR addresses https://jira.unity3d.com/browse/ISXB-1319
* The first issue is fixed with a deemed acceptable trade-off.
* The second issue is documented as known limitation in Events.md

Tech Roundtable Slide-deck: https://docs.google.com/presentation/d/18zL10TRcnVfBiSSBe_YT5EYVkJLyt7gFvD3s7EL0JKY/edit?usp=drive_link

Note: _the fix adds a tight coupling between `InputManager` and `InputEventTrace.ReplayController`._

#### Issue 1: replay requires Game View focus

Root cause: three independent focus-gating layers that block replayed events when Game View is unfocused (event deferral, device-disabled discard, UI module skip). 
The fix implemented uses an InputManager-level `isReplayActive` flag that bypasses all three (**Editor-only**).

<details>

<summary>Issues 1 Details</summary>
  
When Game View loses focus -> `applicationHasFocus=false` -> `gameHasFocus=false`. Replay events are blocked at three independent layers:

```mermaid
sequenceDiagram
    participant IM as InputManager
    participant RC as ReplayController
    participant Dev as Mouse/Keyboard
    participant UIIM as InputSystemUIInputModule
    participant ES as EventSystem

    Note over IM,ES: Game View loses focus
    IM->>IM: gameHasFocus = false
    IM->>Dev: DisableDevice(DisabledWhileInBackground)
    ES->>ES: OnApplicationFocus(false) → m_HasFocus = false

    Note over IM,ES: Replay starts
    RC->>IM: QueueEvent(mouseStateEvent)
    IM->>IM: ❌ A — event deferred (ShouldDefer)
    IM->>IM: ❌ B — event discarded (device disabled)
    ES->>UIIM: Process()
    UIIM->>UIIM: ❌ C — !isFocused → skip ProcessPointer/ProcessNavigation
```

</details>


**Known trade-off**: The bypass doesn't distinguish replayed events from real hardware input, so real keyboard/mouse input also reaches the game during replay even with Game View unfocused. This is acceptable for typical usage (replay in isolation in Editor).

#### Issue 2: TextField text not replayed

**Architectural limitation**. UIToolkit TextField receives text through the native IMGUI event queue (`Event.PopEvent`), which is a separate pipeline from InputSystem. Replayed TextEvents fire correctly through `Keyboard.OnTextInput` but have zero subscribers. The IMGUI queue is only populated by native OS input. Keyboard state (key presses) does replay correctly; only character delivery to TextFields is broken. Fixing this would require engine-side changes (InputForUI / IMGUI bridge), outside scope of this ticket.

This is a consistent pattern across Unity's UI framework: IMGUI, uGUI, and UIToolkit all use `Event.PopEvent()` for text  processing.

JIRA user story: https://jira.unity3d.com/browse/ISX-2562

### Testing status & QA

_Please describe the testing already done by you and what testing you request/recommend QA to execute. If you used or created any testing project please link them here too for QA._

* Tested on 6.0 using InputRecorderSample.unity scene in WinEditor.
* Need to test on 6.5 without the changes to see if latest changes from Vera affect the behavior.

https://github.com/user-attachments/assets/f4263385-7854-4943-9299-374754aabdb2

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

* Paulius: Could you please evaluate the known trade-off for Issue 1?
   * **To Test**: Record a long enough input sequence, then during playback, type on the keyboard or move the mouse while the Game View is unfocused and observe that the real inputs reaches the game.
   * **Context**: The fix works by bypassing the focus gate for the duration of replay — a side effect is that real hardware input (keyboard, mouse) can also pass through during that window, even though the Game View is not focused. This is the trade-off. Rita would like your assessment of how impactful this is in practice, and whether it is acceptable for shipping Issue 1's fix as-is.


### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [x] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
