### PR TITLE
FIX: Inset the search field in the "Add supported device" popup so it no longer sits flush against the popup's left edge [UUM-150217]

### DIFF
--- a/Packages/com.unity.inputsystem/CHANGELOG.md
+++ b/Packages/com.unity.inputsystem/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed the search field in the "Add supported device" popup (Input System Package Settings > Supported Devices > "+") drawing flush against the popup's left edge with no left margin, unlike its right-side spacing; it is now inset to match [UUM-150217](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-150217)
 - Fixed the "Supported Devices" list in the Input System Package Settings sitting flush against the panel edge with no left/right margin, unlike the surrounding fields; it is now inset to line up with the other settings controls [UUM-150207](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-150207)
 - Fixed the Inspector help button for a selected `.inputactions` asset ("Open Reference for Input Action Importer") opening a missing documentation page; it now links to the Action Assets manual page [UUM-149518](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-149518)
 - Fixed an `OverflowException` when creating a control scheme (or other named item) whose all-numeric name exceeds `Int32.MaxValue`, which previously discarded the entered name and fell back to the default [UUM-145766](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-145766)

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -600,9 +600,7 @@ namespace UnityEngine.InputSystem.Editor
                     }
                     else
                     {
-                        // In PickDevice mode there is no leading "Listen" block, so inset the search
-                        // field from the popup's left edge to match its right-side spacing.
-                        GUILayout.Space(3f);
+                        GUILayout.Space(8f);
                     }
 
                     ////FIXME: the search box doesn't clear out when listening; no idea why the new string isn't taking effect

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -575,6 +575,7 @@ namespace UnityEngine.InputSystem.Editor
                     // When picking controls, have a "Listen" button that allows listening for input.
                     if (m_Owner.m_Mode == InputControlPicker.Mode.PickControl)
                     {
+                        GUILayout.Space(3f);
                         using (new EditorGUILayout.VerticalScope(GUILayout.MaxWidth(50)))
                         {
                             GUILayout.Space(4);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -598,6 +598,12 @@ namespace UnityEngine.InputSystem.Editor
                             isListening = isListeningNew;
                         }
                     }
+                    else
+                    {
+                        // In PickDevice mode there is no leading "Listen" block, so inset the search
+                        // field from the popup's left edge to match its right-side spacing.
+                        GUILayout.Space(3f);
+                    }
 
                     ////FIXME: the search box doesn't clear out when listening; no idea why the new string isn't taking effect
                     EditorGUI.BeginDisabledGroup(isListening);

--- a/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Editor/ControlPicker/InputControlPickerDropdown.cs
@@ -575,7 +575,7 @@ namespace UnityEngine.InputSystem.Editor
                     // When picking controls, have a "Listen" button that allows listening for input.
                     if (m_Owner.m_Mode == InputControlPicker.Mode.PickControl)
                     {
-                        GUILayout.Space(3f);
+                        GUILayout.Space(8f);
                         using (new EditorGUILayout.VerticalScope(GUILayout.MaxWidth(50)))
                         {
                             GUILayout.Space(4);


### PR DESCRIPTION
### Description

> [!NOTE]
> This pull request was generated automatically. Please review carefully before merging.

`InputControlPickerDropdown.InputControlPickerGUI.DrawSearchFieldControl(string searchString)` wraps its search field in a `HorizontalScope` whose only leading element is the "Listen" toggle block, and that block is emitted exclusively in `PickControl` mode. In `PickDevice` mode (the "Add supported device" popup opened from Input System Package Settings > Supported Devices > "+"), there is no leading element, so the search field drew flush against the popup's left edge with no left margin while its right edge kept the base field's spacing.

The change emits a `GUILayout.Space(8f)` as the first element of the `HorizontalScope` in both modes: at the start of the `PickControl` branch so the "Listen" block is no longer flush against the popup's left edge, and in an `else` branch so the search field in `PickDevice` mode gets the same left inset (matching its right-side spacing). This is the same family of cosmetic-inset fix as the sibling Supported Devices list fix ([UUM-150207](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-150207)).

### Testing status & QA

- No automated test added — the change is a cosmetic IMGUI layout inset with no observable state to assert; the nearest existing test covers dropdown tree structure, not search-field layout.
- QA: open Project Settings > Input System Package > Supported Devices, click "+", and confirm the search field in the "Add supported device" popup is inset from the left edge and its left margin matches the right-side spacing. Repro and expected behaviour: [UUM-150217](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-150217).

### Overall Product Risks

- Complexity: low
- Halo Effect: low (internal editor-only edit confined to one method, guarded so only PickDevice mode is affected)
- Risk rating: 2/5 — Small internal editor-only cosmetic layout edit with no public API, but the ~3px inset is explicitly a to-be-tuned value whose correctness only shows visually, so the reviewer should eyeball the rendered popup margin.

### Comments to reviewers

N/A

### Checklist

Before review:

- [x] Changelog entry added.
    - Explains the change in `Changed`, `Fixed`, `Added` sections.
    - For API change contains an example snippet and/or migration example.
    - JIRA ticket linked, example ([case %<ID>%](https://issuetracker.unity3d.com/product/unity/issues/guid/<ID>)). If it is a private issue, just add the case ID without a link.
    - Jira port for the next release set as "Resolved".
- [ ] Tests added/changed, if applicable.
    - Functional tests `Area_CanDoX`, `Area_CanDoX_EvenIfYIsTheCase`, `Area_WhenIDoX_AndYHappens_ThisIsTheResult`.
    - Performance tests.
    - Integration tests.
- [ ] Docs for new/changed API's.
    - Xmldoc cross references are set correctly.
    - Added explanation how the API works.
    - Usage code examples added.
    - The manual is updated, if needed.

During merge:

- [ ] Commit message for squash-merge is prefixed with one of the list:
    - `NEW: ___`.
    - `FIX: ___`.
    - `DOCS: ___`.
    - `CHANGE: ___`.
    - `RELEASE: 1.1.0-preview.3`.
