### PR TITLE
FIX: Action Maps list loses keyboard focus after deleting a map [UUM-147152]

### DIFF
--- a/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
+++ b/Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs
@@ -190,6 +190,27 @@ internal class InputActionsEditorTests : UIToolkitBaseTestWindow<InputActionsEdi
     }
 
     [UnityTest]
+    public IEnumerator ActionMapsList_WhenMapDeletedViaKeyboard_ListRetainsFocus()
+    {
+        var actionMapsContainer = m_Window.rootVisualElement.Q("action-maps-container");
+        var listView = m_Window.rootVisualElement.Q<ListView>("action-maps-list-view");
+
+        // Select an action map and make sure the list holds keyboard focus before deleting.
+        var actionMapItem = actionMapsContainer.Query<InputActionMapsTreeViewItem>().ToList();
+        SimulateClickOn(actionMapItem[1]);
+        yield return WaitForFocus(listView);
+
+        SimulateDeleteCommand();
+
+        yield return WaitUntil(() => actionMapsContainer.Query<InputActionMapsTreeViewItem>().ToList().Count == 2, "wait for element to be deleted");
+
+        // After the post-delete rebuild destroys the previously focused row, focus must be
+        // returned to the list so keyboard shortcuts keep flowing without an extra click.
+        yield return WaitForFocus(listView);
+        Assert.That(listView.focusController.focusedElement, Is.EqualTo(listView));
+    }
+
+    [UnityTest]
     public IEnumerator CanRenameAction()
     {
         var actionContainer = m_Window.rootVisualElement.Q("actions-container");

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Fixed
 
+- Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 
 ## [1.20.0] - 2026-07-21
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/ActionMapsView.cs
@@ -131,6 +131,9 @@ namespace UnityEngine.InputSystem.Editor
         internal void DeleteActionMap(int index)
         {
             Dispatch(Commands.DeleteActionMap(index));
+
+            // Deleting an item sometimes causes the UI Panel to lose focus; make sure we keep it
+            m_ListView.Focus();
         }
 
         internal void DuplicateActionMap(int index)


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

`ActionMapsView.DeleteActionMap(int index)` in the UI Toolkit Input Actions editor dispatched the delete command and returned without restoring keyboard focus. The delete triggers a list rebuild that destroys the previously focused row, so the Action Maps list was left with no focused element even though a replacement map was auto-selected and highlighted. As a result Delete, Duplicate, and arrow-key navigation were silently ignored on the highlighted map until the user clicked a row to re-focus the list.

The fix adds `m_ListView.Focus()` immediately after the dispatch, returning focus to the Action Maps list once the rebuild has run so command and navigation events keep reaching it. This reuses the same convention already applied in the sibling `ActionsTreeView.DeleteItem`, which the Action Maps list had never received.

### Testing status & QA

- Added `Assets/Tests/InputSystem.Editor/InputActionsEditorTests.cs` → `[UnityTest] ActionMapsList_WhenMapDeletedViaKeyboard_ListRetainsFocus`, which deletes a selected map via the Delete command and asserts the list view holds focus afterward.
- QA can re-run the manual repro on https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152: with focus on the Action Maps list, delete a map with the keyboard and confirm Delete/arrow keys keep working on the newly selected map without clicking.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (internal-only edit confined to a single method; no public API surface touched)
- Risk rating: 2/5 — Rating 2 because it is a one-line internal-only addition to a single method whose delete path already has direct test coverage (CanDeleteActionMap), and it replicates an already-shipped sibling fix, though no test asserts the focus behaviour it alters.

### Comments to reviewers

N/A

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
