### PR TITLE
FIX: .inputactions Inspector help button opens a missing documentation page [UUM-149518]

### DIFF
--- a/Assets/Tests/InputSystem/APIVerificationTests.cs
+++ b/Assets/Tests/InputSystem/APIVerificationTests.cs
@@ -250,6 +250,25 @@ class APIVerificationTests
         Assert.That(monoBehaviourTypesHelpUrls, Has.All.StartWith(InputSystem.kDocUrl));
     }
 
+    [Test]
+    [Category("API")]
+    public void API_InputActionImporterHasHelpUrlToExistingManualPage()
+    {
+        const string manualPrefix = "/manual/";
+
+        var helpUrlAttribute = typeof(InputActionImporter).GetCustomAttribute<HelpURLAttribute>();
+        Assert.That(helpUrlAttribute, Is.Not.Null, "InputActionImporter has no HelpURL attribute, so the .inputactions Inspector help button falls back to a generated URL with no published page.");
+        Assert.That(helpUrlAttribute.URL, Does.StartWith(InputSystem.kDocUrl + manualPrefix));
+
+        var page = helpUrlAttribute.URL.Substring(InputSystem.kDocUrl.Length + manualPrefix.Length);
+        var anchorIndex = page.IndexOf('#');
+        if (anchorIndex >= 0)
+            page = page.Substring(0, anchorIndex);
+
+        var markdownPath = "Packages/com.unity.inputsystem/Documentation~/" + Path.ChangeExtension(page, ".md");
+        Assert.That(File.Exists(markdownPath), Is.True, $"HelpURL of InputActionImporter points at {helpUrlAttribute.URL} but {markdownPath} does not exist.");
+    }
+
     private const string kAPIDirectory = "Tools/API";
 
     ////FIXME: The .api-based checks are temporary and don't account for platform-specific APIs. Nuke these tests as soon

--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed the Inspector help button for a selected `.inputactions` asset ("Open Reference for Input Action Importer") opening a missing documentation page; it now links to the Action Assets manual page [UUM-149518](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-149518)
 - Fixed an `OverflowException` when creating a control scheme (or other named item) whose all-numeric name exceeds `Int32.MaxValue`, which previously discarded the entered name and fell back to the default [UUM-145766](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-145766)
 - Fixed the Input Actions editor window logging a "Failed to load asset" exception on editor startup when its saved window layout was restored in a project where the referenced asset GUID did not resolve; the window now closes quietly instead [UUM-144318](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144318)
 - Empty foldouts are no longer shown for processors and interactions that have no settings (e.g. "Invert") [UUM-144325](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144325)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/AssetImporter/InputActionImporter.cs
@@ -22,6 +22,7 @@ namespace UnityEngine.InputSystem.Editor
     /// Will not overwrite existing wrappers except if the generated code actually differs.
     /// </remarks>
     [ScriptedImporter(kVersion, InputActionAsset.Extension)]
+    [HelpURL(InputSystem.kDocUrl + "/manual/action-assets.html")]
     internal class InputActionImporter : ScriptedImporter
     {
         private const int kVersion = 14;


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

Selecting an `.inputactions` asset shows an Inspector help button labelled "Open Reference for Input Action Importer". `UnityEngine.InputSystem.Editor.InputActionImporter`, the `ScriptedImporter` that backs those assets, carried no `[HelpURL]` attribute, so `UnityEditor` fell back to the auto-generated documentation URL for the type. No page is published at that address, so clicking the button opened the documentation site's "Sorry... that page seems to be missing!" 404 page.

The class declaration now carries `[HelpURL(InputSystem.kDocUrl + "/manual/action-assets.html")]` next to its existing `[ScriptedImporter(kVersion, InputActionAsset.Extension)]` attribute, which is the pattern already used across the package for Inspector-visible types such as `PlayerInput` and `InputSystemUIInputModule`. `Documentation~/action-assets.md` already exists and covers what this importer's inspector exposes (the `.inputactions` asset, project-wide assignment, and "Generate C# API from actions"), so no documentation page had to be added.

### Testing status & QA

- Added `Assets/Tests/InputSystem/APIVerificationTests.cs` `[Test] API_InputActionImporterHasHelpUrlToExistingManualPage`, which also resolves the URL back to its `Documentation~` markdown file so a future rename of the page is caught. The two existing help-URL tests filter to public `MonoBehaviour` types and therefore do not cover this importer.
- Manual check per https://jira.unity3d.com/browse/UUM-149518: select an `.inputactions` asset and click the Inspector help button; it should open the Action Assets manual page rather than a 404.

### Overall Product Risks

- Complexity: low
- Halo Effect: low (editor-only attribute added to a single internal importer type; no member, public API or serialised data touched)
- Risk rating: 2/5 — Rating 2 because `API_MonoBehaviourHelpUrlsAreValid` filters to public MonoBehaviours so this URL stays unvalidated by CI; the target `action-assets.md` was verified present in `Documentation~` and `TableOfContents.md`.

### Comments to reviewers

If a narrower landing page is preferred, `about-action-assets.html` and `generate-cs-api-from-actions.html` are the alternatives.

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [x] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
