### PR TITLE
FIX: Inset the Supported Devices list in Input System settings so it aligns with the other fields [UUM-150207]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed the "Supported Devices" list in the Input System Package Settings sitting flush against the panel edge with no left/right margin, unlike the surrounding fields; it is now inset to line up with the other settings controls [UUM-150207](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-150207)
 - Fixed the Inspector help button for a selected `.inputactions` asset ("Open Reference for Input Action Importer") opening a missing documentation page; it now links to the Action Assets manual page [UUM-149518](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-149518)
 - Fixed an `OverflowException` when creating a control scheme (or other named item) whose all-numeric name exceeds `Int32.MaxValue`, which previously discarded the entered name and fell back to the default [UUM-145766](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-145766)
 - Fixed the Input Actions editor window logging a "Failed to load asset" exception on editor startup when its saved window layout was restored in a project where the referenced asset GUID did not resolve; the window now closes quietly instead [UUM-144318](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-144318)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/Settings/InputSettingsProvider.cs
@@ -156,7 +156,13 @@ namespace UnityEngine.InputSystem.Editor
                     + "and avoid picking up input from devices not relevant to the project. When you add devices here, any device that will not be classified "
                     + "as supported will appear under 'Unsupported Devices' in the input debugger.", MessageType.None);
 
-                m_SupportedDevices.DoLayoutList();
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    GUILayout.Space(3f);
+                    using (new EditorGUILayout.VerticalScope())
+                        m_SupportedDevices.DoLayoutList();
+                    GUILayout.Space(3f);
+                }
 
                 EditorGUILayout.LabelField("iOS", EditorStyles.boldLabel);
                 EditorGUILayout.Space();


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

In `InputSettingsProvider.OnGUI(string searchContext)`, the "Supported Devices" list is drawn by a `ReorderableList` via `m_SupportedDevices.DoLayoutList()`, which reserves a full-width rect and draws its header, elements and background box flush against the settings panel's content edge. As a result that section had no visible left/right margin while every surrounding `EditorGUILayout` field appeared inset, making the list look misaligned.

The `DoLayoutList()` call is now wrapped in an `EditorGUILayout.HorizontalScope` with a 3px `GUILayout.Space` on each side, and the list itself placed in an `EditorGUILayout.VerticalScope` so it expands to the remaining width. This gives the list the same horizontal inset as the neighbouring controls without changing how the list itself behaves.

### Testing status & QA

- No automated test added — the change only shifts internally-computed IMGUI rects for visual alignment, which has no assertable behaviour via `InputTestFixture`; it was verified by eyeballing the section in the running editor.
- QA: open Project Settings > Input System Package and confirm the "Supported Devices" list now lines up with the other fields on the panel. Repro steps are in https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-150207 (linked once).

### Overall Product Risks

- Complexity: low
- Halo Effect: low (editor-only IMGUI edit confined to a single settings provider method; no public API or serialized data touched)
- Risk rating: 3/5 — The touched OnGUI layout path has no UI-layout test coverage, so a misaligned or broken inset would land uncaught, and the correct inset value is explicitly deferred to visual confirmation in the running editor.

### Comments to reviewers

N/A

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
