### PR TITLE
FIX: Two clicks needed to move focus between parameter fields in the Input Actions editor [UUM-144339]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed the Input Actions editor requiring two clicks to move focus between processor or interaction parameter fields, because committing a parameter value rebuilt the parameter field UI mid-click [UUM-144339](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144339)
 - Fixed `InputSystemProvider` disabling project-wide actions on shutdown when UI Toolkit destroys its objects mid-play. The provider now scopes its lifecycle to the UI action map only and does not disable project-wide actions [UUM-134130](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-134130)
 - Fixed `InputActionRebindingExtensions.GetBindingDisplayString(InputAction, InputBinding, ...)` returning an empty string for composite bindings when the binding mask filters by group [UUM-141423](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141423)
 - Fixed `InputEventPtr.handled` not preventing actions from triggering when switching devices. The default event handled policy has been changed from `SuppressStateUpdates` (now deprecated) to `SuppressActionEventNotifications`, which keeps device state synchronized while suppressing action callbacks for handled events. [ISXB-1097](https://issuetracker.unity3d.com/product/unity/issues/guid/ISXB-1097)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/StateContainer.cs
@@ -22,6 +22,12 @@ namespace UnityEngine.InputSystem.Editor
         private InputActionsEditorState m_State;
         public readonly string assetGUID;
 
+        // When set, the next change detected by the TrackSerializedObjectValue callback below does not rebuild
+        // the editor UI. Used to commit value-only edits (e.g. an interaction/processor parameter) without
+        // tearing down and recreating the field the user is interacting with (UUM-144339). It is a one-shot:
+        // the very next change notification consumes it, so unrelated changes still rebuild as normal.
+        private bool m_IgnoreNextSerializedObjectChange;
+
         public StateContainer(InputActionsEditorState initialState, string assetGUID)
         {
             m_State = initialState;
@@ -52,6 +58,15 @@ namespace UnityEngine.InputSystem.Editor
             });
         }
 
+        // Request that the editor UI is not rebuilt in response to the next change of the tracked serialized
+        // object. Call this immediately before committing a value-only edit (ApplyModifiedProperties) that must
+        // not tear down the VisualElement the user is interacting with. The request is consumed by the next
+        // change notification, so any subsequent change still rebuilds normally.
+        public void IgnoreNextSerializedObjectChange()
+        {
+            m_IgnoreNextSerializedObjectChange = true;
+        }
+
         public void Initialize(VisualElement rootVisualElement)
         {
             // We need to use a root element for the TrackSerializedObjectValue that is destroyed with the view.
@@ -62,6 +77,14 @@ namespace UnityEngine.InputSystem.Editor
             m_RootVisualElement.Unbind();
             m_RootVisualElement.TrackSerializedObjectValue(m_State.serializedObject, so =>
             {
+                // A value-only edit asked us not to rebuild the UI for this change (see
+                // IgnoreNextSerializedObjectChange). Consume the request and skip the rebuild.
+                if (m_IgnoreNextSerializedObjectChange)
+                {
+                    m_IgnoreNextSerializedObjectChange = false;
+                    return;
+                }
+
                 StateChanged?.Invoke(m_State, UIRebuildMode.Rebuild);
             });
             StateChanged?.Invoke(m_State, UIRebuildMode.Rebuild);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -77,7 +77,22 @@ namespace UnityEngine.InputSystem.Editor
         {
             var interactionsOrProcessorsList = NameAndParameters.ParseMultiple(m_ListProperty.stringValue).ToList();
             interactionsOrProcessorsList[index] = new NameAndParameters { name = interactionsOrProcessorsList[index].name, parameters = listView.GetParameters() };
-            m_ListProperty.stringValue = NameAndParameters.ToSerializableString(interactionsOrProcessorsList);
+            var newValue = NameAndParameters.ToSerializableString(interactionsOrProcessorsList);
+
+            // onChange also fires on a plain blur with no edit, leaving the serialized string unchanged. Bail before
+            // arming the ignore flag below: ApplyModifiedProperties would be a no-op that never fires the
+            // TrackSerializedObjectValue callback, so the flag would stay armed and wrongly swallow the next real rebuild.
+            if (m_ListProperty.stringValue == newValue)
+                return;
+
+            m_ListProperty.stringValue = newValue;
+
+            // This is a value-only edit of an existing interaction/processor: the parameter fields are already
+            // showing the new value. A full UI rebuild here would tear down and recreate the field the user is
+            // moving focus into, forcing a second click (UUM-144339). Suppress the rebuild that committing the
+            // value would otherwise trigger via StateContainer's TrackSerializedObjectValue callback. Structural
+            // edits (add/move/delete) intentionally do not call this and still rebuild.
+            stateContainer.IgnoreNextSerializedObjectChange();
             m_ListProperty.serializedObject.ApplyModifiedProperties();
         }
 


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

In the Input Actions editor's Action Properties panel, moving focus directly from one interaction/processor parameter field to another — for example a Normalize processor's `Min` to its `Max` — required two clicks instead of one. The first click was effectively swallowed and only the second moved focus.

The cause is in how a value commit is handled. When `NameAndParametersListView.OnParametersChanged(ParameterListView listView, int index)` commits an edited value via `SerializedProperty.ApplyModifiedProperties()`, `StateContainer`'s `TrackSerializedObjectValue` callback (hardcoded to `UIRebuildMode.Rebuild`) turns that change into a full editor UI rebuild. The rebuild tears down and recreates the parameter field the click is moving focus into, so that first click lands on an element that no longer exists. The fix lets a value-only commit opt out of that single rebuild: `StateContainer.IgnoreNextSerializedObjectChange()` makes the next serialized-object change skip the rebuild (consumed one-shot), and `OnParametersChanged` calls it just before committing. The fields are left intact and focus moves on the first click. Structural edits (add/move/delete) deliberately do not opt out and still rebuild.

### Testing status & QA

- No automated test added — this is a UI Toolkit focus/rebuild-timing behaviour in the editor window that cannot be asserted reliably without a contrived, fragile multi-click focus simulation.
- Manual QA: re-run the repro in [UUM-144339](https://jira.unity3d.com/browse/UUM-144339) — add a processor or interaction with multiple parameters (e.g. Normalize), edit one field then click another, and confirm focus moves on the first click. Also confirm add/reorder/delete of interactions and processors, and switching selection between actions/bindings, still refresh correctly.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (one view method plus a one-shot opt-out flag on the shared `StateContainer` rebuild path; no public API or serialized data changes)
- Risk rating: 3/5 — the value-commit path now opts out of the shared serialized-object-change rebuild via a one-shot flag, so a mis-scoped suppression could skip or defer an unrelated rebuild; the multi-click focus behaviour has no automated coverage.

### Comments to reviewers

The suppression is a one-shot consumed by the next `TrackSerializedObjectValue` notification and is set only for value-only parameter commits (not add/move/delete). Worth confirming no other path depends on a rebuild firing for that specific commit.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
