### PR TITLE
https://jira.unity3d.com/browse/PLAT-20203 docs

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrated sample scenes to use Universal Render Pipeline (URP) with Built-in Render Pipeline fallback shaders. The URP package is now required to run the samples. (ISX-2343)
 - Changed the UI for `Actions.inputactions` asset to use UI Toolkit framework.
 - Changed the UI for `InputSystem.inputsettings` asset to use UI Toolkit framework.
-- Added documentation for rumble support on Android.
+- Added documentation for rumble support on Android and iOS.
 
 ### Added
 

--- a/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
+++ b/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
@@ -29,6 +29,12 @@ Only the following combinations of devices/OSes currently support rumble:
         * Rumble support is limited.
         * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
         * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0` (maximum speed) or `0.0` (turned off).
+* Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.7 or later.
+    * Supports rumble on gamepads for which Apple's GameController framework exposes haptics, including PS4, PS5, Xbox, and Nintendo Switch Pro controllers.
+    * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
+    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
+    * When you set all motor speeds to `0.0`, an inactivity timer starts. After 2 minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.
+    * Not every controller model exposes haptics through Apple's GameController framework. To confirm rumble support for a given controller, test it in a native application.
 
 ## Pausing, resuming, and stopping haptics
 

--- a/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
+++ b/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
@@ -32,8 +32,7 @@ Only the following combinations of devices/OSes currently support rumble:
 * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.7 or later.
     * Supports rumble on gamepads for which Apple's GameController framework exposes haptics. Supported gamepads include PS4, PS5, Xbox, and Nintendo Switch Pro controllers.
     * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
-    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
-    * When you set all motor speeds to `0.0`, an inactivity timer starts. After 2 minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.
+    * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency. When you set all motor speeds to `0.0`, an inactivity timer starts. After 2 minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources, adding further latency.
     * Not every controller model exposes haptics through Apple's GameController framework. To confirm rumble support for a given controller, it's recommended test using a native application.
 
 ## Pausing, resuming, and stopping haptics

--- a/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
+++ b/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
@@ -30,7 +30,7 @@ Only the following combinations of devices/OSes currently support rumble:
         * Only one motor is supported. If the gamepad has more than one motor, the higher value of the left and right motor speed applies to both.
         * On some devices, motor speed control is limited. You can only set the left and right motor speed to either `1.0` (maximum speed) or `0.0` (turned off).
 * Gamepads on iOS, tvOS, and visionOS. Requires Unity 6000.7 or later.
-    * Supports rumble on gamepads for which Apple's GameController framework exposes haptics, including PS4, PS5, Xbox, and Nintendo Switch Pro controllers.
+    * Supports rumble on gamepads for which Apple's GameController framework exposes haptics. Supported gamepads include PS4, PS5, Xbox, and Nintendo Switch Pro controllers.
     * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
     * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
     * When you set all motor speeds to `0.0`, an inactivity timer starts. After 2 minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.

--- a/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
+++ b/Packages/com.unity.inputsystem/Documentation~/gamepad-haptics.md
@@ -34,7 +34,7 @@ Only the following combinations of devices/OSes currently support rumble:
     * If the gamepad supports left and right motors, you can control the speed of each motor individually. Otherwise, the higher value of the left and right motor speed applies to all motors on the gamepad.
     * The first [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call allocates rumble resources, which adds latency.
     * When you set all motor speeds to `0.0`, an inactivity timer starts. After 2 minutes, the system releases rumble resources to preserve the controller's battery. The next [`SetMotorSpeeds`](xref:UnityEngine.InputSystem.Haptics.IDualMotorRumble) call reallocates resources and again incurs allocation latency.
-    * Not every controller model exposes haptics through Apple's GameController framework. To confirm rumble support for a given controller, test it in a native application.
+    * Not every controller model exposes haptics through Apple's GameController framework. To confirm rumble support for a given controller, it's recommended test using a native application.
 
 ## Pausing, resuming, and stopping haptics
 


### PR DESCRIPTION
Description
https://jira.unity3d.com/browse/PLAT-20203

iOS rumble implementation was not ready for Unity 6.6 and will land in 6.7. This is continuation of PR: https://github.com/Unity-Technologies/InputSystem/pull/2420

Unity 6.7 introduces rumble support for iOS:
[iOS]https://github.cds.internal.unity3d.com/unity/unity/pull/105511 LANDED

Changes above hook into existing https://docs.unity3d.com/Packages/com.unity.inputsystem@1.0/api/UnityEngine.InputSystem.Gamepad.html#UnityEngine_InputSystem_Gamepad_SetMotorSpeeds_System_Single_System_Single_ API, thus there's no changes in input system package.

This PR only adds docs to notify user of what is supported.