### PR TITLE
FIX: Control Schemes dropdown keeps showing a deleted scheme name after the last scheme is removed [UUM-141563]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Empty foldouts are no longer shown for processors and interactions that have no settings (e.g. "Invert") [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
 - Fixed the Input Actions editor toolbar buttons being clipped when the Action Properties panel grew tall enough to show a scrollbar
-- Fixed the Control Schemes dropdown in the Input Actions editor continuing to display a deleted scheme's name after the last control scheme was removed, instead of resetting to "No Control Schemes" until the asset was saved or the editor reopened [UUM-141563](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141563).
+- Fixed the Control Schemes dropdown in the Input Actions editor continuing to display a deleted scheme's name after the last control scheme was removed, instead of resetting to "No Control Schemes" until the asset was saved or the editor reopened. [UUM-141563](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141563)
 - Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Empty foldouts are no longer shown for processors and interactions that have no settings (e.g. "Invert") [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
 - Fixed the Input Actions editor toolbar buttons being clipped when the Action Properties panel grew tall enough to show a scrollbar
+- Fixed the Control Schemes dropdown in the Input Actions editor continuing to display a deleted scheme's name after the last control scheme was removed, instead of resetting to "No Control Schemes" until the asset was saved or the editor reopened [UUM-141563](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141563).
 - Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/Views/InputActionsEditorView.cs
@@ -180,6 +180,10 @@ namespace UnityEngine.InputSystem.Editor
                         viewState.selectedControlSchemeIndex == i ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal));
                 m_ControlSchemesToolbar.menu.AppendSeparator();
             }
+            else
+            {
+                m_ControlSchemesToolbar.text = "No Control Schemes";
+            }
 
             m_ControlSchemesToolbar.menu.AppendAction("Add Control Scheme...", _ => AddOrUpdateControlScheme(rootElement));
             m_ControlSchemesToolbar.menu.AppendAction("Edit Control Scheme...", _ => AddOrUpdateControlScheme(rootElement, true),


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

`InputActionsEditorView.SetUpControlSchemesMenu(ViewState viewState)` assigned `m_ControlSchemesToolbar.text` only inside the `viewState.controlSchemes.Any()` branch. When the last control scheme was deleted and the collection became empty, that branch was skipped, so the Control Schemes dropdown in the Input Actions editor kept displaying the just-deleted scheme's name instead of the default until the asset was saved or the editor reopened.

This adds an `else` branch that resets `m_ControlSchemesToolbar.text` to `"No Control Schemes"`, the value the toolbar is seeded with in `InputActionsEditor.uxml`, so the empty state renders correctly on the same redraw that removes the scheme.

### Testing status & QA

- No automated test added — deleting a control scheme is only reachable through the Control Schemes `ToolbarMenu` dropdown, which the editor tests currently cannot drive (the one sibling test exercising this toolbar is `[Ignore]`d for that reason).
- QA can re-run the manual repro from [UUM-141563](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141563): with a single control scheme present, delete it and confirm the dropdown immediately reads "No Control Schemes" without saving or reopening the editor.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (internal-only edit confined to a single editor view method; no public API surface touched)
- Risk rating: 2/5 — Rating 2 because it is a single else-branch text assignment on the editor RedrawUI path whose literal matches the UXML seed, but the only nearby test is [Ignore]d, so no automated guard exists.

### Comments to reviewers

N/A

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
