### PR TITLE
FIX: Mark InputSystemForUI.Editor assembly as Editor-only to fix Assembly Definition Validation failure

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Plugins/InputForUI/InputSystemForUI.Editor.asmdef
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Plugins/InputForUI/InputSystemForUI.Editor.asmdef
@@ -5,7 +5,9 @@
         "Unity.InputSystem",
         "Unity.InputSystem.ForUI"
     ],
-    "includePlatforms": [],
+    "includePlatforms": [
+        "Editor"
+    ],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": false,


### PR DESCRIPTION
### Description

Ran validation, this part failed so added its suggested fix


### Testing status & QA

CI only

### Overall Product Risks

_Please rate the potential complexity and halo effect from low to high for the reviewers. Note down potential risks to specific Editor branches if any._

- Complexity: low
- Halo Effect: low

### Comments to reviewers

N/A

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
