### PR TITLE
FIX: Relaxing timestamp arithmetic error tolerance in filtering

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/InputManager.cs
@@ -3731,19 +3731,22 @@ namespace UnityEngine.InputSystem
             //       that are generated in the backend and would require considerable work to ensure monotonically
             //       increasing timestamps across all such streams.
             var deviceIsStateCallbackReceiver = device.hasStateCallbacks;
+#if UNITY_ANDROID
+            // Android keyboards can send events out of order: Holding down a key will send multiple
+            // presses after a short time, like on most platforms. Unfortunately, on Android, the
+            // last of these "presses" can be timestamped to be after the event of the key release.
+            // If that happens, we'd skip the keyUp here, and the device state will have the key
+            // "stuck" pressed. So, special case here to not skip keyboard events on Android. ISXB-475
+            // N.B. Android seems to have similar issues with touch input (OnStateEvent, Touchscreen.cs)
+            // Android also seems to have similar issue with mouse input, see UUM-136430.
+            if (currentEventTimeInternal < device.m_LastUpdateTimeInternal - 1e-3 && /* 1 ms accepted error */
+#else
             if (currentEventTimeInternal < device.m_LastUpdateTimeInternal &&
+#endif
                 !(deviceIsStateCallbackReceiver && device.stateBlock.format != eventPtr.stateFormat))
             {
 #if UNITY_EDITOR
                 m_Diagnostics?.OnEventTimestampOutdated(new InputEventPtr(currentEventReadPtr), device);
-#elif UNITY_ANDROID
-                // Android keyboards can send events out of order: Holding down a key will send multiple
-                // presses after a short time, like on most platforms. Unfortunately, on Android, the
-                // last of these "presses" can be timestamped to be after the event of the key release.
-                // If that happens, we'd skip the keyUp here, and the device state will have the key
-                // "stuck" pressed. So, special case here to not skip keyboard events on Android. ISXB-475
-                // N.B. Android seems to have similar issues with touch input (OnStateEvent, Touchscreen.cs)
-                if (!(device is Keyboard))
 #endif
                 return;
             }


### PR DESCRIPTION
### Description

Relaxing timestamp arithmetic error tolerance in filtering due to some platform, e.g. Android only as far as I am aware reporting timestamps out of order with respect to sequence in sub-decimal range. This must be investigated on platform side, but this PR exist as a change to be considered (at least as a workaround until resolved). Note that Android specific code in loop is undesirable but this removes previous constraint on Keyboard check as well to at least make it less specific. Note that it could be extended to allow a small error across platforms.

### Testing status & QA

Should definitely be tested with keyboard, mouse and potentially other peripherals on Android.

This have not yet been tested at all.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: Small 
- Halo Effect: Small

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
