### PR TITLE
NEW: Add more genre-style tests for the input consumption rework

### DIFF
--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
@@ -300,6 +300,7 @@ internal partial class CoreTests
             "Team chat should trigger when Alt, Shift, and W are down together.");
 
         Assert.IsFalse(actionMove.IsPressed(), "Move shouldn't be activated!");
+        Assert.IsFalse(actionRunFast.IsPressed(), "Run Fast shouldn't be activated!");
 
         Release(keyboard.leftAltKey);
         Release(keyboard.leftShiftKey);

--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
 
@@ -8,7 +9,7 @@ using UnityEngine.InputSystem.Controls;
 internal partial class CoreTests
 {
     /// <summary>
-    /// Programmatic map matching the RTS example scene: plain <c>1</c>, <c>Shift+1</c>, and <c>Ctrl+Shift+1</c> on the same binding key.
+    /// Here we have some RTS-related actions and tests. This whole thing emerged out of having to implement control groups in RTS games.
     /// </summary>
     private static InputActionMap CreateRtsExampleShortcutMap(
         out InputAction actionOne,
@@ -40,7 +41,8 @@ internal partial class CoreTests
     [Category("Actions Priority")]
     public void Actions_Priority_Genres_RTS_Key1Only_ActivatesPlainOne()
     {
-        EnableComplexityShortcutResolution();
+        EnableActionPriorityShortcutResolution();
+
         var keyboard = InputSystem.AddDevice<Keyboard>();
         using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
         map.Enable();
@@ -60,7 +62,8 @@ internal partial class CoreTests
     [Category("Actions Priority")]
     public void Actions_Priority_Genres_RTS_ShiftOne_SuppressesPlainOne()
     {
-        EnableComplexityShortcutResolution();
+        EnableActionPriorityShortcutResolution();
+
         var keyboard = InputSystem.AddDevice<Keyboard>();
         using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
         map.Enable();
@@ -82,7 +85,8 @@ internal partial class CoreTests
     [Category("Actions Priority")]
     public void Actions_Priority_Genres_RTS_ControlShiftOne_SuppressesLowerTiers()
     {
-        EnableComplexityShortcutResolution();
+        EnableActionPriorityShortcutResolution();
+        
         var keyboard = InputSystem.AddDevice<Keyboard>();
         using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
         map.Enable();
@@ -100,5 +104,102 @@ internal partial class CoreTests
         Release((ButtonControl)keyboard.shiftKey);
         Release((ButtonControl)keyboard.ctrlKey);
         InputSystem.Update();
+    }
+
+    /// <summary>
+    /// The following section emerged from trying input shortcuts with some generic joystick-controlled games, platformer/scroller style.
+    /// In those games, the move action overlaps with a plenty of special abilities.
+    /// </summary>
+    private static InputActionMap CreateGenericJoystickExampleShortcutMap(
+        out InputAction actionMove,
+        out InputAction actionJump,
+        out InputAction actionJumpKick)
+    {
+        var map = new InputActionMap("DualshockExample");
+
+        actionMove = map.AddAction("Move", InputActionType.Value, expectedControlLayout: "Vector2");
+        actionMove.AddBinding("<Gamepad>/leftStick");
+
+        actionJump = map.AddAction("Jump", InputActionType.Button);
+        actionJump.AddBinding("<Gamepad>/buttonSouth");
+
+        actionJumpKick = map.AddAction("Jump Kick", InputActionType.Button);
+        
+        actionJumpKick.AddCompositeBinding("OneModifier")
+            .With("modifier", "<Gamepad>/leftShoulder")
+            .With("binding", "<Gamepad>/buttonSouth");
+
+        actionJumpKick.Priority = 1;
+
+        return map;
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_GenericJoystick_LeftStick_Activates_JustOneAction()
+    {
+        EnableActionPriorityShortcutResolution();
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        using var map = CreateGenericJoystickExampleShortcutMap(out var actionMove, out var actionJump, out var actionJumpKick);
+        map.Enable();
+
+        Set(gamepad.leftStick, Vector2.up);
+
+        InputSystem.Update();
+
+        Assert.IsTrue(actionMove.IsPressed(), "Move should be active when the left stick is tilted.");
+        Assert.IsFalse(actionJump.IsPressed(), "Jump should not be active without X (south).");
+        Assert.IsFalse(actionJumpKick.IsPressed(), "Jump Kick should not be active without L1+X.");
+
+        Set(gamepad.leftStick, Vector2.zero);
+        InputSystem.Update();        
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_GenericJoystick_LeftStickAndX_Triggers_Move_And_Jump()
+    {
+        EnableActionPriorityShortcutResolution();
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        using var map = CreateGenericJoystickExampleShortcutMap(out var actionMove, out var actionJump, out var actionJumpKick);
+        map.Enable();
+
+        Set(gamepad.leftStick, Vector2.up);
+        Press(gamepad.buttonSouth);
+
+        InputSystem.Update();
+
+        Assert.IsTrue(actionMove.IsPressed(), "Move should still be active while the stick is tilted.");
+        Assert.IsTrue(actionJump.IsPressed(), "Jump should be active when X (south) is pressed.");
+        Assert.IsFalse(actionJumpKick.IsPressed(), "Jump Kick should not be active without L1.");
+
+        Release(gamepad.buttonSouth);
+        Set(gamepad.leftStick, Vector2.zero);
+        InputSystem.Update();        
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_GenericJoystick_L1AndX_Only_Triggers_JumpKick()
+    {
+        EnableActionPriorityShortcutResolution();
+
+        var gamepad = InputSystem.AddDevice<Gamepad>();
+        using var map = CreateGenericJoystickExampleShortcutMap(out var actionMove, out var actionJump, out var actionJumpKick);
+        map.Enable();
+
+        Press(gamepad.leftShoulder);
+        Press(gamepad.buttonSouth);
+
+        InputSystem.Update();
+
+        Assert.IsFalse(actionMove.IsPressed(), "Move should not be active when the stick is neutral.");
+        Assert.IsFalse(actionJump.IsPressed(), "Jump should not consume when Jump Kick wins (priority + consume).");
+        Assert.IsTrue(actionJumpKick.IsPressed(), "Jump Kick should be active for L1+X.");
+
+        Release(gamepad.buttonSouth);
+        Release(gamepad.leftShoulder);
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
@@ -201,6 +201,7 @@ internal partial class CoreTests
 
         Release(gamepad.buttonSouth);
         Release(gamepad.leftShoulder);
+        InputSystem.Update();
     }
 
     /// <summary>

--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
@@ -115,7 +115,7 @@ internal partial class CoreTests
         out InputAction actionJump,
         out InputAction actionJumpKick)
     {
-        var map = new InputActionMap("DualshockExample");
+        var map = new InputActionMap("JoystickExample");
 
         actionMove = map.AddAction("Move", InputActionType.Value, expectedControlLayout: "Vector2");
         actionMove.AddBinding("<Gamepad>/leftStick");
@@ -201,5 +201,110 @@ internal partial class CoreTests
 
         Release(gamepad.buttonSouth);
         Release(gamepad.leftShoulder);
+    }
+
+    /// <summary>
+    /// The following section originates from shooter games where move overlaps with a bunch of weapon controls and team interactions.
+    /// </summary>
+    private static InputActionMap CreateShooterExampleShortcutMap(
+        out InputAction actionMove,
+        out InputAction actionRunFast,
+        out InputAction actionTeamChat)
+    {
+
+        var map = new InputActionMap("ShooterExample");
+
+        actionMove = map.AddAction("Move", InputActionType.Value);
+        actionMove.AddCompositeBinding("2DVector")
+            .With("up", "<Keyboard>/w")
+            .With("down", "<Keyboard>/s")
+            .With("left", "<Keyboard>/a")
+            .With("right", "<Keyboard>/d");
+
+        actionRunFast = map.AddAction("Run Fast", InputActionType.Button);
+        actionRunFast.AddCompositeBinding("OneModifier")
+            .With("modifier", "<Keyboard>/shift")
+            .With("binding", "<Keyboard>/w");
+
+        actionTeamChat = map.AddAction("Team chat", InputActionType.Button);
+        actionTeamChat.AddCompositeBinding("TwoModifiers")
+            .With("modifier1", "<Keyboard>/alt")
+            .With("modifier2", "<Keyboard>/shift")
+            .With("binding", "<Keyboard>/w");
+
+        actionTeamChat.Priority = 2;
+
+        return map;
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_Shooter_Move_Only_Triggers_Move()
+    {
+        EnableActionPriorityShortcutResolution();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        using var map = CreateShooterExampleShortcutMap(out var actionMove, out var actionRunFast, out var actionTeamChat);
+        map.Enable();
+
+        Press(keyboard.wKey);
+        InputSystem.Update();
+
+        Assert.IsTrue(actionMove.IsPressed(), "Move should be activated by W.");
+        Assert.IsFalse(actionRunFast.IsPressed(), "Run Fast should not be activated by W alone.");
+        Assert.IsFalse(actionTeamChat.IsPressed(), "Team chat should not be activated by W alone.");
+
+        Release(keyboard.wKey);
+        InputSystem.Update();
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_Shooter_ShiftW_Triggers_Move_And_RunFast()
+    {
+        EnableActionPriorityShortcutResolution();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        using var map = CreateShooterExampleShortcutMap(out var actionMove, out var actionRunFast, out var actionTeamChat);
+        map.Enable();
+
+        Press(keyboard.leftShiftKey);
+        Press(keyboard.wKey);
+
+        InputSystem.Update();
+
+        Assert.IsTrue(actionMove.IsPressed(), "Move should still be activated by W.");
+        Assert.IsTrue(actionRunFast.IsPressed(), "Run Fast should be activated by Shift+W.");
+        Assert.IsFalse(actionTeamChat.IsPressed(), "Team chat should not be activated without Alt.");
+
+        Release(keyboard.wKey);
+        Release(keyboard.leftShiftKey);
+        InputSystem.Update();
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_Shooter_AltShiftW_Only_Triggers_TeamChat()
+    {
+        EnableActionPriorityShortcutResolution();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        using var map = CreateShooterExampleShortcutMap(out var actionMove, out var actionRunFast, out var actionTeamChat);
+        map.Enable();
+
+        Press(keyboard.leftAltKey);
+        Press(keyboard.leftShiftKey);
+        Press(keyboard.wKey);
+
+        InputSystem.Update();
+
+        Assert.IsTrue(
+            actionTeamChat.IsPressed() || actionTeamChat.IsInProgress(),
+            "Team chat should trigger when Alt, Shift, and W are down together.");
+
+        Assert.IsFalse(actionMove.IsPressed(), "Move shouldn't be activated!");
+
+        Release(keyboard.leftAltKey);
+        Release(keyboard.leftShiftKey);
+        Release(keyboard.wKey);
+
+        InputSystem.Update();    
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
@@ -86,7 +86,7 @@ internal partial class CoreTests
     public void Actions_Priority_Genres_RTS_ControlShiftOne_SuppressesLowerTiers()
     {
         EnableActionPriorityShortcutResolution();
-        
+
         var keyboard = InputSystem.AddDevice<Keyboard>();
         using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
         map.Enable();
@@ -124,7 +124,7 @@ internal partial class CoreTests
         actionJump.AddBinding("<Gamepad>/buttonSouth");
 
         actionJumpKick = map.AddAction("Jump Kick", InputActionType.Button);
-        
+
         actionJumpKick.AddCompositeBinding("OneModifier")
             .With("modifier", "<Gamepad>/leftShoulder")
             .With("binding", "<Gamepad>/buttonSouth");
@@ -153,7 +153,7 @@ internal partial class CoreTests
         Assert.IsFalse(actionJumpKick.IsPressed(), "Jump Kick should not be active without L1+X.");
 
         Set(gamepad.leftStick, Vector2.zero);
-        InputSystem.Update();        
+        InputSystem.Update();
     }
 
     [Test]
@@ -177,7 +177,7 @@ internal partial class CoreTests
 
         Release(gamepad.buttonSouth);
         Set(gamepad.leftStick, Vector2.zero);
-        InputSystem.Update();        
+        InputSystem.Update();
     }
 
     [Test]
@@ -211,7 +211,6 @@ internal partial class CoreTests
         out InputAction actionRunFast,
         out InputAction actionTeamChat)
     {
-
         var map = new InputActionMap("ShooterExample");
 
         actionMove = map.AddAction("Move", InputActionType.Value);
@@ -305,6 +304,6 @@ internal partial class CoreTests
         Release(keyboard.leftShiftKey);
         Release(keyboard.wKey);
 
-        InputSystem.Update();    
+        InputSystem.Update();
     }
 }

--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Controls;
+
+/// <summary>
+/// Genre-style shortcut examples (RTS, shooter, etc.) migrated from sample projects into the Input System test suite.
+/// </summary>
+internal partial class CoreTests
+{
+    /// <summary>
+    /// Programmatic map matching the RTS example scene: plain <c>1</c>, <c>Shift+1</c>, and <c>Ctrl+Shift+1</c> on the same binding key.
+    /// </summary>
+    private static InputActionMap CreateRtsExampleShortcutMap(
+        out InputAction actionOne,
+        out InputAction actionShiftOne,
+        out InputAction actionControlShiftOne)
+    {
+        var map = new InputActionMap("RTSShortcuts");
+
+        actionOne = map.AddAction("One", InputActionType.Button);
+        actionOne.AddBinding("<Keyboard>/1");
+
+        actionShiftOne = map.AddAction("ShiftOne", InputActionType.Button);
+        actionShiftOne.AddCompositeBinding("OneModifier")
+            .With("modifier", "<Keyboard>/shift")
+            .With("binding", "<Keyboard>/1");
+        actionShiftOne.Priority = 1;
+
+        actionControlShiftOne = map.AddAction("ControlShiftOne", InputActionType.Button);
+        actionControlShiftOne.AddCompositeBinding("TwoModifiers")
+            .With("modifier1", "<Keyboard>/ctrl")
+            .With("modifier2", "<Keyboard>/shift")
+            .With("binding", "<Keyboard>/1");
+        actionControlShiftOne.Priority = 2;
+
+        return map;
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_RTS_Key1Only_ActivatesPlainOne()
+    {
+        EnableComplexityShortcutResolution();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
+        map.Enable();
+
+        Press((ButtonControl)keyboard.digit1Key);
+        InputSystem.Update();
+
+        Assert.That(actionOne.IsPressed(), Is.True);
+        Assert.That(actionShiftOne.IsPressed(), Is.False);
+        Assert.That(actionControlShiftOne.IsPressed(), Is.False);
+
+        Release((ButtonControl)keyboard.digit1Key);
+        InputSystem.Update();
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_RTS_ShiftOne_SuppressesPlainOne()
+    {
+        EnableComplexityShortcutResolution();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
+        map.Enable();
+
+        Press((ButtonControl)keyboard.shiftKey);
+        Press((ButtonControl)keyboard.digit1Key);
+        InputSystem.Update();
+
+        Assert.That(actionOne.IsPressed(), Is.False, "Plain 1 should not activate when Shift+1 wins.");
+        Assert.That(actionShiftOne.IsPressed(), Is.True, "Shift+1 should activate.");
+        Assert.That(actionControlShiftOne.IsPressed(), Is.False);
+
+        Release((ButtonControl)keyboard.digit1Key);
+        Release((ButtonControl)keyboard.shiftKey);
+        InputSystem.Update();
+    }
+
+    [Test]
+    [Category("Actions Priority")]
+    public void Actions_Priority_Genres_RTS_ControlShiftOne_SuppressesLowerTiers()
+    {
+        EnableComplexityShortcutResolution();
+        var keyboard = InputSystem.AddDevice<Keyboard>();
+        using var map = CreateRtsExampleShortcutMap(out var actionOne, out var actionShiftOne, out var actionControlShiftOne);
+        map.Enable();
+
+        Press((ButtonControl)keyboard.ctrlKey);
+        Press((ButtonControl)keyboard.shiftKey);
+        Press((ButtonControl)keyboard.digit1Key);
+        InputSystem.Update();
+
+        Assert.That(actionOne.IsPressed(), Is.False, "Plain 1 should not activate when Ctrl+Shift+1 wins.");
+        Assert.That(actionShiftOne.IsPressed(), Is.False, "Shift+1 should not activate when Ctrl+Shift+1 wins.");
+        Assert.That(actionControlShiftOne.IsPressed(), Is.True, "Ctrl+Shift+1 should activate.");
+
+        Release((ButtonControl)keyboard.digit1Key);
+        Release((ButtonControl)keyboard.shiftKey);
+        Release((ButtonControl)keyboard.ctrlKey);
+        InputSystem.Update();
+    }
+}

--- a/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs.meta
+++ b/Assets/Tests/InputSystem/CoreTests_ActionPriority_Genres.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8e4f2a1b9c3d4e5f6a7b8c9d0e1f2a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Description

These are the genre-style tests that didn't make it into the main branch when we landed the new input consumption thing. They were originally part of a separate private repo where the demo project lived, and then we moved them to this repository. 

Related to https://jira.unity3d.com/browse/ISX-2544


### Testing status & QA

Doesn't require extra testing work, it's just tests - if it passed CI then it's good. 

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
