### PR TITLE
FIX: Input devices being lost up on upgrade to the new input version [ISX-2569]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed input devices being lost (no keyboard, mouse, gamepad, etc.) after upgrading the package while the Editor is open (related to the recent fast enter playmode change). [ISX-2569]
 - Fixed `InputSystemProvider` disabling project-wide actions on shutdown when UI Toolkit destroys its objects mid-play. The provider now scopes its lifecycle to the UI action map only and does not disable project-wide actions [UUM-134130](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-134130)
 - Fixed `InputActionRebindingExtensions.GetBindingDisplayString(InputAction, InputBinding, ...)` returning an empty string for composite bindings when the binding mask filters by group [UUM-141423](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141423)
 - Fixed `InputEventPtr.handled` not preventing actions from triggering when switching devices. The default event handled policy has been changed from `SuppressStateUpdates` (now deprecated) to `SuppressActionEventNotifications`, which keeps device state synchronized while suppressing action callbacks for handled events. [ISXB-1097](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1097)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemEditorInitializer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemEditorInitializer.cs
@@ -162,6 +162,36 @@ namespace UnityEngine.InputSystem.Editor
             }
 
             var existingStateManagers = Resources.FindObjectsOfTypeAll<InputSystemStateManager>();
+
+            // Upgrade migration: package versions up to and including 1.18 stored this state in a
+            // ScriptableObject named InputSystemObject. That instance survives the domain reload
+            // triggered by a package upgrade, but the renamed InputSystemStateManager type won't match
+            // it. Adopt the surviving legacy instance's state into a new state manager so connected
+            // devices (and other state) are preserved across the upgrade instead of being lost - native
+            // only re-reports devices once per editor process, so there is no in-process recovery
+            // otherwise. See ISX-2569.
+            if (globalReset && (existingStateManagers == null || existingStateManagers.Length == 0))
+            {
+                var legacyObjects = Resources.FindObjectsOfTypeAll<InputSystemObject>();
+                if (legacyObjects != null && legacyObjects.Length > 0)
+                {
+                    var legacy = legacyObjects[0];
+                    var migrated = ScriptableObject.CreateInstance<InputSystemStateManager>();
+                    migrated.hideFlags = HideFlags.HideAndDontSave;
+                    migrated.systemState = legacy.systemState;
+                    migrated.newInputBackendsCheckedAsEnabled = legacy.newInputBackendsCheckedAsEnabled;
+                    migrated.settings = legacy.settings;
+                    migrated.exitEditModeTime = legacy.exitEditModeTime;
+                    migrated.enterPlayModeTime = legacy.enterPlayModeTime;
+
+                    // The legacy instances are no longer needed; get rid of them so we don't migrate twice.
+                    for (var i = 0; i < legacyObjects.Length; ++i)
+                        Object.DestroyImmediate(legacyObjects[i]);
+
+                    existingStateManagers = new[] { migrated };
+                }
+            }
+
             if (existingStateManagers != null && existingStateManagers.Length > 0)
             {
                 if (globalReset)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemObject.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemObject.cs
@@ -1,0 +1,35 @@
+#if UNITY_EDITOR
+using UnityEngine;
+
+namespace UnityEngine.InputSystem
+{
+    /// <summary>
+    /// Legacy compatibility type. Package versions up to and including 1.18 stored the domain-reload
+    /// survival state in a hidden, <see cref="HideFlags.HideAndDontSave"/> ScriptableObject of this
+    /// exact type and name (this type was renamed to <see cref="InputSystemStateManager"/> in 1.20).
+    /// </summary>
+    /// <remarks>
+    /// When a project upgrades from such a version, that instance survives the domain reload triggered
+    /// by the upgrade - but only if its serialized script reference still resolves. That reference is
+    /// <c>{ fileID: 11500000, guid: &lt;this file's guid&gt; }</c>, so this file MUST keep the original
+    /// <c>InputSystemObject.cs</c> GUID (<c>5cdce2bffd1e49bda08b3db54a031207</c>) and this MUST be the
+    /// primary class of the file (matching the file name). If the reference fails to resolve, Unity
+    /// drops the object during the reload and the input state - including the list of connected devices
+    /// - is lost on upgrade, with no in-process recovery (native only re-reports devices once per editor
+    /// process). See ISX-2569.
+    ///
+    /// The fields below must keep the same names and serialized layout as 1.18's InputSystemObject so the
+    /// surviving data deserializes into them. <c>InputSystemEditorInitializer.InitializeInEditor</c>
+    /// detects a surviving instance of this type, migrates its state into a
+    /// <see cref="InputSystemStateManager"/>, and then destroys it.
+    /// </remarks>
+    internal class InputSystemObject : ScriptableObject
+    {
+        [SerializeField] public InputSystemState systemState;
+        [SerializeField] public bool newInputBackendsCheckedAsEnabled;
+        [SerializeField] public string settings;
+        [SerializeField] public double exitEditModeTime;
+        [SerializeField] public double enterPlayModeTime;
+    }
+}
+#endif // UNITY_EDITOR

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemObject.cs.meta
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/InputSystemObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cdce2bffd1e49bda08b3db54a031207
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
### Description

So the problem we're trying to fix here is that when you have a working project with pre-FEPM InputSystem and you then update the input package to the one that has the FEPM change, all input comes broken. The root problem appeared that all devices were lost during upgrade. 

The reason devices got lost during upgrade is somewhat tricky to explain, but it all comes down to the fact that native will only communicate the current devices once per Unity process. If you lose devices once, it's permanent - entering playmode doesn't list devices again. 

The way we lost devices was due to us renaming an in-memory scriptable object class that was used to keep state from InputSystemObject to InputSystemStateManager. Up on upgrade recompilation, Unity realised that the class for the InputSystemObject SO is no longer available so it shall be dropped, and all the devices died with it. 

Hereby, we bring back the old class with the old meta info so that the forward upgrade can work for now. 

### Testing status & QA

Tried locally. 

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [x] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
