### PR TITLE
FIX: Enforce a minimum window size on the Input Debugger window [UUM-137119]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 
 ## [1.20.0] - 2026-07-21

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Debugger/InputDebuggerWindow.cs
@@ -84,6 +84,7 @@ namespace UnityEngine.InputSystem.Editor
         private void OnEnable()
         {
             titleContent = new GUIContent("Input Debugger");
+            minSize = new Vector2(270, 300);
         }
 
         private void OnDeviceChange(InputDevice device, InputDeviceChange change)


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

`InputDebuggerWindow.OnEnable()` assigned only `titleContent` and never set a minimum window size, so the Input Debugger (Window > Analysis > Input Debugger) could be resized arbitrarily small — small enough that its toolbar and the device/action/layout tree view were no longer usably visible.

`OnEnable()` now also assigns `minSize = new Vector2(270, 300)`, the same minimum the sibling `InputDeviceDebuggerWindow` already applies. Setting it in `OnEnable` rather than in `CreateOrShow()` means the minimum is re-applied after domain reloads and when a docked or persisted window is restored from the editor layout, not only when the window is first opened from the menu item.

### Testing status & QA

- No automated test added — the change sets `EditorWindow.minSize` through the editor window lifecycle and there is no existing test fixture exercising the Input Debugger windows.
- Manual QA: open Window > Analysis > Input Debugger and confirm the window can no longer be resized small enough to hide its toolbar and tree view, per the repro in https://jira.unity3d.com/browse/UUM-137119.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (single additive statement confined to one editor-only window's `OnEnable`; no public API surface touched)
- Risk rating: 2/5 — Single additive statement setting an inherited EditorWindow property in a private editor-only window, mirroring three sibling windows; no test exercises it and the type carries inert serialization callbacks.

### Comments to reviewers

N/A

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
