### PR TITLE
DOCS: Rumble support for iOS and Android

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrated sample scenes to use Universal Render Pipeline (URP) with Built-in Render Pipeline fallback shaders. The URP package is now required to run the samples. (ISX-2343)
 - Changed the UI for `Actions.inputactions` asset to use UI Toolkit framework.
 - Changed the UI for `InputSystem.inputsettings` asset to use UI Toolkit framework.
-- Added docs for rumble support on Android and iOS.
+- Added documentation for rumble support on Android and iOS.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrated sample scenes to use Universal Render Pipeline (URP) with Built-in Render Pipeline fallback shaders. The URP package is now required to run the samples. (ISX-2343)
 - Changed the UI for `Actions.inputactions` asset to use UI Toolkit framework.
 - Changed the UI for `InputSystem.inputsettings` asset to use UI Toolkit framework.
+- Added docs for rumble support on Android and iOS.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrated sample scenes to use Universal Render Pipeline (URP) with Built-in Render Pipeline fallback shaders. The URP package is now required to run the samples. (ISX-2343)
 - Changed the UI for `Actions.inputactions` asset to use UI Toolkit framework.
 - Changed the UI for `InputSystem.inputsettings` asset to use UI Toolkit framework.
-- Added documentation for rumble support on Android and iOS.
+- Added documentation for rumble support on Android.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -130,7 +130,7 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >    * Android 11 or earlier:
 >        * Rumble support is limited.
 >        * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
->        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0`(maximum speed) or `0.0` (turned off).
+>        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0` (maximum speed) or `0.0` (turned off).
 > * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
 >    * Rumble is supported on gamepads recognized by Apple's GameController framework, including PS4, PS5, Xbox, and Switch Pro controllers.
 >    * If the gamepad exposes both motors, you can control each speed individually. Otherwise, the higher value of the left and right motor speed applies to all motors.

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -131,11 +131,6 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >        * Rumble support is limited.
 >        * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
 >        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0` (maximum speed) or `0.0` (turned off).
-> * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
->    * Supports rumble on gamepads that Apple's GameController framework recognizes, including PS4, PS5, Xbox, and Nintendo Switch Pro controllers.
->    * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
->    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
->    * When you set all motor speeds to `0.0`, an inactivity timer starts. After two minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.
 [//]: # (TODO: are we missing any supported configs?)
 
 ### Pausing, resuming, and stopping haptics

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -132,11 +132,6 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >        * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
 >        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0` (maximum speed) or `0.0` (turned off).
 > * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
->    * Rumble is supported on gamepads recognized by Apple's GameController framework, including PS4, PS5, Xbox, and Switch Pro controllers.
->    * If the gamepad exposes both motors, you can control each speed individually. Otherwise, the higher value of the left and right motor speed applies to all motors.
->    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
->    * When all motor speeds are set to `0.0`, an inactivity timer starts. After two minutes, rumble resources are released to preserve controller battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates them and again incurs allocation latency.
-> * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
 >    * Supports rumble on gamepads that Apple's GameController framework recognizes, including PS4, PS5, Xbox, and Switch Pro controllers.
 >    * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
 >    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -135,7 +135,7 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >    * Rumble is supported on gamepads recognized by Apple's GameController framework, including PS4, PS5, Xbox, and Switch Pro controllers.
 >    * If the gamepad exposes both motors, you can control each speed individually. Otherwise, the higher value of the left and right motor speed applies to all motors.
 >    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
->    * When all motor speeds are set to `0.0`, an inactivity timer starts. After 2 minutes, rumble resources are released to preserve controller battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates them and again incurs allocation latency.
+>    * When all motor speeds are set to `0.0`, an inactivity timer starts. After two minutes, rumble resources are released to preserve controller battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates them and again incurs allocation latency.
 
 [//]: # (TODO: are we missing any supported configs?)
 

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -136,7 +136,11 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >    * If the gamepad exposes both motors, you can control each speed individually. Otherwise, the higher value of the left and right motor speed applies to all motors.
 >    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
 >    * When all motor speeds are set to `0.0`, an inactivity timer starts. After two minutes, rumble resources are released to preserve controller battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates them and again incurs allocation latency.
-
+> * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
+>    * Supports rumble on gamepads that Apple's GameController framework recognizes, including PS4, PS5, Xbox, and Switch Pro controllers.
+>    * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
+>    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
+>    * When you set all motor speeds to `0.0`, an inactivity timer starts. After two minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.
 [//]: # (TODO: are we missing any supported configs?)
 
 ### Pausing, resuming, and stopping haptics

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -131,6 +131,7 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >    * Android 11 or earlier
 >        * Rumble support is limited.
 >        * __Note:__ Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor strengths is applied to both.
+>        * __Note:__ In some cases, frequency control is limited, meaning the rumble strength can only be either 1.0 or 0.0.
 > * iOS:
 >     * TODO: Paulius
 

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -125,7 +125,7 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >    * Rumble automatically stops about 10 seconds after the last [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call unless you explicitly stop it.
 >    * Android 12 or later:
 >        * Supports most Bluetooth-connected gamepads with rumble support including PS4, PS5, and Xbox controllers.
->        *  If the gamepad is connected via USB cable, rumble support might vary.
+>        *  If the gamepad is connected with a USB cable, rumble support might vary.
 >        *  If the gamepad supports more than one motor, you can control the speed of each motor individually.
 >    * Android 11 or earlier:
 >        * Rumble support is limited.

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -121,17 +121,16 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >* PS4, Xbox, and Switch controllers, when connected to their respective consoles. Only supported if you install console-specific input packages in your Project.
 >* PS4 controllers, when connected to Mac or Windows/UWP computers.
 >* Xbox controllers on Windows.
->* Android:
->    * Note: Rumble automatically stops about 10 seconds after the last SetMotorSpeeds call unless explicitly stopped.
->    * Requires Unity 6000.6 or later
->    * Android 12 or later
->        * Most bluetooth-connected gamepads with rumble support are supported (PS4/PS5 controllers, Xbox controllers, etc.)
->        * __Note:__ If the gamepad is connected via USB cable, rumble support may vary.
->        * __Note:__ If the gamepad supports more than one motor, each motor's strength can be controlled individually.
->    * Android 11 or earlier
+>* Gamepads on Android. Rumble support varies with Android OS version and requires Unity 6000.6 or later.
+>    * Rumble automatically stops about 10 seconds after the last [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call unless you explicitly stop it.
+>    * Android 12 or later:
+>        * Supports most Bluetooth-connected gamepads with rumble support including PS4, PS5, and Xbox controllers.
+>        *  If the gamepad is connected via USB cable, rumble support might vary.
+>        *  If the gamepad supports more than one motor, you can control the speed of each motor individually.
+>    * Android 11 or earlier:
 >        * Rumble support is limited.
->        * __Note:__ Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor strengths is applied to both.
->        * __Note:__ In some cases, frequency control is limited, meaning the rumble strength can only be either 1.0 or 0.0.
+>        * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
+>        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0`(maximum speed) or `0.0` (turned off).
 > * iOS:
 >     * TODO: Paulius
 

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -118,7 +118,7 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 
 > [!NOTE]
 > Only the following combinations of devices/OSes currently support rumble:
->* PS4, Xbox, and Switch controllers, when connected to their respective consoles. Only supported if you install console-specific input packages in your Project.
+>* PS4, Xbox, and Nintendo Switch controllers, when connected to their respective consoles. Only supported if you install console-specific input packages in your Project.
 >* PS4 controllers, when connected to Mac or Windows/UWP computers.
 >* Xbox controllers on Windows.
 >* Gamepads on Android. Rumble support varies with Android OS version and requires Unity 6000.6 or later.
@@ -132,7 +132,7 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >        * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
 >        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0` (maximum speed) or `0.0` (turned off).
 > * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
->    * Supports rumble on gamepads that Apple's GameController framework recognizes, including PS4, PS5, Xbox, and Switch Pro controllers.
+>    * Supports rumble on gamepads that Apple's GameController framework recognizes, including PS4, PS5, Xbox, and Nintendo Switch Pro controllers.
 >    * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
 >    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
 >    * When you set all motor speeds to `0.0`, an inactivity timer starts. After two minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -121,6 +121,18 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >* PS4, Xbox, and Switch controllers, when connected to their respective consoles. Only supported if you install console-specific input packages in your Project.
 >* PS4 controllers, when connected to Mac or Windows/UWP computers.
 >* Xbox controllers on Windows.
+>* Android:
+>    * Note: Rumble automatically stops about 10 seconds after the last SetMotorSpeeds call unless explicitly stopped.
+>    * Requires Unity 6000.6 or later
+>    * Android 12 or later
+>        * Most bluetooth-connected gamepads with rumble support are supported (PS4/PS5 controllers, Xbox controllers, etc.)
+>        * __Note:__ If the gamepad is connected via USB cable, rumble support may vary.
+>        * __Note:__ If the gamepad supports more than one motor, each motor's strength can be controlled individually.
+>    * Android 11 or earlier
+>        * Rumble support is limited.
+>        * __Note:__ Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor strengths is applied to both.
+> * iOS:
+>     * TODO: Paulius
 
 [//]: # (TODO: are we missing any supported configs?)
 

--- a/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
+++ b/Packages/com.unity.inputsystem/Documentation~/Gamepad.md
@@ -131,8 +131,11 @@ Gamepad.current.SetMotorSpeeds(0.25f, 0.75f);
 >        * Rumble support is limited.
 >        * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
 >        * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0`(maximum speed) or `0.0` (turned off).
-> * iOS:
->     * TODO: Paulius
+> * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.6 or later.
+>    * Rumble is supported on gamepads recognized by Apple's GameController framework, including PS4, PS5, Xbox, and Switch Pro controllers.
+>    * If the gamepad exposes both motors, you can control each speed individually. Otherwise, the higher value of the left and right motor speed applies to all motors.
+>    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
+>    * When all motor speeds are set to `0.0`, an inactivity timer starts. After 2 minutes, rumble resources are released to preserve controller battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates them and again incurs allocation latency.
 
 [//]: # (TODO: are we missing any supported configs?)
 


### PR DESCRIPTION
### Description

https://jira.unity3d.com/browse/PLAT-19240

Unity 6.6 introduces rumble support for Android and iOS:
* [Android] https://github.cds.internal.unity3d.com/unity/unity/pull/102096 __LANDED__
* [iOS]https://github.cds.internal.unity3d.com/unity/unity/pull/105511 __IN PROGRESS__

Both of the changes above hook into existing https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.Gamepad.html#UnityEngine_InputSystem_Gamepad_SetMotorSpeeds_System_Single_System_Single_ API, thus there's no changes in input system package.

This PR only adds docs to notify user of what is supported.

Also see this doc - https://docs.google.com/document/d/17PNAd5JGz9MLTzSq5oSnJtJQPJfemLu9XPvV4LE6rjY/edit?tab=t.0#heading=h.oqdem6yytwi9 which provides a matrix of what is supported on Android

### Testing status & QA

N/A

### Overall Product Risks

N/A

- Complexity:
- Halo Effect:

