### PR TITLE
FIX: Input Actions editor window throws a "Failed to load asset" exception on startup when its layout is restored in a different project [UUM-144318]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed the Input Actions editor window logging a "Failed to load asset" exception on editor startup when its saved window layout was restored in a project where the referenced asset GUID did not resolve; the window now closes quietly instead [UUM-144318](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144318)
 - Empty foldouts are no longer shown for processors and interactions that have no settings (e.g. "Invert") [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)
 - Fixed the Input Actions editor toolbar buttons being clipped when the Action Properties panel grew tall enough to show a scrollbar
 - Fixed the Control Schemes dropdown in the Input Actions editor continuing to display a deleted scheme's name after the last control scheme was removed, instead of resetting to "No Control Schemes" until the asset was saved or the editor reopened. [UUM-141563](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-141563)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -209,10 +209,8 @@ namespace UnityEngine.InputSystem.Editor
 
                     if (asset == null)
                     {
-                        // The persisted asset GUID can resolve to no asset when the window layout is
-                        // restored in a different project. Close quietly instead of throwing, but defer
-                        // the close: calling Close() synchronously here tears down the window's panel
-                        // while CreateGUI runs inside the UITK repaint, which then null-refs on repaint.
+                        // Can happen when an asset is deleted while the window is open.
+                        // Delay the closure to avoid null-refs on repaint.
                         EditorApplication.delayCall += Close;
                         return;
                     }

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/UITKAssetEditor/InputActionsEditorWindow.cs
@@ -208,7 +208,14 @@ namespace UnityEngine.InputSystem.Editor
                     var asset = AssetDatabase.LoadAssetAtPath<InputActionAsset>(assetPath);
 
                     if (asset == null)
-                        throw new Exception($"Failed to load asset \"{assetPath}\". The file may have been deleted or moved.");
+                    {
+                        // The persisted asset GUID can resolve to no asset when the window layout is
+                        // restored in a different project. Close quietly instead of throwing, but defer
+                        // the close: calling Close() synchronously here tears down the window's panel
+                        // while CreateGUI runs inside the UITK repaint, which then null-refs on repaint.
+                        EditorApplication.delayCall += Close;
+                        return;
+                    }
 
                     m_AssetJson = InputActionsEditorWindowUtils.ToJsonWithoutName(asset);
 


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

`InputActionsEditorWindow.CreateGUI()` persists its target asset's GUID (`m_AssetGUID`) in the editor window layout, which is shared across projects. When the window's layout is restored in a project where that GUID resolves to no asset, the restore branch loads a null asset and throws, and the surrounding `catch` surfaces it via `Debug.LogException` on editor startup.

The `asset == null` branch now closes the window quietly instead of throwing. The close is scheduled through `EditorApplication.delayCall` rather than called inline: `CreateGUI()` runs inside the UIToolkit repaint, and closing the window synchronously there tears down its panel mid-repaint, which then produces a follow-up `NullReferenceException` in the render tree. Deferring the close lets `CreateGUI()` return cleanly and the window closes on the next editor tick.

### Testing status & QA

- No automated test added - the branch only runs on an editor domain-reload window-layout restore where the persisted asset GUID does not resolve in the current project, which `InputTestFixture` / edit-mode tests cannot reproduce.
- QA can re-run the manual repro from https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144318 and confirm no exception is logged on startup.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (internal-only edit confined to one branch of a private method; no public API surface touched)
- Risk rating: 3/5 - The changed asset==null branch runs only on a real domain-reload/cross-project restore, which the edit-mode tests never reproduce, so the specific behaviour is untested and a regression could land uncaught despite the delta being confined to suppressing one log.

### Comments to reviewers

The window shows an empty panel for a single editor tick before `delayCall` closes it; this is expected given the close is deferred out of the repaint. The sibling `catch` block a few lines below still calls `Close()` synchronously for genuinely unexpected restore exceptions and has the same latent teardown risk, but it was left unchanged to keep this fix scoped to the reported scenario.

Note: if fixing it this way is undesirable then maybe changing the type of the message from error to a warning would be enough?

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
