### PR TITLE
FIX: Change TMP text wrap to supported enum property instead of obsoleted boolean property

### DIFF
--- a/Assets/QA/Tests/Core Platform Menu/SceneMenu.cs
+++ b/Assets/QA/Tests/Core Platform Menu/SceneMenu.cs
@@ -388,7 +388,7 @@ public class SceneMenu : MonoBehaviour
 
         var txt = MakeText("Text", textArea.transform, "", 18,
             kTextPrimary, TextAlignmentOptions.MidlineLeft);
-        ph.textWrappingMode = TextWrappingModes.NoWrap;
+        txt.textWrappingMode = TextWrappingModes.NoWrap;
         Stretch(txt.gameObject);
 
         var input = bar.AddComponent<TMP_InputField>();

--- a/Assets/QA/Tests/Core Platform Menu/SceneMenu.cs
+++ b/Assets/QA/Tests/Core Platform Menu/SceneMenu.cs
@@ -382,13 +382,13 @@ public class SceneMenu : MonoBehaviour
         var ph = MakeText("Placeholder", textArea.transform, "Search scenes\u2026", 18,
             kTextSecondary, TextAlignmentOptions.MidlineLeft);
         ph.fontStyle = FontStyles.Italic;
-        ph.enableWordWrapping = false;
+        ph.textWrappingMode = TextWrappingModes.NoWrap;
         ph.overflowMode = TextOverflowModes.Ellipsis;
         Stretch(ph.gameObject);
 
         var txt = MakeText("Text", textArea.transform, "", 18,
             kTextPrimary, TextAlignmentOptions.MidlineLeft);
-        txt.enableWordWrapping = false;
+        ph.textWrappingMode = TextWrappingModes.NoWrap;
         Stretch(txt.gameObject);
 
         var input = bar.AddComponent<TMP_InputField>();
@@ -614,7 +614,7 @@ public class SceneMenu : MonoBehaviour
         var nameT = MakeText("Name", go.transform, entry.displayName, 15, kTextPrimary,
             TextAlignmentOptions.Center);
         nameT.overflowMode      = TextOverflowModes.Ellipsis;
-        nameT.enableWordWrapping = false;
+        nameT.textWrappingMode = TextWrappingModes.NoWrap;
         var nr = Rect(nameT);
         nr.anchorMin = new Vector2(0.04f, 0.38f);
         nr.anchorMax = new Vector2(0.96f, 0.94f);
@@ -626,7 +626,7 @@ public class SceneMenu : MonoBehaviour
             var subT = MakeText("Sub", go.transform, entry.subcategory, 11, kTextSecondary,
                 TextAlignmentOptions.Center);
             subT.overflowMode      = TextOverflowModes.Ellipsis;
-            subT.enableWordWrapping = false;
+            subT.textWrappingMode = TextWrappingModes.NoWrap;
             var srr = Rect(subT);
             srr.anchorMin = new Vector2(0.04f, 0.06f);
             srr.anchorMax = new Vector2(0.96f, 0.38f);

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an incorrect ArraysHelper.HaveDuplicateReferences implementation that didn't use its arguments right [ISXB-1792] (https://github.com/Unity-Technologies/InputSystem/pull/2376)
 - Fixed `InputAction.IsPressed`, `WasPressedThisFrame`, and `WasReleasedThisFrame` using a `ButtonControl`'s `pressPoint` when a binding also had an explicit `PressInteraction` with its own `pressPoint`, which could make those APIs disagree with the interaction's press and release behavior. Action-level press APIs now follow the interaction threshold when both are set explicitly.
 - Fixed `IndexOutOfRangeException` in `InputDeviceBuilder` when connecting an HID gamepad whose report descriptor declares a hat switch with Report Size 8 (e.g. ESP32-BLE-Gamepad). The HID layer now anchors the hat's directional sub-controls to the hat's own byte instead of letting the layout system auto-allocate a fresh byte for each [UUM-143659](https://jira.unity3d.com/browse/UUM-143659).
-- Fixed a compilation error with newer versions of TextMesh Pro where text wrapping via boolean property have been deprecated. ISXB-1800.
 
 ### Changed
 - Action-level `IsPressed`, `WasPressedThisFrame`, and `WasReleasedThisFrame` for bindings to `Vector2Control` / `StickControl` no longer consult a per-control `pressPoint` on the vector (that field was removed). Use a `Press` interaction to set a custom threshold, or rely on `defaultButtonPressPoint`.

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an incorrect ArraysHelper.HaveDuplicateReferences implementation that didn't use its arguments right [ISXB-1792] (https://github.com/Unity-Technologies/InputSystem/pull/2376)
 - Fixed `InputAction.IsPressed`, `WasPressedThisFrame`, and `WasReleasedThisFrame` using a `ButtonControl`'s `pressPoint` when a binding also had an explicit `PressInteraction` with its own `pressPoint`, which could make those APIs disagree with the interaction's press and release behavior. Action-level press APIs now follow the interaction threshold when both are set explicitly.
 - Fixed `IndexOutOfRangeException` in `InputDeviceBuilder` when connecting an HID gamepad whose report descriptor declares a hat switch with Report Size 8 (e.g. ESP32-BLE-Gamepad). The HID layer now anchors the hat's directional sub-controls to the hat's own byte instead of letting the layout system auto-allocate a fresh byte for each [UUM-143659](https://jira.unity3d.com/browse/UUM-143659).
+- Fixed a compilation error with newer versions of TextMesh Pro where text wrapping via boolean property have been deprecated. ISXB-1800.
 
 ### Changed
 - Action-level `IsPressed`, `WasPressedThisFrame`, and `WasReleasedThisFrame` for bindings to `Vector2Control` / `StickControl` no longer consult a per-control `pressPoint` on the vector (that field was removed). Use a `Press` interaction to set a custom threshold, or rely on `defaultButtonPressPoint`.


### PR DESCRIPTION
### Description

Change TMP text wrap to supported enum property instead of obsoleted boolean property

### Testing status & QA

Verified it compiles. Need to check it works on min supported versions.

### Overall Product Risks

- Complexity: Minimal
- Halo Effect: Minimal

### Comments to reviewers

-

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
