### PR TITLE
FIX: Render parameter-less processors as a plain header and the top button row no longer clips when the properties panel is scrolled [UUM-144325]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed parameter-less processors and interactions (e.g. "Invert") in the Input Actions editor's Action Properties view showing an expandable foldout whose arrow animated on click but revealed no content; such items are now rendered as a plain, non-collapsible header [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
+- Fixed the Input Actions editor toolbar buttons being clipped when the Action Properties panel grew tall enough to show a scrollbar
 - Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed parameter-less processors and interactions (e.g. "Invert") in the Input Actions editor's Action Properties view showing an expandable foldout whose arrow animated on click but revealed no content; such items are now rendered as a plain, non-collapsible header [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
 - Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed parameter-less processors and interactions (e.g. "Invert") in the Input Actions editor's Action Properties view showing an expandable foldout whose arrow animated on click but revealed no content; such items are now rendered as a plain, non-collapsible header [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
+- Empty foldouts are no longer shown for processors and interactions that have no settings (e.g. "Invert") [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
 - Fixed the Input Actions editor toolbar buttons being clipped when the Action Properties panel grew tall enough to show a scrollbar
 - Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/PackageResources/InputActionsEditorStyles.uss
@@ -233,3 +233,7 @@
 #action-editor {
     min-width: 520px;
 }
+
+#control-schemes-toolbar-container {
+    flex-shrink: 0;
+}

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -170,9 +170,24 @@ namespace UnityEngine.InputSystem.Editor
 
             var foldout = container.Q<Foldout>("Foldout");
             foldout.text = parameterListView.name;
-            parameterListView.OnDrawVisualElements(foldout);
 
-            foldout.Add(new IMGUIContainer(parameterListView.OnGUI));
+            // A parameter-less processor/interaction (e.g. "Invert") has no content to reveal, so render it as
+            // a plain, non-collapsible header rather than an empty foldout whose arrow animates but shows nothing.
+            // Mirrors the IMGUI editor, which uses the same hasUIToShow predicate to choose foldout-vs-label.
+            if (parameterListView.hasUIToShow)
+            {
+                parameterListView.OnDrawVisualElements(foldout);
+                foldout.Add(new IMGUIContainer(parameterListView.OnGUI));
+            }
+            else
+            {
+                // Hide the expand arrow and disable picking on the header toggle; the move/delete buttons are
+                // separate child elements and remain clickable.
+                var checkmark = header.Q(className: "unity-toggle__checkmark");
+                if (checkmark != null)
+                    checkmark.style.display = DisplayStyle.None;
+                header.pickingMode = PickingMode.Ignore;
+            }
         }
     }
 }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -182,10 +182,11 @@ namespace UnityEngine.InputSystem.Editor
             else
             {
                 // Hide the expand arrow and disable picking on the header toggle; the move/delete buttons are
-                // separate child elements and remain clickable.
+                // separate child elements and remain clickable. Use visibility (not display) so the arrow keeps
+                // its layout box and the header label stays aligned with the foldout items' labels.
                 var checkmark = header.Q(className: "unity-toggle__checkmark");
                 if (checkmark != null)
-                    checkmark.style.display = DisplayStyle.None;
+                    checkmark.style.visibility = Visibility.Hidden;
                 header.pickingMode = PickingMode.Ignore;
             }
         }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/NameAndParametersListView.cs
@@ -171,9 +171,6 @@ namespace UnityEngine.InputSystem.Editor
             var foldout = container.Q<Foldout>("Foldout");
             foldout.text = parameterListView.name;
 
-            // A parameter-less processor/interaction (e.g. "Invert") has no content to reveal, so render it as
-            // a plain, non-collapsible header rather than an empty foldout whose arrow animates but shows nothing.
-            // Mirrors the IMGUI editor, which uses the same hasUIToShow predicate to choose foldout-vs-label.
             if (parameterListView.hasUIToShow)
             {
                 parameterListView.OnDrawVisualElements(foldout);
@@ -181,9 +178,6 @@ namespace UnityEngine.InputSystem.Editor
             }
             else
             {
-                // Hide the expand arrow and disable picking on the header toggle; the move/delete buttons are
-                // separate child elements and remain clickable. Use visibility (not display) so the arrow keeps
-                // its layout box and the header label stays aligned with the foldout items' labels.
                 var checkmark = header.Q(className: "unity-toggle__checkmark");
                 if (checkmark != null)
                     checkmark.style.visibility = Visibility.Hidden;


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

Two related fixes in the Input Actions editor's Action Properties view.

**Parameter-less processors/interactions [UUM-144325].** The `NameAndParametersListViewItem` constructor always populated the list item's `Foldout` regardless of whether the processor or interaction had any editable parameters, so a parameter-less entry such as "Invert" showed an expandable foldout whose arrow animated on click but revealed no content. The foldout content is now gated on `parameterListView.hasUIToShow`; entries with no parameters render as a plain, non-collapsible header — the expand arrow is hidden with `visibility` (so the label stays aligned with the foldout items) and the header toggle's picking is disabled, while the move/delete buttons stay clickable. This mirrors the IMGUI editor's existing `hasUIToShow` branch.

**Toolbar clipped when the properties panel scrolls.** The top toolbar row (`#control-schemes-toolbar-container`) was vertically shrinkable, so when the Action Properties content grew tall enough to overflow, the flex column compressed the toolbar and clipped its buttons once a scrollbar appeared. It now has `flex-shrink: 0`, keeping its height while the body absorbs the overflow.

### Testing status & QA

- No automated test added — both changes are UI Toolkit layout/visual behaviour in the Action Properties view, which has no test harness that reaches it and depends on in-editor rendering.
- QA: for the foldout, re-run the repro in [UUM-144325](https://jira.unity3d.com/browse/UUM-144325) and confirm a parameter-less processor/interaction renders as a plain header (no expand arrow, no empty expandable area) with working move/delete buttons. Separately, expand Processors on an action until the Action Properties panel shows a scrollbar and confirm the top toolbar buttons are no longer clipped.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (both changes are confined to the Input Actions editor's Action Properties view; no public API surface touched)
- Risk rating: 3/5 — Rating is 3 because this UITK item view has zero automated test coverage, and the arrow-hiding/pickingMode approach relies on Foldout internal USS class names and picking behaviour that need in-editor verification.

### Comments to reviewers

N/A

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
