### PR TITLE
DOCS: fix typos in summaries.

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Analytics/InputActionsEditorSessionAnalytic.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Analytics/InputActionsEditorSessionAnalytic.cs
@@ -50,7 +50,7 @@ namespace UnityEngine.InputSystem.Editor
         }
 
         /// <summary>
-        /// Register than a binding edit has occurred.
+        /// Register that a binding edit has occurred.
         /// </summary>
         public void RegisterBindingEdit()
         {
@@ -297,6 +297,7 @@ namespace UnityEngine.InputSystem.Editor
             /// </summary>
             public int action_modification_count;
 
+            /// <summary>
             /// The total number of binding modifications during the session.
             /// </summary>
             public int binding_modification_count;

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputAction.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputAction.cs
@@ -103,7 +103,7 @@ namespace UnityEngine.InputSystem
     /// of the action as well as on the interactions (see <see cref="IInputInteraction"/>) present
     /// on the bindings of the action. The default behavior is that when a control is actuated
     /// (that is, moving away from its resting position), <see cref="started"/> is called and then
-    /// <see cref="performed"/>. Subsequently, whenever the a control further changes value to
+    /// <see cref="performed"/>. Subsequently, whenever a control further changes value to
     /// anything other than its default value, <see cref="performed"/> will be called again.
     /// Finally, when the control moves back to its default value (i.e. resting position),
     /// <see cref="canceled"/> is called.

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputActionParameters.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputActionParameters.cs
@@ -109,7 +109,7 @@ namespace UnityEngine.InputSystem
         /// parameter from the object registered as <c>"tap"</c> (which will usually be <see cref="Interactions.TapInteraction"/>).</param>
         /// <param name="bindingIndex">Index of the binding in <paramref name="action"/>'s <see cref="InputAction.bindings"/>
         /// to look for processors, interactions, and composites on.</param>
-        /// <returns>The current value of the given parameter or <c>null</c> if the parameter not could be found.</returns>
+        /// <returns>The current value of the given parameter or <c>null</c> if the parameter could not be found.</returns>
         /// <remarks>
         /// This method is a variation of <see cref="ApplyParameterOverride(InputActionMap,string,PrimitiveValue,InputBinding)"/>
         /// to specifically target a single binding by index. Otherwise, the method is identical in functionality.
@@ -139,7 +139,7 @@ namespace UnityEngine.InputSystem
         /// name and type of the parameter being looked for.</param>
         /// <param name="bindingMask">Optional mask that determines on which bindings to look for objects with parameters. If used, only
         /// bindings that match (see <see cref="InputBinding.Matches"/>) the given mask will be taken into account.</param>
-        /// <returns>The current value of the given parameter or <c>null</c> if the parameter not could be found.</returns>
+        /// <returns>The current value of the given parameter or <c>null</c> if the parameter could not be found.</returns>
         /// <remarks>
         /// This method is a variation of <see cref="ApplyParameterOverride(InputActionMap,string,PrimitiveValue,InputBinding)"/>
         /// that encapsulates a reference to the name of the parameter and the type of object it is found on in a way that is

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputActionReference.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Actions/InputActionReference.cs
@@ -110,7 +110,7 @@ namespace UnityEngine.InputSystem
         /// <paramref name="mapName"/> is <c>null</c> or empty -or- <paramref name="actionName"/>
         /// is <c>null</c> or empty.</exception>
         /// <exception cref="InvalidOperationException">If attempting to mutate a reference object
-        /// that is backed by by .inputactions asset. This is not allowed to prevent side-effects.</exception>
+        /// that is backed by .inputactions asset. This is not allowed to prevent side-effects.</exception>
         /// <exception cref="ArgumentException">No action map called <paramref name="mapName"/> could
         /// be found in <paramref name="asset"/> -or- no action called <paramref name="actionName"/>
         /// could be found in the action map called <paramref name="mapName"/> in <paramref name="asset"/>.</exception>


### PR DESCRIPTION
### Description

Fixed typos in 
- InputActionsEditorSessionAnalytic.cs
- InputAction.cs
- InputActionParameters.cs
- InputActionReference.cs

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
