### PR TITLE
DOCS: point backButtonLeavesApp migration at Application (ISX-2229)

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed the Input Debugger window (Window > Analysis > Input Debugger) being resizable arbitrarily small until its toolbar and device/action/layout tree view were no longer usably visible; it now enforces a minimum window size [UUM-137119](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-137119)
 - Fixed the Action Maps list in the Input Actions editor losing keyboard focus after deleting a map, so that Delete, Duplicate, and arrow-key navigation kept working on the auto-selected replacement map without requiring an extra click [UUM-147152](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-147152)
 
+### Changed
+
+- Updated the migration documentation to reflect that `Input.backButtonLeavesApp` is replaced by `Application.backButtonLeavesApp` in Unity 6.7 and later. [ISX-2229](https://jira.unity3d.com/browse/ISX-2229)
+
 ## [1.20.0] - 2026-07-21
 
 ### Fixed

--- a/Packages/com.unity.inputsystem/Documentation~/corresponding-old-new-api.md
+++ b/Packages/com.unity.inputsystem/Documentation~/corresponding-old-new-api.md
@@ -91,7 +91,6 @@ Directly reading hardware controls bypasses the new Input System's action-based 
 [`Input.touches`](https://docs.unity3d.com/scriptreference/input-touches.html)|[`EnhancedTouch.Touch.activeTouches`](xref:UnityEngine.InputSystem.EnhancedTouch.Touch)<br/> **Note:** Enable enhanced touch support first by calling [`EnhancedTouch.Enable()`](xref:UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport)
 [`Input.touchPressureSupported`](https://docs.unity3d.com/ScriptReference/Input-touchPressureSupported.html)|No corresponding API yet.
 [`Input.touchSupported`](https://docs.unity3d.com/ScriptReference/Input-touchSupported.html)|[`Touchscreen.current != null`](xref:UnityEngine.InputSystem.Touchscreen)
-[`Input.backButtonLeavesApp`](https://docs.unity3d.com/ScriptReference/Input-backButtonLeavesApp.html)|No corresponding API yet.
 [`GetPenEvent`](https://docs.unity3d.com/ScriptReference/Input.GetPenEvent.html)<br/>[`GetLastPenContactEvent`](https://docs.unity3d.com/ScriptReference/Input.GetLastPenContactEvent.html)<br/>[`ResetPenEvents`](https://docs.unity3d.com/ScriptReference/Input.ResetPenEvents.html)<br/>[`ClearLastPenContactEvent`](https://docs.unity3d.com/ScriptReference/Input.ClearLastPenContactEvent.html)|Use: [`Pen.current`](xref:UnityEngine.InputSystem.Pen)<br/>See the [Pen, tablet and stylus support](devices-pen.md) docs for more information.
 <hr/>
 
@@ -117,3 +116,11 @@ Note: [`UnityEngine.TouchScreenKeyboard`](https://docs.unity3d.com/ScriptReferen
 [`Input.gyro.userAcceleration`](https://docs.unity3d.com/ScriptReference/Gyroscope-userAcceleration.html)|[`LinearAccelerationSensor.current.acceleration.ReadValue()`](xref:UnityEngine.InputSystem.LinearAccelerationSensor)
 [`Input.location`](https://docs.unity3d.com/ScriptReference/Input-location.html)|No corresponding API yet.
 [`Input.GetAccelerationEvent`](https://docs.unity3d.com/ScriptReference/Input.GetAccelerationEvent.html)|See notes for `Input.accelerationEvents` above.
+
+## Application
+
+Some members of the old `Input` class control application behavior rather than reading input, so the Input System package doesn't replace them. Their replacements are on [`Application`](https://docs.unity3d.com/ScriptReference/Application.html), in the `UnityEngine` namespace rather than `UnityEngine.InputSystem`.
+
+|Input Manager (Old)|Input System (New)|
+|--|--|
+[`Input.backButtonLeavesApp`](https://docs.unity3d.com/ScriptReference/Input-backButtonLeavesApp.html)|Use [`Application.backButtonLeavesApp`](https://docs.unity3d.com/ScriptReference/Application-backButtonLeavesApp.html), available in Unity 6.7 and later. Android and UWP only. On other platforms the getter always returns false and the setter has no effect. Both properties read and write the same flag, so migrating doesn't change behavior.<br/><br/> **Note:** In Unity 6.7 and later, `Input.backButtonLeavesApp` is deprecated and produces a compiler warning. The API updater rewrites existing call sites to `Application.backButtonLeavesApp` for you.


### PR DESCRIPTION
`Input.backButtonLeavesApp` is replaced by `Application.backButtonLeavesApp` in Unity 6.7, so the
migration table no longer says "No corresponding API yet". The row also moves out of "Touch and Pen"
into a new "Application" section, for members of the old `Input` class that control application
behavior rather than reading input, and notes that the `Input` property is deprecated in 6.7 with the
API updater rewriting call sites.

Docs only — the property is engine-side and the package has nothing to add.

Engine PR: `unity/unity#120391` (internal)
Jira: ISX-2229
