### PR TITLE
Clarify InputBinding.Matches mask semantics

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputBinding.cs
@@ -780,7 +780,7 @@ namespace UnityEngine.InputSystem
         /// Note that all comparisons are case-insensitive.
         ///
         /// This method doesn't test bindings for equality. A binding may not match itself if one of
-        /// its mask properties contains a value that does not match as a filter. For example, a binding
+        /// its mask properties contains a value that doesn't match as a filter. For example, a binding
         /// with <see cref="groups"/> set to an empty string has a group filter but no non-empty group
         /// to match against. To compare bindings for equivalence, use <see cref="Equals(InputBinding)"/>
         /// or <see cref="operator=="/>.

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputBinding.cs
@@ -779,6 +779,12 @@ namespace UnityEngine.InputSystem
         ///
         /// Note that all comparisons are case-insensitive.
         ///
+        /// This method does not test bindings for equality. A binding may not match itself if one of
+        /// its mask properties contains a value that does not match as a filter. For example, a binding
+        /// with <see cref="groups"/> set to an empty string has a group filter but no non-empty group
+        /// to match against. To compare bindings for equivalence, use <see cref="Equals(InputBinding)"/>
+        /// or <see cref="operator=="/>.
+        ///
         /// <example>
         /// <code>
         /// // Create a couple bindings which we can test against.
@@ -837,6 +843,7 @@ namespace UnityEngine.InputSystem
         /// </code>
         /// </example>
         /// </remarks>
+        /// <seealso cref="Equals(InputBinding)"/>
         public bool Matches(InputBinding binding)
         {
             return Matches(ref binding);

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputBinding.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputBinding.cs
@@ -779,7 +779,7 @@ namespace UnityEngine.InputSystem
         ///
         /// Note that all comparisons are case-insensitive.
         ///
-        /// This method does not test bindings for equality. A binding may not match itself if one of
+        /// This method doesn't test bindings for equality. A binding may not match itself if one of
         /// its mask properties contains a value that does not match as a filter. For example, a binding
         /// with <see cref="groups"/> set to an empty string has a group filter but no non-empty group
         /// to match against. To compare bindings for equivalence, use <see cref="Equals(InputBinding)"/>


### PR DESCRIPTION
### Description

 Clarifies the XML documentation for `InputBinding.Matches` to state that it performs mask/filter matching, not equality comparison.
The updated docs call out that a binding may not match itself when one of its mask fields, such as `groups`, contains a value that does not match as a filter. The docs now alsopoint users to `Equals(InputBinding)` / `==` for binding equivalence checks.

### Testing status & QA

Documentation-only change. No tests run.

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity:
- Halo Effect:

### Comments to reviewers

_Please describe any additional information such as what to focus on, or historical info for the reviewers._

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
