### PR TITLE
FIX: Re-inject player loop hook after user-driven loop reset (UUM-140343)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where `UIToolkit` `ClickEvent` could be fired on Android after device rotation due to inactive touch state being replayed during action initial state checks [UUM-100125](https://jira.unity3d.com/browse/UUM-100125).
 - Fixed InputSystem.onAnyButtonPress fails to trigger when the device receives a touch [UUM-137930](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137930).
 - Fixed an incorrect ArraysHelper.HaveDuplicateReferences implementation that didn't use its arguments right [ISXB-1792] (https://github.com/Unity-Technologies/InputSystem/pull/2376)
+- Fixed input state freezing in `FixedUpdate` (and other reads) after user code resets the player loop with `PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop())` [UUM-140343](https://jira.unity3d.com/browse/UUM-140343). The InputSystem now re-injects its `PlayerLoop.Initialization` hook on the next editor tick if a user-driven reset has wiped it.
 
 ### Changed
 - Removed 32-bit compilation check for HID on Windows players, which had no impact anymore. (ISX-2543)

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -1933,8 +1933,33 @@ namespace UnityEngine.InputSystem
 
         public void Update(InputUpdateType updateType)
         {
+#if UNITY_EDITOR
+            // Manual InputSystem.Update() calls (especially from tests) are observable: callers
+            // expect to see s_LatestUpdateType reflect the type they just ran, and the active
+            // state buffer to match. Skip the editor->player auto-restore for these so we don't
+            // mutate observable state behind the caller's back. Automatic updates from the player
+            // loop still trigger the restore via OnUpdate's exit paths (see UUM-140343).
+            ++m_ManualUpdateDepth;
+            try
+            {
+                m_Runtime.Update(updateType);
+            }
+            finally
+            {
+                --m_ManualUpdateDepth;
+            }
+#else
             m_Runtime.Update(updateType);
+#endif
         }
+
+#if UNITY_EDITOR
+        // Non-zero when we're inside a manual InputManager.Update() call. Used to suppress the
+        // editor->player auto-restore in RestorePlayerStateAfterEditorUpdateIfNeeded, since manual
+        // callers expect to observe the post-update state untouched. Counter (not bool) so nested
+        // manual updates work correctly.
+        private int m_ManualUpdateDepth;
+#endif
 
         // Initialize project-wide actions:
         // - In editor (edit mode or play-mode) we always use the editor build preferences persisted setting.
@@ -3258,6 +3283,9 @@ namespace UnityEngine.InputSystem
                         ProcessStateChangeMonitorTimeouts();
 
                     InvokeAfterUpdateCallback(updateType);
+#if UNITY_EDITOR
+                    RestorePlayerStateAfterEditorUpdateIfNeeded(updateType);
+#endif
                     m_CurrentUpdate = InputUpdateType.None;
                     return;
                 }
@@ -3267,7 +3295,12 @@ namespace UnityEngine.InputSystem
 
 #else
                 if (LegacyEarlyOutFromEventProcessing(updateType, ref eventBuffer, ref dropStatusEvents))
+                {
+#if UNITY_EDITOR
+                    RestorePlayerStateAfterEditorUpdateIfNeeded(updateType);
+#endif
                     return;
+                }
 #endif
 
                 ProcessEventBuffer(updateType, ref eventBuffer, currentTime, timesliceEvents, dropStatusEvents);
@@ -3991,8 +4024,42 @@ namespace UnityEngine.InputSystem
             if (pointer != null && pointer.added && gameIsPlaying)
                 NativeInputSystem.DoSendMouseEvents(pointer.press.isPressed, pointer.press.wasPressedThisFrame, pointer.position.x.value, pointer.position.y.value);
 #endif
+
+#if UNITY_EDITOR
+            RestorePlayerStateAfterEditorUpdateIfNeeded(updateType);
+#endif
+
             m_CurrentUpdate = default;
         }
+
+#if UNITY_EDITOR
+        // After an editor update, restore the player-mode tracker + state buffers so that any
+        // subsequent reads (including from MonoBehaviour.FixedUpdate, which can run between editor
+        // updates without triggering an OnUpdate(Fixed) when Fixed is not in the update mask)
+        // resolve via the player buffer rather than the editor buffer.
+        //
+        // This used to be handled by OnPlayerLoopInitialization, fired from a PlayerLoopSystem we
+        // injected at PlayerLoop.Initialization. User code calling
+        // PlayerLoop.SetPlayerLoop(GetDefaultPlayerLoop()) wipes that injection (UUM-140343), so
+        // we do the restore here instead -- driven by NativeInputSystem.onUpdate, which is fired
+        // by Unity's built-in player-loop subsystems and therefore cannot be wiped by a
+        // user-initiated player loop reset.
+        private void RestorePlayerStateAfterEditorUpdateIfNeeded(InputUpdateType updateType)
+        {
+            // Skip when called from a manual InputManager.Update() — see Update() for rationale.
+            if (m_ManualUpdateDepth > 0)
+                return;
+
+            if (updateType.IsEditorUpdate()
+                && gameIsPlaying
+                && InputUpdate.s_LatestNonEditorUpdateType.IsPlayerUpdate())
+            {
+                InputUpdate.RestoreStateAfterEditorUpdate();
+                InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup = latestNonEditorTimeOffsetToRealtimeSinceStartup;
+                InputStateBuffers.SwitchTo(m_StateBuffers, InputUpdate.s_LatestUpdateType);
+            }
+        }
+#endif
 
 #if UNITY_EDITOR
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputManager.cs
@@ -1933,33 +1933,8 @@ namespace UnityEngine.InputSystem
 
         public void Update(InputUpdateType updateType)
         {
-#if UNITY_EDITOR
-            // Manual InputSystem.Update() calls (especially from tests) are observable: callers
-            // expect to see s_LatestUpdateType reflect the type they just ran, and the active
-            // state buffer to match. Skip the editor->player auto-restore for these so we don't
-            // mutate observable state behind the caller's back. Automatic updates from the player
-            // loop still trigger the restore via OnUpdate's exit paths (see UUM-140343).
-            ++m_ManualUpdateDepth;
-            try
-            {
-                m_Runtime.Update(updateType);
-            }
-            finally
-            {
-                --m_ManualUpdateDepth;
-            }
-#else
             m_Runtime.Update(updateType);
-#endif
         }
-
-#if UNITY_EDITOR
-        // Non-zero when we're inside a manual InputManager.Update() call. Used to suppress the
-        // editor->player auto-restore in RestorePlayerStateAfterEditorUpdateIfNeeded, since manual
-        // callers expect to observe the post-update state untouched. Counter (not bool) so nested
-        // manual updates work correctly.
-        private int m_ManualUpdateDepth;
-#endif
 
         // Initialize project-wide actions:
         // - In editor (edit mode or play-mode) we always use the editor build preferences persisted setting.
@@ -3283,9 +3258,6 @@ namespace UnityEngine.InputSystem
                         ProcessStateChangeMonitorTimeouts();
 
                     InvokeAfterUpdateCallback(updateType);
-#if UNITY_EDITOR
-                    RestorePlayerStateAfterEditorUpdateIfNeeded(updateType);
-#endif
                     m_CurrentUpdate = InputUpdateType.None;
                     return;
                 }
@@ -3295,12 +3267,7 @@ namespace UnityEngine.InputSystem
 
 #else
                 if (LegacyEarlyOutFromEventProcessing(updateType, ref eventBuffer, ref dropStatusEvents))
-                {
-#if UNITY_EDITOR
-                    RestorePlayerStateAfterEditorUpdateIfNeeded(updateType);
-#endif
                     return;
-                }
 #endif
 
                 ProcessEventBuffer(updateType, ref eventBuffer, currentTime, timesliceEvents, dropStatusEvents);
@@ -4024,42 +3991,8 @@ namespace UnityEngine.InputSystem
             if (pointer != null && pointer.added && gameIsPlaying)
                 NativeInputSystem.DoSendMouseEvents(pointer.press.isPressed, pointer.press.wasPressedThisFrame, pointer.position.x.value, pointer.position.y.value);
 #endif
-
-#if UNITY_EDITOR
-            RestorePlayerStateAfterEditorUpdateIfNeeded(updateType);
-#endif
-
             m_CurrentUpdate = default;
         }
-
-#if UNITY_EDITOR
-        // After an editor update, restore the player-mode tracker + state buffers so that any
-        // subsequent reads (including from MonoBehaviour.FixedUpdate, which can run between editor
-        // updates without triggering an OnUpdate(Fixed) when Fixed is not in the update mask)
-        // resolve via the player buffer rather than the editor buffer.
-        //
-        // This used to be handled by OnPlayerLoopInitialization, fired from a PlayerLoopSystem we
-        // injected at PlayerLoop.Initialization. User code calling
-        // PlayerLoop.SetPlayerLoop(GetDefaultPlayerLoop()) wipes that injection (UUM-140343), so
-        // we do the restore here instead -- driven by NativeInputSystem.onUpdate, which is fired
-        // by Unity's built-in player-loop subsystems and therefore cannot be wiped by a
-        // user-initiated player loop reset.
-        private void RestorePlayerStateAfterEditorUpdateIfNeeded(InputUpdateType updateType)
-        {
-            // Skip when called from a manual InputManager.Update() — see Update() for rationale.
-            if (m_ManualUpdateDepth > 0)
-                return;
-
-            if (updateType.IsEditorUpdate()
-                && gameIsPlaying
-                && InputUpdate.s_LatestNonEditorUpdateType.IsPlayerUpdate())
-            {
-                InputUpdate.RestoreStateAfterEditorUpdate();
-                InputRuntime.s_CurrentTimeOffsetToRealtimeSinceStartup = latestNonEditorTimeOffsetToRealtimeSinceStartup;
-                InputStateBuffers.SwitchTo(m_StateBuffers, InputUpdate.s_LatestUpdateType);
-            }
-        }
-#endif
 
 #if UNITY_EDITOR
         /// <summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/NativeInputRuntime.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/NativeInputRuntime.cs
@@ -148,32 +148,62 @@ namespace UnityEngine.InputSystem.LowLevel
                 // TODO move it to a proper native callback instead
                 if (value != null)
                 {
-                    // Inject ourselves directly to PlayerLoop.Initialization as first subsystem to run,
-                    // Use InputSystemPlayerLoopRunnerInitializationSystem as system type
-                    var playerLoop = UnityEngine.LowLevel.PlayerLoop.GetCurrentPlayerLoop();
-                    var initStepIndex = playerLoop.subSystemList.IndexOf(x => x.type == typeof(PlayerLoop.Initialization));
-                    if (initStepIndex >= 0)
-                    {
-                        var systems = playerLoop.subSystemList[initStepIndex].subSystemList;
+                    EnsurePlayerLoopInjection();
 
-                        // Check if we're not already injected
-                        if (!systems.Select(x => x.type)
-                            .Contains(typeof(InputSystemPlayerLoopRunnerInitializationSystem)))
-                        {
-                            ArrayHelpers.InsertAt(ref systems, 0, new UnityEngine.LowLevel.PlayerLoopSystem
-                            {
-                                type = typeof(InputSystemPlayerLoopRunnerInitializationSystem),
-                                updateDelegate = () => m_PlayerLoopInitialization?.Invoke()
-                            });
-
-                            playerLoop.subSystemList[initStepIndex].subSystemList = systems;
-                            UnityEngine.LowLevel.PlayerLoop.SetPlayerLoop(playerLoop);
-                        }
-                    }
+                    // Watchdog for UUM-140343: user code calling
+                    // PlayerLoop.SetPlayerLoop(GetDefaultPlayerLoop()) wipes our injection,
+                    // and Unity provides no callback for SetPlayerLoop, no engine API to add to
+                    // the default loop, and no per-frame hook inside the player loop that we
+                    // could anchor to (anything in the loop can be wiped the same way).
+                    // EditorApplication.update is invoked by SceneTracker, not by the player loop
+                    // (see Editor/Src/Selection/SceneInspector.cpp), so it survives a user reset
+                    // and lets us re-inject on the next editor tick. The cost is one cheap
+                    // PlayerLoopSystem-array scan per editor tick while playing -- effectively zero
+                    // when nothing's wrong. Outside play mode the early-return below skips it.
+                    UnityEditor.EditorApplication.update -= EnsurePlayerLoopInjectionIfPlaying;
+                    UnityEditor.EditorApplication.update += EnsurePlayerLoopInjectionIfPlaying;
+                }
+                else
+                {
+                    UnityEditor.EditorApplication.update -= EnsurePlayerLoopInjectionIfPlaying;
                 }
 
                 m_PlayerLoopInitialization = value;
             }
+        }
+
+        // Idempotent: inserts InputSystemPlayerLoopRunnerInitializationSystem at the top of
+        // PlayerLoop.Initialization if it's not already there.
+        private void EnsurePlayerLoopInjection()
+        {
+            var playerLoop = UnityEngine.LowLevel.PlayerLoop.GetCurrentPlayerLoop();
+            var initStepIndex = playerLoop.subSystemList.IndexOf(x => x.type == typeof(PlayerLoop.Initialization));
+            if (initStepIndex < 0)
+                return;
+
+            var systems = playerLoop.subSystemList[initStepIndex].subSystemList;
+            if (systems.Select(x => x.type)
+                .Contains(typeof(InputSystemPlayerLoopRunnerInitializationSystem)))
+                return; // Already injected.
+
+            ArrayHelpers.InsertAt(ref systems, 0, new UnityEngine.LowLevel.PlayerLoopSystem
+            {
+                type = typeof(InputSystemPlayerLoopRunnerInitializationSystem),
+                updateDelegate = () => m_PlayerLoopInitialization?.Invoke()
+            });
+
+            playerLoop.subSystemList[initStepIndex].subSystemList = systems;
+            UnityEngine.LowLevel.PlayerLoop.SetPlayerLoop(playerLoop);
+        }
+
+        // Watchdog tick. Fires from EditorApplication.update (independent of the player loop) and
+        // re-injects only when actually needed. In edit mode we don't care; OnPlayerLoopInitialization
+        // is gated on gameIsPlaying anyway, so a wiped injection while not playing is harmless.
+        private void EnsurePlayerLoopInjectionIfPlaying()
+        {
+            if (!UnityEditor.EditorApplication.isPlaying)
+                return;
+            EnsurePlayerLoopInjection();
         }
         #endif
 

--- a/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
+++ b/Packages/com.unity.inputsystem/Tests/IntegrationTests/IntegrationTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.LowLevel;
 using UnityEngine.Scripting;
 using UnityEngine.TestTools;
 #if UNITY_EDITOR
@@ -100,6 +101,54 @@ public class IntegrationTests
         finally
         {
             InputSystem.RemoveDevice(keyboard);
+        }
+    }
+
+    // Regression test for UUM-140343: resetting the player loop to the engine
+    // default (e.g. user code calling PlayerLoop.SetPlayerLoop(GetDefaultPlayerLoop()))
+    // wipes any subsystem the InputSystem injected into PlayerLoop.Initialization.
+    // Without re-injection / a fallback path, input state buffers stop being
+    // switched correctly between editor and player updates, and FixedUpdate sees
+    // stale input data.
+    [UnityTest]
+    [Category("Integration")]
+    public IEnumerator Integration_InputUpdatesContinue_AfterResettingPlayerLoopToDefault()
+    {
+        var originalPlayerLoop = PlayerLoop.GetCurrentPlayerLoop();
+
+        var addedMouse = false;
+        var mouse = InputSystem.GetDevice<Mouse>();
+        if (mouse == null)
+        {
+            mouse = InputSystem.AddDevice<Mouse>();
+            addedMouse = true;
+        }
+
+        try
+        {
+            // Reproduce the user scenario: reset the player loop to default mid-play.
+            PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop());
+
+            // Let one frame go by so any re-injection / detection has a chance to run.
+            yield return null;
+
+            // Queue a left-button-down event for the mouse.
+            InputSystem.QueueStateEvent(mouse, new MouseState().WithButton(MouseButton.Left));
+
+            // Wait for the next FixedUpdate phase. The InputSystem should have
+            // processed the queued event by the time FixedUpdate runs.
+            yield return new WaitForFixedUpdate();
+
+            Assert.That(mouse.leftButton.isPressed, Is.True,
+                "Expected LMB state to be observed in FixedUpdate after PlayerLoop was reset to default. " +
+                "If this fails with isPressed=False, the bug from UUM-140343 is reproduced.");
+        }
+        finally
+        {
+            // Restore the player loop so sibling tests are not contaminated.
+            PlayerLoop.SetPlayerLoop(originalPlayerLoop);
+            if (addedMouse)
+                InputSystem.RemoveDevice(mouse);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes [UUM-140343](https://jira.unity3d.com/browse/UUM-140343) — `PlayerLoop.SetPlayerLoop(PlayerLoop.GetDefaultPlayerLoop())` called from user code mid-play wipes the InputSystem's editor-only `InputSystemPlayerLoopRunnerInitializationSystem`, causing input state to freeze in `FixedUpdate` and other reads that occur between editor updates.

## Root cause

The InputSystem injects an editor-only subsystem into `PlayerLoop.Initialization` to drive `OnPlayerLoopInitialization`, which switches input state buffers back to player mode after an editor update. PR #1424 introduced this as a self-described hot-fix (see comment at `NativeInputRuntime.cs:147-148`). When the user resets the loop to Unity's default, that injection is dropped — the default loop only contains Unity's native subsystems — and the buffer-switch never fires again.

## Fix

Subscribe a watchdog to `EditorApplication.update` that re-injects the subsystem if it's missing. `EditorApplication.update` fires from `SceneTracker::Update()` (`Editor/Src/Selection/SceneInspector.cpp:742`), independently of the player loop, so a user `SetPlayerLoop` cannot wipe it. The watchdog is gated on `EditorApplication.isPlaying`:
- Edit mode: zero work (early return).
- Play mode: one `PlayerLoopSystem`-array scan per editor tick. Common case (injection present) returns immediately.

The original `OnPlayerLoopInitialization` mechanism is left untouched — the watchdog only re-establishes the injection when needed.

## Why not other approaches

Investigated and ruled out (Unity source-confirmed):
- **Add to default player loop**: no managed-side API. `s_defaultLoop` is built from C++ `PLAYER_LOOP_INJECT(...)` macros (`Runtime/Misc/PlayerLoop.cpp:270-292`).
- **Hook `SetPlayerLoop` event**: no callback fires (`PlayerLoop.cpp:368-389` — buffer swap, no events).
- **Move restore into `OnUpdate`**: tried (commit `12a5921f7`), preserved in branch history. Works but breaks the contract that manual `InputSystem.Update(Editor)` callers observe `s_LatestUpdateType == Editor` immediately after; required a `m_ManualUpdateDepth` counter to gate the restore. Reverted in favor of this approach.

## Test plan
- [x] New `[UnityTest]` `Integration_InputUpdatesContinue_AfterResettingPlayerLoopToDefault` reproduces the bug pre-fix and passes post-fix.
- [x] `Devices_CanHandleFocusChanges` (parametrized variants) still pass — no manual-update contract changes.
- [ ] Full `Unity.InputSystem.IntegrationTests` assembly via Yamato.
- [ ] Editor functional tests via Yamato (Windows + macOS + Linux).
- [ ] Manual walkthrough of the Jira repro scripts (LMB-in-FixedUpdate logger and RMB freeze script).

## Branch history

The branch keeps Option B (`OnUpdate`-based restore) committed and reverted (`12a5921f7` + `209331a5b`) so reviewers can compare both approaches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)