### PR TITLE
CHANGE: Add AndroidDeviceCapabilities.vibratorCount

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -133,15 +133,16 @@ namespace UnityEngine.InputSystem.Android.LowLevel
 
         public override string ToString()
         {
+            var motionAxesString = motionAxes == null ? "<null>" : string.Join(",", motionAxes);
             var entries = new[]
             {
-                $"deviceDescriptor: {deviceDescriptor}",
-                $"productId: {productId}",
-                $"vendorId: {vendorId}",
-                $"isVirtual: {isVirtual}",
-                $"motionAxes: {(motionAxes == null ? "<null>" : String.Join(",", motionAxes.Select(i => i.ToString()).ToArray()))}",
-                $"inputSources: {inputSources}",
-                $"vibratorCount: {vibratorCount}"
+                $"deviceDescriptor = {deviceDescriptor}",
+                $"productId = {productId}",
+                $"vendorId = {vendorId}",
+                $"isVirtual = {isVirtual}",
+                $"motionAxes = {motionAxesString}",
+                $"inputSources = {inputSources}",
+                $"vibratorCount = {vibratorCount}"
             };
 
             return string.Join(", ", entries);

--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/Android/AndroidGameController.cs
@@ -117,6 +117,7 @@ namespace UnityEngine.InputSystem.Android.LowLevel
         public bool isVirtual;
         public AndroidAxis[] motionAxes;
         public AndroidInputSource inputSources;
+        public int vibratorCount;
 
         public string ToJson()
         {
@@ -132,8 +133,18 @@ namespace UnityEngine.InputSystem.Android.LowLevel
 
         public override string ToString()
         {
-            return
-                $"deviceDescriptor = {deviceDescriptor}, productId = {productId}, vendorId = {vendorId}, isVirtual = {isVirtual}, motionAxes = {(motionAxes == null ? "<null>" : String.Join(",", motionAxes.Select(i => i.ToString()).ToArray()))}, inputSources = {inputSources}";
+            var entries = new[]
+            {
+                $"deviceDescriptor: {deviceDescriptor}",
+                $"productId: {productId}",
+                $"vendorId: {vendorId}",
+                $"isVirtual: {isVirtual}",
+                $"motionAxes: {(motionAxes == null ? "<null>" : String.Join(",", motionAxes.Select(i => i.ToString()).ToArray()))}",
+                $"inputSources: {inputSources}",
+                $"vibratorCount: {vibratorCount}"
+            };
+
+            return string.Join(", ", entries);
         }
     }
 }


### PR DESCRIPTION
### Description

Android team is adding rumble support for gamepads - https://jira.unity3d.com/browse/PLAT-19228 (The changes will be done mainly in Android's backend).  One of the changes is DeviceCapabilities expansion - https://github.cds.internal.unity3d.com/unity/unity/pull/102096/commits/f682823cc6640dddb48d172bb57cb1f2bdd2b460

Basically it allows you to query how many motors (a.k.a vibrators in Android term) the device has.

This PR simply  mirrors the change on input system package.

__Note__ AndroidDeviceCapabilities is an internal class, so no user facing changes, additionally if backend doesn't report vibratorCount, it will simply default to 0.