### PR TITLE
CHANGE: docs tools update

### DIFF
--- a/.yamato/input-system-editor-functional-tests.yml
+++ b/.yamato/input-system-editor-functional-tests.yml
@@ -13,7 +13,8 @@ inputsystem-editorfunctionaltests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.0_project;flags:inputsystem_MacOS_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -31,7 +32,8 @@ inputsystem-editorfunctionaltests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.0_project;flags:inputsystem_Ubuntu_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -49,8 +51,8 @@ inputsystem-editorfunctionaltests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.0_project;flags:inputsystem_Windows_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -68,7 +70,8 @@ inputsystem-editorfunctionaltests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.3_project;flags:inputsystem_MacOS_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -86,7 +89,8 @@ inputsystem-editorfunctionaltests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.3_project;flags:inputsystem_Ubuntu_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -104,8 +108,8 @@ inputsystem-editorfunctionaltests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.3_project;flags:inputsystem_Windows_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -123,7 +127,8 @@ inputsystem-editorfunctionaltests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.5_project;flags:inputsystem_MacOS_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -141,7 +146,8 @@ inputsystem-editorfunctionaltests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.5_project;flags:inputsystem_Ubuntu_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -159,8 +165,8 @@ inputsystem-editorfunctionaltests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.5_project;flags:inputsystem_Windows_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -179,7 +185,8 @@ inputsystem-editorfunctionaltests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.6_project;flags:inputsystem_MacOS_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -197,7 +204,8 @@ inputsystem-editorfunctionaltests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.6_project;flags:inputsystem_Ubuntu_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -215,8 +223,8 @@ inputsystem-editorfunctionaltests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.6_project;flags:inputsystem_Windows_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -234,7 +242,8 @@ inputsystem-editorfunctionaltests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -253,7 +262,8 @@ inputsystem-editorfunctionaltests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -271,7 +281,8 @@ inputsystem-editorfunctionaltests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.7_project;flags:inputsystem_Ubuntu_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
@@ -289,8 +300,8 @@ inputsystem-editorfunctionaltests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.7_project;flags:inputsystem_Windows_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:

--- a/.yamato/input-system-editor-functional-tests.yml
+++ b/.yamato/input-system-editor-functional-tests.yml
@@ -13,9 +13,10 @@ inputsystem-editorfunctionaltests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.0_project;flags:inputsystem_MacOS_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -32,9 +33,10 @@ inputsystem-editorfunctionaltests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.0_project;flags:inputsystem_Ubuntu_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -51,9 +53,10 @@ inputsystem-editorfunctionaltests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
+  - command: .Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.0_project;flags:inputsystem_Windows_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -70,9 +73,10 @@ inputsystem-editorfunctionaltests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.3_project;flags:inputsystem_MacOS_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -89,9 +93,10 @@ inputsystem-editorfunctionaltests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.3_project;flags:inputsystem_Ubuntu_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -108,9 +113,10 @@ inputsystem-editorfunctionaltests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
+  - command: .Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.3_project;flags:inputsystem_Windows_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -127,9 +133,10 @@ inputsystem-editorfunctionaltests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.5_project;flags:inputsystem_MacOS_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -146,9 +153,10 @@ inputsystem-editorfunctionaltests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.5_project;flags:inputsystem_Ubuntu_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -165,9 +173,10 @@ inputsystem-editorfunctionaltests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
+  - command: .Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.5_project;flags:inputsystem_Windows_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -185,9 +194,10 @@ inputsystem-editorfunctionaltests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.6_project;flags:inputsystem_MacOS_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -204,9 +214,10 @@ inputsystem-editorfunctionaltests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.6_project;flags:inputsystem_Ubuntu_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -223,9 +234,10 @@ inputsystem-editorfunctionaltests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
+  - command: .Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.6_project;flags:inputsystem_Windows_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd
@@ -242,9 +254,10 @@ inputsystem-editorfunctionaltests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -262,9 +275,10 @@ inputsystem-editorfunctionaltests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -281,9 +295,10 @@ inputsystem-editorfunctionaltests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.7_project;flags:inputsystem_Ubuntu_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -300,9 +315,10 @@ inputsystem-editorfunctionaltests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
+  - command: .Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:%YAMATO_SOURCE_DIR%/Packages;" --coverage-results-path=%YAMATO_SOURCE_DIR%/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Windows_6000.7_project;flags:inputsystem_Windows_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: .yamato\generated-scripts\infrastructure-instability-detection-win.cmd

--- a/.yamato/input-system-editor-functional-tests.yml
+++ b/.yamato/input-system-editor-functional-tests.yml
@@ -16,7 +16,7 @@ inputsystem-editorfunctionaltests_-_6000_0_-_macos13:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.0_project;flags:inputsystem_MacOS_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -36,7 +36,7 @@ inputsystem-editorfunctionaltests_-_6000_0_-_ubuntu2204:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
-  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.0_project;flags:inputsystem_Ubuntu_6000.0_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -76,7 +76,7 @@ inputsystem-editorfunctionaltests_-_6000_3_-_macos13:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.3_project;flags:inputsystem_MacOS_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -96,7 +96,7 @@ inputsystem-editorfunctionaltests_-_6000_3_-_ubuntu2204:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
-  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.3_project;flags:inputsystem_Ubuntu_6000.3_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -136,7 +136,7 @@ inputsystem-editorfunctionaltests_-_6000_5_-_macos13:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
-  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.5_project;flags:inputsystem_MacOS_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -156,7 +156,7 @@ inputsystem-editorfunctionaltests_-_6000_5_-_ubuntu2204:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
-  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.5_project;flags:inputsystem_Ubuntu_6000.5_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -197,7 +197,7 @@ inputsystem-editorfunctionaltests_-_6000_6_-_macos13arm:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
-  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.6_project;flags:inputsystem_MacOS_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -217,7 +217,7 @@ inputsystem-editorfunctionaltests_-_6000_6_-_ubuntu2204:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
-  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.6_project;flags:inputsystem_Ubuntu_6000.6_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
@@ -257,7 +257,7 @@ inputsystem-editorfunctionaltests_-_6000_7_-_macos13:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -278,7 +278,7 @@ inputsystem-editorfunctionaltests_-_6000_7_-_macos13arm:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_MacOS_6000.7_project;flags:inputsystem_MacOS_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-mac.sh
@@ -298,7 +298,7 @@ inputsystem-editorfunctionaltests_-_6000_7_-_ubuntu2204:
   - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
-  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout
+  - command: .Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --enable-code-coverage --coverage-options="generateAdditionalMetrics;generateHtmlReport;assemblyFilters:+Unity.InputSystem*;pathReplacePatterns:@*,,**/PackageCache/,;sourcePaths:$YAMATO_SOURCE_DIR/Packages;" --coverage-results-path=$YAMATO_SOURCE_DIR/upm-ci~/CodeCoverage --coverage-upload-options="reportsDir:upm-ci~/CodeCoverage;name:inputsystem_Ubuntu_6000.7_project;flags:inputsystem_Ubuntu_6000.7_project" --timeout=3600 --artifacts-path=artifacts
   after:
   - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh

--- a/.yamato/input-system-editor-performance-tests.yml
+++ b/.yamato/input-system-editor-performance-tests.yml
@@ -13,7 +13,7 @@ inputsystem-editorperformancetests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -32,7 +32,7 @@ inputsystem-editorperformancetests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -51,7 +51,7 @@ inputsystem-editorperformancetests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -70,7 +70,7 @@ inputsystem-editorperformancetests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -89,7 +89,7 @@ inputsystem-editorperformancetests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -108,7 +108,7 @@ inputsystem-editorperformancetests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -127,7 +127,7 @@ inputsystem-editorperformancetests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -146,7 +146,7 @@ inputsystem-editorperformancetests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -165,7 +165,7 @@ inputsystem-editorperformancetests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -185,7 +185,7 @@ inputsystem-editorperformancetests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -204,7 +204,7 @@ inputsystem-editorperformancetests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -223,7 +223,7 @@ inputsystem-editorperformancetests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -242,7 +242,7 @@ inputsystem-editorperformancetests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -262,7 +262,7 @@ inputsystem-editorperformancetests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -281,7 +281,7 @@ inputsystem-editorperformancetests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -300,7 +300,7 @@ inputsystem-editorperformancetests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts

--- a/.yamato/input-system-editor-performance-tests.yml
+++ b/.yamato/input-system-editor-performance-tests.yml
@@ -13,7 +13,8 @@ inputsystem-editorperformancetests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -31,7 +32,8 @@ inputsystem-editorperformancetests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -49,8 +51,8 @@ inputsystem-editorperformancetests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -68,7 +70,8 @@ inputsystem-editorperformancetests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -86,7 +89,8 @@ inputsystem-editorperformancetests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -104,8 +108,8 @@ inputsystem-editorperformancetests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -123,7 +127,8 @@ inputsystem-editorperformancetests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -141,7 +146,8 @@ inputsystem-editorperformancetests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -159,8 +165,8 @@ inputsystem-editorperformancetests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -179,7 +185,8 @@ inputsystem-editorperformancetests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -197,7 +204,8 @@ inputsystem-editorperformancetests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -215,8 +223,8 @@ inputsystem-editorperformancetests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -234,7 +242,8 @@ inputsystem-editorperformancetests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -253,7 +262,8 @@ inputsystem-editorperformancetests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -271,7 +281,8 @@ inputsystem-editorperformancetests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -289,8 +300,8 @@ inputsystem-editorperformancetests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=Editor --suite=Playmode --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:

--- a/.yamato/input-system-standalone-functional-tests.yml
+++ b/.yamato/input-system-standalone-functional-tests.yml
@@ -13,7 +13,7 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -32,7 +32,7 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -51,7 +51,7 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -70,7 +70,7 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -89,7 +89,7 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -108,7 +108,7 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -127,7 +127,7 @@ inputsystem-standalonefunctionaltests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -146,7 +146,7 @@ inputsystem-standalonefunctionaltests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -165,7 +165,7 @@ inputsystem-standalonefunctionaltests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -185,7 +185,7 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -204,7 +204,7 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -223,7 +223,7 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -242,7 +242,7 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -262,7 +262,7 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -281,7 +281,7 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -300,7 +300,7 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts

--- a/.yamato/input-system-standalone-functional-tests.yml
+++ b/.yamato/input-system-standalone-functional-tests.yml
@@ -13,7 +13,8 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -31,7 +32,8 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -49,8 +51,8 @@ inputsystem-standalonefunctionaltests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -68,7 +70,8 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -86,7 +89,8 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -104,8 +108,8 @@ inputsystem-standalonefunctionaltests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -123,7 +127,8 @@ inputsystem-standalonefunctionaltests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -141,7 +146,8 @@ inputsystem-standalonefunctionaltests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -159,8 +165,8 @@ inputsystem-standalonefunctionaltests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -179,7 +185,8 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -197,7 +204,8 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -215,8 +223,8 @@ inputsystem-standalonefunctionaltests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -234,7 +242,8 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -253,7 +262,8 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -271,7 +281,8 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -289,8 +300,8 @@ inputsystem-standalonefunctionaltests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:

--- a/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
@@ -13,7 +13,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -32,7 +32,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -51,7 +51,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -70,7 +70,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -89,7 +89,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -108,7 +108,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -127,7 +127,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -146,7 +146,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -165,7 +165,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -185,7 +185,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -204,7 +204,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -223,7 +223,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -242,7 +242,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -262,7 +262,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -281,7 +281,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
@@ -300,7 +300,7 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts

--- a/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-functional-tests.yml
@@ -13,7 +13,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -31,7 +32,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -49,8 +51,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -68,7 +70,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -86,7 +89,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -104,8 +108,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -123,7 +127,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -141,7 +146,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -159,8 +165,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -179,7 +185,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -197,7 +204,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -215,8 +223,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -234,7 +242,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -253,7 +262,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -271,7 +281,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:
@@ -289,8 +300,8 @@ inputsystem-standaloneil2cppfunctionaltests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=!Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --timeout=3600 --artifacts-path=artifacts
   after:

--- a/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
@@ -13,7 +13,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -31,7 +32,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -49,8 +51,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -68,7 +70,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -86,7 +89,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -104,8 +108,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -123,7 +127,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -141,7 +146,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -159,8 +165,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -179,7 +185,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -197,7 +204,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -215,8 +223,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -234,7 +242,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -253,7 +262,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -271,7 +281,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -289,8 +300,8 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:

--- a/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
+++ b/.yamato/input-system-standalone-il2-cpp-performance-tests.yml
@@ -13,7 +13,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -32,7 +32,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -51,7 +51,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -70,7 +70,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -89,7 +89,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -108,7 +108,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -127,7 +127,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -146,7 +146,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -165,7 +165,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -185,7 +185,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -204,7 +204,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -223,7 +223,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -242,7 +242,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -262,7 +262,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -281,7 +281,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -300,7 +300,7 @@ inputsystem-standaloneil2cppperformancetests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor -c StandaloneSupport-IL2CPP --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --scripting-backend=il2cpp --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts

--- a/.yamato/input-system-standalone-performance-tests.yml
+++ b/.yamato/input-system-standalone-performance-tests.yml
@@ -13,7 +13,7 @@ inputsystem-standaloneperformancetests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -32,7 +32,7 @@ inputsystem-standaloneperformancetests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -51,7 +51,7 @@ inputsystem-standaloneperformancetests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -70,7 +70,7 @@ inputsystem-standaloneperformancetests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -89,7 +89,7 @@ inputsystem-standaloneperformancetests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -108,7 +108,7 @@ inputsystem-standaloneperformancetests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -127,7 +127,7 @@ inputsystem-standaloneperformancetests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -146,7 +146,7 @@ inputsystem-standaloneperformancetests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -165,7 +165,7 @@ inputsystem-standaloneperformancetests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -185,7 +185,7 @@ inputsystem-standaloneperformancetests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -204,7 +204,7 @@ inputsystem-standaloneperformancetests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -223,7 +223,7 @@ inputsystem-standaloneperformancetests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -242,7 +242,7 @@ inputsystem-standaloneperformancetests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -262,7 +262,7 @@ inputsystem-standaloneperformancetests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -281,7 +281,7 @@ inputsystem-standaloneperformancetests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
@@ -300,7 +300,7 @@ inputsystem-standaloneperformancetests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt
   - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts

--- a/.yamato/input-system-standalone-performance-tests.yml
+++ b/.yamato/input-system-standalone-performance-tests.yml
@@ -13,7 +13,8 @@ inputsystem-standaloneperformancetests_-_6000_0_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -31,7 +32,8 @@ inputsystem-standaloneperformancetests_-_6000_0_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -49,8 +51,8 @@ inputsystem-standaloneperformancetests_-_6000_0_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.0/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -68,7 +70,8 @@ inputsystem-standaloneperformancetests_-_6000_3_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -86,7 +89,8 @@ inputsystem-standaloneperformancetests_-_6000_3_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -104,8 +108,8 @@ inputsystem-standaloneperformancetests_-_6000_3_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.3/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -123,7 +127,8 @@ inputsystem-standaloneperformancetests_-_6000_5_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -141,7 +146,8 @@ inputsystem-standaloneperformancetests_-_6000_5_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -159,8 +165,8 @@ inputsystem-standaloneperformancetests_-_6000_5_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.5/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -179,7 +185,8 @@ inputsystem-standaloneperformancetests_-_6000_6_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -197,7 +204,8 @@ inputsystem-standaloneperformancetests_-_6000_6_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -215,8 +223,8 @@ inputsystem-standaloneperformancetests_-_6000_6_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u 6000.6/staging -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -234,7 +242,8 @@ inputsystem-standaloneperformancetests_-_6000_7_-_macos13:
     type: Unity::VM::osx
     flavor: b1.xlarge
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -253,7 +262,8 @@ inputsystem-standaloneperformancetests_-_6000_7_-_macos13arm:
     flavor: m1.mac
     model: M1
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneOSX --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -271,7 +281,8 @@ inputsystem-standaloneperformancetests_-_6000_7_-_ubuntu2204:
     type: Unity::VM::GPU
     flavor: b1.large
   commands:
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path $HOME/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneLinux64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:
@@ -289,8 +300,8 @@ inputsystem-standaloneperformancetests_-_6000_7_-_win10:
     type: Unity::VM
     flavor: b1.large
   commands:
-  - command: '%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes'
-  - command: git clone --branch "2.3.0-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
+  - command: dotnet tool install docfx --version 2.70.0 --tool-path %USERPROFILE%/.pmdt --add-source https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget
+  - command: git clone --branch "3.14.8-preview" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools
   - command: unity-downloader-cli -u trunk -c Editor --fast --wait
   - command: UnifiedTestRunner.exe --testproject=. --editor-location=.Editor --suite=playmode --platform=StandaloneWindows64 --category=Performance --clean-library --api-profile=NET_4_6 --reruncount=1 --clean-library-on-rerun --report-performance-data --performance-project-id=InputSystem --timeout=3600 --artifacts-path=artifacts
   after:

--- a/.yamato/wrench/package-pack-jobs.yml
+++ b/.yamato/wrench/package-pack-jobs.yml
@@ -33,3 +33,28 @@ package_pack_-_inputsystem:
     Job Maintainers: '#rm-packageworks'
     Wrench: 3.2.1.0
 
+# Pack Package Manager DocTools
+package_pack_-_package-manager-doctools:
+  name: Package Pack - package-manager-doctools
+  agent:
+    image: package-ci/ubuntu-22.04:v4
+    type: Unity::VM::GPU
+    flavor: b1.large
+  commands:
+  - command: npm install upm-ci-utils@stable -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+    timeout: 20
+    retries: 10
+  - command: upm-ci package pack --package-path Packages/com.unity.package-manager-doctools
+  - command: cp upm-ci~/packages/packages.json upm-ci~/packages/com.unity.package-manager-doctools_packages.json
+  after:
+  - command: bash .yamato/generated-scripts/infrastructure-instability-detection-linux.sh
+  artifacts:
+    packages:
+      paths:
+      - upm-ci~/packages/**/*
+  variables:
+    UPMCI_ACK_LARGE_PACKAGE: 1
+  metadata:
+    Job Maintainers: '#rm-packageworks'
+    Wrench: 3.2.1.0
+

--- a/.yamato/wrench/wrench_config.json
+++ b/.yamato/wrench/wrench_config.json
@@ -38,6 +38,31 @@
         ]
       },
       "postPackCommands": []
+    },
+    "com.unity.package-manager-doctools": {
+      "directory": "Packages/com.unity.package-manager-doctools/",
+      "prePackCommands": [],
+      "preTestCommands": {
+        "MacOs13": [],
+        "MacOs13Arm": [],
+        "Ubuntu1804": [],
+        "Ubuntu2004": [],
+        "Ubuntu2204": [],
+        "Win10": [],
+        "Win10GPU": [],
+        "Win11": [],
+        "Win11Arm": [],
+        "Win11GPU": []
+      },
+      "InternalOnly": false,
+      "NeverPublish": false,
+      "MaxEditorVersion": "",
+      "coverageEnabled": false,
+      "coverageCommands": [
+        "generateAdditionalMetrics;generateHtmlReport;assemblyFilters:ASSEMBLY_NAME;"
+      ],
+      "dependantsToIgnoreInPreviewApv": {},
+      "postPackCommands": []
     }
   },
   "releasing_packages": [

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -48,9 +48,7 @@ class DocumentationBasedAPIVerficationTests
         // On CI (fresh clone, no IDE installed), SyncAll() is a no-op and no .sln/.csproj files
         // exist yet. Force solution generation via reflection since SyncVS is internal in Unity 6.x.
         var syncVsType = Type.GetType("UnityEditor.SyncVS, UnityEditor");
-        syncVsType?.GetMethod("SyncSolution",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
-            ?.Invoke(null, null);
+        syncVsType?.GetMethod("SyncSolution", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)?.Invoke(null, null);
 
 #if HAVE_DOCTOOLS_INSTALLED
         (_documentationBuilderLogs, _docsFolder) = Documentation.Instance.GenerateEx(inputSystemPackageInfo, InputSystem.version.ToString(), docsPath);

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using HtmlAgilityPack;
 using Mono.Cecil;
@@ -45,10 +44,50 @@ class DocumentationBasedAPIVerficationTests
         var inputSystemPackageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath("Packages/com.unity.inputsystem");
 
         // PMDT 3.x generates API docs from .csproj files rather than compiled assemblies.
-        // On CI (fresh clone, no IDE installed), SyncAll() is a no-op and no .sln/.csproj files
-        // exist yet. Force solution generation via reflection since SyncVS is internal in Unity 6.x.
-        var syncVsType = Type.GetType("UnityEditor.SyncVS, UnityEditor");
-        syncVsType?.GetMethod("SyncSolution", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)?.Invoke(null, null);
+        // When no IDE is configured (CI fresh clones), no .csproj files exist and PMDT
+        // generates no API documentation. Generate minimal .csproj files for InputSystem
+        // package assemblies using the CompilationPipeline API.
+        var projectName = new DirectoryInfo(Directory.GetCurrentDirectory()).Name;
+        if (!File.Exists($"{projectName}.sln"))
+        {
+            var assemblies = UnityEditor.Compilation.CompilationPipeline.GetAssemblies(
+                UnityEditor.Compilation.AssembliesType.Editor);
+            foreach (var asm in assemblies)
+            {
+                if (asm.sourceFiles.Length == 0 ||
+                    !asm.sourceFiles.Any(f => f.Replace("\\", "/").Contains("Packages/com.unity.inputsystem/")))
+                    continue;
+                var csprojPath = $"{asm.name}.csproj";
+                if (File.Exists(csprojPath))
+                    continue;
+                var csprojContent = new StringBuilder();
+                csprojContent.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+                csprojContent.AppendLine("<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" " +
+                    "xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
+                csprojContent.AppendLine("  <PropertyGroup Condition=\" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' \">");
+                csprojContent.AppendLine($"    <AssemblyName>{asm.name}</AssemblyName>");
+                csprojContent.AppendLine("    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>");
+                csprojContent.AppendLine("    <OutputType>Library</OutputType>");
+                csprojContent.AppendLine($"    <DefineConstants>{string.Join(";", asm.defines)}</DefineConstants>");
+                csprojContent.AppendLine("    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>");
+                csprojContent.AppendLine("    <LangVersion>9.0</LangVersion>");
+                csprojContent.AppendLine("    <NoConfig>true</NoConfig>");
+                csprojContent.AppendLine("    <NoStdLib>true</NoStdLib>");
+                csprojContent.AppendLine("  </PropertyGroup>");
+                csprojContent.AppendLine("  <ItemGroup>");
+                foreach (var src in asm.sourceFiles)
+                    csprojContent.AppendLine($"    <Compile Include=\"{src}\" />");
+                csprojContent.AppendLine("  </ItemGroup>");
+                csprojContent.AppendLine("  <ItemGroup>");
+                foreach (var refPath in asm.compiledAssemblyReferences)
+                    csprojContent.AppendLine(
+                        $"    <Reference Include=\"{Path.GetFileNameWithoutExtension(refPath)}\">" +
+                        $"<HintPath>{refPath}</HintPath></Reference>");
+                csprojContent.AppendLine("  </ItemGroup>");
+                csprojContent.AppendLine("</Project>");
+                File.WriteAllText(csprojPath, csprojContent.ToString(), Encoding.UTF8);
+            }
+        }
 
 #if HAVE_DOCTOOLS_INSTALLED
         (_documentationBuilderLogs, _docsFolder) = Documentation.Instance.GenerateEx(inputSystemPackageInfo, InputSystem.version.ToString(), docsPath);

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -44,6 +44,14 @@ class DocumentationBasedAPIVerficationTests
         Directory.CreateDirectory(docsPath);
         var inputSystemPackageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath("Packages/com.unity.inputsystem");
 
+        // PMDT 3.x generates API docs from .csproj files rather than compiled assemblies.
+        // On CI (fresh clone, no IDE installed), SyncAll() is a no-op and no .sln/.csproj files
+        // exist yet. Force solution generation via reflection since SyncVS is internal in Unity 6.x.
+        var syncVsType = Type.GetType("UnityEditor.SyncVS, UnityEditor");
+        syncVsType?.GetMethod("SyncSolution",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            ?.Invoke(null, null);
+
 #if HAVE_DOCTOOLS_INSTALLED
         (_documentationBuilderLogs, _docsFolder) = Documentation.Instance.GenerateEx(inputSystemPackageInfo, InputSystem.version.ToString(), docsPath);
         _docsFolder = Path.Combine(docsPath, _docsFolder);
@@ -392,6 +400,14 @@ class DocumentationBasedAPIVerficationTests
                 continue;
 
             if (link.StartsWith("https://"))
+                continue;
+
+            // javascript: URIs are used by the PMDT 3.x HTML theme for collapsible navigation elements
+            if (link.StartsWith("javascript:"))
+                continue;
+
+            // xref: URIs are unresolved DocFX cross-references to types outside this package
+            if (link.StartsWith("xref:"))
                 continue;
 
             if (link == "#top")

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using HtmlAgilityPack;
 using Mono.Cecil;

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -44,56 +44,6 @@ class DocumentationBasedAPIVerficationTests
         Directory.CreateDirectory(docsPath);
         var inputSystemPackageInfo = UnityEditor.PackageManager.PackageInfo.FindForAssetPath("Packages/com.unity.inputsystem");
 
-        // PMDT 3.x generates API docs from .csproj files rather than compiled assemblies.
-        // When no IDE is configured (CI fresh clones), no .csproj files exist and PMDT
-        // generates no API documentation. Generate minimal .csproj files for InputSystem
-        // package assemblies using the CompilationPipeline API.
-        var projectName = new DirectoryInfo(Directory.GetCurrentDirectory()).Name;
-        if (!File.Exists($"{projectName}.sln"))
-        {
-            var assemblies = UnityEditor.Compilation.CompilationPipeline.GetAssemblies(
-                UnityEditor.Compilation.AssembliesType.Editor);
-            foreach (var asm in assemblies)
-            {
-                if (asm.sourceFiles.Length == 0 ||
-                    !asm.sourceFiles.Any(f => f.Replace("\\", "/").Contains("Packages/com.unity.inputsystem/")))
-                    continue;
-                var csprojPath = $"{asm.name}.csproj";
-                if (File.Exists(csprojPath))
-                    continue;
-                var csprojContent = new StringBuilder();
-                csprojContent.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
-                csprojContent.AppendLine("<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" " +
-                    "xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
-                // DefineConstants must be in an unconditional PropertyGroup so DocFX reads them
-                // regardless of whether MSBuild's Platform property is set.
-                csprojContent.AppendLine("  <PropertyGroup>");
-                csprojContent.AppendLine($"    <DefineConstants>{string.Join(";", asm.defines)}</DefineConstants>");
-                csprojContent.AppendLine("  </PropertyGroup>");
-                csprojContent.AppendLine("  <PropertyGroup Condition=\" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' \">");
-                csprojContent.AppendLine($"    <AssemblyName>{asm.name}</AssemblyName>");
-                csprojContent.AppendLine("    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>");
-                csprojContent.AppendLine("    <OutputType>Library</OutputType>");
-                csprojContent.AppendLine("    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>");
-                csprojContent.AppendLine("    <LangVersion>9.0</LangVersion>");
-                csprojContent.AppendLine("    <NoConfig>true</NoConfig>");
-                csprojContent.AppendLine("    <NoStdLib>true</NoStdLib>");
-                csprojContent.AppendLine("  </PropertyGroup>");
-                csprojContent.AppendLine("  <ItemGroup>");
-                foreach (var src in asm.sourceFiles)
-                    csprojContent.AppendLine($"    <Compile Include=\"{src}\" />");
-                csprojContent.AppendLine("  </ItemGroup>");
-                csprojContent.AppendLine("  <ItemGroup>");
-                foreach (var refPath in asm.compiledAssemblyReferences)
-                    csprojContent.AppendLine(
-                        $"    <Reference Include=\"{Path.GetFileNameWithoutExtension(refPath)}\">" +
-                        $"<HintPath>{refPath}</HintPath></Reference>");
-                csprojContent.AppendLine("  </ItemGroup>");
-                csprojContent.AppendLine("</Project>");
-                File.WriteAllText(csprojPath, csprojContent.ToString(), Encoding.UTF8);
-            }
-        }
-
 #if HAVE_DOCTOOLS_INSTALLED
         (_documentationBuilderLogs, _docsFolder) = Documentation.Instance.GenerateEx(inputSystemPackageInfo, InputSystem.version.ToString(), docsPath);
         _docsFolder = Path.Combine(docsPath, _docsFolder);

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -66,7 +66,7 @@ class DocumentationBasedAPIVerficationTests
                 csprojContent.AppendLine("<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" " +
                     "xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
                 // DefineConstants must be in an unconditional PropertyGroup so DocFX reads them
-                // regardless of whether MSBuild's Platform property is set. 
+                // regardless of whether MSBuild's Platform property is set.
                 csprojContent.AppendLine("  <PropertyGroup>");
                 csprojContent.AppendLine($"    <DefineConstants>{string.Join(";", asm.defines)}</DefineConstants>");
                 csprojContent.AppendLine("  </PropertyGroup>");

--- a/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
+++ b/Assets/Tests/InputSystem/DocumentationBasedAPIVerficationTests.cs
@@ -65,11 +65,15 @@ class DocumentationBasedAPIVerficationTests
                 csprojContent.AppendLine("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
                 csprojContent.AppendLine("<Project ToolsVersion=\"4.0\" DefaultTargets=\"Build\" " +
                     "xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\">");
+                // DefineConstants must be in an unconditional PropertyGroup so DocFX reads them
+                // regardless of whether MSBuild's Platform property is set. 
+                csprojContent.AppendLine("  <PropertyGroup>");
+                csprojContent.AppendLine($"    <DefineConstants>{string.Join(";", asm.defines)}</DefineConstants>");
+                csprojContent.AppendLine("  </PropertyGroup>");
                 csprojContent.AppendLine("  <PropertyGroup Condition=\" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' \">");
                 csprojContent.AppendLine($"    <AssemblyName>{asm.name}</AssemblyName>");
                 csprojContent.AppendLine("    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>");
                 csprojContent.AppendLine("    <OutputType>Library</OutputType>");
-                csprojContent.AppendLine($"    <DefineConstants>{string.Join(";", asm.defines)}</DefineConstants>");
                 csprojContent.AppendLine("    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>");
                 csprojContent.AppendLine("    <LangVersion>9.0</LangVersion>");
                 csprojContent.AppendLine("    <NoConfig>true</NoConfig>");

--- a/Packages/com.unity.inputsystem/Documentation~/built-in-interactions.md
+++ b/Packages/com.unity.inputsystem/Documentation~/built-in-interactions.md
@@ -93,7 +93,7 @@ A [`SlowTapInteraction`](xref:UnityEngine.InputSystem.Interactions.SlowTapIntera
 
 ## MultiTap
 
-You can use `MultiTap` to detect double-click or multi-click gestures. For a [`MultiTapInteraction`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) to trigger, the user must press a control and release it within [`tapTime`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) seconds, repeating the press-and-release process [`tapCount`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) times. There can't be more than [`tapDelay`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) seconds between taps. 
+You can use `MultiTap` to detect double-click or multi-click gestures. For a [`MultiTapInteraction`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) to trigger, the user must press a control and release it within [`tapTime`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) seconds, repeating the press-and-release process [`tapCount`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) times. There can't be more than [`tapDelay`](xref:UnityEngine.InputSystem.Interactions.MultiTapInteraction) seconds between taps.
 
 |__Parameters__|Type|Default value|
 |---|---|---|

--- a/Packages/com.unity.inputsystem/Documentation~/config.json
+++ b/Packages/com.unity.inputsystem/Documentation~/config.json
@@ -1,1 +1,0 @@
-{ "DefineConstants": "UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS" }

--- a/Packages/com.unity.inputsystem/Documentation~/projectMetadata.json
+++ b/Packages/com.unity.inputsystem/Documentation~/projectMetadata.json
@@ -1,6 +1,6 @@
 {
     "hideGlobalNamespace": true,
-    "DefineConstants": "UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS",
+    "DefineConstants": "UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS;PACKAGE_DOCS_GENERATION",
     "xref": [
         "com.unity.xr.openxr",
         "com.unity.xr.interaction.toolkit"

--- a/Packages/com.unity.inputsystem/Documentation~/projectMetadata.json
+++ b/Packages/com.unity.inputsystem/Documentation~/projectMetadata.json
@@ -1,5 +1,6 @@
 {
     "hideGlobalNamespace": true,
+    "DefineConstants": "UNITY_INPUT_SYSTEM_PROJECT_WIDE_ACTIONS",
     "xref": [
         "com.unity.xr.openxr",
         "com.unity.xr.interaction.toolkit"

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputSettings.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputSettings.cs
@@ -1021,7 +1021,7 @@ namespace UnityEngine.InputSystem
         /// <summary>
         /// Determines if we should render the UI with IMGUI even if an UI Toolkit UI is available.
         ///
-        /// This should be used when writing a custom <see cref="InputParameterEditor"/> to :
+        /// This should be used when writing a custom <see cref="UnityEngine.InputSystem.Editor.InputParameterEditor"/> to :
         /// * support inspector view which only work in IMGUI for now.
         /// * prevent the UI to be rendered in IMGUI and UI Toolkit in the Input Actions Editor window.
         /// </summary>

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/InputSystem.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/InputSystem.cs
@@ -2904,8 +2904,8 @@ namespace UnityEngine.InputSystem
         /// <example>
         /// <code>
         /// InputSystem.customBindingPathValidators += (string bindingPath) => {
-        ///     // Mark <Gamepad> bindings with a warning
-        ///     if (!bindingPath.StartsWith("<Gamepad>"))
+        ///     // Mark &lt;Gamepad&gt; bindings with a warning
+        ///     if (!bindingPath.StartsWith("&lt;Gamepad&gt;"))
         ///         return null;
         ///
         ///     // Draw the warning information in the Binding Properties panel

--- a/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/Steam/SteamController.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Runtime/Plugins/Steam/SteamController.cs
@@ -21,12 +21,12 @@ namespace UnityEngine.InputSystem.Steam
     ///
     /// Note that as the Steam controller API supports PS4 and Xbox controllers as well,
     /// the actual hardware device behind a SteamController instance may not be a
-    /// Steam Controller. The <see cref="steamControllerType"/> property can be used what kind
+    /// Steam Controller. The steamControllerType property can be used what kind
     /// of controller the Steam runtime is talking to internally.
     ///
     /// This class is abstract. Specific Steam controller interfaces can either be implemented
     /// manually based on this class or generated automatically from Steam IGA files using
-    /// <see cref="SteamIGAConverter"/>. This can be done in the editor by right-clicking
+    /// <see cref="UnityEngine.InputSystem.Steam.Editor.SteamIGAConverter"/>. This can be done in the editor by right-clicking
     /// a .VDF file containing the actions and then selecting "Steam >> Generate Unity Input Device...".
     /// The result is a newly generated device layout that will automatically register itself
     /// with the input system and will represent a Steam controller with the specific action

--- a/Tools/CI/Recipes/EditorFunctionalTests.cs
+++ b/Tools/CI/Recipes/EditorFunctionalTests.cs
@@ -60,8 +60,8 @@ public class EditorFunctionalTests: BaseRecipe
         SystemType.Windows =>
             @".Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -",
         SystemType.MacOS =>
-            ".Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout",
+            ".Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -",
         _ =>
-            ".Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout"
+            ".Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -"
     };
 }

--- a/Tools/CI/Recipes/EditorFunctionalTests.cs
+++ b/Tools/CI/Recipes/EditorFunctionalTests.cs
@@ -24,10 +24,9 @@ public class EditorFunctionalTests: BaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform);
 
-        if (platform.System == SystemType.Windows)
-        {
-            job.WithCommands(c => c.Add(InputSystemSettings.NetfxInstallCmd));
-        }
+        job.WithCommands(c => c.Add(platform.System == SystemType.Windows
+            ? InputSystemSettings.DocfxInstallCmdWindows
+            : InputSystemSettings.DocfxInstallCmdUnix));
 
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)

--- a/Tools/CI/Recipes/EditorFunctionalTests.cs
+++ b/Tools/CI/Recipes/EditorFunctionalTests.cs
@@ -31,6 +31,7 @@ public class EditorFunctionalTests: BaseRecipe
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)
                 .Add(Utilities.GetEditorDownloadCommand(unityBranch, platform))
+                .Add(GetSyncSolutionCommand(platform))
                 .Add(UtrCommand.Run(platform.System, b => b
                     .WithTestProject($"{ProjectPath}")
                     .WithEditor(".Editor")
@@ -51,4 +52,16 @@ public class EditorFunctionalTests: BaseRecipe
 
         return job;
     }
+
+    // Generates .sln/.csproj files via the Rider editor package so that PMDT 3.x can find
+    // them on CI where no IDE is configured and SyncAll() would otherwise be a no-op.
+    private static string GetSyncSolutionCommand(Platform platform) => platform.System switch
+    {
+        SystemType.Windows =>
+            @".Editor\Unity.exe -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile -",
+        SystemType.MacOS =>
+            ".Editor/Unity.app/Contents/MacOS/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout",
+        _ =>
+            ".Editor/Unity -projectPath . -batchmode -nographics -quit -executeMethod Packages.Rider.Editor.RiderScriptEditor.SyncSolution -logFile /dev/stdout"
+    };
 }

--- a/Tools/CI/Recipes/EditorPerformanceTests.cs
+++ b/Tools/CI/Recipes/EditorPerformanceTests.cs
@@ -24,10 +24,9 @@ public class EditorPerformanceTests: BaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform);
 
-        if (platform.System == SystemType.Windows)
-        {
-            job.WithCommands(c => c.Add(InputSystemSettings.NetfxInstallCmd));
-        }
+        job.WithCommands(c => c.Add(platform.System == SystemType.Windows
+            ? InputSystemSettings.DocfxInstallCmdWindows
+            : InputSystemSettings.DocfxInstallCmdUnix));
 
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)

--- a/Tools/CI/Recipes/StandaloneFunctionalTests.cs
+++ b/Tools/CI/Recipes/StandaloneFunctionalTests.cs
@@ -23,10 +23,9 @@ public class StandaloneFunctionalTests: BaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform);
 
-        if (platform.System == SystemType.Windows)
-        {
-            job.WithCommands(c => c.Add(InputSystemSettings.NetfxInstallCmd));
-        }
+        job.WithCommands(c => c.Add(platform.System == SystemType.Windows
+            ? InputSystemSettings.DocfxInstallCmdWindows
+            : InputSystemSettings.DocfxInstallCmdUnix));
 
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)

--- a/Tools/CI/Recipes/StandaloneIl2CppFunctionalTests.cs
+++ b/Tools/CI/Recipes/StandaloneIl2CppFunctionalTests.cs
@@ -23,10 +23,9 @@ public class StandaloneIl2CppFunctionalTests: BaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform);
 
-        if (platform.System == SystemType.Windows)
-        {
-            job.WithCommands(c => c.Add(InputSystemSettings.NetfxInstallCmd));
-        }
+        job.WithCommands(c => c.Add(platform.System == SystemType.Windows
+            ? InputSystemSettings.DocfxInstallCmdWindows
+            : InputSystemSettings.DocfxInstallCmdUnix));
 
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)

--- a/Tools/CI/Recipes/StandaloneIl2CppPerformanceTests.cs
+++ b/Tools/CI/Recipes/StandaloneIl2CppPerformanceTests.cs
@@ -23,10 +23,9 @@ public class StandaloneIl2CppPerformanceTests: BaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform);
 
-        if (platform.System == SystemType.Windows)
-        {
-            job.WithCommands(c => c.Add(InputSystemSettings.NetfxInstallCmd));
-        }
+        job.WithCommands(c => c.Add(platform.System == SystemType.Windows
+            ? InputSystemSettings.DocfxInstallCmdWindows
+            : InputSystemSettings.DocfxInstallCmdUnix));
 
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)

--- a/Tools/CI/Recipes/StandalonePerformanceTests.cs
+++ b/Tools/CI/Recipes/StandalonePerformanceTests.cs
@@ -23,10 +23,9 @@ public class StandalonePerformanceTests: BaseRecipe
             .WithDescription(jobName)
             .WithPlatform(platform);
 
-        if (platform.System == SystemType.Windows)
-        {
-            job.WithCommands(c => c.Add(InputSystemSettings.NetfxInstallCmd));
-        }
+        job.WithCommands(c => c.Add(platform.System == SystemType.Windows
+            ? InputSystemSettings.DocfxInstallCmdWindows
+            : InputSystemSettings.DocfxInstallCmdUnix));
 
         job.WithCommands(c => c
                 .Add(InputSystemSettings.DoctoolsInstallCmd)

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -28,10 +28,6 @@ public class InputSystemSettings : AnnotatedSettingsBase
     // dotnet SDK availability: confirmed present on package-ci images (Windows, Mac, and Ubuntu) via
     // #devs-pets / #devs-ci Slack history - it's a centrally maintained, version-pinned component of
     // the image family. So extra .NET SDK install step is needed here.
-    //
-    // NuGet source reachability - `dotnet tool install` needs to resolve the docfx package from a feed.
-    // There's no nuget.config at the repo root (only Tools/CI/nuget.config, which NuGet won't discover
-    // from here since it only walks upward from the working directory).
     public static readonly string DocfxVersion = "2.70.0";
 
     // Installs the DocFX version PMDT 3.x expects, as a dotnet tool, per-platform.

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -29,11 +29,27 @@ public class InputSystemSettings : AnnotatedSettingsBase
     // NOTE: Starting with PMDT 3.0.0, DocFX is no longer bundled with the package and must be
     // installed separately as a dotnet tool. See:
     // https://docs.unity3d.com/Packages/com.unity.package-manager-doctools@3.14/manual/installation.html
+    //
+    // dotnet SDK availability: confirmed present on package-ci images (Windows, Mac, and Ubuntu) via
+    // #devs-pets / #devs-ci Slack history - it's a centrally maintained, version-pinned component of
+    // the image family (e.g. package-ci/ubuntu-22.04:v4 SDK version pinning discussion, and a Windows
+    // package-ci job observed spawning a .NET 8 subprocess), not something jobs install themselves.
+    // So no extra .NET SDK install step is needed here.
+    //
+    // NuGet source reachability - `dotnet tool install` needs to resolve the docfx package from a feed.
+    // There's no nuget.config at the repo root (only Tools/CI/nuget.config, which NuGet won't discover
+    // from here since it only walks upward from the working directory), so we pin --add-source
+    // explicitly below to Unity's internal Artifactory NuGet proxy - the same source Tools/CI/nuget.config
+    // uses, and one we know CI agents can already reach since the recipe-regeneration job restores
+    // packages through it. Default sources (nuget.org) are likely unreachable from these locked-down
+    // build agents. Still worth confirming on the first real CI run that Artifactory actually mirrors
+    // the "docfx" package specifically (vs. only packages requested before).
     public static readonly string DocfxVersion = "2.70.0";
+    public static readonly string NugetInternalSource = "https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget";
 
     // Installs the DocFX version PMDT 3.x expects, as a dotnet tool, per-platform.
-    public static readonly string DocfxInstallCmdWindows = $"dotnet tool install docfx --version {DocfxVersion} --tool-path %USERPROFILE%/.pmdt";
-    public static readonly string DocfxInstallCmdUnix = $"dotnet tool install docfx --version {DocfxVersion} --tool-path $HOME/.pmdt";
+    public static readonly string DocfxInstallCmdWindows = $"dotnet tool install docfx --version {DocfxVersion} --tool-path %USERPROFILE%/.pmdt --add-source {NugetInternalSource}";
+    public static readonly string DocfxInstallCmdUnix = $"dotnet tool install docfx --version {DocfxVersion} --tool-path $HOME/.pmdt --add-source {NugetInternalSource}";
 
     public static readonly string DoctoolsInstallCmd = "git clone --branch \"3.14.8-preview\" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools";
 

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -33,11 +33,10 @@ public class InputSystemSettings : AnnotatedSettingsBase
     // There's no nuget.config at the repo root (only Tools/CI/nuget.config, which NuGet won't discover
     // from here since it only walks upward from the working directory).
     public static readonly string DocfxVersion = "2.70.0";
-    public static readonly string NugetInternalSource = "https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget";
 
     // Installs the DocFX version PMDT 3.x expects, as a dotnet tool, per-platform.
-    public static readonly string DocfxInstallCmdWindows = $"dotnet tool install docfx --version {DocfxVersion} --tool-path %USERPROFILE%/.pmdt --add-source {NugetInternalSource}";
-    public static readonly string DocfxInstallCmdUnix = $"dotnet tool install docfx --version {DocfxVersion} --tool-path $HOME/.pmdt --add-source {NugetInternalSource}";
+    public static readonly string DocfxInstallCmdWindows = $"dotnet tool install docfx --version {DocfxVersion} --tool-path %USERPROFILE%/.pmdt";
+    public static readonly string DocfxInstallCmdUnix = $"dotnet tool install docfx --version {DocfxVersion} --tool-path $HOME/.pmdt";
 
     public static readonly string DoctoolsInstallCmd = "git clone --branch \"3.14.8-preview\" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools";
 

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -21,29 +21,17 @@ public class InputSystemSettings : AnnotatedSettingsBase
     public static readonly string BranchName = "develop";
     public static readonly string InputSystemPackageName = "com.unity.inputsystem";
 
-    // PMDT (Package Manager Doctools) 2.3 has been unmaintained for ~3 years and its bundled DocFX
-    // started failing intermittently on CI (the "manual" folder silently not being generated) due to
-    // unrelated tooling backports on the Yamato images. Per USF Docs Engineering guidance, the recommended fix is
-    // to upgrade to a current PMDT release rather than continue pinning the old version.
-    //
     // NOTE: Starting with PMDT 3.0.0, DocFX is no longer bundled with the package and must be
     // installed separately as a dotnet tool. See:
     // https://docs.unity3d.com/Packages/com.unity.package-manager-doctools@3.14/manual/installation.html
     //
     // dotnet SDK availability: confirmed present on package-ci images (Windows, Mac, and Ubuntu) via
     // #devs-pets / #devs-ci Slack history - it's a centrally maintained, version-pinned component of
-    // the image family (e.g. package-ci/ubuntu-22.04:v4 SDK version pinning discussion, and a Windows
-    // package-ci job observed spawning a .NET 8 subprocess), not something jobs install themselves.
-    // So no extra .NET SDK install step is needed here.
+    // the image family. So extra .NET SDK install step is needed here.
     //
     // NuGet source reachability - `dotnet tool install` needs to resolve the docfx package from a feed.
     // There's no nuget.config at the repo root (only Tools/CI/nuget.config, which NuGet won't discover
-    // from here since it only walks upward from the working directory), so we pin --add-source
-    // explicitly below to Unity's internal Artifactory NuGet proxy - the same source Tools/CI/nuget.config
-    // uses, and one we know CI agents can already reach since the recipe-regeneration job restores
-    // packages through it. Default sources (nuget.org) are likely unreachable from these locked-down
-    // build agents. Still worth confirming on the first real CI run that Artifactory actually mirrors
-    // the "docfx" package specifically (vs. only packages requested before).
+    // from here since it only walks upward from the working directory).
     public static readonly string DocfxVersion = "2.70.0";
     public static readonly string NugetInternalSource = "https://artifactory.prd.it.unity3d.com/artifactory/api/nuget/v3/nuget";
 

--- a/Tools/CI/Settings/InputSystemSettings.cs
+++ b/Tools/CI/Settings/InputSystemSettings.cs
@@ -21,9 +21,21 @@ public class InputSystemSettings : AnnotatedSettingsBase
     public static readonly string BranchName = "develop";
     public static readonly string InputSystemPackageName = "com.unity.inputsystem";
 
-    // Command to install .NET Framework 4.7.1 Developer Pack which is used by doctools on Windows.
-    public static readonly string NetfxInstallCmd = "%GSUDO% choco install netfx-4.7.1-devpack -y --ignore-detected-reboot --ignore-package-codes";
-    public static readonly string DoctoolsInstallCmd = "git clone --branch \"2.3.0-preview\" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools";
+    // PMDT (Package Manager Doctools) 2.3 has been unmaintained for ~3 years and its bundled DocFX
+    // started failing intermittently on CI (the "manual" folder silently not being generated) due to
+    // unrelated tooling backports on the Yamato images. Per USF Docs Engineering guidance, the recommended fix is
+    // to upgrade to a current PMDT release rather than continue pinning the old version.
+    //
+    // NOTE: Starting with PMDT 3.0.0, DocFX is no longer bundled with the package and must be
+    // installed separately as a dotnet tool. See:
+    // https://docs.unity3d.com/Packages/com.unity.package-manager-doctools@3.14/manual/installation.html
+    public static readonly string DocfxVersion = "2.70.0";
+
+    // Installs the DocFX version PMDT 3.x expects, as a dotnet tool, per-platform.
+    public static readonly string DocfxInstallCmdWindows = $"dotnet tool install docfx --version {DocfxVersion} --tool-path %USERPROFILE%/.pmdt";
+    public static readonly string DocfxInstallCmdUnix = $"dotnet tool install docfx --version {DocfxVersion} --tool-path $HOME/.pmdt";
+
+    public static readonly string DoctoolsInstallCmd = "git clone --branch \"3.14.8-preview\" git@github.cds.internal.unity3d.com:unity/com.unity.package-manager-doctools.git Packages/com.unity.package-manager-doctools";
 
     public WrenchPackage InputSystemPackage => Wrench.Packages[InputSystemPackageName];
 


### PR DESCRIPTION
### Description

Upgrading docs package tools. DocFX is no longer part of the package and needs to be installed separately. 
Also the .csproj file creation is not handled by the docs package anymore, so I included a command that creates the project files via the rider package. 

Additionally I added a small format fix in [‎Packages/com.unity.inputsystem/Documentation~/built-in-interactions.md‎](https://github.com/Unity-Technologies/InputSystem/pull/2460/changes#diff-b7dae7bdaf4c564b4323b0af6e3a9a25d4ab1b4b9bc5bd7dfe19e89865bebd05). 

### Testing status & QA

None.

### Overall Product Risks

- Complexity: Low
- Halo Effect: Low

### Comments to reviewers

### Checklist

Before review:

- [ ] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
