### PR TITLE
CHANGE: Add CI job to check Editor references in Runtime code

### DIFF
--- a/.github/workflows/check-runtime-editor-refs.yml
+++ b/.github/workflows/check-runtime-editor-refs.yml
@@ -1,0 +1,20 @@
+name: Check Editor references in Runtime code
+
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+    branches: [ "develop" ]
+
+  workflow_dispatch:
+
+jobs:
+  check-runtime-editor-refs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Runtime code has no Editor namespace references
+        run: bash check-runtime-editor-refs.sh

--- a/.github/workflows/check-runtime-editor-refs.yml
+++ b/.github/workflows/check-runtime-editor-refs.yml
@@ -16,8 +16,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install ripgrep
-        run: sudo apt-get install -y ripgrep
-
       - name: Check Runtime code has no Editor namespace references
         run: bash check-runtime-editor-refs.sh

--- a/.github/workflows/check-runtime-editor-refs.yml
+++ b/.github/workflows/check-runtime-editor-refs.yml
@@ -16,5 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install ripgrep
+        run: sudo apt-get install -y ripgrep
+
       - name: Check Runtime code has no Editor namespace references
         run: bash check-runtime-editor-refs.sh

--- a/.github/workflows/check-runtime-editor-refs.yml
+++ b/.github/workflows/check-runtime-editor-refs.yml
@@ -3,9 +3,9 @@ name: Check Editor references in Runtime code
 on:
   pull_request:
     types:
-      - edited
       - opened
       - synchronize
+      - reopened
     branches: [ "develop" ]
 
   workflow_dispatch:

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemEditorInitializer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemEditorInitializer.cs
@@ -277,6 +277,8 @@ namespace UnityEngine.InputSystem.Editor
             InputManager.s_GetProjectWideActions = () => ProjectWideActionsBuildProvider.actionsToIncludeInPlayerBuild;
 
             InputActionReference.s_CheckImmutableReference = CheckImmutableInputActionReference;
+
+            InputSettings.s_GetIsInspectorIndented = () => EditorGUI.indentLevel > 0;
         }
 
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputSettings.cs
@@ -988,7 +988,10 @@ namespace UnityEngine.InputSystem
         /// * support inspector view which only work in IMGUI for now.
         /// * prevent the UI to be rendered in IMGUI and UI Toolkit in the Input Actions Editor window.
         /// </summary>
-        public bool useIMGUIEditorForAssets => UnityEditor.EditorGUI.indentLevel > 0 || IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets);
+        public bool useIMGUIEditorForAssets =>
+            (s_GetIsInspectorIndented?.Invoke() == true) || IsFeatureEnabled(InputFeatureNames.kUseIMGUIEditorForAssets);
+
+        internal static Func<bool> s_GetIsInspectorIndented;
 #endif
 
         private static bool CompareFloats(float a, float b)

--- a/check-runtime-editor-refs.sh
+++ b/check-runtime-editor-refs.sh
@@ -42,7 +42,7 @@ done
 
 COMBINED=$(IFS='|'; echo "${FORBIDDEN_REGEX[*]}")
 
-GREP_OUTPUT=$(grep -rn --include='*.cs' --color=never -E "$COMBINED" "$RUNTIME_DIR" || true)
+GREP_OUTPUT=$(grep -rnw --include='*.cs' --color=never -E "$COMBINED" "$RUNTIME_DIR" || true)
 
 if [ "$INCLUDE_COMMENTS" = false ]; then
     VIOLATIONS=$(echo "$GREP_OUTPUT" | grep -Ev ':[0-9]+:[[:space:]]*//' || true)

--- a/check-runtime-editor-refs.sh
+++ b/check-runtime-editor-refs.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 RUNTIME_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/Packages/com.unity.inputsystem/InputSystem/Runtime"
 
-# PCRE2 regexes — \b prevents matching identifiers that merely contain these strings.
+# Rust regexes (no PCRE2 required) — \b prevents matching identifiers that merely contain these strings.
 # (\.[A-Za-z0-9_]+)* covers sub-namespaces (UnityEditor.UI, …Editor.Tools, …).
 # Add more lines as needed, e.g. '\bUnityEditorInternal(\.[A-Za-z0-9_]+)*\b'
 FORBIDDEN_REGEX=(
@@ -24,7 +24,7 @@ for arg in "$@"; do
 Usage: $(basename "$0") [OPTIONS]
 
 Check that Runtime code has no Editor namespace dependencies.
-Patterns are PCRE2; edit FORBIDDEN_REGEX in this script to add roots.
+Edit FORBIDDEN_REGEX in this script to add patterns.
 
 Options:
   --include-comments   Also flag references inside XML doc and // comments
@@ -39,13 +39,16 @@ done
 
 COMBINED=$(IFS='|'; echo "${FORBIDDEN_REGEX[*]}")
 
-if [ "$INCLUDE_COMMENTS" = false ]; then
-    PATTERN="^(?!\s*//).*(?:$COMBINED)"
-else
-    PATTERN="(?:$COMBINED)"
-fi
+PATTERN="(?:$COMBINED)"
 
-VIOLATIONS=$(rg --type cs --line-number --no-heading --color never --pcre2 "$PATTERN" "$RUNTIME_DIR" 2>/dev/null || true)
+RG_OUTPUT=$(rg --type cs --line-number --no-heading --color never "$PATTERN" "$RUNTIME_DIR" || true)
+
+if [ "$INCLUDE_COMMENTS" = false ]; then
+    # Filter out pure comment lines (/// and //) by checking the content portion (field 3+)
+    VIOLATIONS=$(echo "$RG_OUTPUT" | grep -Ev ':[0-9]+:[[:space:]]*//' || true)
+else
+    VIOLATIONS="$RG_OUTPUT"
+fi
 
 if [ -z "$VIOLATIONS" ]; then
     echo -e "${GREEN}PASS: No Editor namespace references found in Runtime code.${NC}"

--- a/check-runtime-editor-refs.sh
+++ b/check-runtime-editor-refs.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/bin/bash
+
 set -euo pipefail
 
 RUNTIME_DIR="Packages/com.unity.inputsystem/InputSystem/Runtime"
@@ -11,9 +12,9 @@ FORBIDDEN_REGEX=(
     '\bUnityEngine\.InputSystem\.Editor(\.[A-Za-z0-9_]+)*\b'
 )
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NC='\033[0m'
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
 
 command -v rg >/dev/null 2>&1 || { echo "ERROR: ripgrep (rg) is not installed. See https://github.com/BurntSushi/ripgrep#installation" >&2; exit 1; }
 

--- a/check-runtime-editor-refs.sh
+++ b/check-runtime-editor-refs.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNTIME_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/Packages/com.unity.inputsystem/InputSystem/Runtime"
+
+# PCRE2 regexes — \b prevents matching identifiers that merely contain these strings.
+# (\.[A-Za-z0-9_]+)* covers sub-namespaces (UnityEditor.UI, …Editor.Tools, …).
+# Add more lines as needed, e.g. '\bUnityEditorInternal(\.[A-Za-z0-9_]+)*\b'
+FORBIDDEN_REGEX=(
+    '\bUnityEditor(\.[A-Za-z0-9_]+)*\b'
+    '\bUnityEngine\.InputSystem\.Editor(\.[A-Za-z0-9_]+)*\b'
+)
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+INCLUDE_COMMENTS=false
+for arg in "$@"; do
+    case "$arg" in
+        --include-comments) INCLUDE_COMMENTS=true ;;
+        --help)
+            cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Check that Runtime code has no Editor namespace dependencies.
+Patterns are PCRE2; edit FORBIDDEN_REGEX in this script to add roots.
+
+Options:
+  --include-comments   Also flag references inside XML doc and // comments
+  --help               Show this help
+EOF
+            exit 0 ;;
+        *) echo "Unknown option: $arg"; exit 1 ;;
+    esac
+done
+
+[ -d "$RUNTIME_DIR" ] || { echo -e "${RED}ERROR: Runtime directory not found: $RUNTIME_DIR${NC}" >&2; exit 1; }
+
+COMBINED=$(IFS='|'; echo "${FORBIDDEN_REGEX[*]}")
+
+if [ "$INCLUDE_COMMENTS" = false ]; then
+    PATTERN="^(?!\s*//).*(?:$COMBINED)"
+else
+    PATTERN="(?:$COMBINED)"
+fi
+
+VIOLATIONS=$(rg --type cs --line-number --no-heading --color never --pcre2 "$PATTERN" "$RUNTIME_DIR" 2>/dev/null || true)
+
+if [ -z "$VIOLATIONS" ]; then
+    echo -e "${GREEN}PASS: No Editor namespace references found in Runtime code.${NC}"
+    exit 0
+fi
+
+VIOLATION_COUNT=$(echo "$VIOLATIONS" | wc -l | tr -d ' ')
+echo -e "${RED}FAIL: Found $VIOLATION_COUNT Editor namespace reference(s) in Runtime code:${NC}"
+echo ""
+echo "$VIOLATIONS"
+echo ""
+echo -e "${RED}Active patterns:${NC}"
+for re in "${FORBIDDEN_REGEX[@]}"; do
+    printf '  \033[0;31m%s\033[0m\n' "$re"
+done
+exit 1

--- a/check-runtime-editor-refs.sh
+++ b/check-runtime-editor-refs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-RUNTIME_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/Packages/com.unity.inputsystem/InputSystem/Runtime"
+RUNTIME_DIR="Packages/com.unity.inputsystem/InputSystem/Runtime"
 
 # Rust regexes (no PCRE2 required) — \b prevents matching identifiers that merely contain these strings.
 # (\.[A-Za-z0-9_]+)* covers sub-namespaces (UnityEditor.UI, …Editor.Tools, …).
@@ -14,6 +14,8 @@ FORBIDDEN_REGEX=(
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
+
+command -v rg >/dev/null 2>&1 || { echo "ERROR: ripgrep (rg) is not installed. See https://github.com/BurntSushi/ripgrep#installation" >&2; exit 1; }
 
 INCLUDE_COMMENTS=false
 for arg in "$@"; do
@@ -35,7 +37,7 @@ EOF
     esac
 done
 
-[ -d "$RUNTIME_DIR" ] || { echo -e "${RED}ERROR: Runtime directory not found: $RUNTIME_DIR${NC}" >&2; exit 1; }
+[ -d "$RUNTIME_DIR" ] || { echo "${RED}ERROR: Runtime directory not found: $RUNTIME_DIR${NC}" >&2; exit 1; }
 
 COMBINED=$(IFS='|'; echo "${FORBIDDEN_REGEX[*]}")
 
@@ -51,16 +53,16 @@ else
 fi
 
 if [ -z "$VIOLATIONS" ]; then
-    echo -e "${GREEN}PASS: No Editor namespace references found in Runtime code.${NC}"
+    echo "${GREEN}PASS: No Editor namespace references found in Runtime code.${NC}"
     exit 0
 fi
 
 VIOLATION_COUNT=$(echo "$VIOLATIONS" | wc -l | tr -d ' ')
-echo -e "${RED}FAIL: Found $VIOLATION_COUNT Editor namespace reference(s) in Runtime code:${NC}"
+echo "${RED}FAIL: Found $VIOLATION_COUNT Editor namespace reference(s) in Runtime code:${NC}"
 echo ""
 echo "$VIOLATIONS"
 echo ""
-echo -e "${RED}Active patterns:${NC}"
+echo "${RED}Active patterns:${NC}"
 for re in "${FORBIDDEN_REGEX[@]}"; do
     printf '  \033[0;31m%s\033[0m\n' "$re"
 done

--- a/check-runtime-editor-refs.sh
+++ b/check-runtime-editor-refs.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
-
+[ -n "$BASH_VERSION" ] || { echo "ERROR: This script requires bash. Run with: bash $0" >&2; exit 1; }
 set -euo pipefail
 
 RUNTIME_DIR="Packages/com.unity.inputsystem/InputSystem/Runtime"
 
-# Rust regexes (no PCRE2 required) — \b prevents matching identifiers that merely contain these strings.
+# POSIX ERE patterns for grep -E, compatible with macOS (BSD grep) and Ubuntu (GNU grep).
+# No \b word boundaries — not portable across both. False positive risk is negligible
+# since no real identifiers contain these namespace roots as substrings.
 # (\.[A-Za-z0-9_]+)* covers sub-namespaces (UnityEditor.UI, …Editor.Tools, …).
-# Add more lines as needed, e.g. '\bUnityEditorInternal(\.[A-Za-z0-9_]+)*\b'
+# Add more lines as needed, e.g. 'UnityEditorInternal(\.[A-Za-z0-9_]+)*'
 FORBIDDEN_REGEX=(
-    '\bUnityEditor(\.[A-Za-z0-9_]+)*\b'
-    '\bUnityEngine\.InputSystem\.Editor(\.[A-Za-z0-9_]+)*\b'
+    'UnityEditor(\.[A-Za-z0-9_]+)*'
+    'UnityEngine\.InputSystem\.Editor(\.[A-Za-z0-9_]+)*'
 )
 
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
 NC=$'\033[0m'
-
-command -v rg >/dev/null 2>&1 || { echo "ERROR: ripgrep (rg) is not installed. See https://github.com/BurntSushi/ripgrep#installation" >&2; exit 1; }
 
 INCLUDE_COMMENTS=false
 for arg in "$@"; do
@@ -42,15 +42,12 @@ done
 
 COMBINED=$(IFS='|'; echo "${FORBIDDEN_REGEX[*]}")
 
-PATTERN="(?:$COMBINED)"
-
-RG_OUTPUT=$(rg --type cs --line-number --no-heading --color never "$PATTERN" "$RUNTIME_DIR" || true)
+GREP_OUTPUT=$(grep -rn --include='*.cs' --color=never -E "$COMBINED" "$RUNTIME_DIR" || true)
 
 if [ "$INCLUDE_COMMENTS" = false ]; then
-    # Filter out pure comment lines (/// and //) by checking the content portion (field 3+)
-    VIOLATIONS=$(echo "$RG_OUTPUT" | grep -Ev ':[0-9]+:[[:space:]]*//' || true)
+    VIOLATIONS=$(echo "$GREP_OUTPUT" | grep -Ev ':[0-9]+:[[:space:]]*//' || true)
 else
-    VIOLATIONS="$RG_OUTPUT"
+    VIOLATIONS="$GREP_OUTPUT"
 fi
 
 if [ -z "$VIOLATIONS" ]; then


### PR DESCRIPTION
### Description

Following #2321 we lack the way to validate that new code added to Runtime folder doesn't contain Editor references. This is because we don't have the code in 2 separate assemblies. There might be a better way of achieving this by creating a proper test or somekind of C# code analyzer.
But at this stage, having something is better than nothing. 

A text based search using `grep` seems fast enough, and the script can potentially be added to run in a commit hook.

It runs and fails like this:

<img width="828" height="210" alt="image" src="https://github.com/user-attachments/assets/69dc0607-1892-41b7-b9a7-2c6e53b4426f" />

Logs:

<img width="1268" height="531" alt="image" src="https://github.com/user-attachments/assets/4340735a-5c0d-4df3-995f-275b267f0720" />


### Testing status & QA

PS: ⚠️ It's currently macOS only but can potentially be converted to a PowerShell script for Windows as well

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

The script was built with LLM help so let me know if something is not clear.

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
