### PR TITLE
FIX: Add test and fix for multiple touchscreen input bug.

### DIFF
--- a/Assets/Tests/InputSystem/TouchscreenMultiDisplayTests.cs
+++ b/Assets/Tests/InputSystem/TouchscreenMultiDisplayTests.cs
@@ -1,0 +1,84 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+using TouchPhase = UnityEngine.InputSystem.TouchPhase;
+
+// Tests covering touch tracking across multiple physical touchscreen monitors.
+// Regression coverage for IN-108611: touches from one screen incorrectly matching
+// ongoing touches from another screen when both screens report the same touchId.
+[TestFixture]
+internal class TouchscreenMultiDisplayTests : CoreTestsFixture
+{
+    // When two physical touchscreens both have an active touch with the same touchId,
+    // a Move event from screen 2 must update screen 2's touch slot, not screen 1's.
+    //
+    // Failure mode (pre-fix): OnStateEvent matches ongoing touches by touchId alone,
+    // so screen 2's Move event finds screen 1's slot first (both have touchId=1) and
+    // incorrectly updates it, leaving screen 1's position changed and screen 2 stale.
+    [Test]
+    [Category("Devices")]
+    public void Devices_TouchMoveOnSecondDisplay_DoesNotUpdateTouchOnFirstDisplay()
+    {
+        var device = InputSystem.AddDevice<Touchscreen>();
+
+        // Finger down on display 0 (touchId=1).
+        InputSystem.QueueStateEvent(device, new TouchState
+        {
+            phase = TouchPhase.Began,
+            touchId = 1,
+            position = new Vector2(100, 100),
+            displayIndex = 0,
+        });
+
+        // Finger down on display 1 — same touchId, different screen.
+        InputSystem.QueueStateEvent(device, new TouchState
+        {
+            phase = TouchPhase.Began,
+            touchId = 1,
+            position = new Vector2(200, 200),
+            displayIndex = 1,
+        });
+
+        InputSystem.Update();
+
+        // Both touches should be allocated to separate slots.
+        Assert.That(device.touches[0].phase.ReadValue(), Is.EqualTo(TouchPhase.Began));
+        Assert.That(device.touches[1].phase.ReadValue(), Is.EqualTo(TouchPhase.Began));
+
+        var display0SlotIndex = -1;
+        var display1SlotIndex = -1;
+        for (var i = 0; i < 2; i++)
+        {
+            var displayIdx = device.touches[i].displayIndex.ReadValue();
+            if (displayIdx == 0) display0SlotIndex = i;
+            else if (displayIdx == 1) display1SlotIndex = i;
+        }
+
+        Assert.That(display0SlotIndex, Is.Not.EqualTo(-1), "No touch slot found for display 0");
+        Assert.That(display1SlotIndex, Is.Not.EqualTo(-1), "No touch slot found for display 1");
+
+        var display0PositionBefore = device.touches[display0SlotIndex].position.ReadValue();
+
+        // Swipe on display 1 (same touchId=1 as display 0's held touch).
+        InputSystem.QueueStateEvent(device, new TouchState
+        {
+            phase = TouchPhase.Moved,
+            touchId = 1,
+            position = new Vector2(300, 300),
+            displayIndex = 1,
+        });
+
+        InputSystem.Update();
+
+        // Display 0's touch must be unchanged.
+        Assert.That(device.touches[display0SlotIndex].position.ReadValue(), Is.EqualTo(display0PositionBefore),
+            "Touch on display 0 was incorrectly updated by a Move event from display 1");
+
+        // Display 1's touch must reflect the new position.
+        Assert.That(device.touches[display1SlotIndex].position.ReadValue(), Is.EqualTo(new Vector2(300, 300)),
+            "Touch on display 1 was not updated by its own Move event");
+
+        Assert.That(device.touches[display1SlotIndex].phase.ReadValue(), Is.EqualTo(TouchPhase.Moved));
+    }
+}

--- a/Assets/Tests/InputSystem/TouchscreenMultiDisplayTests.cs.meta
+++ b/Assets/Tests/InputSystem/TouchscreenMultiDisplayTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a5c39c3a4a0654c28a5b7754add41d2a

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Devices/Touchscreen.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Devices/Touchscreen.cs
@@ -694,7 +694,7 @@ namespace UnityEngine.InputSystem
                 var touchId = newTouchState.touchId;
                 for (var i = 0; i < touchControlCount; ++i)
                 {
-                    if (currentTouchState[i].touchId == touchId)
+                    if (currentTouchState[i].touchId == touchId && currentTouchState[i].displayIndex == newTouchState.displayIndex)
                     {
                         // Preserve primary touch state.
                         var isPrimaryTouch = currentTouchState[i].isPrimaryTouch;
@@ -915,7 +915,7 @@ namespace UnityEngine.InputSystem
                 for (var i = 0; i < touchControlCount; ++i)
                 {
                     var touch = &currentTouchState[i];
-                    if (touch->touchId == eventTouchId || (!touch->isInProgress && eventTouchPhase.IsActive()))
+                    if ((touch->touchId == eventTouchId && touch->displayIndex == eventTouchState->displayIndex) || (!touch->isInProgress && eventTouchPhase.IsActive()))
                     {
                         offset = primaryTouch.m_StateBlock.byteOffset + primaryTouch.m_StateBlock.alignedSizeInBytes - m_StateBlock.byteOffset +
                             (uint)(i * UnsafeUtility.SizeOf<TouchState>());
@@ -1002,7 +1002,7 @@ namespace UnityEngine.InputSystem
             var currentState = (TouchState*)currentEvent->state;
             var nextState = (TouchState*)nextEvent->state;
 
-            if (currentState->touchId != nextState->touchId || currentState->phaseId != nextState->phaseId || currentState->flags != nextState->flags)
+            if (currentState->touchId != nextState->touchId || currentState->phaseId != nextState->phaseId || currentState->flags != nextState->flags || currentState->displayIndex != nextState->displayIndex)
                 return false;
 
             nextState->delta += currentState->delta;

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/EnhancedTouch/TouchSimulation.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/EnhancedTouch/TouchSimulation.cs
@@ -253,6 +253,9 @@ namespace UnityEngine.InputSystem.EnhancedTouch
             if (m_TouchIds == null)
                 m_TouchIds = new int[simulatedTouchscreen.touches.Count];
 
+            if (m_TouchDisplayIndices == null)
+                m_TouchDisplayIndices = new byte[simulatedTouchscreen.touches.Count];
+
             foreach (var device in InputSystem.devices)
                 OnDeviceChange(device, InputDeviceChange.Added);
 
@@ -306,10 +309,12 @@ namespace UnityEngine.InputSystem.EnhancedTouch
                 touch.startPosition = position;
                 touch.touchId = ++m_LastTouchId;
                 m_TouchIds[touchIndex] = m_LastTouchId;
+                m_TouchDisplayIndices[touchIndex] = displayIndex;
             }
             else
             {
                 touch.touchId = m_TouchIds[touchIndex];
+                touch.displayIndex = m_TouchDisplayIndices[touchIndex];
             }
 
             //NOTE: Processing these events still happen in the current frame.
@@ -327,6 +332,7 @@ namespace UnityEngine.InputSystem.EnhancedTouch
         [NonSerialized] private int[] m_CurrentDisplayIndices;
         [NonSerialized] private ButtonControl[] m_Touches;
         [NonSerialized] private int[] m_TouchIds;
+        [NonSerialized] private byte[] m_TouchDisplayIndices;
 
         [NonSerialized] private int m_LastTouchId;
         [NonSerialized] private Action<InputDevice, InputDeviceChange> m_OnDeviceChange;


### PR DESCRIPTION
## Purpose of this PR

Fixes a bug (IN-108611) where an ongoing touch on one physical touchscreen could be incorrectly updated by touch events originating from a second physical touchscreen, when both screens reported the same `touchId`. The root cause was that three touch-matching code paths in `Touchscreen.cs` identified touches by `touchId` alone, ignoring `displayIndex`.

## Release Notes

**[IN-108611] Input System — Bug Fixes**
- Fixed: Touch events from one physical touchscreen incorrectly updating touch state on another touchscreen when both screens reported the same `touchId`.

## Functional Testing status

- Automated: New regression test `Devices_TouchMoveOnSecondDisplay_DoesNotUpdateTouchOnFirstDisplay` added to `TouchscreenMultiDisplayTests.cs`, covering the exact failure sequence (two `Began` events with the same `touchId` on different `displayIndex` values, followed by a `Moved` from one screen verifying the other is untouched).
- Manual: Reproducible via two physical touchscreen monitors per the original bug report steps (hold finger on screen 1, swipe on screen 2). This hasn't been tested by me manually due to no device, we need QA to test this.

## Performance Testing Status

No performance impact. The three changed comparisons each add a single byte comparison (`displayIndex`) to an existing conditional — no additional allocations, iterations, or data structure changes.

## Overall Product Risks

**Technical Risk:** 1 — Self-contained fix to three closely related conditions in one file. Behaviour change is additive (stricter matching); single-screen setups are entirely unaffected since `displayIndex` will always match itself.

**Halo Effect:** 1 — Could affect any code path relying on `Touchscreen` with multi-display touch input, but the existing behaviour in those paths was already incorrect.

## Class diagram

Changes analysed from `origin/develop...HEAD`

<details><summary>Class diagram</summary>

```mermaid
classDiagram
    class Touchscreen {
        «modified» OnStateEvent()
        «modified» GetCurrentValueAsObject()
        «modified» MergeForward()
    }
```

</details>
