### PR TITLE
FIX: auto-update of InputManager.LegacyFocusHandling.cs.meta

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.LegacyFocusHandling.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.LegacyFocusHandling.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 37c57605ec1653942a94491298f0b3b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

FIX: auto-update of `InputManager.LegacyFocusHandling.cs.meta`
This meta file from `input` package gets updated everytime one opens a unity project.

Used the oldest default editor 22.3.

### Testing status & QA

After opening the project, there shouldnt be any auto-updates from input package.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: 0
- Halo Effect: 0

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
