### PR TITLE
FIX: Restore CI compilation broken by stale Wrench 1.x platform override

### DIFF
--- a/.yamato/input-system-editor-functional-tests.yml
+++ b/.yamato/input-system-editor-functional-tests.yml
@@ -115,61 +115,6 @@ inputsystem-editorfunctionaltests_-_6000_3_-_win10:
       paths:
       - artifacts/**/*
 
-# InputSystem-EditorFunctionalTests - 6000.4 - MacOs13
-inputsystem-editorfunctionaltests_-_6000_4_-_macos13:
-  name: InputSystem-EditorFunctionalTests - 6000.4 - MacOs13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.4_project;flags:inputsystem_MacOS_6000.4_project" --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-EditorFunctionalTests - 6000.4 - Ubuntu2204
-inputsystem-editorfunctionaltests_-_6000_4_-_ubuntu2204:
-  name: InputSystem-EditorFunctionalTests - 6000.4 - Ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.4_project;flags:inputsystem_Ubuntu_6000.4_project" --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-EditorFunctionalTests - 6000.4 - Win10
-inputsystem-editorfunctionaltests_-_6000_4_-_win10:
-  name: InputSystem-EditorFunctionalTests - 6000.4 - Win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.4_project;flags:inputsystem_Windows_6000.4_project" --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
 # InputSystem-EditorFunctionalTests - 6000.5 - MacOs13
 inputsystem-editorfunctionaltests_-_6000_5_-_macos13:
   name: InputSystem-EditorFunctionalTests - 6000.5 - MacOs13
@@ -235,7 +180,7 @@ inputsystem-editorfunctionaltests_-_6000_6_-_macos13arm:
     model: M1
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.6_project;flags:inputsystem_MacOS_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -253,7 +198,7 @@ inputsystem-editorfunctionaltests_-_6000_6_-_ubuntu2204:
     flavor: b1.large
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.6_project;flags:inputsystem_Ubuntu_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -272,8 +217,82 @@ inputsystem-editorfunctionaltests_-_6000_6_-_win10:
   commands:
   - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.6_project;flags:inputsystem_Windows_6000.6_project" --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorFunctionalTests - 6000.7 - MacOs13
+inputsystem-editorfunctionaltests_-_6000_7_-_macos13:
+  name: InputSystem-EditorFunctionalTests - 6000.7 - MacOs13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorFunctionalTests - 6000.7 - MacOs13Arm
+inputsystem-editorfunctionaltests_-_6000_7_-_macos13arm:
+  name: InputSystem-EditorFunctionalTests - 6000.7 - MacOs13Arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorFunctionalTests - 6000.7 - Ubuntu2204
+inputsystem-editorfunctionaltests_-_6000_7_-_ubuntu2204:
+  name: InputSystem-EditorFunctionalTests - 6000.7 - Ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.7_project;flags:inputsystem_Ubuntu_6000.7_project" --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorFunctionalTests - 6000.7 - Win10
+inputsystem-editorfunctionaltests_-_6000_7_-_win10:
+  name: InputSystem-EditorFunctionalTests - 6000.7 - Win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.7_project;flags:inputsystem_Windows_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/input-system-editor-performance-tests.yml
+++ b/.yamato/input-system-editor-performance-tests.yml
@@ -115,61 +115,6 @@ inputsystem-editorperformancetests_-_6000_3_-_win10:
       paths:
       - artifacts/**/*
 
-# InputSystem-EditorPerformanceTests - 6000.4 - MacOs13
-inputsystem-editorperformancetests_-_6000_4_-_macos13:
-  name: InputSystem-EditorPerformanceTests - 6000.4 - MacOs13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-EditorPerformanceTests - 6000.4 - Ubuntu2204
-inputsystem-editorperformancetests_-_6000_4_-_ubuntu2204:
-  name: InputSystem-EditorPerformanceTests - 6000.4 - Ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-EditorPerformanceTests - 6000.4 - Win10
-inputsystem-editorperformancetests_-_6000_4_-_win10:
-  name: InputSystem-EditorPerformanceTests - 6000.4 - Win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
 # InputSystem-EditorPerformanceTests - 6000.5 - MacOs13
 inputsystem-editorperformancetests_-_6000_5_-_macos13:
   name: InputSystem-EditorPerformanceTests - 6000.5 - MacOs13
@@ -235,7 +180,7 @@ inputsystem-editorperformancetests_-_6000_6_-_macos13arm:
     model: M1
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -253,7 +198,7 @@ inputsystem-editorperformancetests_-_6000_6_-_ubuntu2204:
     flavor: b1.large
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -265,6 +210,80 @@ inputsystem-editorperformancetests_-_6000_6_-_ubuntu2204:
 # InputSystem-EditorPerformanceTests - 6000.6 - Win10
 inputsystem-editorperformancetests_-_6000_6_-_win10:
   name: InputSystem-EditorPerformanceTests - 6000.6 - Win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorPerformanceTests - 6000.7 - MacOs13
+inputsystem-editorperformancetests_-_6000_7_-_macos13:
+  name: InputSystem-EditorPerformanceTests - 6000.7 - MacOs13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorPerformanceTests - 6000.7 - MacOs13Arm
+inputsystem-editorperformancetests_-_6000_7_-_macos13arm:
+  name: InputSystem-EditorPerformanceTests - 6000.7 - MacOs13Arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorPerformanceTests - 6000.7 - Ubuntu2204
+inputsystem-editorperformancetests_-_6000_7_-_ubuntu2204:
+  name: InputSystem-EditorPerformanceTests - 6000.7 - Ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-EditorPerformanceTests - 6000.7 - Win10
+inputsystem-editorperformancetests_-_6000_7_-_win10:
+  name: InputSystem-EditorPerformanceTests - 6000.7 - Win10
   agent:
     image: package-ci/win10:v4
     type: Unity::VM

--- a/.yamato/input-system-mobile-functional-build-jobs.yml
+++ b/.yamato/input-system-mobile-functional-build-jobs.yml
@@ -184,96 +184,6 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_tvos:
       paths:
       - build/players/**/*
 
-# InputSystem-MobileFunctionalBuildJobs - 6000.4 - Android - il2cpp
-inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_il2cpp:
-  name: InputSystem-MobileFunctionalBuildJobs - 6000.4 - Android - il2cpp
-  agent:
-    image: package-ci/win10:default
-    type: Unity::VM
-    flavor: b1.xlarge
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-
-# InputSystem-MobileFunctionalBuildJobs - 6000.4 - Android - mono
-inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_mono:
-  name: InputSystem-MobileFunctionalBuildJobs - 6000.4 - Android - mono
-  agent:
-    image: package-ci/win10:default
-    type: Unity::VM
-    flavor: b1.xlarge
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-
-# InputSystem-MobileFunctionalBuildJobs - 6000.4 - IOS
-inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios:
-  name: InputSystem-MobileFunctionalBuildJobs - 6000.4 - IOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::VM::osx
-    flavor: m1.mac
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c iOS --fast --wait
-  - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
-      chmod u+x utr
-  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-  variables:
-    UNITY_HANDLEUIINTERRUPTIONS: 1
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobileFunctionalBuildJobs - 6000.4 - TvOS
-inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_tvos:
-  name: InputSystem-MobileFunctionalBuildJobs - 6000.4 - TvOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::VM::osx
-    flavor: m1.mac
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-
 # InputSystem-MobileFunctionalBuildJobs - 6000.5 - Android - il2cpp
 inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalBuildJobs - 6000.5 - Android - il2cpp
@@ -372,7 +282,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_android_-_il2cpp:
     type: Unity::VM
     flavor: b1.xlarge
   commands:
-  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
@@ -394,7 +304,7 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_android_-_mono:
     type: Unity::VM
     flavor: b1.xlarge
   commands:
-  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
@@ -411,6 +321,96 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_android_-_mono:
 # InputSystem-MobileFunctionalBuildJobs - 6000.6 - IOS
 inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_ios:
   name: InputSystem-MobileFunctionalBuildJobs - 6000.6 - IOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::VM::osx
+    flavor: m1.mac
+  commands:
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c iOS --fast --wait
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+  variables:
+    UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobileFunctionalBuildJobs - 6000.6 - TvOS
+inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_tvos:
+  name: InputSystem-MobileFunctionalBuildJobs - 6000.6 - TvOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::VM::osx
+    flavor: m1.mac
+  commands:
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c AppleTV --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+
+# InputSystem-MobileFunctionalBuildJobs - 6000.7 - Android - il2cpp
+inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_android_-_il2cpp:
+  name: InputSystem-MobileFunctionalBuildJobs - 6000.7 - Android - il2cpp
+  agent:
+    image: package-ci/win10:default
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+
+# InputSystem-MobileFunctionalBuildJobs - 6000.7 - Android - mono
+inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_android_-_mono:
+  name: InputSystem-MobileFunctionalBuildJobs - 6000.7 - Android - mono
+  agent:
+    image: package-ci/win10:default
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=!Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+
+# InputSystem-MobileFunctionalBuildJobs - 6000.7 - IOS
+inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_ios:
+  name: InputSystem-MobileFunctionalBuildJobs - 6000.7 - IOS
   agent:
     image: package-ci/macos-13:default
     type: Unity::VM::osx
@@ -434,9 +434,9 @@ inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_ios:
     UNITY_HANDLEUIINTERRUPTIONS: 1
     UTR_VERSION: 1.42.0
 
-# InputSystem-MobileFunctionalBuildJobs - 6000.6 - TvOS
-inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_tvos:
-  name: InputSystem-MobileFunctionalBuildJobs - 6000.6 - TvOS
+# InputSystem-MobileFunctionalBuildJobs - 6000.7 - TvOS
+inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_tvos:
+  name: InputSystem-MobileFunctionalBuildJobs - 6000.7 - TvOS
   agent:
     image: package-ci/macos-13:default
     type: Unity::VM::osx

--- a/.yamato/input-system-mobile-functional-tests.yml
+++ b/.yamato/input-system-mobile-functional-tests.yml
@@ -201,104 +201,6 @@ inputsystem-mobilefunctionaltests_-_6000_3_-_tvos:
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_tvos
 
-# InputSystem-MobileFunctionalTests - 6000.4 - Android - il2cpp
-inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp:
-  name: InputSystem-MobileFunctionalTests - 6000.4 - Android - il2cpp
-  agent:
-    image: mobile/android-execution-base:v2.3785910
-    type: Unity::mobile::shield
-    flavor: b1.xlarge
-  commands:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
-  after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_il2cpp
-  variables:
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobileFunctionalTests - 6000.4 - Android - mono
-inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono:
-  name: InputSystem-MobileFunctionalTests - 6000.4 - Android - mono
-  agent:
-    image: mobile/android-execution-base:v2.3785910
-    type: Unity::mobile::shield
-    flavor: b1.xlarge
-  commands:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
-  after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_android_-_mono
-  variables:
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobileFunctionalTests - 6000.4 - IOS
-inputsystem-mobilefunctionaltests_-_6000_4_-_ios:
-  name: InputSystem-MobileFunctionalTests - 6000.4 - IOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::mobile::iPhone
-    flavor: m1.mac
-    model: SE-Gen3
-  commands:
-  - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
-      chmod u+x utr
-  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_ios
-  variables:
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobileFunctionalTests - 6000.4 - TvOS
-inputsystem-mobilefunctionaltests_-_6000_4_-_tvos:
-  name: InputSystem-MobileFunctionalTests - 6000.4 - TvOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::mobile::appletv
-    flavor: m1.mac
-  commands:
-  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_tvos
-
 # InputSystem-MobileFunctionalTests - 6000.5 - Android - il2cpp
 inputsystem-mobilefunctionaltests_-_6000_5_-_android_-_il2cpp:
   name: InputSystem-MobileFunctionalTests - 6000.5 - Android - il2cpp
@@ -494,4 +396,102 @@ inputsystem-mobilefunctionaltests_-_6000_6_-_tvos:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_tvos
+
+# InputSystem-MobileFunctionalTests - 6000.7 - Android - il2cpp
+inputsystem-mobilefunctionaltests_-_6000_7_-_android_-_il2cpp:
+  name: InputSystem-MobileFunctionalTests - 6000.7 - Android - il2cpp
+  agent:
+    image: mobile/android-execution-base:v2.3785910
+    type: Unity::mobile::shield
+    flavor: b1.xlarge
+  commands:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+  after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobileFunctionalTests - 6000.7 - Android - mono
+inputsystem-mobilefunctionaltests_-_6000_7_-_android_-_mono:
+  name: InputSystem-MobileFunctionalTests - 6000.7 - Android - mono
+  agent:
+    image: mobile/android-execution-base:v2.3785910
+    type: Unity::mobile::shield
+    flavor: b1.xlarge
+  commands:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      utr.bat --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+  after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobileFunctionalTests - 6000.7 - IOS
+inputsystem-mobilefunctionaltests_-_6000_7_-_ios:
+  name: InputSystem-MobileFunctionalTests - 6000.7 - IOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::mobile::iPhone
+    flavor: m1.mac
+    model: SE-Gen3
+  commands:
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobileFunctionalTests - 6000.7 - TvOS
+inputsystem-mobilefunctionaltests_-_6000_7_-_tvos:
+  name: InputSystem-MobileFunctionalTests - 6000.7 - TvOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::mobile::appletv
+    flavor: m1.mac
+  commands:
+  - command: UnifiedTestRunner --suite=playmode --category=!Performance --reruncount=1 --clean-library --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_tvos
 

--- a/.yamato/input-system-mobile-performance-build-jobs.yml
+++ b/.yamato/input-system-mobile-performance-build-jobs.yml
@@ -184,96 +184,6 @@ inputsystem-mobileperformancebuildjobs_-_6000_3_-_tvos:
       paths:
       - build/players/**/*
 
-# InputSystem-MobilePerformanceBuildJobs - 6000.4 - Android - il2cpp
-inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_il2cpp:
-  name: InputSystem-MobilePerformanceBuildJobs - 6000.4 - Android - il2cpp
-  agent:
-    image: package-ci/win10:default
-    type: Unity::VM
-    flavor: b1.xlarge
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-
-# InputSystem-MobilePerformanceBuildJobs - 6000.4 - Android - mono
-inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_mono:
-  name: InputSystem-MobilePerformanceBuildJobs - 6000.4 - Android - mono
-  agent:
-    image: package-ci/win10:default
-    type: Unity::VM
-    flavor: b1.xlarge
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c Android --fast --wait
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-
-# InputSystem-MobilePerformanceBuildJobs - 6000.4 - IOS
-inputsystem-mobileperformancebuildjobs_-_6000_4_-_ios:
-  name: InputSystem-MobilePerformanceBuildJobs - 6000.4 - IOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::VM::osx
-    flavor: m1.mac
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c iOS --fast --wait
-  - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
-      chmod u+x utr
-  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-  variables:
-    UNITY_HANDLEUIINTERRUPTIONS: 1
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobilePerformanceBuildJobs - 6000.4 - TvOS
-inputsystem-mobileperformancebuildjobs_-_6000_4_-_tvos:
-  name: InputSystem-MobilePerformanceBuildJobs - 6000.4 - TvOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::VM::osx
-    flavor: m1.mac
-  commands:
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c AppleTV --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/logs/**/*
-    players:
-      paths:
-      - build/players/**/*
-
 # InputSystem-MobilePerformanceBuildJobs - 6000.5 - Android - il2cpp
 inputsystem-mobileperformancebuildjobs_-_6000_5_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceBuildJobs - 6000.5 - Android - il2cpp
@@ -372,7 +282,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_6_-_android_-_il2cpp:
     type: Unity::VM
     flavor: b1.xlarge
   commands:
-  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
@@ -394,7 +304,7 @@ inputsystem-mobileperformancebuildjobs_-_6000_6_-_android_-_mono:
     type: Unity::VM
     flavor: b1.xlarge
   commands:
-  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c Android --fast --wait
   - command: |-
       set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
       UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
@@ -411,6 +321,96 @@ inputsystem-mobileperformancebuildjobs_-_6000_6_-_android_-_mono:
 # InputSystem-MobilePerformanceBuildJobs - 6000.6 - IOS
 inputsystem-mobileperformancebuildjobs_-_6000_6_-_ios:
   name: InputSystem-MobilePerformanceBuildJobs - 6000.6 - IOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::VM::osx
+    flavor: m1.mac
+  commands:
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c iOS --fast --wait
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=ios
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+  variables:
+    UNITY_HANDLEUIINTERRUPTIONS: 1
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobilePerformanceBuildJobs - 6000.6 - TvOS
+inputsystem-mobileperformancebuildjobs_-_6000_6_-_tvos:
+  name: InputSystem-MobilePerformanceBuildJobs - 6000.6 - TvOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::VM::osx
+    flavor: m1.mac
+  commands:
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c AppleTV --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=tvOS
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+
+# InputSystem-MobilePerformanceBuildJobs - 6000.7 - Android - il2cpp
+inputsystem-mobileperformancebuildjobs_-_6000_7_-_android_-_il2cpp:
+  name: InputSystem-MobilePerformanceBuildJobs - 6000.7 - Android - il2cpp
+  agent:
+    image: package-ci/win10:default
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android --scripting-backend=il2cpp
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+
+# InputSystem-MobilePerformanceBuildJobs - 6000.7 - Android - mono
+inputsystem-mobileperformancebuildjobs_-_6000_7_-_android_-_mono:
+  name: InputSystem-MobilePerformanceBuildJobs - 6000.7 - Android - mono
+  agent:
+    image: package-ci/win10:default
+    type: Unity::VM
+    flavor: b1.xlarge
+  commands:
+  - command: unity-downloader-cli -u trunk -c Editor -c Android --fast --wait
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --category=Performance --clean-library --reruncount=1 --clean-library-on-rerun --build-only --report-performance-data --performance-project-id=InputSystem --player-save-path=build/players --timeout=3600 --artifacts-path=build/logs --platform=android
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/logs/**/*
+    players:
+      paths:
+      - build/players/**/*
+
+# InputSystem-MobilePerformanceBuildJobs - 6000.7 - IOS
+inputsystem-mobileperformancebuildjobs_-_6000_7_-_ios:
+  name: InputSystem-MobilePerformanceBuildJobs - 6000.7 - IOS
   agent:
     image: package-ci/macos-13:default
     type: Unity::VM::osx
@@ -434,9 +434,9 @@ inputsystem-mobileperformancebuildjobs_-_6000_6_-_ios:
     UNITY_HANDLEUIINTERRUPTIONS: 1
     UTR_VERSION: 1.42.0
 
-# InputSystem-MobilePerformanceBuildJobs - 6000.6 - TvOS
-inputsystem-mobileperformancebuildjobs_-_6000_6_-_tvos:
-  name: InputSystem-MobilePerformanceBuildJobs - 6000.6 - TvOS
+# InputSystem-MobilePerformanceBuildJobs - 6000.7 - TvOS
+inputsystem-mobileperformancebuildjobs_-_6000_7_-_tvos:
+  name: InputSystem-MobilePerformanceBuildJobs - 6000.7 - TvOS
   agent:
     image: package-ci/macos-13:default
     type: Unity::VM::osx

--- a/.yamato/input-system-mobile-performance-tests.yml
+++ b/.yamato/input-system-mobile-performance-tests.yml
@@ -201,104 +201,6 @@ inputsystem-mobileperformancetests_-_6000_3_-_tvos:
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_3_-_tvos
 
-# InputSystem-MobilePerformanceTests - 6000.4 - Android - il2cpp
-inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp:
-  name: InputSystem-MobilePerformanceTests - 6000.4 - Android - il2cpp
-  agent:
-    image: mobile/android-execution-base:v2.3785910
-    type: Unity::mobile::shield
-    flavor: b1.xlarge
-  commands:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
-  after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_il2cpp
-  variables:
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobilePerformanceTests - 6000.4 - Android - mono
-inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono:
-  name: InputSystem-MobilePerformanceTests - 6000.4 - Android - mono
-  agent:
-    image: mobile/android-execution-base:v2.3785910
-    type: Unity::mobile::shield
-    flavor: b1.xlarge
-  commands:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
-  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
-  - command: |-
-      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
-      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
-  after:
-  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
-  - command: if not exist build\test-results mkdir build\test-results
-  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_android_-_mono
-  variables:
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobilePerformanceTests - 6000.4 - IOS
-inputsystem-mobileperformancetests_-_6000_4_-_ios:
-  name: InputSystem-MobilePerformanceTests - 6000.4 - IOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::mobile::iPhone
-    flavor: m1.mac
-    model: SE-Gen3
-  commands:
-  - command: |-
-      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
-      chmod u+x utr
-  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_ios
-  variables:
-    UTR_VERSION: 1.42.0
-
-# InputSystem-MobilePerformanceTests - 6000.4 - TvOS
-inputsystem-mobileperformancetests_-_6000_4_-_tvos:
-  name: InputSystem-MobilePerformanceTests - 6000.4 - TvOS
-  agent:
-    image: package-ci/macos-13:default
-    type: Unity::mobile::appletv
-    flavor: m1.mac
-  commands:
-  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    logs:
-      paths:
-      - build/test-results/**/*
-  dependencies:
-  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_tvos
-
 # InputSystem-MobilePerformanceTests - 6000.5 - Android - il2cpp
 inputsystem-mobileperformancetests_-_6000_5_-_android_-_il2cpp:
   name: InputSystem-MobilePerformanceTests - 6000.5 - Android - il2cpp
@@ -494,4 +396,102 @@ inputsystem-mobileperformancetests_-_6000_6_-_tvos:
       - build/test-results/**/*
   dependencies:
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_6_-_tvos
+
+# InputSystem-MobilePerformanceTests - 6000.7 - Android - il2cpp
+inputsystem-mobileperformancetests_-_6000_7_-_android_-_il2cpp:
+  name: InputSystem-MobilePerformanceTests - 6000.7 - Android - il2cpp
+  agent:
+    image: mobile/android-execution-base:v2.3785910
+    type: Unity::mobile::shield
+    flavor: b1.xlarge
+  commands:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+  after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_7_-_android_-_il2cpp
+  variables:
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobilePerformanceTests - 6000.7 - Android - mono
+inputsystem-mobileperformancetests_-_6000_7_-_android_-_mono:
+  name: InputSystem-MobilePerformanceTests - 6000.7 - Android - mono
+  agent:
+    image: mobile/android-execution-base:v2.3785910
+    type: Unity::mobile::shield
+    flavor: b1.xlarge
+  commands:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe devices
+  - command: curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr.bat --output utr.bat
+  - command: |-
+      set ANDROID_DEVICE_CONNECTION=%BOKKEN_DEVICE_IP%
+      utr.bat --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=android
+  after:
+  - command: start %ANDROID_SDK_ROOT%\platform-tools\adb.exe connect %BOKKEN_DEVICE_IP%
+  - command: if not exist build\test-results mkdir build\test-results
+  - command: powershell %ANDROID_SDK_ROOT%\platform-tools\adb.exe logcat -d > build/test-results/device_log.txt
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_7_-_android_-_mono
+  variables:
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobilePerformanceTests - 6000.7 - IOS
+inputsystem-mobileperformancetests_-_6000_7_-_ios:
+  name: InputSystem-MobilePerformanceTests - 6000.7 - IOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::mobile::iPhone
+    flavor: m1.mac
+    model: SE-Gen3
+  commands:
+  - command: |-
+      curl -s https://artifactory-slo.bf.unity3d.com/artifactory/unity-tools-local/utr-standalone/utr --output utr
+      chmod u+x utr
+  - command: ./utr --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=ios
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_7_-_ios
+  variables:
+    UTR_VERSION: 1.42.0
+
+# InputSystem-MobilePerformanceTests - 6000.7 - TvOS
+inputsystem-mobileperformancetests_-_6000_7_-_tvos:
+  name: InputSystem-MobilePerformanceTests - 6000.7 - TvOS
+  agent:
+    image: package-ci/macos-13:default
+    type: Unity::mobile::appletv
+    flavor: m1.mac
+  commands:
+  - command: UnifiedTestRunner --suite=playmode --category=Performance --reruncount=1 --clean-library --report-performance-data --performance-project-id=InputSystem --player-load-path=build/players --timeout=3600 --artifacts-path=build/test-results --platform=tvOS
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    logs:
+      paths:
+      - build/test-results/**/*
+  dependencies:
+  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_7_-_tvos
 

--- a/.yamato/input-system-standalone-functional-tests.yml
+++ b/.yamato/input-system-standalone-functional-tests.yml
@@ -115,61 +115,6 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_win10:
       paths:
       - artifacts/**/*
 
-# InputSystem-StandaloneFunctionalTests - 6000.4 - MacOs13
-inputsystem-standalonefunctionaltests_-_6000_4_-_macos13:
-  name: InputSystem-StandaloneFunctionalTests - 6000.4 - MacOs13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandaloneFunctionalTests - 6000.4 - Ubuntu2204
-inputsystem-standalonefunctionaltests_-_6000_4_-_ubuntu2204:
-  name: InputSystem-StandaloneFunctionalTests - 6000.4 - Ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandaloneFunctionalTests - 6000.4 - Win10
-inputsystem-standalonefunctionaltests_-_6000_4_-_win10:
-  name: InputSystem-StandaloneFunctionalTests - 6000.4 - Win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
 # InputSystem-StandaloneFunctionalTests - 6000.5 - MacOs13
 inputsystem-standalonefunctionaltests_-_6000_5_-_macos13:
   name: InputSystem-StandaloneFunctionalTests - 6000.5 - MacOs13
@@ -235,7 +180,7 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_macos13arm:
     model: M1
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -253,7 +198,7 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_ubuntu2204:
     flavor: b1.large
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -265,6 +210,80 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_ubuntu2204:
 # InputSystem-StandaloneFunctionalTests - 6000.6 - Win10
 inputsystem-standalonefunctionaltests_-_6000_6_-_win10:
   name: InputSystem-StandaloneFunctionalTests - 6000.6 - Win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneFunctionalTests - 6000.7 - MacOs13
+inputsystem-standalonefunctionaltests_-_6000_7_-_macos13:
+  name: InputSystem-StandaloneFunctionalTests - 6000.7 - MacOs13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneFunctionalTests - 6000.7 - MacOs13Arm
+inputsystem-standalonefunctionaltests_-_6000_7_-_macos13arm:
+  name: InputSystem-StandaloneFunctionalTests - 6000.7 - MacOs13Arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneFunctionalTests - 6000.7 - Ubuntu2204
+inputsystem-standalonefunctionaltests_-_6000_7_-_ubuntu2204:
+  name: InputSystem-StandaloneFunctionalTests - 6000.7 - Ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneFunctionalTests - 6000.7 - Win10
+inputsystem-standalonefunctionaltests_-_6000_7_-_win10:
+  name: InputSystem-StandaloneFunctionalTests - 6000.7 - Win10
   agent:
     image: package-ci/win10:v4
     type: Unity::VM

--- a/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
@@ -115,61 +115,6 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_win10:
       paths:
       - artifacts/**/*
 
-# InputSystem-StandaloneIl2CppFunctionalTests - 6000.4 - MacOs13
-inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_macos13:
-  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.4 - MacOs13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandaloneIl2CppFunctionalTests - 6000.4 - Ubuntu2204
-inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_ubuntu2204:
-  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.4 - Ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandaloneIl2CppFunctionalTests - 6000.4 - Win10
-inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_win10:
-  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.4 - Win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
 # InputSystem-StandaloneIl2CppFunctionalTests - 6000.5 - MacOs13
 inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_macos13:
   name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.5 - MacOs13
@@ -235,7 +180,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_macos13arm:
     model: M1
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -253,7 +198,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_ubuntu2204:
     flavor: b1.large
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -265,6 +210,80 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_ubuntu2204:
 # InputSystem-StandaloneIl2CppFunctionalTests - 6000.6 - Win10
 inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_win10:
   name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.6 - Win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - MacOs13
+inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13:
+  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - MacOs13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - MacOs13Arm
+inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13arm:
+  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - MacOs13Arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - Ubuntu2204
+inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_ubuntu2204:
+  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - Ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - Win10
+inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_win10:
+  name: InputSystem-StandaloneIl2CppFunctionalTests - 6000.7 - Win10
   agent:
     image: package-ci/win10:v4
     type: Unity::VM

--- a/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
@@ -115,61 +115,6 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_win10:
       paths:
       - artifacts/**/*
 
-# InputSystem-StandaloneIl2CppPerformanceTests - 6000.4 - MacOs13
-inputsystem-standaloneil2cppperformancetests_-_6000_4_-_macos13:
-  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.4 - MacOs13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandaloneIl2CppPerformanceTests - 6000.4 - Ubuntu2204
-inputsystem-standaloneil2cppperformancetests_-_6000_4_-_ubuntu2204:
-  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.4 - Ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandaloneIl2CppPerformanceTests - 6000.4 - Win10
-inputsystem-standaloneil2cppperformancetests_-_6000_4_-_win10:
-  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.4 - Win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
 # InputSystem-StandaloneIl2CppPerformanceTests - 6000.5 - MacOs13
 inputsystem-standaloneil2cppperformancetests_-_6000_5_-_macos13:
   name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.5 - MacOs13
@@ -235,7 +180,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_macos13arm:
     model: M1
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -253,7 +198,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_ubuntu2204:
     flavor: b1.large
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -265,6 +210,80 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_ubuntu2204:
 # InputSystem-StandaloneIl2CppPerformanceTests - 6000.6 - Win10
 inputsystem-standaloneil2cppperformancetests_-_6000_6_-_win10:
   name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.6 - Win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - MacOs13
+inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13:
+  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - MacOs13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - MacOs13Arm
+inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13arm:
+  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - MacOs13Arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - Ubuntu2204
+inputsystem-standaloneil2cppperformancetests_-_6000_7_-_ubuntu2204:
+  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - Ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - Win10
+inputsystem-standaloneil2cppperformancetests_-_6000_7_-_win10:
+  name: InputSystem-StandaloneIl2CppPerformanceTests - 6000.7 - Win10
   agent:
     image: package-ci/win10:v4
     type: Unity::VM

--- a/.yamato/input-system-standalone-performance-tests.yml
+++ b/.yamato/input-system-standalone-performance-tests.yml
@@ -115,61 +115,6 @@ inputsystem-standaloneperformancetests_-_6000_3_-_win10:
       paths:
       - artifacts/**/*
 
-# InputSystem-StandalonePerformanceTests - 6000.4 - MacOs13
-inputsystem-standaloneperformancetests_-_6000_4_-_macos13:
-  name: InputSystem-StandalonePerformanceTests - 6000.4 - MacOs13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandalonePerformanceTests - 6000.4 - Ubuntu2204
-inputsystem-standaloneperformancetests_-_6000_4_-_ubuntu2204:
-  name: InputSystem-StandalonePerformanceTests - 6000.4 - Ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
-# InputSystem-StandalonePerformanceTests - 6000.4 - Win10
-inputsystem-standaloneperformancetests_-_6000_4_-_win10:
-  name: InputSystem-StandalonePerformanceTests - 6000.4 - Win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u 6000.4/staging -c Editor --fast --wait
-  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    artifacts:
-      paths:
-      - artifacts/**/*
-
 # InputSystem-StandalonePerformanceTests - 6000.5 - MacOs13
 inputsystem-standaloneperformancetests_-_6000_5_-_macos13:
   name: InputSystem-StandalonePerformanceTests - 6000.5 - MacOs13
@@ -235,7 +180,7 @@ inputsystem-standaloneperformancetests_-_6000_6_-_macos13arm:
     model: M1
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -253,7 +198,7 @@ inputsystem-standaloneperformancetests_-_6000_6_-_ubuntu2204:
     flavor: b1.large
   commands:
   - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
-  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -265,6 +210,80 @@ inputsystem-standaloneperformancetests_-_6000_6_-_ubuntu2204:
 # InputSystem-StandalonePerformanceTests - 6000.6 - Win10
 inputsystem-standaloneperformancetests_-_6000_6_-_win10:
   name: InputSystem-StandalonePerformanceTests - 6000.6 - Win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
+  - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandalonePerformanceTests - 6000.7 - MacOs13
+inputsystem-standaloneperformancetests_-_6000_7_-_macos13:
+  name: InputSystem-StandalonePerformanceTests - 6000.7 - MacOs13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandalonePerformanceTests - 6000.7 - MacOs13Arm
+inputsystem-standaloneperformancetests_-_6000_7_-_macos13arm:
+  name: InputSystem-StandalonePerformanceTests - 6000.7 - MacOs13Arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandalonePerformanceTests - 6000.7 - Ubuntu2204
+inputsystem-standaloneperformancetests_-_6000_7_-_ubuntu2204:
+  name: InputSystem-StandalonePerformanceTests - 6000.7 - Ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    artifacts:
+      paths:
+      - artifacts/**/*
+
+# InputSystem-StandalonePerformanceTests - 6000.7 - Win10
+inputsystem-standaloneperformancetests_-_6000_7_-_win10:
+  name: InputSystem-StandalonePerformanceTests - 6000.7 - Win10
   agent:
     image: package-ci/win10:v4
     type: Unity::VM

--- a/.yamato/triggers.yml
+++ b/.yamato/triggers.yml
@@ -13,60 +13,63 @@ all_functional_tests:
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_3_-_macos13
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_3_-_ubuntu2204
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_3_-_win10
-  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_4_-_macos13
-  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_4_-_ubuntu2204
-  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_4_-_win10
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_5_-_macos13
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_5_-_ubuntu2204
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_5_-_win10
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_6_-_macos13arm
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_6_-_ubuntu2204
   - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_6_-_win10
+  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_7_-_macos13
+  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_7_-_macos13arm
+  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_7_-_ubuntu2204
+  - path: .yamato/input-system-editor-functional-tests.yml#inputsystem-editorfunctionaltests_-_6000_7_-_win10
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_0_-_tvos
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_3_-_tvos
-  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_4_-_tvos
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_5_-_tvos
   - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_6_-_tvos
+  - path: .yamato/input-system-mobile-functional-build-jobs.yml#inputsystem-mobilefunctionalbuildjobs_-_6000_7_-_tvos
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_0_-_android_-_mono
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_0_-_ios
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_3_-_android_-_mono
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_3_-_ios
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_4_-_android_-_mono
-  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_4_-_ios
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_5_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_5_-_android_-_mono
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_5_-_ios
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_6_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_6_-_android_-_mono
   - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_6_-_ios
+  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_7_-_android_-_il2cpp
+  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_7_-_android_-_mono
+  - path: .yamato/input-system-mobile-functional-tests.yml#inputsystem-mobilefunctionaltests_-_6000_7_-_ios
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_0_-_macos13
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_0_-_ubuntu2204
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_0_-_win10
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_3_-_macos13
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_3_-_ubuntu2204
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_3_-_win10
-  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_4_-_macos13
-  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_4_-_ubuntu2204
-  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_4_-_win10
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_5_-_macos13
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_5_-_ubuntu2204
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_5_-_win10
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_6_-_macos13arm
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_6_-_ubuntu2204
   - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_6_-_win10
+  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_7_-_macos13
+  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_7_-_macos13arm
+  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_7_-_ubuntu2204
+  - path: .yamato/input-system-standalone-functional-tests.yml#inputsystem-standalonefunctionaltests_-_6000_7_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_macos13
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_macos13
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_win10
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_macos13
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_macos13
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_macos13arm
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_win10
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13arm
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_win10
   - path: .yamato/wrench/promotion-jobs.yml#publish_dry_run_inputsystem
   triggers:
     expression: |-
@@ -84,73 +87,76 @@ all_performance_tests:
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_3_-_macos13
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_3_-_ubuntu2204
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_3_-_win10
-  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_4_-_macos13
-  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_4_-_ubuntu2204
-  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_4_-_win10
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_5_-_macos13
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_5_-_ubuntu2204
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_5_-_win10
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_6_-_macos13arm
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_6_-_ubuntu2204
   - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_6_-_win10
+  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_7_-_macos13
+  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_7_-_macos13arm
+  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_7_-_ubuntu2204
+  - path: .yamato/input-system-editor-performance-tests.yml#inputsystem-editorperformancetests_-_6000_7_-_win10
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_0_-_tvos
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_3_-_tvos
-  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_4_-_tvos
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_5_-_tvos
   - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_6_-_tvos
+  - path: .yamato/input-system-mobile-performance-build-jobs.yml#inputsystem-mobileperformancebuildjobs_-_6000_7_-_tvos
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_0_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_0_-_android_-_mono
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_0_-_ios
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_3_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_3_-_android_-_mono
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_3_-_ios
-  - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_4_-_android_-_il2cpp
-  - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_4_-_android_-_mono
-  - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_4_-_ios
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_5_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_5_-_android_-_mono
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_5_-_ios
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_6_-_android_-_il2cpp
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_6_-_android_-_mono
   - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_6_-_ios
+  - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_7_-_android_-_il2cpp
+  - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_7_-_android_-_mono
+  - path: .yamato/input-system-mobile-performance-tests.yml#inputsystem-mobileperformancetests_-_6000_7_-_ios
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_0_-_macos13
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_0_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_0_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_3_-_macos13
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_3_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_3_-_win10
-  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_4_-_macos13
-  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_4_-_ubuntu2204
-  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_4_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_5_-_macos13
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_5_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_5_-_win10
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_6_-_macos13arm
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_6_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_6_-_win10
+  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13
+  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13arm
+  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_7_-_ubuntu2204
+  - path: .yamato/input-system-standalone-il2-cpp-performance-tests.yml#inputsystem-standaloneil2cppperformancetests_-_6000_7_-_win10
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_0_-_macos13
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_0_-_ubuntu2204
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_0_-_win10
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_3_-_macos13
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_3_-_ubuntu2204
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_3_-_win10
-  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_4_-_macos13
-  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_4_-_ubuntu2204
-  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_4_-_win10
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_5_-_macos13
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_5_-_ubuntu2204
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_5_-_win10
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_6_-_macos13arm
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_6_-_ubuntu2204
   - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_6_-_win10
+  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_7_-_macos13
+  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_7_-_macos13arm
+  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_7_-_ubuntu2204
+  - path: .yamato/input-system-standalone-performance-tests.yml#inputsystem-standaloneperformancetests_-_6000_7_-_win10
 nightly_trigger:
   name: Nightly trigger
   dependencies:
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_ubuntu2204
-  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_4_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_ubuntu2204
   - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_ubuntu2204
+  - path: .yamato/input-system-standalone-il2-cpp-functional-tests.yml#inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_ubuntu2204
   - path: .yamato/triggers.yml#all_performance_tests
   triggers:
     recurring:

--- a/.yamato/wrench/preview-a-p-v.yml
+++ b/.yamato/wrench/preview-a-p-v.yml
@@ -16,15 +16,15 @@ all_preview_apv_jobs:
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_macos13
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_ubuntu2204
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_3_-_win10
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_4_-_macos13
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_4_-_ubuntu2204
-  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_4_-_win10
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_5_-_macos13
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_5_-_ubuntu2204
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_5_-_win10
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_macos13arm
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_ubuntu2204
   - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_6_-_win10
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_7_-_macos13arm
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_7_-_ubuntu2204
+  - path: .yamato/wrench/preview-a-p-v.yml#preview_apv_-_6000_7_-_win10
   metadata:
     Job Maintainers: '#rm-packageworks'
     Wrench: 2.12.0.0
@@ -379,181 +379,6 @@ preview_apv_-_6000_3_-_win10:
     Job Maintainers: '#rm-packageworks'
     Wrench: 2.12.0.0
 
-# Functional tests for dependents found in the latest 6000.4 manifest (MacOS).
-preview_apv_-_6000_4_-_macos13:
-  name: Preview APV - 6000.4 - macos13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.4 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-
-# Functional tests for dependents found in the latest 6000.4 manifest (Ubuntu).
-preview_apv_-_6000_4_-_ubuntu2204:
-  name: Preview APV - 6000.4 - ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.4 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-
-# Functional tests for dependents found in the latest 6000.4 manifest (Windows).
-preview_apv_-_6000_4_-_win10:
-  name: Preview APV - 6000.4 - win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
-    timeout: 20
-    retries: 10
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 10
-    retries: 3
-  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.4 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
-  - command: python PythonScripts/editor_manifest_validator.py --version=6000.4 --wrench-config=.yamato/wrench/wrench_config.json
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    logs:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - upm-ci~/test-results/**/*
-      - upm-ci~/temp/*/Logs/**
-      - upm-ci~/temp/*/Library/*.log
-      - upm-ci~/temp/*/*.log
-      - upm-ci~/temp/Builds/*.log
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    PreviewAPVResults:
-      paths:
-      - PreviewApvArtifacts~/**
-      - APVTest/**/manifest.json
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-
 # Functional tests for dependents found in the latest 6000.5 manifest (MacOS).
 preview_apv_-_6000_5_-_macos13:
   name: Preview APV - 6000.5 - macos13
@@ -745,7 +570,7 @@ preview_apv_-_6000_6_-_macos13arm:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast --arch arm64
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast --arch arm64
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.6 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -803,7 +628,7 @@ preview_apv_-_6000_6_-_ubuntu2204:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.6 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
@@ -862,11 +687,187 @@ preview_apv_-_6000_6_-_win10:
   - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
     timeout: 20
     retries: 10
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
     timeout: 10
     retries: 3
   - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.6 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
   - command: python PythonScripts/editor_manifest_validator.py --version=6000.6 --wrench-config=.yamato/wrench/wrench_config.json
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+
+# Functional tests for dependents found in the latest 6000.7 manifest (MacOS).
+preview_apv_-_6000_7_-_macos13arm:
+  name: Preview APV - 6000.7 - macos13arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast --arch arm64
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.7 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+
+# Functional tests for dependents found in the latest 6000.7 manifest (Ubuntu).
+preview_apv_-_6000_7_-_ubuntu2204:
+  name: Preview APV - 6000.7 - ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.7 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: echo 'Skipping Editor Manifest Validator as it is only supported on Windows'
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    logs:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - upm-ci~/test-results/**/*
+      - upm-ci~/temp/*/Logs/**
+      - upm-ci~/temp/*/Library/*.log
+      - upm-ci~/temp/*/*.log
+      - upm-ci~/temp/Builds/*.log
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    PreviewAPVResults:
+      paths:
+      - PreviewApvArtifacts~/**
+      - APVTest/**/manifest.json
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+
+# Functional tests for dependents found in the latest 6000.7 manifest (Windows).
+preview_apv_-_6000_7_-_win10:
+  name: Preview APV - 6000.7 - win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: gsudo reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 10
+    retries: 3
+  - command: python PythonScripts/preview_apv.py --wrench-config=.yamato/wrench/wrench_config.json --editor-version=6000.7 --testsuite=editor,playmode --artifacts-path=PreviewApvArtifacts~
+  - command: python PythonScripts/editor_manifest_validator.py --version=6000.7 --wrench-config=.yamato/wrench/wrench_config.json
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
   artifacts:

--- a/.yamato/wrench/promotion-jobs.yml
+++ b/.yamato/wrench/promotion-jobs.yml
@@ -91,36 +91,6 @@ publish_dry_run_inputsystem:
       UTR:
         location: results/UTR/validate-inputsystem-6000.3-win10
         unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_4_-_macos13
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-inputsystem-6000.4-macos13
-        unzip: true
-      UTR:
-        location: results/UTR/validate-inputsystem-6000.4-macos13
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_4_-_ubuntu2204
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-inputsystem-6000.4-ubuntu2204
-        unzip: true
-      UTR:
-        location: results/UTR/validate-inputsystem-6000.4-ubuntu2204
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_4_-_win10
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-inputsystem-6000.4-win10
-        unzip: true
-      UTR:
-        location: results/UTR/validate-inputsystem-6000.4-win10
-        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_5_-_macos13
     specific_options:
       packages:
@@ -180,6 +150,46 @@ publish_dry_run_inputsystem:
         unzip: true
       UTR:
         location: results/UTR/validate-inputsystem-6000.6-win10
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_macos13
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-macos13
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-macos13
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_macos13arm
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-macos13arm
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-macos13arm
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_ubuntu2204
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-ubuntu2204
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-ubuntu2204
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_win10
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-win10
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-win10
         unzip: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
@@ -273,36 +283,6 @@ publish_inputsystem:
       UTR:
         location: results/UTR/validate-inputsystem-6000.3-win10
         unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_4_-_macos13
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-inputsystem-6000.4-macos13
-        unzip: true
-      UTR:
-        location: results/UTR/validate-inputsystem-6000.4-macos13
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_4_-_ubuntu2204
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-inputsystem-6000.4-ubuntu2204
-        unzip: true
-      UTR:
-        location: results/UTR/validate-inputsystem-6000.4-ubuntu2204
-        unzip: true
-  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_4_-_win10
-    specific_options:
-      packages:
-        ignore_artifact: true
-      pvp-results:
-        location: results/pvp/validate-inputsystem-6000.4-win10
-        unzip: true
-      UTR:
-        location: results/UTR/validate-inputsystem-6000.4-win10
-        unzip: true
   - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_5_-_macos13
     specific_options:
       packages:
@@ -362,6 +342,46 @@ publish_inputsystem:
         unzip: true
       UTR:
         location: results/UTR/validate-inputsystem-6000.6-win10
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_macos13
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-macos13
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-macos13
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_macos13arm
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-macos13arm
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-macos13arm
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_ubuntu2204
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-ubuntu2204
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-ubuntu2204
+        unzip: true
+  - path: .yamato/wrench/validation-jobs.yml#validate_-_inputsystem_-_6000_7_-_win10
+    specific_options:
+      packages:
+        ignore_artifact: true
+      pvp-results:
+        location: results/pvp/validate-inputsystem-6000.7-win10
+        unzip: true
+      UTR:
+        location: results/UTR/validate-inputsystem-6000.7-win10
         unzip: true
   variables:
     UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1

--- a/.yamato/wrench/validation-jobs.yml
+++ b/.yamato/wrench/validation-jobs.yml
@@ -444,225 +444,6 @@ validate_-_inputsystem_-_6000_3_-_win10:
   labels:
   - Packages:inputsystem
 
-# PVP Editor and Playmode tests for Validate - inputsystem - 6000.4 - macos13 (6000.4 - MacOS).
-validate_-_inputsystem_-_6000_4_-_macos13:
-  name: Validate - inputsystem - 6000.4 - macos13
-  agent:
-    image: package-ci/macos-13:v4
-    type: Unity::VM::osx
-    flavor: b1.xlarge
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 20
-    retries: 3
-  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 20
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.4;flags:inputsystem_MacOS_6000.4" --coverage-pkg-version=1.3.0
-    timeout: 20
-    retries: 1
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
-  artifacts:
-    Coverage:
-      paths:
-      - upm-ci~/CodeCoverage/**
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - test-inputsystem/Logs/**
-      - test-inputsystem/Library/*.log
-      - test-inputsystem/*.log
-      - test-inputsystem/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-  labels:
-  - Packages:inputsystem
-
-# PVP Editor and Playmode tests for Validate - inputsystem - 6000.4 - ubuntu2204 (6000.4 - Ubuntu).
-validate_-_inputsystem_-_6000_4_-_ubuntu2204:
-  name: Validate - inputsystem - 6000.4 - ubuntu2204
-  agent:
-    image: package-ci/ubuntu-22.04:v4
-    type: Unity::VM::GPU
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 20
-    retries: 3
-  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 20
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.4;flags:inputsystem_Ubuntu_6000.4" --coverage-pkg-version=1.3.0
-    timeout: 20
-    retries: 1
-  after:
-  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
-  artifacts:
-    Coverage:
-      paths:
-      - upm-ci~/CodeCoverage/**
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - test-inputsystem/Logs/**
-      - test-inputsystem/Library/*.log
-      - test-inputsystem/*.log
-      - test-inputsystem/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-  labels:
-  - Packages:inputsystem
-
-# PVP Editor and Playmode tests for Validate - inputsystem - 6000.4 - win10 (6000.4 - Windows).
-validate_-_inputsystem_-_6000_4_-_win10:
-  name: Validate - inputsystem - 6000.4 - win10
-  agent:
-    image: package-ci/win10:v4
-    type: Unity::VM
-    flavor: b1.large
-  commands:
-  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
-  - command: 7z x -aoa wrench-localapv.zip
-  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
-  - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u 6000.4/staging -c editor --path .Editor --fast
-    timeout: 20
-    retries: 3
-  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
-    timeout: 10
-    retries: 1
-  - command: echo No internal packages to add.
-  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
-    timeout: 20
-    retries: 0
-  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 5
-    retries: 0
-  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
-    timeout: 10
-    retries: 0
-  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.4;flags:inputsystem_Windows_6000.4" --coverage-pkg-version=1.3.0
-    timeout: 20
-    retries: 1
-  after:
-  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
-  artifacts:
-    Coverage:
-      paths:
-      - upm-ci~/CodeCoverage/**
-    Crash Dumps:
-      paths:
-      - CrashDumps/**
-    packages:
-      paths:
-      - upm-ci~/packages/**/*
-    pvp-results:
-      paths:
-      - upm-ci~/pvp/**/*
-      browsable: onDemand
-    UTR:
-      paths:
-      - '*.log'
-      - '*.xml'
-      - artifacts/**/*
-      - test-inputsystem/Logs/**
-      - test-inputsystem/Library/*.log
-      - test-inputsystem/*.log
-      - test-inputsystem/Builds/*.log
-      - build/test-results/**
-      browsable: onDemand
-  dependencies:
-  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
-  variables:
-    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
-    UNITY_LICENSING_SERVER_DELETE_NUL: 0
-    UNITY_LICENSING_SERVER_DELETE_ULF: 0
-    UNITY_LICENSING_SERVER_TOOLSET: pro
-    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
-    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
-  metadata:
-    Job Maintainers: '#rm-packageworks'
-    Wrench: 2.12.0.0
-  labels:
-  - Packages:inputsystem
-
 # PVP Editor and Playmode tests for Validate - inputsystem - 6000.5 - macos13 (6000.5 - MacOS).
 validate_-_inputsystem_-_6000_5_-_macos13:
   name: Validate - inputsystem - 6000.5 - macos13
@@ -895,7 +676,7 @@ validate_-_inputsystem_-_6000_6_-_macos13arm:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast --arch arm64
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast --arch arm64
     timeout: 20
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
@@ -968,7 +749,7 @@ validate_-_inputsystem_-_6000_6_-_ubuntu2204:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
     timeout: 20
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
@@ -1041,7 +822,7 @@ validate_-_inputsystem_-_6000_6_-_win10:
   - command: 7z x -aoa wrench-localapv.zip
   - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
   - command: python PythonScripts/print_machine_info.py
-  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+  - command: unity-downloader-cli -u 6000.6/staging -c editor --path .Editor --fast
     timeout: 20
     retries: 3
   - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
@@ -1058,6 +839,299 @@ validate_-_inputsystem_-_6000_6_-_win10:
     timeout: 10
     retries: 0
   - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.6;flags:inputsystem_Windows_6000.6" --coverage-pkg-version=1.3.0
+    timeout: 20
+    retries: 1
+  after:
+  - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
+  artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.7 - macos13 (6000.7 - MacOS).
+validate_-_inputsystem_-_6000_7_-_macos13:
+  name: Validate - inputsystem - 6000.7 - macos13
+  agent:
+    image: package-ci/macos-13:v4
+    type: Unity::VM::osx
+    flavor: b1.xlarge
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7;flags:inputsystem_MacOS_6000.7" --coverage-pkg-version=1.3.0
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.7 - macos13arm (6000.7 - MacOS).
+validate_-_inputsystem_-_6000_7_-_macos13arm:
+  name: Validate - inputsystem - 6000.7 - macos13arm
+  agent:
+    image: package-ci/macos-13-arm64:v4
+    type: Unity::VM::osx
+    flavor: m1.mac
+    model: M1
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast --arch arm64
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7;flags:inputsystem_MacOS_6000.7" --coverage-pkg-version=1.3.0
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
+  artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.7 - ubuntu2204 (6000.7 - Ubuntu).
+validate_-_inputsystem_-_6000_7_-_ubuntu2204:
+  name: Validate - inputsystem - 6000.7 - ubuntu2204
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: UnifiedTestRunner --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.7;flags:inputsystem_Ubuntu_6000.7" --coverage-pkg-version=1.3.0
+    timeout: 20
+    retries: 1
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    Coverage:
+      paths:
+      - upm-ci~/CodeCoverage/**
+    Crash Dumps:
+      paths:
+      - CrashDumps/**
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+    pvp-results:
+      paths:
+      - upm-ci~/pvp/**/*
+      browsable: onDemand
+    UTR:
+      paths:
+      - '*.log'
+      - '*.xml'
+      - artifacts/**/*
+      - test-inputsystem/Logs/**
+      - test-inputsystem/Library/*.log
+      - test-inputsystem/*.log
+      - test-inputsystem/Builds/*.log
+      - build/test-results/**
+      browsable: onDemand
+  dependencies:
+  - path: .yamato/wrench/package-pack-jobs.yml#package_pack_-_inputsystem
+  variables:
+    UNITY_LICENSING_SERVER_BASE_URL: http://unity-ci-licenses.hq.unity3d.com:8080/
+    UNITY_LICENSING_SERVER_DELETE_NUL: 0
+    UNITY_LICENSING_SERVER_DELETE_ULF: 0
+    UNITY_LICENSING_SERVER_TOOLSET: pro
+    UPMPVP_ACK_UPMPVP_DOES_NO_API_VALIDATION: 1
+    UPMPVP_CONTEXT_WRENCH: 2.12.0.0
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 2.12.0.0
+  labels:
+  - Packages:inputsystem
+
+# PVP Editor and Playmode tests for Validate - inputsystem - 6000.7 - win10 (6000.7 - Windows).
+validate_-_inputsystem_-_6000_7_-_win10:
+  name: Validate - inputsystem - 6000.7 - win10
+  agent:
+    image: package-ci/win10:v4
+    type: Unity::VM
+    flavor: b1.large
+  commands:
+  - command: curl https://artifactory.prd.it.unity3d.com/artifactory/stevedore-unity-internal/wrench-localapv/1-3-3_51b4e6affb4c10b90f92db9551b9dc80c5520794983600cff4fa925111db116d.zip -o wrench-localapv.zip
+  - command: 7z x -aoa wrench-localapv.zip
+  - command: pip install semver requests --index-url https://artifactory-slo.bf.unity3d.com/artifactory/api/pypi/pypi/simple
+  - command: python PythonScripts/print_machine_info.py
+  - command: unity-downloader-cli -u trunk -c editor --path .Editor --fast
+    timeout: 20
+    retries: 3
+  - command: upm-pvp create-test-project test-inputsystem --packages "upm-ci~/packages/*.tgz" --filter "com.unity.inputsystem com.unity.inputsystem.tests" --unity .Editor
+    timeout: 10
+    retries: 1
+  - command: echo No internal packages to add.
+  - command: upm-pvp test --unity .Editor --packages "upm-ci~/packages/*.tgz" --results upm-ci~/pvp
+    timeout: 20
+    retries: 0
+  - command: upm-pvp require "pkgprom-promote -PVP-29-2 rme" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 5
+    retries: 0
+  - command: upm-pvp require "rme PVP-160-1 supported .yamato/wrench/pvp-exemptions.json" --results upm-ci~/pvp --exemptions upm-ci~/pvp/failures.json
+    timeout: 10
+    retries: 0
+  - command: UnifiedTestRunner.exe --testproject=test-inputsystem --editor-location=.Editor --clean-library --reruncount=1 --clean-library-on-rerun --artifacts-path=artifacts --suite=Editor --suite=Playmode "--ff={ops.upmpvpevidence.enable=true}" --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem,+Unity.InputSystem.DocCodeSamples,+Unity.InputSystem.ForUI,+Unity.InputSystem.ForUI.Editor,+Unity.InputSystem.IntegrationTests,+Unity.InputSystem.TestFramework;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.7;flags:inputsystem_Windows_6000.7" --coverage-pkg-version=1.3.0
     timeout: 20
     retries: 1
   after:

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -127,11 +127,6 @@ public class InputSystemSettings : AnnotatedSettingsBase
 
         OverridePackagePlatform(InputSystemPackage);
 
-        foreach ((string name, WrenchPackage package) in Wrench.Packages)
-        {
-            Wrench.Packages[name].EditorPlatforms[SystemType.MacOS] = new Platform(new Agent("package-ci/macos-13-arm64:v4", FlavorType.MacDefault, ResourceType.VmOsx, "M1"), SystemType.MacOS);
-        }
-
         ReadMobileConfig();
 
         var oldIOSAgent = MobileTestPlatforms[SystemType.IOS].Agent;


### PR DESCRIPTION
### Description

The Wrench job failed to compile InputSystem.Cookbook with:
```
  InputSystemSettings.cs(132,35): error CS1061: 'WrenchPackage' does
  not contain a definition for 'EditorPlatforms'
```

Introduced by: https://github.com/Unity-Technologies/InputSystem/pull/2402/changes#diff-6adf83bfcc4d79145f07fd4cb68146078ca080ea086346f67afa591278bf8186

Since there's no mentions of it anywhere there I assume this was a mistake addition and claude agrees (but of course don't trust it and opinions are welcome)

### Testing status & QA

CI only

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: low
- Halo Effect: low

### Comments to reviewers

I'm not 100% sure if it was better to try and rework this or removing it was the right call. Opinions on that are needed

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
